### PR TITLE
Workaround image loading on Wine

### DIFF
--- a/def.cpp
+++ b/def.cpp
@@ -204,3 +204,20 @@ char* replace(const char* const original, const char* const pattern, const char*
     return returned;
   }
 }
+
+// Helper function for isOnWine
+//
+// This exists such that we only check if we're on wine once, and assign the result of this function to a static const var
+static bool isOnWineInternal()
+{
+   // See https://www.winehq.org/pipermail/wine-devel/2008-September/069387.html
+   HMODULE ntdllHandle = GetModuleHandleW(L"ntdll.dll");
+   assert(ntdllHandle != NULL && "Could not GetModuleHandleW(L\"ntdll.dll\")");
+   return GetProcAddress(ntdllHandle, "wine_get_version") != NULL;
+}
+
+bool isOnWine()
+{
+   static const bool result = isOnWineInternal();
+   return result;
+}

--- a/def.h
+++ b/def.h
@@ -450,3 +450,8 @@ inline int MultiByteToWideCharNull(
 
 
 char* replace(const char* const original, const char* const pattern, const char* const replacement);
+
+/**
+ * @brief Detect whether the program is running on the Wine compatability layer
+ */
+bool isOnWine();


### PR DESCRIPTION
Trying out VP 10.7 on Wine for me has had a large tendency to crash while loading images. I'm not entirely sure why, but I've managed to narrow it down to the multithreaded image load, introduced in commit `cf271af186ae96fe1960e16b88dc3f94b14f8e20`.

Backtrace
```
                  // Relevant bits of backtrace as of commit cf271af186ae96fe1960e16b88dc3f94b14f8e20
                  // ================================================================================
                  //  0 EntryPoint+0x1fff9f7bd in ole32
                  //  1 EntryPoint+0x1fffa18fa in ole32
                  //  2 EntryPoint+0x1fff98d1a in ole32
                  //  3 BiffReader::ReadBytes+0x3d [vpinball\Media\fileio.cpp:321] in vpinballx
                  //  4 BiffReader::GetInt+0x5b [vpinball\Media\fileio.cpp:344] in vpinballx
                  //  5 BiffReader::Load+0xc0 [vpinball\Media\fileio.cpp:442] in vpinballx
                  //  6 PinBinary::LoadFromStream+0x73 [vpinball\pinbinary.cpp:101] in vpinballx
                  //  7 Texture::LoadToken+0x553 [vpinball\Texture.cpp:358] in vpinballx
                  //  8 BiffReader::Load+0xf0 [vpinball\Media\fileio.cpp:446] in vpinballx
                  //  9 Texture::LoadFromStream+0x7d [vpinball\Texture.cpp:273] in vpinballx
                  // 10 PinTable::LoadImageFromStream+0xbb [vpinball\pintable.cpp:7877] in vpinballx
```

Iiiii cannot figure out why it's crashing, or whether this is a issue with VP or Wine - but in an effort to try and get it working on Wine again, this PR tries to detect if VP is running on Wine, and forces image loading to only use one thread if so (which appears to work for me).

Understandable if you don't want to merge this in, since this is more of a band-aid than an actual fix, though I've not a clue what's causing the crash right now. >.<