### PR TITLE
10.6.0

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -964,11 +964,11 @@ RenderDevice::~RenderDevice()
    //!! if (m_pD3DDeviceEx == m_pD3DDevice) m_pD3DDevice = NULL; //!! needed for Caligula if m_adapter > 0 ?? weird!! BUT MESSES UP FULLSCREEN EXIT (=hangs)
    SAFE_RELEASE_NO_RCC(m_pD3DDeviceEx);
 #endif
-   SAFE_RELEASE(m_pD3DDevice);
+   FORCE_RELEASE(m_pD3DDevice);
 #ifdef USE_D3D9EX
    SAFE_RELEASE_NO_RCC(m_pD3DEx);
 #endif
-   SAFE_RELEASE(m_pD3D);
+   FORCE_RELEASE(m_pD3D);
 
    /*
     * D3D sets the FPU to single precision/round to nearest int mode when it's initialized,

--- a/def.h
+++ b/def.h
@@ -137,6 +137,7 @@ inline void ref_count_trigger(const ULONG r, const char *file, const int line) /
 #define SAFE_RELEASE_NO_SET(p)	{ if(p) { const ULONG rcc = (p)->Release(); if(rcc != 0) ref_count_trigger(rcc, __FILE__, __LINE__); } }
 #define SAFE_RELEASE_NO_CHECK_NO_SET(p)	{ const ULONG rcc = (p)->Release(); if(rcc != 0) ref_count_trigger(rcc, __FILE__, __LINE__); }
 #define SAFE_RELEASE_NO_RCC(p)	{ if(p) { (p)->Release(); (p)=NULL; } } // use for releasing things like surfaces gotten from GetSurfaceLevel (that seem to "share" the refcount with the underlying texture)
+#define FORCE_RELEASE(p)		{ if(p) { ULONG rcc = 1; while(rcc!=0) {rcc = (p)->Release();} (p)=NULL; } } // release all references until it is 0
 
 #define hrNotImplemented ResultFromScode(E_NOTIMPL)
 

--- a/def.h
+++ b/def.h
@@ -331,6 +331,21 @@ __forceinline float radical_inverse(unsigned int v)
    return (float)v * 0.00000000023283064365386962890625f; // /2^32
 }
 
+template <unsigned int base>
+float radical_inverse(unsigned int a) {
+    const float invBase = (float)(1. / (double)base);
+    unsigned int reversedDigits = 0;
+    float invBaseN = 1.f;
+    while (a) {
+        const unsigned int next  = a / base;
+        const unsigned int digit = a - next * base;
+        reversedDigits = reversedDigits * base + digit;
+        invBaseN *= invBase;
+        a = next;
+    }
+    return (float)((double)reversedDigits * invBaseN);
+}
+
 __forceinline float sobol(unsigned int i, unsigned int scramble = 0)
 {
    for (unsigned int v = 1u << 31; (i != 0); i >>= 1, v ^= v >> 1) if (i & 1)

--- a/dialogs/AboutDialog.cpp
+++ b/dialogs/AboutDialog.cpp
@@ -26,7 +26,7 @@ INT_PTR AboutDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
       {
          HWND hwndDlg = GetHwnd();
          char versionString[256];
-         sprintf_s(versionString, "Version %i.%i.%i (Revision %i, %ubit)", VP_VERSION_MAJOR,VP_VERSION_MINOR,VP_VERSION_REV, SVN_REVISION,
+         sprintf_s(versionString, "Version %i.%i.%i Final (Revision %i, %ubit)", VP_VERSION_MAJOR,VP_VERSION_MINOR,VP_VERSION_REV, SVN_REVISION,
 #ifdef _WIN64
             64u
 #else

--- a/dialogs/AudioOptionsDialog.cpp
+++ b/dialogs/AudioOptionsDialog.cpp
@@ -53,6 +53,10 @@ BOOL AudioOptionsDialog::OnInitDialog()
 	   hwndControl = GetDlgItem(IDC_RADIO_SND3D6CH).GetHwnd();
 	   SendMessage(hwndControl, BM_SETCHECK, BST_CHECKED, 0);
 	   break;
+   case SNDCFG_SND3DSSF:
+	   hwndControl = GetDlgItem(IDC_RADIO_SND3DSSF).GetHwnd();
+	   SendMessage(hwndControl, BM_SETCHECK, BST_CHECKED, 0);
+	   break;
    default:
 	   hwndControl = GetDlgItem(IDC_RADIO_SND3D2CH).GetHwnd();
 	   SendMessage(hwndControl, BM_SETCHECK, BST_CHECKED, 0);
@@ -184,6 +188,12 @@ void AudioOptionsDialog::OnOK()
    if (checked)
    {
 	   fmusic = SNDCFG_SND3D6CH;
+   }
+   hwndControl = GetDlgItem(IDC_RADIO_SND3DSSF).GetHwnd();
+   checked = SendMessage(hwndControl, BM_GETCHECK, 0, 0);
+   if (checked)
+   {
+	   fmusic = SNDCFG_SND3DSSF;
    }
    SaveValueInt("Player", "Sound3D", fmusic);
 

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1197,9 +1197,9 @@ void Flasher::RenderDynamic()
        pd3dDevice->DMDShader->SetVector("vColor_Intensity", &color);
 
 #ifdef DMD_UPSCALE
-       const vec4 r((float)(g_pplayer->m_dmdx*3), (float)(g_pplayer->m_dmdy*3), m_d.m_modulate_vs_add, g_pplayer->m_overall_frames%2048); //(float)(0.5 / m_width), (float)(0.5 / m_height));
+       const vec4 r((float)(g_pplayer->m_dmdx*3), (float)(g_pplayer->m_dmdy*3), m_d.m_modulate_vs_add, (float)(g_pplayer->m_overall_frames%2048)); //(float)(0.5 / m_width), (float)(0.5 / m_height));
 #else
-       const vec4 r((float)g_pplayer->m_dmdx, (float)g_pplayer->m_dmdy, m_d.m_modulate_vs_add, g_pplayer->m_overall_frames%2048); //(float)(0.5 / m_width), (float)(0.5 / m_height));
+       const vec4 r((float)g_pplayer->m_dmdx, (float)g_pplayer->m_dmdy, m_d.m_modulate_vs_add, (float)(g_pplayer->m_overall_frames%2048)); //(float)(0.5 / m_width), (float)(0.5 / m_height));
 #endif
        pd3dDevice->DMDShader->SetVector("vRes_Alpha_time", &r);
 

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1197,11 +1197,11 @@ void Flasher::RenderDynamic()
        pd3dDevice->DMDShader->SetVector("vColor_Intensity", &color);
 
 #ifdef DMD_UPSCALE
-       const vec4 r((float)(g_pplayer->m_dmdx*3), (float)(g_pplayer->m_dmdy*3), m_d.m_modulate_vs_add, 0.f); //(float)(0.5 / m_width), (float)(0.5 / m_height));
+       const vec4 r((float)(g_pplayer->m_dmdx*3), (float)(g_pplayer->m_dmdy*3), m_d.m_modulate_vs_add, g_pplayer->m_overall_frames%2048); //(float)(0.5 / m_width), (float)(0.5 / m_height));
 #else
-       const vec4 r((float)g_pplayer->m_dmdx, (float)g_pplayer->m_dmdy, m_d.m_modulate_vs_add, 0.f); //(float)(0.5 / m_width), (float)(0.5 / m_height));
+       const vec4 r((float)g_pplayer->m_dmdx, (float)g_pplayer->m_dmdy, m_d.m_modulate_vs_add, g_pplayer->m_overall_frames%2048); //(float)(0.5 / m_width), (float)(0.5 / m_height));
 #endif
-       pd3dDevice->DMDShader->SetVector("vRes_Alpha", &r);
+       pd3dDevice->DMDShader->SetVector("vRes_Alpha_time", &r);
 
        pd3dDevice->DMDShader->SetTexture("Texture0", g_pplayer->m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, false));
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -4359,10 +4359,12 @@ void Player::PrepareVideoBuffersNormal()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("color_grade", pin != NULL);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("do_bloom", (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
 
+   //const unsigned int jittertime = (unsigned int)((U64)msec()*90/1000);
+   const float jitter = (float)((msec()&2047)/1000.0);
    const vec4 fb_inv_resolution_05((float)(0.5 / (double)m_width), (float)(0.5 / (double)m_height),
       //1.0f, 1.0f);
-      radical_inverse(m_overall_frames)*(float)(1. / 8.0),
-      sobol(m_overall_frames)*(float)(5. / 8.0)); // jitter for dither pattern
+      jitter, //radical_inverse(jittertime)*11.0f,
+      jitter);//sobol(jittertime)*13.0f); // jitter for dither pattern
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &fb_inv_resolution_05);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(useAA ? "fb_tonemap" : (m_BWrendering == 1 ? "fb_tonemap_no_filterRG" : (m_BWrendering == 2 ? "fb_tonemap_no_filterR" : "fb_tonemap_no_filterRGB")));
 
@@ -4511,10 +4513,12 @@ void Player::PrepareVideoBuffersAO()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("color_grade", pin != NULL);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("do_bloom", (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
 
+   //const unsigned int jittertime = (unsigned int)((U64)msec()*90/1000);
+   const float jitter = (float)((msec()&2047)/1000.0);
    const vec4 fb_inv_resolution_05((float)(0.5 / (double)m_width), (float)(0.5 / (double)m_height),
       //1.0f, 1.0f);
-      radical_inverse(m_overall_frames)*(float)(1. / 8.0),
-      sobol(m_overall_frames)*(float)(5. / 8.0)); // jitter for dither pattern
+      jitter, //radical_inverse(jittertime)*11.0f,
+      jitter);//sobol(jittertime)*13.0f); // jitter for dither pattern
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &fb_inv_resolution_05);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(RenderAOOnly() ? "fb_AO" :
                                                 (useAA ? "fb_tonemap_AO" : "fb_tonemap_AO_no_filter"));

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -3471,9 +3471,9 @@ void Player::DMDdraw(const float DMDposx, const float DMDposy, const float DMDwi
       const vec4 c = convertColor(DMDcolor, intensity);
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetVector("vColor_Intensity", &c);
 #ifdef DMD_UPSCALE
-      const vec4 r((float)(m_dmdx*3), (float)(m_dmdy*3), 1.f, g_pplayer->m_overall_frames%2048);
+      const vec4 r((float)(m_dmdx*3), (float)(m_dmdy*3), 1.f, (float)(g_pplayer->m_overall_frames%2048));
 #else
-      const vec4 r((float)m_dmdx, (float)m_dmdy, 1.f, g_pplayer->m_overall_frames%2048);
+      const vec4 r((float)m_dmdx, (float)m_dmdy, 1.f, (float)(g_pplayer->m_overall_frames%2048));
 #endif
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetVector("vRes_Alpha_time", &r);
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -3470,11 +3470,11 @@ void Player::DMDdraw(const float DMDposx, const float DMDposy, const float DMDwi
       const vec4 c = convertColor(DMDcolor, intensity);
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetVector("vColor_Intensity", &c);
 #ifdef DMD_UPSCALE
-      const vec4 r((float)(m_dmdx*3), (float)(m_dmdy*3), 1.f, 0.f);
+      const vec4 r((float)(m_dmdx*3), (float)(m_dmdy*3), 1.f, g_pplayer->m_overall_frames%2048);
 #else
-      const vec4 r((float)m_dmdx, (float)m_dmdy, 1.f, 0.f);
+      const vec4 r((float)m_dmdx, (float)m_dmdy, 1.f, g_pplayer->m_overall_frames%2048);
 #endif
-      m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetVector("vRes_Alpha", &r);
+      m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetVector("vRes_Alpha_time", &r);
 
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetTexture("Texture0", m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_texdmd, false));
 
@@ -3870,7 +3870,7 @@ void Player::SSRefl()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture3", m_pin3d.m_pdds3DZBuffer);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture4", &m_pin3d.m_aoDitherTexture, true); //!!!
 
-   const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height), 1.0f/*radical_inverse(m_overall_frames)*/, 1.0f);
+   const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height), 1.0f/*radical_inverse(m_overall_frames%2048)*/, 1.0f);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &w_h_height);
 
    const float rotation = fmodf(m_ptable->m_BG_rotation[m_ptable->m_BG_current_set], 360.f);
@@ -4439,8 +4439,8 @@ void Player::PrepareVideoBuffersAO()
    m_pin3d.m_pd3dDevice->FBShader->SetTexture("Texture3", m_pin3d.m_pdds3DZBuffer);
    
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height),
-      radical_inverse(m_overall_frames)*(float)(1. / 8.0),
-      sobol(m_overall_frames)*(float)(5. / 8.0)); // jitter within lattice cell //!! ?
+      radical_inverse(m_overall_frames%2048)*(float)(1. / 8.0),
+      sobol(m_overall_frames%2048)*(float)(5. / 8.0)); // jitter within lattice cell //!! ?
    m_pin3d.m_pd3dDevice->FBShader->SetVector("w_h_height", &w_h_height);
 
    m_pin3d.m_pd3dDevice->FBShader->SetTechnique("normals");
@@ -4460,8 +4460,8 @@ void Player::PrepareVideoBuffersAO()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture3", m_pin3d.m_pdds3DZBuffer);
 
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height),
-      radical_inverse(m_overall_frames)*(float)(1. / 8.0),
-      /*sobol*/radical_inverse<3>(m_overall_frames)*(float)(1. / 8.0)); // jitter within (64/8)x(64/8) neighborhood of 64x64 tex, good compromise between blotches and noise
+      radical_inverse(m_overall_frames%2048)*(float)(1. / 8.0),
+      /*sobol*/radical_inverse<3>(m_overall_frames%2048)*(float)(1. / 8.0)); // jitter within (64/8)x(64/8) neighborhood of 64x64 tex, good compromise between blotches and noise
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &w_h_height);
    const vec4 ao_s_tb(m_ptable->m_AOScale, 0.4f, 0.f,0.f); //!! 0.4f: fake global option in video pref? or time dependent? //!! commonly used is 0.1, but would require to clear history for moving stuff
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("AO_scale_timeblur", &ao_s_tb);

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -2142,7 +2142,7 @@ void Player::InitStatic(HWND hwndProgress)
 
          const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height),
             radical_inverse(i)*(float)(1. / 8.0),
-            sobol(i)*(float)(5. / 8.0)); // jitter within lattice cell //!! ?
+             /*sobol*/radical_inverse<3>(i)*(float)(1. / 8.0)); // jitter within (64/8)x(64/8) neighborhood of 64x64 tex, good compromise between blotches and noise
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &w_h_height);
 
          m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
@@ -3870,7 +3870,7 @@ void Player::SSRefl()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture3", m_pin3d.m_pdds3DZBuffer);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture4", &m_pin3d.m_aoDitherTexture, true); //!!!
 
-   const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height), 1.0f, 1.0f);
+   const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height), 1.0f/*radical_inverse(m_overall_frames)*/, 1.0f);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &w_h_height);
 
    const float rotation = fmodf(m_ptable->m_BG_rotation[m_ptable->m_BG_current_set], 360.f);
@@ -4461,9 +4461,9 @@ void Player::PrepareVideoBuffersAO()
 
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height),
       radical_inverse(m_overall_frames)*(float)(1. / 8.0),
-      sobol(m_overall_frames)*(float)(5. / 8.0)); // jitter within lattice cell //!! ?
+      /*sobol*/radical_inverse<3>(m_overall_frames)*(float)(1. / 8.0)); // jitter within (64/8)x(64/8) neighborhood of 64x64 tex, good compromise between blotches and noise
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("w_h_height", &w_h_height);
-   const vec4 ao_s_tb(m_ptable->m_AOScale, 0.4f, 0.f,0.f); //!! 0.4f: fake global option in video pref? or time dependent?
+   const vec4 ao_s_tb(m_ptable->m_AOScale, 0.4f, 0.f,0.f); //!! 0.4f: fake global option in video pref? or time dependent? //!! commonly used is 0.1, but would require to clear history for moving stuff
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector("AO_scale_timeblur", &ao_s_tb);
 
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique("AO");

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -511,6 +511,7 @@ Player::Player(const bool cameraMode, PinTable * const ptable, const HWND hwndPr
    m_disableDWM = LoadValueBoolWithDefault("Player", "DisableDWM", false);
    m_useNvidiaApi = LoadValueBoolWithDefault("Player", "UseNVidiaAPI", false);
    m_bloomOff = LoadValueBoolWithDefault("Player", "ForceBloomOff", false);
+   m_ditherOff = LoadValueBoolWithDefault("Player", "Render10Bit", false); // if rendering at 10bit output resolution, disable dithering
    m_BWrendering = LoadValueIntWithDefault("Player", "BWRendering", 0);
    m_detectScriptHang = LoadValueBoolWithDefault("Player", "DetectHang", false);
 
@@ -4357,6 +4358,7 @@ void Player::PrepareVideoBuffersNormal()
    if (pin)
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture4", pin, false);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("color_grade", pin != NULL);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("do_dither", !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("do_bloom", (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
 
    //const unsigned int jittertime = (unsigned int)((U64)msec()*90/1000);
@@ -4511,6 +4513,7 @@ void Player::PrepareVideoBuffersAO()
    if (pin)
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture("Texture4", pin, false);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("color_grade", pin != NULL);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("do_dither", !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool("do_bloom", (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
 
    //const unsigned int jittertime = (unsigned int)((U64)msec()*90/1000);

--- a/pin/player.h
+++ b/pin/player.h
@@ -404,6 +404,7 @@ public:
    int m_BWrendering; // 0=off, 1=Black&White from RedGreen, 2=B&W from Red only
 
    bool m_bloomOff;
+   bool m_ditherOff;
 
    bool m_PlayMusic;
    bool m_PlaySound;

--- a/pinsound.h
+++ b/pinsound.h
@@ -26,7 +26,7 @@ BOOL CALLBACK DSEnumCallBack(LPGUID guid, LPCSTR desc, LPCSTR mod, LPVOID list);
 
 enum SoundOutTypes : char { SNDOUT_TABLE = 0, SNDOUT_BACKGLASS = 1 };
 enum SoundConfigTypes : int { SNDCFG_SND3D2CH = 0, SNDCFG_SND3DALLREAR = 1, SNDCFG_SND3DFRONTISREAR = 2, 
-                              SNDCFG_SND3DFRONTISFRONT = 3, SNDCFG_SND3D6CH = 4};
+                              SNDCFG_SND3DFRONTISFRONT = 3, SNDCFG_SND3D6CH = 4, SNDCFG_SND3DSSF = 5};
 
 // Surround modes
 // ==============
@@ -46,6 +46,11 @@ enum SoundConfigTypes : int { SNDCFG_SND3D2CH = 0, SNDCFG_SND3DALLREAR = 1, SNDC
 //
 // 6CH: Rear of playfield shifted to the sides, and front of playfield shifted to the far rear.   Leaves front channels open
 // for default backglass and VPinMame. 
+//
+// SSF: 6CH still has significant surround sound directed to the backglass speakers in VPX 10.6 due to the way DirectSound3D
+// models sound. This mode ensures that these sounds are instead routed fully to the side channels by remapping table positions
+// to areas of the 3D sound stage that behave close what we are looking for. Furthermore horizontal panning and vertical fading
+// are enhanced for a more realistic experience.
 
 class PinSoundCopy
 {
@@ -97,6 +102,8 @@ public:
 
    void InitDirectSound(const HWND hwnd, const bool IsBackglass);
    static float PanTo3D(float input);
+   static float PanSSF(float input);
+   static float FadeSSF(float input);
 
    PinSound *LoadWaveFile(const TCHAR* const strFileName);
    HRESULT CreateStaticBuffer(const TCHAR* const strFileName, PinSound * const pps);

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -3617,7 +3617,8 @@ HRESULT PinTable::LoadGameFromStorage(IStorage *pstgRoot)
                   piedit->InitVBA(fFalse, id, NULL);
                   pstmItem->Release();
                   pstmItem = NULL;
-                  if (FAILED(hr)) break;
+                  if (FAILED(hr)) 
+                      break;
 
                   m_vedit.push_back(piedit);
 

--- a/resource.h
+++ b/resource.h
@@ -983,6 +983,7 @@
 #define IDC_EDIT_BALANCE                813
 #define IDC_RADIO_SND3D6CH              814
 #define IDC_EDIT_FADER                  814
+#define IDC_RADIO_SND3DSSF              815
 #define IDC_EDIT5                       815
 #define IDC_EDIT_VOL                    815
 #define IDC_DBG_MATERIAL_THICKNESS_EDIT 816

--- a/shader/BallShader.fx
+++ b/shader/BallShader.fx
@@ -6,12 +6,12 @@
 #include "Helpers.fxh"
 
 // transformation matrices
-float4x4 matWorldViewProj : WORLDVIEWPROJ;
-float4x4 matWorldView     : WORLDVIEW;
-float4x3 matWorldViewInverse;
-//float4x4 matWorldViewInverseTranspose; // matWorldViewInverse used instead and multiplied from other side
-float4x3 matView;
-//float4x4 matViewInverseInverseTranspose; // matView used instead and multiplied from other side
+const float4x4 matWorldViewProj : WORLDVIEWPROJ;
+const float4x4 matWorldView     : WORLDVIEW;
+const float4x3 matWorldViewInverse;
+//const float4x4 matWorldViewInverseTranspose; // matWorldViewInverse used instead and multiplied from other side
+const float4x3 matView;
+//const float4x4 matViewInverseInverseTranspose; // matView used instead and multiplied from other side
 
 texture  Texture0; // base texture
 texture  Texture1; // playfield (should be envmap if specular or glossy needed/enabled, see below)
@@ -58,17 +58,17 @@ sampler2D texSampler7 : TEXUNIT3 = sampler_state // ball decal
 	ADDRESSV  = Wrap;
 };
 
-bool     hdrEnvTextures = false;
+const bool     hdrEnvTextures = false;
 
 #include "Material.fxh"
 
-float4   invTableRes__playfield_height_reflection;
+const float4   invTableRes__playfield_height_reflection;
 
-//float    reflection_ball_playfield;
+//const float    reflection_ball_playfield;
 
-float4x3 orientation;
+const float4x3 orientation;
 
-bool     hdrTexture0;
+const bool     hdrTexture0;
 
 //------------------------------------
 
@@ -106,7 +106,7 @@ struct voutTrail
 //------------------------------------
 // VERTEX SHADER
 
-vout vsBall( in vin IN )
+vout vsBall( const in vin IN )
 {
 	// apply spinning and move the ball to it's actual position
 	float4 pos = IN.position;
@@ -126,7 +126,7 @@ vout vsBall( in vin IN )
 }
 
 #if 0
-voutReflection vsBallReflection( in vin IN )
+voutReflection vsBallReflection( const in vin IN )
 {
 	// apply spinning and move the ball to it's actual position
 	float4 pos = IN.position;
@@ -152,10 +152,9 @@ voutReflection vsBallReflection( in vin IN )
 }
 #endif
 
-voutTrail vsBallTrail( in vin IN )
+voutTrail vsBallTrail( const in vin IN )
 {
     voutTrail OUT;
-    
     OUT.position = mul(IN.position, matWorldViewProj);
 	OUT.tex0_alpha = float3(IN.tex0, IN.normal.x); //!! abuses normal for now
 
@@ -240,7 +239,7 @@ float3 PFlightLoop(const float3 pos, const float3 N, const float3 diffuse)
 //------------------------------------
 // PIXEL SHADER
 
-float4 psBall( in vout IN, uniform bool cabMode, uniform bool decalMode ) : COLOR
+float4 psBall( const in vout IN, uniform bool cabMode, uniform bool decalMode ) : COLOR
 {
     const float3 v = normalize(/*camera=0,0,0,1*/-IN.worldPos_t0y.xyz);
     const float3 r = reflect(v, normalize(IN.normal_t0x.xyz));
@@ -307,7 +306,7 @@ float4 psBall( in vout IN, uniform bool cabMode, uniform bool decalMode ) : COLO
 }
 
 #if 0
-float4 psBallReflection( in voutReflection IN ) : COLOR
+float4 psBallReflection( const in voutReflection IN ) : COLOR
 {
    const float2 envTex = cabMode ? float2(IN.r.y*0.5f + 0.5f, -IN.r.x*0.5f + 0.5f) : float2(IN.r.x*0.5f + 0.5f, IN.r.y*0.5f + 0.5f);
    float3 ballImageColor = tex2D(texSampler0, envTex).xyz;

--- a/shader/BasicShader.fx
+++ b/shader/BasicShader.fx
@@ -5,11 +5,11 @@
 #include "Helpers.fxh"
 
 // transformation matrices
-float4x4 matWorldViewProj : WORLDVIEWPROJ;
-float4x4 matWorldView     : WORLDVIEW;
-float3x4 matWorldViewInverseTranspose;
-float4x3 matView;
-//float4x4 matViewInverseInverseTranspose; // matView used instead and multiplied from other side
+const float4x4 matWorldViewProj : WORLDVIEWPROJ;
+const float4x4 matWorldView     : WORLDVIEW;
+const float3x4 matWorldViewInverseTranspose;
+const float4x3 matView;
+//const float4x4 matViewInverseInverseTranspose; // matView used instead and multiplied from other side
 
 texture Texture0; // base texture
 texture Texture1; // envmap
@@ -68,19 +68,19 @@ sampler2D texSamplerN : TEXUNIT4 = sampler_state // normal map texture
     //ADDRESSV  = Wrap;
 };
 
-bool hdrEnvTextures;
-bool objectSpaceNormalMap;
+const bool hdrEnvTextures;
+const bool objectSpaceNormalMap;
 
 #include "Material.fxh"
 
-float4 cClearcoat_EdgeAlpha;
-float4 cGlossy_ImageLerp;
+const float4 cClearcoat_EdgeAlpha;
+const float4 cGlossy_ImageLerp;
 //!! No value is under 0.02
 //!! Non-metals value are un-intuitively low: 0.02-0.08
 //!! Gemstones are 0.05-0.17
 //!! Metals have high specular reflectance: 0.5-1.0
 
-float alphaTestValue;
+const float alphaTestValue;
 
 struct VS_OUTPUT 
 { 
@@ -108,11 +108,9 @@ struct VS_DEPTH_ONLY_TEX_OUTPUT
    float2 tex0     : TEXCOORD0;
 };
 
-float3x3 TBN_trafo(const float3 N, const float3 V, const float2 uv)
+float3x3 TBN_trafo(const float3 N, const float3 V, const float2 uv, const float3 dpx, const float3 dpy)
 {
    // derivatives: edge vectors for tri-pos and tri-uv
-   const float3 dpx = ddx(V);
-   const float3 dpy = ddy(V);
    const float2 duvx = ddx(uv);
    const float2 duvy = ddy(uv);
 
@@ -130,12 +128,15 @@ float3 normal_map(const float3 N, const float3 V, const float2 uv)
 {
    float3 tn = tex2D(texSamplerN, uv).xyz * (255./127.) - (128./127.); // Note that Blender apparently does export tangent space normalmaps for Z (Blue) at full range, so 0..255 -> 0..1, which misses an option for here!
 
+   const float3 dpx = ddx(V); //!! these 2 are declared here instead of TBN_trafo() to workaround a compiler quirk
+   const float3 dpy = ddy(V);
+
    [branch] if (objectSpaceNormalMap)
    {
       tn.z = -tn.z; // this matches the object space, +X +Y +Z, export/baking in Blender with our trafo setup
       return normalize( mul(tn, matWorldViewInverseTranspose).xyz );
    } else // tangent space
-      return normalize( mul(TBN_trafo(N, V, uv),
+      return normalize( mul(TBN_trafo(N, V, uv, dpx, dpy),
                             tn) );
 }
 
@@ -144,10 +145,10 @@ float3 normal_map(const float3 N, const float3 V, const float2 uv)
 // Standard Materials
 //
 
-VS_OUTPUT vs_main (in float4 vPosition : POSITION0,  
-                   in float3 vNormal   : NORMAL0,  
-                   in float2 tc        : TEXCOORD0) 
-{ 
+VS_OUTPUT vs_main (const in float4 vPosition : POSITION0,
+                   const in float3 vNormal   : NORMAL0,
+                   const in float2 tc        : TEXCOORD0)
+{
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
    const float3 P = mul(vPosition, matWorldView).xyz;
    const float3 N = normalize(mul(vNormal, matWorldViewInverseTranspose).xyz);
@@ -160,10 +161,10 @@ VS_OUTPUT vs_main (in float4 vPosition : POSITION0,
    return Out; 
 }
 
-VS_NOTEX_OUTPUT vs_notex_main (in float4 vPosition : POSITION0,  
-                               in float3 vNormal   : NORMAL0,  
-                               in float2 tc        : TEXCOORD0)
-{ 
+VS_NOTEX_OUTPUT vs_notex_main (const in float4 vPosition : POSITION0,
+                               const in float3 vNormal   : NORMAL0,
+                               const in float2 tc        : TEXCOORD0)
+{
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
    const float3 P = mul(vPosition, matWorldView).xyz;
    const float3 N = normalize(mul(vNormal, matWorldViewInverseTranspose).xyz);
@@ -180,8 +181,8 @@ VS_NOTEX_OUTPUT vs_notex_main (in float4 vPosition : POSITION0,
    return Out; 
 }
 
-VS_DEPTH_ONLY_NOTEX_OUTPUT vs_depth_only_main_without_texture(in float4 vPosition : POSITION0) 
-{ 
+VS_DEPTH_ONLY_NOTEX_OUTPUT vs_depth_only_main_without_texture(const in float4 vPosition : POSITION0)
+{
    VS_DEPTH_ONLY_NOTEX_OUTPUT Out;
 
    Out.pos = mul(vPosition, matWorldViewProj);
@@ -189,8 +190,8 @@ VS_DEPTH_ONLY_NOTEX_OUTPUT vs_depth_only_main_without_texture(in float4 vPositio
    return Out; 
 }
 
-VS_DEPTH_ONLY_TEX_OUTPUT vs_depth_only_main_with_texture(in float4 vPosition : POSITION0,
-                                                         in float2 tc : TEXCOORD0)
+VS_DEPTH_ONLY_TEX_OUTPUT vs_depth_only_main_with_texture(const in float4 vPosition : POSITION0,
+                                                         const in float2 tc : TEXCOORD0)
 {
    VS_DEPTH_ONLY_TEX_OUTPUT Out;
 
@@ -200,13 +201,13 @@ VS_DEPTH_ONLY_TEX_OUTPUT vs_depth_only_main_with_texture(in float4 vPosition : P
    return Out;
 }
 
-float4 ps_main(in VS_NOTEX_OUTPUT IN, uniform bool is_metal) : COLOR
+float4 ps_main(const in VS_NOTEX_OUTPUT IN, uniform bool is_metal) : COLOR
 {
    const float3 diffuse  = cBase_Alpha.xyz;
    const float3 glossy   = is_metal ? cBase_Alpha.xyz : cGlossy_ImageLerp.xyz*0.08;
    const float3 specular = cClearcoat_EdgeAlpha.xyz*0.08;
    const float  edge     = is_metal ? 1.0 : Roughness_WrapL_Edge_Thickness.z;
-   
+
    const float3 V = normalize(/*camera=0,0,0,1*/-IN.worldPos_t1x.xyz);
    const float3 N = normalize(IN.normal_t1y.xyz);
 
@@ -227,7 +228,7 @@ float4 ps_main(in VS_NOTEX_OUTPUT IN, uniform bool is_metal) : COLOR
    return result;
 }
 
-float4 ps_main_texture(in VS_OUTPUT IN, uniform bool is_metal, uniform bool doNormalMapping) : COLOR
+float4 ps_main_texture(const in VS_OUTPUT IN, uniform bool is_metal, uniform bool doNormalMapping) : COLOR
 {
    float4 pixel = tex2D(texSampler0, IN.tex01.xy);
 
@@ -264,12 +265,12 @@ float4 ps_main_texture(in VS_OUTPUT IN, uniform bool is_metal, uniform bool doNo
    return result;
 }
 
-float4 ps_main_depth_only_without_texture(in VS_DEPTH_ONLY_NOTEX_OUTPUT IN) : COLOR
+float4 ps_main_depth_only_without_texture(const in VS_DEPTH_ONLY_NOTEX_OUTPUT IN) : COLOR
 {
     return float4(0.,0.,0.,1.);
 }
 
-float4 ps_main_depth_only_with_texture(in VS_DEPTH_ONLY_TEX_OUTPUT IN) : COLOR
+float4 ps_main_depth_only_with_texture(const in VS_DEPTH_ONLY_TEX_OUTPUT IN) : COLOR
 {
    clip(tex2D(texSampler0, IN.tex0).a <= alphaTestValue ? -1 : 1); // stop the pixel shader if alpha test should reject pixel
 
@@ -279,12 +280,12 @@ float4 ps_main_depth_only_with_texture(in VS_DEPTH_ONLY_TEX_OUTPUT IN) : COLOR
 //------------------------------------------
 // BG-Decal
 
-float4 ps_main_bg_decal(in VS_NOTEX_OUTPUT IN) : COLOR
+float4 ps_main_bg_decal(const in VS_NOTEX_OUTPUT IN) : COLOR
 {
    return float4(InvToneMap(cBase_Alpha.xyz), cBase_Alpha.a);
 }
 
-float4 ps_main_bg_decal_texture(in VS_OUTPUT IN) : COLOR
+float4 ps_main_bg_decal_texture(const in VS_OUTPUT IN) : COLOR
 {
    float4 pixel = tex2D(texSampler0, IN.tex01.xy);
 
@@ -299,12 +300,12 @@ float4 ps_main_bg_decal_texture(in VS_OUTPUT IN) : COLOR
 //------------------------------------------
 // Kicker boolean vertex shader
 
-float fKickerScale = 1.;
+const float fKickerScale = 1.;
 
-VS_NOTEX_OUTPUT vs_kicker (in float4 vPosition : POSITION0,  
-                           in float3 vNormal   : NORMAL0,  
-                           in float2 tc        : TEXCOORD0) 
-{ 
+VS_NOTEX_OUTPUT vs_kicker (const in float4 vPosition : POSITION0,
+                           const in float3 vNormal   : NORMAL0,
+                           const in float2 tc        : TEXCOORD0)
+{
     const float3 P = mul(vPosition, matWorldView).xyz;
     const float3 N = normalize(mul(vNormal, matWorldViewInverseTranspose).xyz);
 

--- a/shader/ClassicLightShader.fx
+++ b/shader/ClassicLightShader.fx
@@ -6,11 +6,11 @@
 #include "Helpers.fxh"
 
 // transformation matrices
-float4x4 matWorldViewProj : WORLDVIEWPROJ;
-float4x4 matWorldView     : WORLDVIEW;
-float3x4 matWorldViewInverseTranspose;
-float4x3 matView;
-//float4x4 matViewInverseInverseTranspose; // matView used instead and multiplied from other side
+const float4x4 matWorldViewProj : WORLDVIEWPROJ;
+const float4x4 matWorldView     : WORLDVIEW;
+const float3x4 matWorldViewInverseTranspose;
+const float4x3 matView;
+//const float4x4 matViewInverseInverseTranspose; // matView used instead and multiplied from other side
 
 texture Texture0; // base texture
 texture Texture1; // envmap
@@ -49,24 +49,24 @@ sampler2D texSampler2 : TEXUNIT2 = sampler_state // diffuse environment contribu
 
 #include "Material.fxh"
 
-float3 cGlossy_ImageLerp; // actually doesn't feature image lerp
-float3 cClearcoat_EdgeAlpha; // actually doesn't feature edge-alpha
+const float3 cGlossy_ImageLerp; // actually doesn't feature image lerp
+const float3 cClearcoat_EdgeAlpha; // actually doesn't feature edge-alpha
 //!! No value is under 0.02
 //!! Non-metals value are un-intuitively low: 0.02-0.08
 //!! Gemstones are 0.05-0.17
 //!! Metals have high specular reflectance:  0.5-1.0
 
-//float  alphaTestValue;
+//const float  alphaTestValue;
 
-bool hdrEnvTextures;
+const bool hdrEnvTextures;
 #endif
 
-float4 lightColor_intensity;
-float4 lightColor2_falloff_power;
-float4 lightCenter_maxRange;
-bool lightingOff;
+const float4 lightColor_intensity;
+const float4 lightColor2_falloff_power;
+const float4 lightCenter_maxRange;
+const bool lightingOff;
 
-bool hdrTexture0;
+const bool hdrTexture0;
 
 struct VS_LIGHT_OUTPUT
 {
@@ -79,9 +79,9 @@ struct VS_LIGHT_OUTPUT
 };
 
 // vertex shader is skipped for backglass elements, due to D3DDECLUSAGE_POSITIONT 
-VS_LIGHT_OUTPUT vs_light_main (in float4 vPosition : POSITION0,  
-                               in float3 vNormal   : NORMAL0,  
-                               in float2 tc        : TEXCOORD0) 
+VS_LIGHT_OUTPUT vs_light_main (const in float4 vPosition : POSITION0,
+                               const in float3 vNormal   : NORMAL0,
+                               const in float2 tc        : TEXCOORD0)
 {
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
    const float3 P = mul(vPosition, matWorldView).xyz;
@@ -96,7 +96,7 @@ VS_LIGHT_OUTPUT vs_light_main (in float4 vPosition : POSITION0,
    return Out; 
 }
 
-float4 PS_LightWithTexel(in VS_LIGHT_OUTPUT IN, uniform bool is_metal) : COLOR
+float4 PS_LightWithTexel(const in VS_LIGHT_OUTPUT IN, uniform bool is_metal) : COLOR
 {
     float4 pixel = tex2D(texSampler0, IN.tex0);
     //if (!hdrTexture0)
@@ -133,7 +133,7 @@ float4 PS_LightWithTexel(in VS_LIGHT_OUTPUT IN, uniform bool is_metal) : COLOR
     return color;
 }
 
-float4 PS_LightWithoutTexel(in VS_LIGHT_OUTPUT IN, uniform bool is_metal) : COLOR
+float4 PS_LightWithoutTexel(const in VS_LIGHT_OUTPUT IN, uniform bool is_metal) : COLOR
 {
     float4 result = float4(0.0, 0.0, 0.0, 0.0);
     [branch] if (lightColor_intensity.w != 0.0)

--- a/shader/DMDShader.fx
+++ b/shader/DMDShader.fx
@@ -2,8 +2,8 @@
 
 #include "Helpers.fxh"
 
-float4 vColor_Intensity;
-float4 vRes_Alpha_time;
+const float4 vColor_Intensity;
+const float4 vRes_Alpha_time;
 
 texture Texture0;
 
@@ -40,9 +40,9 @@ struct VS_OUTPUT
    float2 tex0 : TEXCOORD0;
 }; 
 
-VS_OUTPUT vs_main (in float4 vPosition : POSITION0,
-                   in float2 tc        : TEXCOORD0)
-{ 
+VS_OUTPUT vs_main (const in float4 vPosition : POSITION0,
+                   const in float2 tc        : TEXCOORD0)
+{
    VS_OUTPUT Out;
 
    Out.pos = float4(vPosition.xy, 0.0,1.0);
@@ -52,10 +52,10 @@ VS_OUTPUT vs_main (in float4 vPosition : POSITION0,
 }
 
 // transformation matrices (only used for flashers and backbox so far)
-float4x4 matWorldViewProj : WORLDVIEWPROJ;
+const float4x4 matWorldViewProj : WORLDVIEWPROJ;
 
-VS_OUTPUT vs_simple_world(in float4 vPosition : POSITION0,
-                          in float2 tc : TEXCOORD0)
+VS_OUTPUT vs_simple_world(const in float4 vPosition : POSITION0,
+                          const in float2 tc : TEXCOORD0)
 {
     VS_OUTPUT Out;
 
@@ -70,7 +70,7 @@ VS_OUTPUT vs_simple_world(in float4 vPosition : POSITION0,
 //
 
 #if 0 // raw pixelated output
-float4 ps_main_DMD_no(in VS_OUTPUT IN) : COLOR
+float4 ps_main_DMD_no(const in VS_OUTPUT IN) : COLOR
 {
    const float4 rgba = tex2Dlod(texSampler0, float4(IN.tex0, 0.,0.));
    float3 color = vColor_Intensity.xyz * vColor_Intensity.w; //!! create function that resembles LUT from VPM?
@@ -119,7 +119,7 @@ float2 gaussianPDF(const float2 xi)
 
 //!! this is incredibly heavy for a supposedly simple DMD output shader, but then again this is pretty robust for all kinds of scales and input resolutions now, plus also for 'distorted' output (via the flashers)!
 //!! gaussianPDF is even more heavy, introduces more noise and is only barely higher quality (=bit less moiree) 
-float4 ps_main_DMD(in VS_OUTPUT IN) : COLOR
+float4 ps_main_DMD(const in VS_OUTPUT IN) : COLOR
 {
    const float blur = /*gaussian: 4.0; /*/ 1.5; // 1.0..2.0 looks best (between sharp and blurry), and 1.5 matches the intention of the triangle filter (see triangularPDF calls below)!
    const float2 ddxs = ddx(IN.tex0)*blur; // use ddx and ddy to help the oversampling below/make filtering radius dependent on projected 'dots'/texel
@@ -163,21 +163,21 @@ float4 ps_main_DMD(in VS_OUTPUT IN) : COLOR
    return float4(InvToneMap(InvGamma(color2/*+colorg*/)), vRes_Alpha_time.z); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }
 
-float4 ps_main_noDMD(in VS_OUTPUT IN) : COLOR
+float4 ps_main_noDMD(const in VS_OUTPUT IN) : COLOR
 {
    const float4 l = tex2D(texSampler1, IN.tex0);
 
    return float4(InvToneMap(/*InvGamma*/(l.xyz * vColor_Intensity.xyz * vColor_Intensity.w)), l.w); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }
 
-float4 ps_main_noDMD_notex(in VS_OUTPUT IN) : COLOR
+float4 ps_main_noDMD_notex(const in VS_OUTPUT IN) : COLOR
 {
    return float4(InvToneMap(InvGamma(vColor_Intensity.xyz * vColor_Intensity.w)), 1.0); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }
 
 
 technique basic_DMD
-{ 
+{
    pass P0
    {
       VertexShader = compile vs_3_0 vs_main();
@@ -196,7 +196,7 @@ technique basic_DMD_world
 
 
 technique basic_noDMD
-{ 
+{
    pass P0
    {
       VertexShader = compile vs_3_0 vs_main();
@@ -205,7 +205,7 @@ technique basic_noDMD
 }
 
 technique basic_noDMD_world
-{ 
+{
    pass P0
    {
       VertexShader = compile vs_3_0 vs_simple_world();
@@ -214,7 +214,7 @@ technique basic_noDMD_world
 }
 
 technique basic_noDMD_notex
-{ 
+{
    pass P0
    {
       VertexShader = compile vs_3_0 vs_main();

--- a/shader/DMDShader.fx
+++ b/shader/DMDShader.fx
@@ -3,7 +3,7 @@
 #include "Helpers.fxh"
 
 float4 vColor_Intensity;
-float3 vRes_Alpha;
+float4 vRes_Alpha_time;
 
 texture Texture0;
 
@@ -83,35 +83,46 @@ float4 ps_main_DMD_no(in VS_OUTPUT IN) : COLOR
 }
 #endif
 
+float nrand(float2 uv)
+{
+   return frac(sin(dot(uv, float2(12.9898, 78.233))) * 43758.5453);
+}
+
+#if 0
+float gold_noise(in float2 xy, in float seed)
+{
+   return frac(tan(distance(xy * 1.61803398874989484820459, xy) * seed) * xy.x); // tan is usually slower than sin/cos
+}
+#endif
+
 float4 ps_main_DMD(in VS_OUTPUT IN) : COLOR
 {
-   const float2 ddxs = ddx(IN.tex0)*0.4; // use ddx and ddy to help the oversampling below/make filtering radius dependent on projected 'dot'/texel
-   const float2 ddys = ddy(IN.tex0)*0.4;
+   const float blur = 0.75; // 0.5..1.0 looks best (between sharp and blurry)
+   const float2 ddxs = ddx(IN.tex0); // use ddx and ddy to help the oversampling below/make filtering radius dependent on projected 'dots'/texel
+   const float2 ddys = ddy(IN.tex0);
+
+   const float2 offs = float2(nrand(IN.tex0 + vRes_Alpha_time.w), nrand(IN.tex0 + (2048.0 + vRes_Alpha_time.w))); // random offset for the oversampling
 
    // brute force oversampling of DMD-texture and especially the dot-function (using 25 samples)
    float3 color2 = float3(0., 0., 0.);
-   [unroll] for(int j = -2; j <= 2; ++j)
+
+   const int samples = 13; //4,8,9,13,21,25,32 korobov,fibonacci
+   [unroll] for (int i = 0; i < samples; ++i) // oversample the dots
    {
-   const float2 uvj = IN.tex0 + float(j)*ddys; 
-   [unroll] for (int i = -2; i <= 2; ++i)
-   {
-      const float2 uv = uvj + float(i)*ddxs;
+      const float2 uv = IN.tex0 + (frac(i* (1.0 / samples) + offs.x)*(2.*blur)-blur)*ddxs + (frac(i* (8.0 / samples) + offs.y)*(2.*blur)-blur)*ddys; //1,5,2,8,13,7,7 korobov,fibonacci
 
       const float4 rgba = tex2Dlod(texSampler0, float4(uv, 0., 0.)); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
-      float3 color = vColor_Intensity.xyz * vColor_Intensity.w; //!! create function that resembles LUT from VPM?
-      if (rgba.a != 0.0)
-         color *= rgba.bgr;
-      else
-         color *= rgba.b * (255.9 / 100.);
 
       // simulate dot within the sampled texel
-      const float2 dist = frac(uv*vRes_Alpha.xy)*2.2 - 1.1;
-      const float d = dist.x*dist.x + dist.y*dist.y;
+      const float2 dist = frac(uv*vRes_Alpha_time.xy)*2.2 - 1.1;
+      const float d = smoothstep(0., 1., 1.0 - sqr(dist.x*dist.x + dist.y*dist.y));
 
-      color2 += color*smoothstep(0., 1., 1.0 - d*d);
+      if (rgba.a != 0.0)
+         color2 += rgba.bgr * d;
+      else
+         color2 += rgba.b * (255.9 / 100.) * d;
    }
-   }
-   color2 *= 1./25.;
+   color2 *= vColor_Intensity.xyz * (vColor_Intensity.w/samples); //!! create function that resembles LUT from VPM?
 
    /*float3 colorg = float3(0,0,0);
    [unroll] for(int j = -1; j <= 1; ++j)
@@ -123,7 +134,7 @@ float4 ps_main_DMD(in VS_OUTPUT IN) : COLOR
    //if (rgba.b > 200.0)
    //   return float4(InvToneMap(InvGamma(min(color2,float3(1.5,1.5,1.5))/*+colorg*/)), 0.5);
    //else
-   return float4(InvToneMap(InvGamma(color2/*+colorg*/)), vRes_Alpha.z); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
+   return float4(InvToneMap(InvGamma(color2/*+colorg*/)), vRes_Alpha_time.z); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }
 
 float4 ps_main_noDMD(in VS_OUTPUT IN) : COLOR

--- a/shader/DMDShader.fx
+++ b/shader/DMDShader.fx
@@ -79,37 +79,63 @@ float4 ps_main_DMD_no(in VS_OUTPUT IN) : COLOR
    else
       color *= rgba.b * (255.9 / 100.);
 
-   return float4(InvToneMap(InvGamma(color)), 1.); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
+   return float4(InvToneMap(InvGamma(color)), vRes_Alpha_time.z); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }
 #endif
 
-float nrand(float2 uv)
+float nrand(const float2 uv)
 {
    return frac(sin(dot(uv, float2(12.9898, 78.233))) * 43758.5453);
 }
 
 #if 0
-float gold_noise(in float2 xy, in float seed)
+float gold_noise(const float2 xy, const float seed)
 {
    return frac(tan(distance(xy * 1.61803398874989484820459, xy) * seed) * xy.x); // tan is usually slower than sin/cos
 }
 #endif
 
+float triangularPDF(const float r) // from -1..1, c=0 (with random no r=0..1)
+{
+   float p = 2.*r;
+   const bool b = (p > 1.);
+   if (b)
+      p = 2.-p;
+   p = 1.-sqrt(p); //!! handle 0 explicitly due to compiler doing 1/rsqrt(0)? but might be still 0 according to spec, as rsqrt(0) = inf and 1/inf = 0, but values close to 0 could be screwed up still
+   return b ? p : -p;
+}
+
+#if 0
+// approximation, mainly to get limited support (i.e. not infinite, like real gauss, which is nonsense for a small amount of samples)
+float2 gaussianPDF(const float2 xi)
+{
+   float2 u;
+   sincos(6.283185307179586476925286766559 * xi.y, u.x, u.y);
+   const float root4 = sqrt(sqrt(1.0 - xi.x));
+   const float half_r = sqrt(0.25 - 0.25 * root4);
+   return u * half_r;
+}
+#endif
+
+//!! this is incredibly heavy for a supposedly simple DMD output shader, but then again this is pretty robust for all kinds of scales and input resolutions now, plus also for 'distorted' output (via the flashers)!
+//!! gaussianPDF is even more heavy, introduces more noise and is only barely higher quality (=bit less moiree) 
 float4 ps_main_DMD(in VS_OUTPUT IN) : COLOR
 {
-   const float blur = 0.75; // 0.5..1.0 looks best (between sharp and blurry)
-   const float2 ddxs = ddx(IN.tex0); // use ddx and ddy to help the oversampling below/make filtering radius dependent on projected 'dots'/texel
-   const float2 ddys = ddy(IN.tex0);
+   const float blur = /*gaussian: 4.0; /*/ 1.5; // 1.0..2.0 looks best (between sharp and blurry), and 1.5 matches the intention of the triangle filter (see triangularPDF calls below)!
+   const float2 ddxs = ddx(IN.tex0)*blur; // use ddx and ddy to help the oversampling below/make filtering radius dependent on projected 'dots'/texel
+   const float2 ddys = ddy(IN.tex0)*blur;
 
    const float2 offs = float2(nrand(IN.tex0 + vRes_Alpha_time.w), nrand(IN.tex0 + (2048.0 + vRes_Alpha_time.w))); // random offset for the oversampling
 
    // brute force oversampling of DMD-texture and especially the dot-function (using 25 samples)
    float3 color2 = float3(0., 0., 0.);
 
-   const int samples = 13; //4,8,9,13,21,25,32 korobov,fibonacci
+   const int samples = 21; //4,8,9,13,21,25,32 korobov,fibonacci
    [unroll] for (int i = 0; i < samples; ++i) // oversample the dots
    {
-      const float2 uv = IN.tex0 + (frac(i* (1.0 / samples) + offs.x)*(2.*blur)-blur)*ddxs + (frac(i* (8.0 / samples) + offs.y)*(2.*blur)-blur)*ddys; //1,5,2,8,13,7,7 korobov,fibonacci
+      const float2 xi = float2(frac(i* (1.0 / samples) + offs.x), frac(i* (13.0 / samples) + offs.y)); //1,5,2,8,13,7,7 korobov,fibonacci
+      //const float2 gxi = gaussianPDF(xi);
+      const float2 uv = IN.tex0 + /*gxi.x*ddxs + gxi.y*ddys; /*/ triangularPDF(xi.x)*ddxs + triangularPDF(xi.y)*ddys; //!! lots of ALU
 
       const float4 rgba = tex2Dlod(texSampler0, float4(uv, 0., 0.)); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
 

--- a/shader/FXAAStereoAO.fxh
+++ b/shader/FXAAStereoAO.fxh
@@ -80,7 +80,7 @@ float3 rotate_to_vector_upper(const float3 vec, const float3 normal)
 	return normal + spherePoint;
 }*/
 
-/*float4 ps_main_normals(in VS_OUTPUT_2D IN) : COLOR // separate pass to generate normals (should actually reduce bandwidth needed in AO pass, but overall close to no performance difference or even much worse perf, depending on gfxboard)
+/*float4 ps_main_normals(const in VS_OUTPUT_2D IN) : COLOR // separate pass to generate normals (should actually reduce bandwidth needed in AO pass, but overall close to no performance difference or even much worse perf, depending on gfxboard)
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
@@ -174,7 +174,7 @@ float3 decompress_normal(const float2 c)
 }
 #endif
 
-float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_ao(const in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
@@ -225,7 +225,7 @@ float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
 // stereo
 
 //!! opt.?
-float4 ps_main_stereo(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_stereo(const in VS_OUTPUT_2D IN) : COLOR
 {
 	float2 u = IN.tex0 + w_h_height.xy*0.5;
 	const float MaxSeparation = ms_zpd_ya_td.x;
@@ -338,7 +338,7 @@ float2 findContrastByColor(const float2 XYCoord, const float filterSpread)
 }
 #endif
 
-float4 ps_main_nfaa(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_nfaa(const in VS_OUTPUT_2D IN) : COLOR
 {
 #ifndef NFAA_VARIANT2
  #ifdef NFAA_VARIANT
@@ -415,7 +415,7 @@ float avg(const float3 l)
    return (l.x+l.y+l.z) * (1.0 / 3.0);
 }
 
-float4 ps_main_dlaa_edge(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_dlaa_edge(const in VS_OUTPUT_2D IN) : COLOR
 {
    const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
@@ -432,7 +432,7 @@ float4 ps_main_dlaa_edge(in VS_OUTPUT_2D IN) : COLOR
 }
 
 
-float4 ps_main_dlaa(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_dlaa(const in VS_OUTPUT_2D IN) : COLOR
 {
    const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
@@ -542,7 +542,7 @@ float luma(const float3 l)
 }
 
 // Approximation of FXAA
-float4 ps_main_fxaa1(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_fxaa1(const in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
@@ -594,7 +594,7 @@ float4 ps_main_fxaa1(in VS_OUTPUT_2D IN) : COLOR
 #define FXAA_QUALITY__P2 8.0
 
 // Full mid-quality PC FXAA 3.11
-float4 ps_main_fxaa2(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_fxaa2(const in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
@@ -741,7 +741,7 @@ float4 ps_main_fxaa2(in VS_OUTPUT_2D IN) : COLOR
 #define FXAA_QUALITY__P11 8.0
 
 // Full extreme-quality PC FXAA 3.11
-float4 ps_main_fxaa3(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_fxaa3(const in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 

--- a/shader/FXAAStereoAO.fxh
+++ b/shader/FXAAStereoAO.fxh
@@ -190,7 +190,7 @@ float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
 	//const float base = 0.0;
 	const float area = 0.06; //!!
 	const float falloff = 0.0002; //!!
-	const int samples = 8/*9*/; //4,8,9,13,21,25,32 korobov,fibonacci
+	const int samples = 8/*9*/; //4,8,9,13,16,21,25,32 korobov,fibonacci
 	const float radius = 0.001+/*frac*/(ushift.z)*0.009; // sample radius
 	const float depth_threshold_normal = 0.005;
 	const float total_strength = AO_scale_timeblur.x * (/*1.0 for uniform*/0.5 / samples);
@@ -200,7 +200,7 @@ float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
 
 	float occlusion = 0.0;
 	[unroll] for(int i=0; i < samples; ++i) {
-		const float2 r = float2(i*(1.0 / samples), i*(5.0/*2.0*/ / samples)); //1,5,2,8,13,7,7 korobov,fibonacci //!! could also use progressive/extensible lattice via rad_inv(i)*(1501825329, 359975893) (check precision though as this should be done in double or uint64)
+		const float2 r = float2(i*(1.0 / samples), i*(5.0/*2.0*/ / samples)); //1,5,2,8,4,13,7,7 korobov,fibonacci //!! could also use progressive/extensible lattice via rad_inv(i)*(1501825329, 359975893) (check precision though as this should be done in double or uint64)
 		//const float3 ray = sphere_sample(frac(r+ushift.xy)); // shift lattice // uniform variant
 		const float2 ray = rotate_to_vector_upper(cos_hemisphere_sample(frac(r+ushift.xy)), normal).xy; // shift lattice
 		//!! maybe a bit worse distribution: const float2 ray = cos_hemisphere_sample(normal,frac(r+ushift.xy)).xy; // shift lattice

--- a/shader/FXAAStereoAO.fxh
+++ b/shader/FXAAStereoAO.fxh
@@ -178,6 +178,9 @@ float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
+	const float2 uv0 = IN.tex0 + w_h_height.xy; // half pixel shift in x & y for filter
+	const float2 uv1 = IN.tex0;                 // dto.
+
 	const float depth0 = tex2Dlod(texSamplerDepth, float4(u, 0.,0.)).x;
 	[branch] if((depth0 == 1.0) || (depth0 == 0.0)) //!! early out if depth too large (=BG) or too small (=DMD,etc -> retweak render options (depth write on), otherwise also screwup with stereo)
 		return float4(1.0, 0.,0.,0.);
@@ -188,7 +191,7 @@ float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
 	const float area = 0.06; //!!
 	const float falloff = 0.0002; //!!
 	const int samples = 8/*9*/; //4,8,9,13,21,25,32 korobov,fibonacci
-	const float radius = 0.001+frac(ushift.z+w_h_height.z*(float)(samples-1))*0.009; // sample radius //!! w_h_height.z reused, but should not be that bad
+	const float radius = 0.001+/*frac*/(ushift.z)*0.009; // sample radius
 	const float depth_threshold_normal = 0.005;
 	const float total_strength = AO_scale_timeblur.x * (/*1.0 for uniform*/0.5 / samples);
 	const float3 normal = normalize(get_nonunit_normal(depth0, u));
@@ -212,10 +215,10 @@ float4 ps_main_ao(in VS_OUTPUT_2D IN) : COLOR
 	}
 	// weight with result(s) from previous frames
 	const float ao = 1.0 - total_strength * occlusion;
-	return float4( (tex2Dlod(texSampler5, float4(u+w_h_height.xy*0.5, 0.,0.)).x //abuse bilerp for filtering (by using half texel/pixel shift)
-				   +tex2Dlod(texSampler5, float4(u-w_h_height.xy*0.5, 0.,0.)).x
-				   +tex2Dlod(texSampler5, float4(u+float2(w_h_height.x,-w_h_height.y)*0.5, 0.,0.)).x
-				   +tex2Dlod(texSampler5, float4(u-float2(w_h_height.x,-w_h_height.y)*0.5, 0.,0.)).x)
+	return float4( (tex2Dlod(texSampler5, float4(uv0, 0.,0.)).x //abuse bilerp for filtering (by using half texel/pixel shift)
+				   +tex2Dlod(texSampler5, float4(uv1, 0.,0.)).x
+				   +tex2Dlod(texSampler5, float4(uv0.x,uv1.y, 0.,0.)).x
+				   +tex2Dlod(texSampler5, float4(uv1.x,uv0.y, 0.,0.)).x)
 		*(0.25*(1.0-AO_scale_timeblur.y))+saturate(ao /*+base*/)*AO_scale_timeblur.y, 0.,0.,0.);
 }
 

--- a/shader/FXAAStereoAO.fxh
+++ b/shader/FXAAStereoAO.fxh
@@ -543,7 +543,7 @@ float4 ps_main_fxaa1(in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
-	const float3 rMc = tex2Dlod(texSampler5, float4(u, 0.,0.)).xyz;
+	const float3 rMc = tex2Dlod(texSampler4, float4(u, 0.,0.)).xyz;
 	[branch] if(w_h_height.w == 1.0) // depth buffer available?
 	{
 		const float depth0 = tex2Dlod(texSamplerDepth, float4(u, 0.,0.)).x;
@@ -552,15 +552,15 @@ float4 ps_main_fxaa1(in VS_OUTPUT_2D IN) : COLOR
 	}
 
 	const float2 offs = w_h_height.xy;
-	const float rNW = luma(tex2Dlod(texSampler5, float4(u - offs, 0.,0.)).xyz);
-	const float rN = luma(tex2Dlod(texSampler5, float4(u - float2(0.0,offs.y), 0.,0.)).xyz);
-	const float rNE = luma(tex2Dlod(texSampler5, float4(u - float2(-offs.x,offs.y), 0.,0.)).xyz);
-	const float rW = luma(tex2Dlod(texSampler5, float4(u - float2(offs.x,0.0), 0.,0.)).xyz);
+	const float rNW = luma(tex2Dlod(texSampler4, float4(u - offs, 0.,0.)).xyz);
+	const float rN = luma(tex2Dlod(texSampler4, float4(u - float2(0.0,offs.y), 0.,0.)).xyz);
+	const float rNE = luma(tex2Dlod(texSampler4, float4(u - float2(-offs.x,offs.y), 0.,0.)).xyz);
+	const float rW = luma(tex2Dlod(texSampler4, float4(u - float2(offs.x,0.0), 0.,0.)).xyz);
 	const float rM = luma(rMc);
-	const float rE = luma(tex2Dlod(texSampler5, float4(u + float2(offs.x,0.0), 0.,0.)).xyz);
-	const float rSW = luma(tex2Dlod(texSampler5, float4(u + float2(-offs.x,offs.y), 0.,0.)).xyz);
-	const float rS = luma(tex2Dlod(texSampler5, float4(u + float2(0.0,offs.y), 0.,0.)).xyz);
-	const float rSE = luma(tex2Dlod(texSampler5, float4(u + offs, 0.,0.)).xyz);
+	const float rE = luma(tex2Dlod(texSampler4, float4(u + float2(offs.x,0.0), 0.,0.)).xyz);
+	const float rSW = luma(tex2Dlod(texSampler4, float4(u + float2(-offs.x,offs.y), 0.,0.)).xyz);
+	const float rS = luma(tex2Dlod(texSampler4, float4(u + float2(0.0,offs.y), 0.,0.)).xyz);
+	const float rSE = luma(tex2Dlod(texSampler4, float4(u + offs, 0.,0.)).xyz);
 	const float rMrN = rM+rN;
 	const float lumaNW = rMrN+rNW+rW;
 	const float lumaNE = rMrN+rNE+rE;
@@ -595,7 +595,7 @@ float4 ps_main_fxaa2(in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
-	const float3 rgbyM = tex2Dlod(texSampler5, float4(u, 0.,0.)).xyz;
+	const float3 rgbyM = tex2Dlod(texSampler4, float4(u, 0.,0.)).xyz;
 	[branch] if(w_h_height.w == 1.0) // depth buffer available?
 	{
 		const float depth0 = tex2Dlod(texSamplerDepth, float4(u, 0.,0.)).x;
@@ -604,15 +604,15 @@ float4 ps_main_fxaa2(in VS_OUTPUT_2D IN) : COLOR
 	}
 
 	const float2 offs = w_h_height.xy;
-	const float lumaNW = luma(tex2Dlod(texSampler5, float4(u - offs, 0.f,0.f)).xyz);
-	float lumaN = luma(tex2Dlod(texSampler5, float4(u - float2(0.0,offs.y), 0.f,0.f)).xyz);
-	const float lumaNE = luma(tex2Dlod(texSampler5, float4(u - float2(-offs.x,offs.y), 0.f,0.f)).xyz);
-	const float lumaW = luma(tex2Dlod(texSampler5, float4(u - float2(offs.x,0.0), 0.f,0.f)).xyz);
+	const float lumaNW = luma(tex2Dlod(texSampler4, float4(u - offs, 0.f,0.f)).xyz);
+	float lumaN = luma(tex2Dlod(texSampler4, float4(u - float2(0.0,offs.y), 0.f,0.f)).xyz);
+	const float lumaNE = luma(tex2Dlod(texSampler4, float4(u - float2(-offs.x,offs.y), 0.f,0.f)).xyz);
+	const float lumaW = luma(tex2Dlod(texSampler4, float4(u - float2(offs.x,0.0), 0.f,0.f)).xyz);
 	const float lumaM = luma(rgbyM);
-	const float lumaE = luma(tex2Dlod(texSampler5, float4(u + float2(offs.x,0.0), 0.f,0.f)).xyz);
-	const float lumaSW = luma(tex2Dlod(texSampler5, float4(u + float2(-offs.x,offs.y), 0.f,0.f)).xyz);
-	float lumaS = luma(tex2Dlod(texSampler5, float4(u + float2(0.0,offs.y), 0.f,0.f)).xyz);
-	const float lumaSE = luma(tex2Dlod(texSampler5, float4(u + offs, 0.f,0.f)).xyz);
+	const float lumaE = luma(tex2Dlod(texSampler4, float4(u + float2(offs.x,0.0), 0.f,0.f)).xyz);
+	const float lumaSW = luma(tex2Dlod(texSampler4, float4(u + float2(-offs.x,offs.y), 0.f,0.f)).xyz);
+	float lumaS = luma(tex2Dlod(texSampler4, float4(u + float2(0.0,offs.y), 0.f,0.f)).xyz);
+	const float lumaSE = luma(tex2Dlod(texSampler4, float4(u + offs, 0.f,0.f)).xyz);
 	const float maxSM = max(lumaS, lumaM);
 	const float minSM = min(lumaS, lumaM);
 	const float maxESM = max(lumaE, maxSM);
@@ -621,9 +621,9 @@ float4 ps_main_fxaa2(in VS_OUTPUT_2D IN) : COLOR
 	const float minWN = min(lumaN, lumaW);
 	const float rangeMax = max(maxWN, maxESM);
 	const float rangeMin = min(minWN, minESM);
-	const float rangeMaxScaled = rangeMax * 0.166; //0.333 (faster) .. 0.063 (slower)
+	const float rangeMaxScaled = rangeMax * 0.125; //0.333 (faster) .. 0.063 (slower) // reshade: 0.125, fxaa : 0.166
 	const float range = rangeMax - rangeMin;
-	const float rangeMaxClamped = max(0.0833, rangeMaxScaled); //0.0625 (high quality/faster) .. 0.0312 (visible limit/slower)
+	const float rangeMaxClamped = max(0.0833, rangeMaxScaled); //0.0625 (high quality/faster) .. 0.0312 (visible limit/slower) // reshade: 0.0, fxaa : 0.0833
 	const bool earlyExit = range < rangeMaxClamped;
 	[branch] if(earlyExit)
 		return float4(rgbyM, 1.0);
@@ -710,14 +710,14 @@ float4 ps_main_fxaa2(in VS_OUTPUT_2D IN) : COLOR
 	const bool goodSpan = directionN ? goodSpanN : goodSpanP;
 	const float subpixG = subpixF * subpixF;
 	const float pixelOffset = 0.5 - dst * spanLengthRcp;
-	const float subpixH = subpixG * 0.75; //1.00 (upper limit/softer) .. 0.50 (lower limit/sharper) .. 0.00 (completely off)
+	const float subpixH = subpixG * 0.5; //1.00 (upper limit/softer) .. 0.50 (lower limit/sharper) .. 0.00 (completely off) // reshade : 0.25, fxaa : 0.75
 	const float pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
 	const float pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
 	float2 un = u;
 	const float pl = pixelOffsetSubpix * lengthSign;
 	if(horzSpan) un.y += pl;
 	else un.x += pl;
-	return float4(tex2Dlod(texSampler5, float4(un, 0.f,0.f)).xyz, 1.0f);
+	return float4(tex2Dlod(texSampler5, float4(un, 0.f,0.f)).xyz, 1.0);
 }
 
 #undef FXAA_QUALITY__P0
@@ -742,7 +742,7 @@ float4 ps_main_fxaa3(in VS_OUTPUT_2D IN) : COLOR
 {
 	const float2 u = IN.tex0 + w_h_height.xy*0.5;
 
-	const float3 rgbyM = tex2Dlod(texSampler5, float4(u, 0.,0.)).xyz;
+	const float3 rgbyM = tex2Dlod(texSampler4, float4(u, 0.,0.)).xyz;
 	[branch] if(w_h_height.w == 1.0) // depth buffer available?
 	{
 		const float depth0 = tex2Dlod(texSamplerDepth, float4(u, 0.,0.)).x;
@@ -751,15 +751,15 @@ float4 ps_main_fxaa3(in VS_OUTPUT_2D IN) : COLOR
 	}
 
 	const float2 offs = w_h_height.xy;
-	const float lumaNW = luma(tex2Dlod(texSampler5, float4(u - offs, 0.f,0.f)).xyz);
-	float lumaN = luma(tex2Dlod(texSampler5, float4(u - float2(0.0,offs.y), 0.f,0.f)).xyz);
-	const float lumaNE = luma(tex2Dlod(texSampler5, float4(u - float2(-offs.x,offs.y), 0.f,0.f)).xyz);
-	const float lumaW = luma(tex2Dlod(texSampler5, float4(u - float2(offs.x,0.0), 0.f,0.f)).xyz);
+	const float lumaNW = luma(tex2Dlod(texSampler4, float4(u - offs, 0.f,0.f)).xyz);
+	float lumaN = luma(tex2Dlod(texSampler4, float4(u - float2(0.0,offs.y), 0.f,0.f)).xyz);
+	const float lumaNE = luma(tex2Dlod(texSampler4, float4(u - float2(-offs.x,offs.y), 0.f,0.f)).xyz);
+	const float lumaW = luma(tex2Dlod(texSampler4, float4(u - float2(offs.x,0.0), 0.f,0.f)).xyz);
 	const float lumaM = luma(rgbyM);
-	const float lumaE = luma(tex2Dlod(texSampler5, float4(u + float2(offs.x,0.0), 0.f,0.f)).xyz);
-	const float lumaSW = luma(tex2Dlod(texSampler5, float4(u + float2(-offs.x,offs.y), 0.f,0.f)).xyz);
-	float lumaS = luma(tex2Dlod(texSampler5, float4(u + float2(0.0,offs.y), 0.f,0.f)).xyz);
-	const float lumaSE = luma(tex2Dlod(texSampler5, float4(u + offs, 0.f,0.f)).xyz);
+	const float lumaE = luma(tex2Dlod(texSampler4, float4(u + float2(offs.x,0.0), 0.f,0.f)).xyz);
+	const float lumaSW = luma(tex2Dlod(texSampler4, float4(u + float2(-offs.x,offs.y), 0.f,0.f)).xyz);
+	float lumaS = luma(tex2Dlod(texSampler4, float4(u + float2(0.0,offs.y), 0.f,0.f)).xyz);
+	const float lumaSE = luma(tex2Dlod(texSampler4, float4(u + offs, 0.f,0.f)).xyz);
 	const float maxSM = max(lumaS, lumaM);
 	const float minSM = min(lumaS, lumaM);
 	const float maxESM = max(lumaE, maxSM);
@@ -768,12 +768,12 @@ float4 ps_main_fxaa3(in VS_OUTPUT_2D IN) : COLOR
 	const float minWN = min(lumaN, lumaW);
 	const float rangeMax = max(maxWN, maxESM);
 	const float rangeMin = min(minWN, minESM);
-	const float rangeMaxScaled = rangeMax * 0.166; //0.333 (faster) .. 0.063 (slower)
+	const float rangeMaxScaled = rangeMax * 0.125; //0.333 (faster) .. 0.063 (slower) // reshade: 0.125, fxaa : 0.166
 	const float range = rangeMax - rangeMin;
-	const float rangeMaxClamped = max(0.0833, rangeMaxScaled); //0.0625 (high quality/faster) .. 0.0312 (visible limit/slower)
+	const float rangeMaxClamped = max(0.0833, rangeMaxScaled); //0.0625 (high quality/faster) .. 0.0312 (visible limit/slower) // reshade: 0.0, fxaa : 0.0833
 	const bool earlyExit = range < rangeMaxClamped;
 	[branch] if(earlyExit)
-		return float4(rgbyM, 1.0f);
+		return float4(rgbyM, 1.0);
 	const float lumaNS = lumaN + lumaS;
 	const float lumaWE = lumaW + lumaE;
 	const float subpixRcpRange = 1.0/range;
@@ -985,12 +985,12 @@ float4 ps_main_fxaa3(in VS_OUTPUT_2D IN) : COLOR
 	const bool goodSpan = directionN ? goodSpanN : goodSpanP;
 	const float subpixG = subpixF * subpixF;
 	const float pixelOffset = 0.5 - dst * spanLengthRcp;
-	const float subpixH = subpixG * 0.75; //1.00 (upper limit/softer) .. 0.50 (lower limit/sharper) .. 0.00 (completely off)
+	const float subpixH = subpixG * 0.5; //1.00 (upper limit/softer) .. 0.50 (lower limit/sharper) .. 0.00 (completely off) // reshade : 0.25, fxaa : 0.75
 	const float pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
 	const float pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
 	float2 un = u;
 	const float pl = pixelOffsetSubpix * lengthSign;
 	if(horzSpan) un.y += pl;
 	else un.x += pl;
-	return float4(tex2Dlod(texSampler5, float4(un, 0.f,0.f)).xyz, 1.0f);
+	return float4(tex2Dlod(texSampler5, float4(un, 0.f,0.f)).xyz, 1.0);
 }

--- a/shader/FlasherShader.fx
+++ b/shader/FlasherShader.fx
@@ -7,12 +7,12 @@
 #define Filter_Screen   4.
 
 // transformation matrices
-float4x4 matWorldViewProj : WORLDVIEWPROJ;
+const float4x4 matWorldViewProj : WORLDVIEWPROJ;
 
-float4 staticColor_Alpha;
-float4 alphaTestValueAB_filterMode_addBlend;        // last one is bool
-float4 amount__blend_modulate_vs_add__hdrTexture01; // last two are bools
-float  flasherMode;
+const float4 staticColor_Alpha;
+const float4 alphaTestValueAB_filterMode_addBlend;        // last one is bool
+const float4 amount__blend_modulate_vs_add__hdrTexture01; // last two are bools
+const float  flasherMode;
 
 texture Texture0; // base texture
 texture Texture1; // second image
@@ -44,8 +44,8 @@ struct VS_OUTPUT_2D
    float2 tex0 : TEXCOORD0;
 };
 
-VS_OUTPUT_2D vs_simple_main (in float4 vPosition : POSITION0,
-                             in float2 tc        : TEXCOORD0)
+VS_OUTPUT_2D vs_simple_main (const in float4 vPosition : POSITION0,
+                             const in float2 tc        : TEXCOORD0)
 {
    VS_OUTPUT_2D Out;
 
@@ -55,7 +55,7 @@ VS_OUTPUT_2D vs_simple_main (in float4 vPosition : POSITION0,
    return Out;
 }
 
-float4 ps_main_noLight(in VS_OUTPUT_2D IN) : COLOR
+float4 ps_main_noLight(const in VS_OUTPUT_2D IN) : COLOR
 {
    float4 pixel1,pixel2;
    bool stop = false;

--- a/shader/Helpers.fxh
+++ b/shader/Helpers.fxh
@@ -34,9 +34,9 @@ float3 mul_w0(const float3 v, const float4x3 m)
 float acos_approx(const float v)
 {
     const float x = abs(v);
-    if(1.0 - x < 0.0000001) // necessary due to compiler doing 1./rsqrt instead of sqrt
+    if(1. - x < 0.0000001) // necessary due to compiler doing 1./rsqrt instead of sqrt
        return (v >= 0.) ? 0. : PI;
-    const float res = (-0.155972/*C1*/ * x + 1.56467/*C0*/) * sqrt(1.0 - x);
+    const float res = (-0.155972/*C1*/ * x + 1.56467/*C0*/) * sqrt(1. - x);
     return (v >= 0.) ? res : PI - res;
 }
 #endif
@@ -46,9 +46,9 @@ float acos_approx_divPI(const float v)
     //return acos(v)*(1./PI);
 
     const float x = abs(v);
-    if(1.0 - x < 0.0000001) // necessary due to compiler doing 1./rsqrt instead of sqrt
+    if(1. - x < 0.0000001) // necessary due to compiler doing 1./rsqrt instead of sqrt
        return (v >= 0.) ? 0. : 1.;
-    const float res = ((-0.155972/PI)/*C1*/ * x + (1.56467/PI)/*C0*/) * sqrt(1.0 - x);
+    const float res = ((-0.155972/PI)/*C1*/ * x + (1.56467/PI)/*C0*/) * sqrt(1. - x);
     return (v >= 0.) ? res : 1. - res;
 }
 
@@ -83,6 +83,22 @@ float atan2_approx_div2PI(const float y, const float x)
 	                  + (0.211868/*C3*//(2.*PI) * r * r - 0.987305/*C1*//(2.*PI)) * ((x < 0.) ? -r : r);
 	return (y < 0.) ? -angle : angle;
 }
+
+#if 0
+float asin_approx(const float v)
+{
+	return (0.5*PI) - acos_approx(v);
+}
+
+//!! this one is untested for special values (see atan2 approx!)
+// 4th order hyperbolical approximation
+// 7 * 10^-5 radians precision 
+// Reference : Efficient approximations for the arctangent function, Rajan, S. Sichun Wang Inkol, R. Joyal, A., May 2006
+float atan_approx(const float x)
+{
+	return x * (-0.1784 * abs(x) - 0.0663 * x*x + 1.0301);
+}
+#endif
 
 //
 // Gamma & ToneMapping
@@ -177,8 +193,8 @@ float3 FilmicToneMap(const float3 hdr, const float whitepoint) //!! test/experim
 
 float3 FilmicToneMap2(const float3 texColor) //!! test/experimental
 {
-   const float3 x = max(0.,texColor-0.004); // Filmic Curve
-   return (x*(6.2*x+.5))/(x*(6.2*x+1.7)+0.06);
+    const float3 x = max(0.,texColor-0.004); // Filmic Curve
+    return (x*(6.2*x+.5))/(x*(6.2*x+1.7)+0.06);
 }
 
 
@@ -216,7 +232,7 @@ float4 EncodeRGBD(const float3 rgb)
 
 float4 Additive(const float4 cBase, const float4 cBlend, const float percent)
 {
-   return cBase + cBlend*percent;
+	return cBase + cBlend*percent;
 }
 
 float3 Screen (const float3 cBase, const float3 cBlend)
@@ -251,13 +267,13 @@ float4 Overlay (const float4 cBase, const float4 cBlend)
 	// is below half or not
 
 	float4 cNew = step(0.5, cBase);
-	
+
 	// we pick either solution
 	// depending on pixel
-	
+
 	// first is case of < 0.5
 	// second is case for >= 0.5
-	
+
 	// interpolate between the two, 
 	// using color as influence value
 	cNew = lerp(cBase*cBlend*2.0, 1.0-2.0*(1.0-cBase)*(1.0-cBlend), cNew);
@@ -273,13 +289,13 @@ float4 OverlayHDR (const float4 cBase, const float4 cBlend)
 	// is below half or not
 
 	float4 cNew = step(0.5, cBase);
-	
+
 	// we pick either solution
 	// depending on pixel
 	
 	// first is case of < 0.5
 	// second is case for >= 0.5
-	
+
 	// interpolate between the two, 
 	// using color as influence value
 	cNew = max(lerp(cBase*cBlend*2.0, 1.0-2.0*(1.0-cBase)*(1.0-cBlend), cNew), float4(0.,0.,0.,0.));

--- a/shader/Helpers.fxh
+++ b/shader/Helpers.fxh
@@ -5,6 +5,11 @@ float sqr(const float v)
     return v*v;
 }
 
+float2 sqr(const float2 v)
+{
+    return v*v;
+}
+
 float3 sqr(const float3 v)
 {
     return v*v;

--- a/shader/LightShader.fx
+++ b/shader/LightShader.fx
@@ -1,10 +1,10 @@
 // transformation matrices
-float4x4 matWorldViewProj : WORLDVIEWPROJ;
+const float4x4 matWorldViewProj : WORLDVIEWPROJ;
 
-float4   lightColor_intensity;
-float4   lightColor2_falloff_power;
-float4   lightCenter_maxRange;
-float    blend_modulate_vs_add;
+const float4   lightColor_intensity;
+const float4   lightColor2_falloff_power;
+const float4   lightCenter_maxRange;
+const float    blend_modulate_vs_add;
 
 struct VS_LIGHTBULB_OUTPUT
 {
@@ -13,9 +13,9 @@ struct VS_LIGHTBULB_OUTPUT
 };
 
 // vertex shader is skipped for backglass elements, due to D3DDECLUSAGE_POSITIONT
-VS_LIGHTBULB_OUTPUT vs_lightbulb_main (in float4 vPosition : POSITION0/*,
-                                       in float3 vNormal   : NORMAL0,
-                                       in float2 tc        : TEXCOORD0*/)
+VS_LIGHTBULB_OUTPUT vs_lightbulb_main (const in float4 vPosition : POSITION0/*,
+                                       const in float3 vNormal   : NORMAL0,
+                                       const in float2 tc        : TEXCOORD0*/)
 {
    VS_LIGHTBULB_OUTPUT Out;
 
@@ -26,7 +26,7 @@ VS_LIGHTBULB_OUTPUT vs_lightbulb_main (in float4 vPosition : POSITION0/*,
    return Out; 
 }
 
-float4 PS_BulbLight(in VS_LIGHTBULB_OUTPUT IN) : COLOR
+float4 PS_BulbLight(const in VS_LIGHTBULB_OUTPUT IN) : COLOR
 {
 	const float len = length(lightCenter_maxRange.xyz - IN.tablePos) * lightCenter_maxRange.w;
 	const float atten = pow(1.0 - saturate(len), lightColor2_falloff_power.w);

--- a/shader/Material.fxh
+++ b/shader/Material.fxh
@@ -14,26 +14,26 @@ struct CLight
 #define iLightPointBallsNum (NUM_LIGHTS+NUM_BALL_LIGHTS)
 
 #if iLightPointBallsNum == iLightPointNum // basic shader
-float4 packedLights[3]; //!! 4x3 = NUM_LIGHTSx6
-static CLight lights[iLightPointBallsNum] = (CLight[iLightPointBallsNum])packedLights;
+const float4 packedLights[3]; //!! 4x3 = NUM_LIGHTSx6
+static const CLight lights[iLightPointBallsNum] = (CLight[iLightPointBallsNum])packedLights;
 #else                                     // ball shader
-float4 packedLights[15]; //!! 4x15 = (NUM_LIGHTS+NUM_BALL_LIGHTS)x6
-static CLight lights[iLightPointBallsNum] = (CLight[iLightPointBallsNum])packedLights;
+const float4 packedLights[15]; //!! 4x15 = (NUM_LIGHTS+NUM_BALL_LIGHTS)x6
+static const CLight lights[iLightPointBallsNum] = (CLight[iLightPointBallsNum])packedLights;
 #endif
 
-float4 cAmbient_LightRange = float4(0.0,0.0,0.0, 0.0); //!! remove completely, just rely on envmap/IBL?
+const float4 cAmbient_LightRange = float4(0.0,0.0,0.0, 0.0); //!! remove completely, just rely on envmap/IBL?
 
-float2 fenvEmissionScale_TexWidth;
+const float2 fenvEmissionScale_TexWidth;
 
-float2 fDisableLighting_top_below = float2(0.,0.);
+const float2 fDisableLighting_top_below = float2(0.,0.);
 
 //
 // Material Params
 //
 
-float4 cBase_Alpha = float4(0.5,0.5,0.5, 1.0); //!! 0.04-0.95 in RGB
+const float4 cBase_Alpha = float4(0.5,0.5,0.5, 1.0); //!! 0.04-0.95 in RGB
 
-float4 Roughness_WrapL_Edge_Thickness = float4(4.0, 0.5, 1.0, 0.05); // wrap in [0..1] for rim/wrap lighting
+const float4 Roughness_WrapL_Edge_Thickness = float4(4.0, 0.5, 1.0, 0.05); // wrap in [0..1] for rim/wrap lighting
 
 //
 // Material Helper Functions
@@ -71,7 +71,7 @@ float3 DoPointLight(const float3 pos, const float3 N, const float3 V, const floa
    // compute diffuse color (lambert with optional rim/wrap component)
    if (!is_metal && (NdotL + Roughness_WrapL_Edge_Thickness.y > 0.0))
       Out = diffuse * ((NdotL + Roughness_WrapL_Edge_Thickness.y) / sqr(1.0+Roughness_WrapL_Edge_Thickness.y));
-    
+
    // add glossy component (modified ashikhmin/blinn bastard), not fully energy conserving, but good enough
    [branch] if (NdotL > 0.0)
    {
@@ -82,10 +82,10 @@ float3 DoPointLight(const float3 pos, const float3 N, const float3 V, const floa
 	 if ((NdotH > 0.0) && (LdotH > 0.0) && (VdotH > 0.0))
 		Out += FresnelSchlick(glossy, LdotH, edge) * (((glossyPower + 1.0) / (8.0*VdotH)) * pow(NdotH, glossyPower));
    }
- 
+
    //float fAtten = saturate( 1.0 - dot(lightDir/cAmbient_LightRange.w, lightDir/cAmbient_LightRange.w) );
    //float fAtten = 1.0/dot(lightDir,lightDir); // original/correct falloff
-   
+
    const float sqrl_lightDir = dot(lightDir,lightDir); // tweaked falloff to have ranged lightsources
    float fAtten = saturate(1.0 - sqrl_lightDir*sqrl_lightDir/(cAmbient_LightRange.w*cAmbient_LightRange.w*cAmbient_LightRange.w*cAmbient_LightRange.w)); //!! pre-mult/invert cAmbient_LightRange.w?
    fAtten = fAtten*fAtten/(sqrl_lightDir + 1.0);

--- a/shader/SMAA.hlsl
+++ b/shader/SMAA.hlsl
@@ -50,7 +50,7 @@
  *
  * The shader has three passes, chained together as follows:
  *
- *                           |input|------------------·
+ *                           |input|------------------+
  *                              v                     |
  *                    [ SMAA*EdgeDetection ]          |
  *                              v                     |
@@ -60,7 +60,7 @@
  *                              v                     |
  *                          |blendTex|                |
  *                              v                     |
- *                [ SMAANeighborhoodBlending ] <------·
+ *                [ SMAANeighborhoodBlending ] <------+
  *                              v
  *                           |output|
  *
@@ -313,8 +313,8 @@
 #define SMAA_DISABLE_CORNER_DETECTION
 #elif defined(SMAA_PRESET_HIGH)
 #define SMAA_THRESHOLD 0.1
-#define SMAA_MAX_SEARCH_STEPS 16
-#define SMAA_MAX_SEARCH_STEPS_DIAG 8
+#define SMAA_MAX_SEARCH_STEPS 32 //CeeJayDK, org was 16
+#define SMAA_MAX_SEARCH_STEPS_DIAG 16 //CeeJayDK, org was 8
 #define SMAA_CORNER_ROUNDING 25
 #elif defined(SMAA_PRESET_ULTRA)
 #define SMAA_THRESHOLD 0.05
@@ -436,7 +436,7 @@
  * How much to scale the global threshold used for luma or color edge
  * detection when using predication.
  *
- * Range: [1, 5]
+ * Range: [1, 16]
  */
 #ifndef SMAA_PREDICATION_SCALE
 #define SMAA_PREDICATION_SCALE 2.0
@@ -445,7 +445,7 @@
 /**
  * How much to locally decrease the threshold.
  *
- * Range: [0, 1]
+ * Range: [0, 4]
  */
 #ifndef SMAA_PREDICATION_STRENGTH
 #define SMAA_PREDICATION_STRENGTH 0.4
@@ -801,11 +801,11 @@ float2 SMAAColorEdgeDetectionPS(float2 texcoord,
 
     // Calculate left-left and top-top deltas:
     float3 Cleftleft  = SMAASamplePoint(colorTex, offset[2].xy).rgb;
-    t = abs(C - Cleftleft);
+    t = abs(Cleft - Cleftleft);
     delta.z = max(max(t.r, t.g), t.b);
 
     float3 Ctoptop = SMAASamplePoint(colorTex, offset[2].zw).rgb;
-    t = abs(C - Ctoptop);
+    t = abs(Ctop - Ctoptop);
     delta.w = max(max(t.r, t.g), t.b);
 
     // Calculate the final maximum delta:

--- a/shader/SSR.fxh
+++ b/shader/SSR.fxh
@@ -1,6 +1,6 @@
 // uses texSamplerDepth & texSampler4,texSampler5 & texSamplerAOdither & w_h_height.xy
 
-float4 SSR_bumpHeight_fresnelRefl_scale_FS;
+const float4 SSR_bumpHeight_fresnelRefl_scale_FS;
 
 float3 approx_bump_normal(const float2 coords, const float2 offs, const float scale, const float sharpness)
 {

--- a/shader/SSR.fxh
+++ b/shader/SSR.fxh
@@ -54,11 +54,11 @@ float4 ps_main_fb_ss_refl(in VS_OUTPUT_2D IN) : COLOR
 	[branch] if(fresnel < 0.01) //!! early out if contribution too low
 		return float4(color0, 1.0);
 
-	const int samples = 32;
+	const int samples = 32; //!! reduce to ~24? would save ~1-4% overall frame time, depending on table
 	const float ReflBlurWidth = 2.2; //!! magic, small enough to not collect too much, and large enough to have cool reflection effects
 
 	const float ushift = /*hash(IN.tex0) + w_h_height.zw*/ // jitter samples via hash of position on screen and then jitter samples by time //!! see below for non-shifted variant
-	                     /*frac(*/tex2Dlod(texSamplerAOdither, float4(IN.tex0/(64.0*w_h_height.xy), 0.,0.)).x /*+ w_h_height.z)*/; // use dither texture instead nowadays // 64 is the hardcoded dither texture size for AOdither.bmp
+	                     /*frac(*/tex2Dlod(texSamplerAOdither, float4(IN.tex0/(64.0*w_h_height.xy), 0.,0.)).z /*+ w_h_height.z)*/; // use dither texture instead nowadays // 64 is the hardcoded dither texture size for AOdither.bmp
 	const float2 offsMul = normal_b.xy * (/*w_h_height.xy*/ float2(1.0/1920.0,1.0/1080.0) * ReflBlurWidth * (32./(float)samples)); //!! makes it more resolution independent?? test with 4xSSAA
 
 	// loop in screen space, simply collect all pixels in the normal direction (not even a depth check done!)

--- a/shader/SSR.fxh
+++ b/shader/SSR.fxh
@@ -58,7 +58,7 @@ float4 ps_main_fb_ss_refl(in VS_OUTPUT_2D IN) : COLOR
 	const float ReflBlurWidth = 2.2; //!! magic, small enough to not collect too much, and large enough to have cool reflection effects
 
 	const float ushift = /*hash(IN.tex0) + w_h_height.zw*/ // jitter samples via hash of position on screen and then jitter samples by time //!! see below for non-shifted variant
-	                     tex2Dlod(texSamplerAOdither, float4(IN.tex0/(64.0*w_h_height.xy) /*+ w_h_height.zw*/, 0.,0.)).x; // use dither texture instead nowadays // 64 is the hardcoded dither texture size for AOdither.bmp
+	                     /*frac(*/tex2Dlod(texSamplerAOdither, float4(IN.tex0/(64.0*w_h_height.xy), 0.,0.)).x /*+ w_h_height.z)*/; // use dither texture instead nowadays // 64 is the hardcoded dither texture size for AOdither.bmp
 	const float2 offsMul = normal_b.xy * (/*w_h_height.xy*/ float2(1.0/1920.0,1.0/1080.0) * ReflBlurWidth * (32./(float)samples)); //!! makes it more resolution independent?? test with 4xSSAA
 
 	// loop in screen space, simply collect all pixels in the normal direction (not even a depth check done!)

--- a/svn_version.h
+++ b/svn_version.h
@@ -1,6 +1,6 @@
 #ifndef _SVN_VERSION_H_
 #define _SVN_VERSION_H_
 
-#define SVN_REVISION            3735       // Highest committed revision number in the working copy
+#define SVN_REVISION            4042       // Highest committed revision number in the working copy
 
 #endif

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -1,3 +1,8 @@
+VP 10.6.1 Changelog
+------------------------
+
+- fix hang on player exit on some setups
+
 VP 10.6.0 Changelog
 ------------------------
 

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -8,6 +8,7 @@ VP 10.6.2 Changelog
 - improve quality and performance of internal DMD shader (especially visible on FSS tables)
 
 - replace dithering code with blue noise, fixes flickering patterns (especially in darker table areas)
+- disable dithering code when running in 10bit output mode
 - tweak AO (Ambient Occlusion) and SSR (Screen Space Reflections) to be a bit less noisy
 - fix a small error in the original SMAA filter code, and also increase quality parameters slightly (to match reshade)
 - retweak Standard FXAA and Quality FXAA filters to be a bit sharper

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -6,6 +6,7 @@ VP 10.6.2 Changelog
   played in a cabinet with exciter pairs positioned at each end of the cabinet
 
 - replace dithering code with blue noise, fixes flickering patterns (especially in darker table areas)
+- tweak AO (Ambient Occlusion) and SSR (Screen Space Reflections) to be a bit less noisy
 - fix a small error in the original SMAA filter code, and also increase quality parameters slightly (to match reshade)
 - retweak Standard FXAA and Quality FXAA filters to be a bit sharper
 

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -5,7 +5,8 @@ VP 10.6.2 Changelog
   this exaggerates the positional feel of the playfield sound effects when
   played in a cabinet with exciter pairs positioned at each end of the cabinet
 
-- fix a small error in the original SMAA shader code, and also increase quality parameters slightly (to match reshade)
+- fix a small error in the original SMAA filter code, and also increase quality parameters slightly (to match reshade)
+- retweak Standard FXAA and Quality FXAA filters to be a bit sharper
 
 VP 10.6.1 Changelog
 ------------------------

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -5,6 +5,8 @@ VP 10.6.2 Changelog
   this exaggerates the positional feel of the playfield sound effects when
   played in a cabinet with exciter pairs positioned at each end of the cabinet
 
+- improve quality and performance of internal DMD shader (especially visible on FSS tables)
+
 - replace dithering code with blue noise, fixes flickering patterns (especially in darker table areas)
 - tweak AO (Ambient Occlusion) and SSR (Screen Space Reflections) to be a bit less noisy
 - fix a small error in the original SMAA filter code, and also increase quality parameters slightly (to match reshade)

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -1,3 +1,10 @@
+VP 10.6.2 Changelog
+------------------------
+
+- add another 7.1 SurroundSound mode tuned for SSF cabinet configurations
+  this exaggerates the positional feel of the playfield sound effects when
+  played in a cabinet with exciter pairs positioned at each end of the cabinet
+
 VP 10.6.1 Changelog
 ------------------------
 

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -5,6 +5,7 @@ VP 10.6.2 Changelog
   this exaggerates the positional feel of the playfield sound effects when
   played in a cabinet with exciter pairs positioned at each end of the cabinet
 
+- replace dithering code with blue noise, fixes flickering patterns (especially in darker table areas)
 - fix a small error in the original SMAA filter code, and also increase quality parameters slightly (to match reshade)
 - retweak Standard FXAA and Quality FXAA filters to be a bit sharper
 

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -5,6 +5,8 @@ VP 10.6.2 Changelog
   this exaggerates the positional feel of the playfield sound effects when
   played in a cabinet with exciter pairs positioned at each end of the cabinet
 
+- fix a small error in the original SMAA shader code, and also increase quality parameters slightly (to match reshade)
+
 VP 10.6.1 Changelog
 ------------------------
 

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -1,7 +1,7 @@
 VP 10.6.2 Changelog
 ------------------------
 
-- add another 7.1 SurroundSound mode tuned for SSF cabinet configurations
+- add another 7.1 SurroundSound mode tuned for SSF cabinet configurations (7.1 Surround Sound Feedback (enhanced))
   this exaggerates the positional feel of the playfield sound effects when
   played in a cabinet with exciter pairs positioned at each end of the cabinet
 

--- a/vpinball_eng.rc
+++ b/vpinball_eng.rc
@@ -259,7 +259,7 @@ BEGIN
     CTEXT           "This application uses Visual Basic Scripting Edition by Microsoft",IDC_STATIC,23,277,119,17
     CONTROL         IDC_RIGHTFLIPPERBUTTON,IDC_STATIC,"Static",SS_BITMAP,7,7,94,27
     LTEXT           "A Randy Davis and Visual Pinball team Production",IDC_STATIC,13,35,209,8
-    LTEXT           "Version 10.6.0",IDC_ABOUT_VERSION,13,45,135,10
+    LTEXT           "Version 10.6.0 Final",IDC_ABOUT_VERSION,13,45,135,10
     GROUPBOX        "Credits",IDC_STATIC,7,57,216,108
     LTEXT           "Original VP8/VP9 Team",IDC_STATIC,68,65,88,9
     LTEXT           "Randy Davis - designer, developer",IDC_STATIC,13,77,115,9

--- a/vpinball_eng.rc
+++ b/vpinball_eng.rc
@@ -605,7 +605,7 @@ BEGIN
     LTEXT           "Y",IDC_STATIC,37,28,8,10
 END
 
-IDD_AUDIO_OPTIONS DIALOGEX 0, 0, 457, 159
+IDD_AUDIO_OPTIONS DIALOGEX 0, 0, 468, 159
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Audio Options"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -622,7 +622,7 @@ BEGIN
     LISTBOX         IDC_SoundListBG,123,86,171,40,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     DEFPUSHBUTTON   "OK",IDOK,350,141,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,403,141,50,14
-    GROUPBOX        "Multi-channel output",IDC_STATIC,303,11,147,89,BS_LEFT
+    GROUPBOX        "Multi-channel output",IDC_STATIC,303,11,159,104,BS_LEFT
     CONTROL         "Standard 2 channel",IDC_RADIO_SND3D2CH,"Button",BS_AUTORADIOBUTTON | WS_GROUP,309,24,125,10
     CONTROL         "Surround (All effects to rear channels)",IDC_RADIO_SND3DALLREAR,
                     "Button",BS_AUTORADIOBUTTON,309,37,137,10
@@ -631,7 +631,8 @@ BEGIN
     CONTROL         "Surround (Front is rear of cab)",IDC_RADIO_SND3DFRONTISREAR,
                     "Button",BS_AUTORADIOBUTTON,309,63,114,10
     CONTROL         "7.1 Surround (Front is rear,",IDC_RADIO_SND3D6CH,"Button",BS_AUTORADIOBUTTON,309,76,120,10
-    LTEXT           "back is side, backbox is front)",IDC_STATIC,320,86,101,8
+    LTEXT           "back is side, backbox is front)",IDC_STATIC,320,86,101,8,NOT WS_GROUP
+    CONTROL         "7.1 Surround Sound Feedback (enhanced)",IDC_RADIO_SND3DSSF,"Button",BS_AUTORADIOBUTTON,309,99,150,10
 END
 
 IDD_PHYSICS_OPTIONS DIALOGEX 0, 0, 199, 378

--- a/vpversion.h
+++ b/vpversion.h
@@ -2,7 +2,7 @@
 
 #define VP_VERSION_MAJOR    10 // X Digits
 #define VP_VERSION_MINOR    6  // Max 2 Digits
-#define VP_VERSION_REV      0  // Max 1 Digit
+#define VP_VERSION_REV      1  // Max 1 Digit
 
 #define _STR(x)    #x
 #define STR(x)     _STR(x)

--- a/vpversion.h
+++ b/vpversion.h
@@ -2,7 +2,7 @@
 
 #define VP_VERSION_MAJOR    10 // X Digits
 #define VP_VERSION_MINOR    6  // Max 2 Digits
-#define VP_VERSION_REV      1  // Max 1 Digit
+#define VP_VERSION_REV      2  // Max 1 Digit
 
 #define _STR(x)    #x
 #define STR(x)     _STR(x)


### PR DESCRIPTION
Idea: Make a "Quick-POV-export" function with assigned shortcut. That saves a POV-file with the exact name of the active table, no popups, no questions, no nothing. Like Ctrl+Shift+P or similar.