### PR TITLE
Fix `GetMaterial` type mismatch errors

### DIFF
--- a/pintable.cpp
+++ b/pintable.cpp
@@ -699,9 +699,9 @@ STDMETHODIMP ScriptGlobalTable::UpdateMaterial(BSTR pVal, float wrapLighting, fl
       return E_FAIL;
 }
 
-STDMETHODIMP ScriptGlobalTable::GetMaterial(BSTR pVal, float *wrapLighting, float *roughness, float *glossyImageLerp, float *thickness, float *edge, float *edgeAlpha, float *opacity,
-   OLE_COLOR *base, OLE_COLOR *glossy, OLE_COLOR *clearcoat, VARIANT_BOOL *isMetal, VARIANT_BOOL *opacityActive,
-   float *elasticity, float *elasticityFalloff, float *friction, float *scatterAngle)
+STDMETHODIMP ScriptGlobalTable::GetMaterial(BSTR pVal, VARIANT *wrapLighting, VARIANT *roughness, VARIANT *glossyImageLerp, VARIANT *thickness, VARIANT *edge, VARIANT *edgeAlpha, VARIANT *opacity,
+   VARIANT *base, VARIANT *glossy, VARIANT *clearcoat, VARIANT *isMetal, VARIANT *opacityActive,
+   VARIANT *elasticity, VARIANT *elasticityFalloff, VARIANT *friction, VARIANT *scatterAngle)
 {
    if (!g_pplayer)
       return E_POINTER;
@@ -712,22 +712,22 @@ STDMETHODIMP ScriptGlobalTable::GetMaterial(BSTR pVal, float *wrapLighting, floa
    const Material * const pMat = m_pt->GetMaterial(Name);
    if (pMat != &m_vpinball->m_dummyMaterial)
    {
-      *wrapLighting = pMat->m_fWrapLighting;
-      *roughness = pMat->m_fRoughness;
-      *glossyImageLerp = pMat->m_fGlossyImageLerp;
-      *thickness = pMat->m_fThickness;
-      *edge = pMat->m_fEdge;
-      *edgeAlpha = pMat->m_fEdgeAlpha;
-      *opacity = pMat->m_fOpacity;
-      *base = pMat->m_cBase;
-      *glossy = pMat->m_cGlossy;
-      *clearcoat = pMat->m_cClearcoat;
-      *isMetal = FTOVB(pMat->m_bIsMetal);
-      *opacityActive = FTOVB(pMat->m_bOpacityActive);
-      *elasticity = pMat->m_fElasticity;
-      *elasticityFalloff = pMat->m_fElasticityFalloff;
-      *friction = pMat->m_fFriction;
-      *scatterAngle = pMat->m_fScatterAngle;
+      CComVariant(pMat->m_fWrapLighting).Detach(wrapLighting);
+      CComVariant(pMat->m_fRoughness).Detach(roughness);
+      CComVariant(pMat->m_fGlossyImageLerp).Detach(glossyImageLerp);
+      CComVariant(pMat->m_fThickness).Detach(thickness);
+      CComVariant(pMat->m_fEdge).Detach(edge);
+      CComVariant(pMat->m_fEdgeAlpha).Detach(edgeAlpha);
+      CComVariant(pMat->m_fOpacity).Detach(opacity);
+      CComVariant(pMat->m_cBase).Detach(base);
+      CComVariant(pMat->m_cGlossy).Detach(glossy);
+      CComVariant(pMat->m_cClearcoat).Detach(clearcoat);
+      CComVariant(pMat->m_bIsMetal).Detach(isMetal);
+      CComVariant(pMat->m_bOpacityActive).Detach(opacityActive);
+      CComVariant(pMat->m_fElasticity).Detach(elasticity);
+      CComVariant(pMat->m_fElasticityFalloff).Detach(elasticityFalloff);
+      CComVariant(pMat->m_fFriction).Detach(friction);
+      CComVariant(pMat->m_fScatterAngle).Detach(scatterAngle);
 
       return S_OK;
    }

--- a/pintable.h
+++ b/pintable.h
@@ -988,9 +988,9 @@ public:
    STDMETHOD(UpdateMaterial)(BSTR pVal, float wrapLighting, float roughness, float glossyImageLerp, float thickness, float edge, float edgeAlpha, float opacity,
       OLE_COLOR base, OLE_COLOR glossy, OLE_COLOR clearcoat, VARIANT_BOOL isMetal, VARIANT_BOOL opacityActive,
       float elasticity, float elasticityFalloff, float friction, float scatterAngle);
-   STDMETHOD(GetMaterial)(BSTR pVal, float *wrapLighting, float *roughness, float *glossyImageLerp, float *thickness, float *edge, float *edgeAlpha, float *opacity,
-      OLE_COLOR *base, OLE_COLOR *glossy, OLE_COLOR *clearcoat, VARIANT_BOOL *isMetal, VARIANT_BOOL *opacityActive,
-      float *elasticity, float *elasticityFalloff, float *friction, float *scatterAngle);
+   STDMETHOD(GetMaterial)(BSTR pVal, VARIANT *wrapLighting, VARIANT *roughness, VARIANT *glossyImageLerp, VARIANT *thickness, VARIANT *edge, VARIANT *edgeAlpha, VARIANT *opacity,
+      VARIANT *base, VARIANT *glossy, VARIANT *clearcoat, VARIANT *isMetal, VARIANT *opacityActive,
+      VARIANT *elasticity, VARIANT *elasticityFalloff, VARIANT *friction, VARIANT *scatterAngle);
    STDMETHOD(UpdateMaterialPhysics)(BSTR pVal, float elasticity, float elasticityFalloff, float friction, float scatterAngle);
    STDMETHOD(GetMaterialPhysics)(BSTR pVal, float *elasticity, float *elasticityFalloff, float *friction, float *scatterAngle);
    STDMETHOD(MaterialColor)(BSTR pVal, OLE_COLOR newVal);

--- a/vpinball.idl
+++ b/vpinball.idl
@@ -765,9 +765,9 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [id(230), helpstring("method UpdateMaterial")] HRESULT UpdateMaterial([in] BSTR pVal, [in] float wrapLighting, [in] float roughness, [in] float glossyImageLerp, [in] float thickness, [in] float edge, [in] float edgeAlpha, [in] float opacity,
                     [in] OLE_COLOR base, [in] OLE_COLOR glossy, [in] OLE_COLOR clearcoat, [in] VARIANT_BOOL isMetal, [in] VARIANT_BOOL opacityActive,
                     [in] float elasticity, [in] float elasticityFalloff, [in] float friction, [in] float scatterAngle);
-                [id(231), helpstring("method GetMaterial")] HRESULT GetMaterial([in] BSTR pVal, [out] float *wrapLighting, [out] float *roughness, [out] float *glossyImageLerp, [out] float *thickness, [out] float *edge, [out] float *edgeAlpha, [out] float *opacity,
-                    [out] OLE_COLOR *base, [out] OLE_COLOR *glossy, [out] OLE_COLOR *clearcoat, [out] VARIANT_BOOL *isMetal, [out] VARIANT_BOOL *opacityActive,
-                    [out] float *elasticity, [out] float *elasticityFalloff, [out] float *friction, [out] float *scatterAngle);
+                [id(231), helpstring("method GetMaterial")] HRESULT GetMaterial([in] BSTR pVal, [out] VARIANT *wrapLighting, [out] VARIANT *roughness, [out] VARIANT *glossyImageLerp, [out] VARIANT *thickness, [out] VARIANT *edge, [out] VARIANT *edgeAlpha, [out] VARIANT *opacity,
+                    [out] VARIANT *base, [out] VARIANT *glossy, [out] VARIANT *clearcoat, [out] VARIANT *isMetal, [out] VARIANT *opacityActive,
+                    [out] VARIANT *elasticity, [out] VARIANT *elasticityFalloff, [out] VARIANT *friction, [out] VARIANT *scatterAngle);
                 [id(247), helpstring("method UpdateMaterialPhysics")] HRESULT UpdateMaterialPhysics([in] BSTR pVal,
                     [in] float elasticity, [in] float elasticityFalloff, [in] float friction, [in] float scatterAngle);
                 [id(248), helpstring("method GetMaterialPhysics")] HRESULT GetMaterialPhysics([in] BSTR pVal,


### PR DESCRIPTION
Trying to use the global `GetMaterial` func from a script always seemed to error with a "type mismatch" error - a little digging and it looks like `VARIANT *` is the only supported type for out-parameters in VBScript (https://stackoverflow.com/questions/1241076/vbscript-type-mismatch-issue-with-in-out-bstr-parameter).

This PR changes all the out parameters for `GetMaterial` to be of type `VARIANT *`. If it's any reference, the test script I was using was...
```vbs
Sub ATimer_Timer()
    Dim MatWrapLighting
    Dim MatRoughness
    Dim MatGlossyImageLerp
    Dim MatThickness
    Dim MatEdge
    Dim MatEdgeAlpha
    Dim MatOpacity
    Dim MatBase
    Dim MatGlossy
    Dim MatClearcoat
    Dim MatIsMetal
    Dim MatOpacityActive
    Dim MatElasticity
    Dim MatElasticityFalloff
    Dim MatFriction
    Dim MatScatterAngle

    GetMaterial _
        "PlasticTrigger", _
        MatWrapLighting, _
        MatRoughness, _
        MatGlossyImageLerp, _
        MatThickness, _
        MatEdge, _
        MatEdgeAlpha, _
        MatOpacity, _
        MatBase, _
        MatGlossy, _
        MatClearcoat, _
        MatIsMetal, _
        MatOpacityActive, _
        MatElasticity, _
        MatElasticityFalloff, _
        MatFriction, _
        MatScatterAngle

    MatOpacity = (Sin(GameTime / 1000) * 0.5) + 0.5

    UpdateMaterial _
        "PlasticTrigger", _
        MatWrapLighting, _
        MatRoughness, _
        MatGlossyImageLerp, _
        MatThickness, _
        MatEdge, _
        MatEdgeAlpha, _
        MatOpacity, _
        MatBase, _
        MatGlossy, _
        MatClearcoat, _
        MatIsMetal, _
        MatOpacityActive, _
        MatElasticity, _
        MatElasticityFalloff, _
        MatFriction, _
        MatScatterAngle
End Sub
```