### PR TITLE
check if .WAV samples are flagged to go to backglass (music) audio device

### DIFF
--- a/pinsound.cpp
+++ b/pinsound.cpp
@@ -155,7 +155,7 @@ HRESULT PinSound::ReInitialize()
       return E_FAIL;
    }
 
-   const SoundConfigTypes SoundMode3D = (SoundConfigTypes)LoadValueIntWithDefault("Player", "Sound3D", (int)SNDCFG_SND3D2CH);
+   const SoundConfigTypes SoundMode3D = (m_outputTarget == SNDOUT_BACKGLASS) ? SNDCFG_SND3D2CH : (SoundConfigTypes)LoadValueIntWithDefault("Player", "Sound3D", (int)SNDCFG_SND3D2CH);
 
    DSBUFFERDESC dsbd;
    ZeroMemory(&dsbd, sizeof(DSBUFFERDESC));
@@ -766,7 +766,8 @@ void PinDirectSoundWavCopy::PlayInternal(const float volume, const float randomp
 		}
 	}
 
-	const SoundConfigTypes SoundMode3D = (SoundConfigTypes)LoadValueIntWithDefault("Player", "Sound3D", (int)SNDCFG_SND3D2CH);
+	const SoundConfigTypes SoundMode3D = (m_ppsOriginal->m_outputTarget == SNDOUT_BACKGLASS) ? SNDCFG_SND3D2CH : (SoundConfigTypes)LoadValueIntWithDefault("Player", "Sound3D", (int)SNDCFG_SND3D2CH);
+
 	switch (SoundMode3D)
 	{
 	case SNDCFG_SND3DALLREAR:


### PR DESCRIPTION
Checks if .WAV samples have been flagged to go to backglass/music audio
device in the table sound manager. If so this will cause the creation of a regular
(not 3D) DirectSound buffer which will then be so played.

I will submit another PR which will turn .WAV mono samples into 2-channel samples
on the fly when targeted to the backglass (otherwise they get played to a usually 
non-existent center channel). This will use more memory but I see no other option.
