### PR TITLE
7.1 Surround Sound Feedback (enhanced) mode [10.6]

### DIFF
--- a/dialogs/AudioOptionsDialog.cpp
+++ b/dialogs/AudioOptionsDialog.cpp
@@ -53,6 +53,10 @@ BOOL AudioOptionsDialog::OnInitDialog()
 	   hwndControl = GetDlgItem(IDC_RADIO_SND3D6CH).GetHwnd();
 	   SendMessage(hwndControl, BM_SETCHECK, BST_CHECKED, 0);
 	   break;
+   case SNDCFG_SND3DSSF:
+	   hwndControl = GetDlgItem(IDC_RADIO_SND3DSSF).GetHwnd();
+	   SendMessage(hwndControl, BM_SETCHECK, BST_CHECKED, 0);
+	   break;
    default:
 	   hwndControl = GetDlgItem(IDC_RADIO_SND3D2CH).GetHwnd();
 	   SendMessage(hwndControl, BM_SETCHECK, BST_CHECKED, 0);
@@ -184,6 +188,12 @@ void AudioOptionsDialog::OnOK()
    if (checked)
    {
 	   fmusic = SNDCFG_SND3D6CH;
+   }
+   hwndControl = GetDlgItem(IDC_RADIO_SND3DSSF).GetHwnd();
+   checked = SendMessage(hwndControl, BM_GETCHECK, 0, 0);
+   if (checked)
+   {
+	   fmusic = SNDCFG_SND3DSSF;
    }
    SaveValueInt("Player", "Sound3D", fmusic);
 

--- a/pinsound.h
+++ b/pinsound.h
@@ -26,7 +26,7 @@ BOOL CALLBACK DSEnumCallBack(LPGUID guid, LPCSTR desc, LPCSTR mod, LPVOID list);
 
 enum SoundOutTypes : char { SNDOUT_TABLE = 0, SNDOUT_BACKGLASS = 1 };
 enum SoundConfigTypes : int { SNDCFG_SND3D2CH = 0, SNDCFG_SND3DALLREAR = 1, SNDCFG_SND3DFRONTISREAR = 2, 
-                              SNDCFG_SND3DFRONTISFRONT = 3, SNDCFG_SND3D6CH = 4};
+                              SNDCFG_SND3DFRONTISFRONT = 3, SNDCFG_SND3D6CH = 4, SNDCFG_SND3DSSF = 5};
 
 // Surround modes
 // ==============
@@ -46,6 +46,11 @@ enum SoundConfigTypes : int { SNDCFG_SND3D2CH = 0, SNDCFG_SND3DALLREAR = 1, SNDC
 //
 // 6CH: Rear of playfield shifted to the sides, and front of playfield shifted to the far rear.   Leaves front channels open
 // for default backglass and VPinMame. 
+//
+// SSF: 6CH still has significant surround sound directed to the backglass speakers in VPX 10.6 due to the way DirectSound3D
+// models sound. This mode ensures that these sounds are instead routed fully to the side channels by remapping table positions
+// to areas of the 3D sound stage that behave close what we are looking for. Furthermore horizontal panning and vertical fading
+// are enhanced for a more realistic experience.
 
 class PinSoundCopy
 {
@@ -97,6 +102,8 @@ public:
 
    void InitDirectSound(const HWND hwnd, const bool IsBackglass);
    static float PanTo3D(float input);
+   static float PanSSF(float input);
+   static float FadeSSF(float input);
 
    PinSound *LoadWaveFile(const TCHAR* const strFileName);
    HRESULT CreateStaticBuffer(const TCHAR* const strFileName, PinSound * const pps);

--- a/resource.h
+++ b/resource.h
@@ -983,6 +983,7 @@
 #define IDC_EDIT_BALANCE                813
 #define IDC_RADIO_SND3D6CH              814
 #define IDC_EDIT_FADER                  814
+#define IDC_RADIO_SND3DSSF              815
 #define IDC_EDIT5                       815
 #define IDC_EDIT_VOL                    815
 #define IDC_DBG_MATERIAL_THICKNESS_EDIT 816

--- a/vpinball_eng.rc
+++ b/vpinball_eng.rc
@@ -605,7 +605,7 @@ BEGIN
     LTEXT           "Y",IDC_STATIC,37,28,8,10
 END
 
-IDD_AUDIO_OPTIONS DIALOGEX 0, 0, 457, 159
+IDD_AUDIO_OPTIONS DIALOGEX 0, 0, 468, 159
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Audio Options"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -622,7 +622,7 @@ BEGIN
     LISTBOX         IDC_SoundListBG,123,86,171,40,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     DEFPUSHBUTTON   "OK",IDOK,350,141,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,403,141,50,14
-    GROUPBOX        "Multi-channel output",IDC_STATIC,303,11,147,89,BS_LEFT
+    GROUPBOX        "Multi-channel output",IDC_STATIC,303,11,159,104,BS_LEFT
     CONTROL         "Standard 2 channel",IDC_RADIO_SND3D2CH,"Button",BS_AUTORADIOBUTTON | WS_GROUP,309,24,125,10
     CONTROL         "Surround (All effects to rear channels)",IDC_RADIO_SND3DALLREAR,
                     "Button",BS_AUTORADIOBUTTON,309,37,137,10
@@ -631,7 +631,8 @@ BEGIN
     CONTROL         "Surround (Front is rear of cab)",IDC_RADIO_SND3DFRONTISREAR,
                     "Button",BS_AUTORADIOBUTTON,309,63,114,10
     CONTROL         "7.1 Surround (Front is rear,",IDC_RADIO_SND3D6CH,"Button",BS_AUTORADIOBUTTON,309,76,120,10
-    LTEXT           "back is side, backbox is front)",IDC_STATIC,320,86,101,8
+    LTEXT           "back is side, backbox is front)",IDC_STATIC,320,86,101,8,NOT WS_GROUP
+    CONTROL         "7.1 Surround Sound Feedback (enhanced)",IDC_RADIO_SND3DSSF,"Button",BS_AUTORADIOBUTTON,309,99,150,10
 END
 
 IDD_PHYSICS_OPTIONS DIALOGEX 0, 0, 199, 378


### PR DESCRIPTION
[10.6] Add a 7.1 SurroundSound mode tuned for SSF cabinet configurations.
This exaggerates the positional feel of the playfield sound effects when
played in a cabinet with exciter pairs positioned at each end of the cabinet.