### PR TITLE
codeview: fix exception when bstrDescription is null

### DIFF
--- a/codeview.cpp
+++ b/codeview.cpp
@@ -887,13 +887,13 @@ STDMETHODIMP CodeViewer::OnScriptError(IActiveScriptError *pscripterror)
 	pscripterror->GetSourcePosition(&dwCookie, &nLine, &nChar);
 	BSTR bstr = 0;
 	pscripterror->GetSourceLineText(&bstr);
-	EXCEPINFO ei;
-	ZeroMemory(&ei, sizeof(ei));
-	pscripterror->GetExceptionInfo(&ei);
+	EXCEPINFO exception;
+	ZeroMemory(&exception, sizeof(exception));
+	pscripterror->GetExceptionInfo(&exception);
 	nLine++;
 	if (dwCookie == CONTEXTCOOKIE_DEBUG)
 	{
-		char* szT = MakeChar(ei.bstrDescription);
+		char* szT = MakeChar(exception.bstrDescription);
 		AddToDebugOutput(szT);
 		delete[] szT;
 		SysFreeString(bstr);
@@ -931,13 +931,13 @@ STDMETHODIMP CodeViewer::OnScriptError(IActiveScriptError *pscripterror)
 
 	errorStream << L"-------------\r\n";
 	errorStream << L"Line: " << nLine << "\r\n";
-	errorStream << ei.bstrDescription << "\r\n";
+	errorStream << (exception.bstrDescription ? exception.bstrDescription : L"Description unavailable") << "\r\n";
 	errorStream << L"\r\n";
 
 	SysFreeString(bstr);
-	SysFreeString(ei.bstrSource);
-	SysFreeString(ei.bstrDescription);
-	SysFreeString(ei.bstrHelpFile);
+	SysFreeString(exception.bstrSource);
+	SysFreeString(exception.bstrDescription);
+	SysFreeString(exception.bstrHelpFile);
 
 	g_pvp->EnableWindow(FALSE);
 
@@ -1051,13 +1051,13 @@ STDMETHODIMP CodeViewer::OnScriptErrorDebug(
 	pscripterror->GetSourcePosition(&dwCookie, &nLine, &nChar);
 	BSTR bstr = 0;
 	pscripterror->GetSourceLineText(&bstr);
-	EXCEPINFO ei;
-	ZeroMemory(&ei, sizeof(ei));
-	pscripterror->GetExceptionInfo(&ei);
+	EXCEPINFO exception;
+	ZeroMemory(&exception, sizeof(exception));
+	pscripterror->GetExceptionInfo(&exception);
 	nLine++;
 	if (dwCookie == CONTEXTCOOKIE_DEBUG)
 	{
-		char* szT = MakeChar(ei.bstrDescription);
+		char* szT = MakeChar(exception.bstrDescription);
 		AddToDebugOutput(szT);
 		delete[] szT;
 		SysFreeString(bstr);
@@ -1085,7 +1085,7 @@ STDMETHODIMP CodeViewer::OnScriptErrorDebug(
 	errorStream << L"Runtime error\r\n";
 	errorStream << L"-------------\r\n";
 	errorStream << L"Line: " << nLine << "\r\n";
-	errorStream << ei.bstrDescription << "\r\n";
+	errorStream << (exception.bstrDescription ? exception.bstrDescription : L"Description unavailable") << "\r\n";
 
 	// Get stack trace
 	IDebugStackFrame* errStackFrame;
@@ -1160,9 +1160,9 @@ STDMETHODIMP CodeViewer::OnScriptErrorDebug(
 	errorStream << L"\r\n";
 
 	SysFreeString(bstr);
-	SysFreeString(ei.bstrSource);
-	SysFreeString(ei.bstrDescription);
-	SysFreeString(ei.bstrHelpFile);
+	SysFreeString(exception.bstrSource);
+	SysFreeString(exception.bstrDescription);
+	SysFreeString(exception.bstrHelpFile);
 
 	const std::wstring errorStr = errorStream.str();
 


### PR DESCRIPTION
This PR fixes the crash @jpsalas found when performing the following:

> To reproduce it, just start VPX, choose file new, new table. Run it. Press D and select "Throw balls in player", and then click on the ball which rests on the plunger. Or throw a ball and left click on it. 
>  
> Without the instruction GetBalls on the script you can left click on the ball  and throw away that same ball. But if the script has the GetBalls in it, then it gives the error,
