### PR TITLE
Support HDR (.HDR/.EXR) image for primitive like VPX does for flashers

### DIFF
--- a/Shader.h
+++ b/Shader.h
@@ -30,7 +30,7 @@ enum shaderUniforms {
    SHADER_fDisableLighting_top_below, SHADER_backBoxSize, SHADER_quadOffsetScale, SHADER_quadOffsetScaleTex, SHADER_vColor_Intensity, SHADER_w_h_height, SHADER_alphaTestValueAB_filterMode_addBlend,
    SHADER_amount_blend_modulate_vs_add_hdrTexture01, SHADER_staticColor_Alpha, SHADER_width_height_rotated_flipLR, SHADER_vRes_Alpha_time, SHADER_mirrorFactor, SHADER_SSR_bumpHeight_fresnelRefl_scale_FS, SHADER_AO_scale_timeblur,
    //Integer and Bool
-   SHADER_ignoreStereo, SHADER_SRGBTexture, SHADER_hdrTexture0, SHADER_disableLighting, SHADER_lightSources, SHADER_doNormalMapping, SHADER_hdrEnvTextures, SHADER_is_metal, SHADER_color_grade, SHADER_do_bloom, SHADER_lightingOff, SHADER_objectSpaceNormalMap, SHADER_do_dither,
+   SHADER_ignoreStereo, SHADER_SRGBTexture, SHADER_hdrBaseTexture, SHADER_hdrTexture0, SHADER_disableLighting, SHADER_lightSources, SHADER_doNormalMapping, SHADER_hdrEnvTextures, SHADER_is_metal, SHADER_color_grade, SHADER_do_bloom, SHADER_lightingOff, SHADER_objectSpaceNormalMap, SHADER_do_dither,
    //Textures
    SHADER_Texture0, SHADER_Texture1, SHADER_Texture2, SHADER_Texture3, SHADER_Texture4, SHADER_edgesTex2D, SHADER_blendTex2D, SHADER_areaTex2D, SHADER_searchTex2D,
    SHADER_UNIFORM_COUNT, SHADER_UNIFORM_INVALID
@@ -102,6 +102,7 @@ typedef void ID3DXEffect;
 #define SHADER_ignoreStereo "ignoreStereo"
 #define SHADER_SRGBTexture "SRGBTexture"
 #define SHADER_hdrTexture0 "hdrTexture0"
+#define SHADER_hdrBaseTexture "hdrBaseTexture"
 #define SHADER_disableLighting "disableLighting"
 #define SHADER_lightSources "lightSources"
 #define SHADER_doNormalMapping "doNormalMapping"

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1233,6 +1233,7 @@ void Primitive::RenderObject()
       {
          pd3dDevice->basicShader->SetTechnique(mat->m_bIsMetal ? "basic_with_texture_normal_isMetal" : "basic_with_texture_normal_isNotMetal");
          pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, false);
+         pd3dDevice->basicShader->SetBool(SHADER_hdrBaseTexture, pin->IsHDR());
          pd3dDevice->basicShader->SetTexture(SHADER_Texture4, nMap, true);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
          pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
@@ -1245,6 +1246,7 @@ void Primitive::RenderObject()
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, false);
+         pd3dDevice->basicShader->SetBool(SHADER_hdrBaseTexture, pin->IsHDR());
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -1272,6 +1274,8 @@ void Primitive::RenderObject()
          pd3dDevice->basicShader->SetFlasherColorAlpha(color);
       }
 
+      pd3dDevice->basicShader->SetBool(SHADER_hdrBaseTexture, false);
+
       // draw the mesh
       pd3dDevice->basicShader->Begin(0);
       if (m_d.m_groupdRendering)
@@ -1291,6 +1295,7 @@ void Primitive::RenderObject()
          pd3dDevice->basicShader->End();
       }
 
+      pd3dDevice->basicShader->SetBool(SHADER_hdrBaseTexture, false);
       pd3dDevice->basicShader->SetFlasherColorAlpha(previousFlasherColorAlpha);
 
       // reset transform
@@ -2063,11 +2068,6 @@ STDMETHODIMP Primitive::put_Image(BSTR newVal)
    char szImage[MAXTOKEN];
    WideCharToMultiByteNull(CP_ACP, 0, newVal, -1, szImage, MAXTOKEN, nullptr, nullptr);
    const Texture * const tex = m_ptable->GetImage(szImage);
-   if (tex && tex->IsHDR())
-   {
-       ShowError("Cannot use a HDR image (.exr/.hdr) here");
-       return E_FAIL;
-   }
 
    m_d.m_szImage = szImage;
 

--- a/shader/BasicShader.hlsl
+++ b/shader/BasicShader.hlsl
@@ -68,6 +68,7 @@ sampler2D texSamplerN : TEXUNIT4 = sampler_state // normal map texture
     //ADDRESSV  = Wrap;
 };
 
+const bool hdrBaseTexture;
 const bool hdrEnvTextures;
 const bool objectSpaceNormalMap;
 
@@ -234,6 +235,9 @@ float4 ps_main_texture(const in VS_OUTPUT IN, uniform bool is_metal, uniform boo
    float4 pixel = tex2D(texSampler0, IN.tex01.xy);
 
    clip(pixel.a <= alphaTestValue ? - 1 : 1); // stop the pixel shader if alpha test should reject pixel
+
+   [branch] if (hdrBaseTexture)
+       pixel.xyz = InvGamma(pixel.xyz);
 
    pixel.a *= cBase_Alpha.a;
    const float3 t = /*InvGamma*/(pixel.xyz); // uses automatic sRGB trafo instead in sampler!


### PR DESCRIPTION
This little PR just allows to use .hdr/.exr image for primitive. The use case is the same than for flashers (baked light effects with a range above 1).

I did test it with a few tables and did not notice any regression.

I also checked that the result is the intended one, meaning primitive behaving the same as flasher. Here is a screenshot of the comparison table (bottom are flashers, top are primitives with different comparison textures):
![image](https://user-images.githubusercontent.com/2796036/162580755-d2946e3e-1ebe-4e88-b152-7acb9de8c7dc.png)

The test table for the above screenshot:
[HDR Prim Test.zip](https://github.com/vpinball/vpinball/files/8457244/HDR.Prim.Test.zip)