### PR TITLE
changed `SeqBlink` to accept a `TailLength` this fixes the sequencer …

### DIFF
--- a/lightseq.cpp
+++ b/lightseq.cpp
@@ -664,7 +664,8 @@ void LightSeq::SetupTracers(const SequencerState Animation, long TailLength, lon
    // blink all lights on and off
    case SeqBlinking:
       m_th1.type = eSeqBlink;
-      m_th1.length = 0;
+      m_th1.length = TailLength;
+      TailLength = 0;
       m_th1.frameCount = 2;
       break;
 
@@ -1488,12 +1489,12 @@ bool LightSeq::ProcessTracer(_tracer * const pTracer, const LightState State)
          switch (pTracer->frameCount--)
          {
          case 2:
-            SetAllLightsToState(LightStateOn);
+            SetAllLightsToState(pTracer->length <=0 ? LightStateOn : LightStateOff);
             m_timeNextUpdate = g_pplayer->m_time_msec + m_pauseValue;
             break;
 
          case 1:
-            SetAllLightsToState(LightStateOff);
+            SetAllLightsToState(pTracer->length <= 0 ? LightStateOff : LightStateOn);
             m_timeNextUpdate = g_pplayer->m_time_msec + m_pauseValue;
             break;
 


### PR DESCRIPTION
…getting stuck if value greater than 0 is sent. Any value higher than 0 will `Reverse`, where the lights will turn `off/on` instead of default `on/off`.