### PR TITLE
Allow playfield_mesh for visuals only

### DIFF
--- a/pintable.cpp
+++ b/pintable.cpp
@@ -3641,6 +3641,14 @@ HRESULT PinTable::LoadGameFromStorage(IStorage *pstgRoot)
             for (size_t i = 0; i < m_materials.size(); ++i)
                m_materials[i]->m_fThickness = 0.05f;
 
+         if (loadfileversion < 1072) // playfield_mesh were always collidable until 10.72
+            for (size_t i = 0; i < m_vedit.size(); ++i)
+               if (m_vedit[i]->GetItemType() == ItemTypeEnum::eItemPrimitive && strcmp(m_vedit[i]->GetName(), "playfield_mesh") == 0)
+               {
+                  ((Primitive*)m_vedit[i])->put_IsToy(False);
+                  ((Primitive*)m_vedit[i])->put_Collidable(True);
+               }
+
          //////// End Authentication block
       }
       pstgData->Release();

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -453,8 +453,7 @@ void Primitive::GetHitShapes(vector<HitObject*> &pvho)
 
    //
 
-   // playfield can't be a toy
-   if (m_d.m_toy && !m_d.m_useAsPlayfield)
+   if (m_d.m_toy)
       return;
 
    RecalculateMatrices();
@@ -595,33 +594,29 @@ void Primitive::AddHitEdge(vector<HitObject*> &pvho, std::set< std::pair<unsigne
 void Primitive::SetupHitObject(vector<HitObject*> &pvho, HitObject * obj)
 {
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szPhysicsMaterial);
-   if (!m_d.m_useAsPlayfield)
+   if (m_d.m_useAsPlayfield)
    {
-       if (mat != nullptr && !m_d.m_overwritePhysics)
-       {
-           obj->m_elasticity = mat->m_fElasticity;
-           obj->m_elasticityFalloff = mat->m_fElasticityFalloff;
-           obj->SetFriction(mat->m_fFriction);
-           obj->m_scatter = ANGTORAD(mat->m_fScatterAngle);
-       }
-       else
-       {
-           obj->m_elasticity = m_d.m_elasticity;
-           obj->m_elasticityFalloff = m_d.m_elasticityFalloff;
-           obj->SetFriction(m_d.m_friction);
-           obj->m_scatter = ANGTORAD(m_d.m_scatter);
-       }
-
-       obj->m_enabled = m_d.m_collidable;
+      obj->m_elasticity = m_ptable->m_elasticity;
+      obj->m_elasticityFalloff = m_ptable->m_elasticityFalloff;
+      obj->SetFriction(m_ptable->m_friction);
+      obj->m_scatter = ANGTORAD(m_ptable->m_scatter);
+   }
+   else if (mat != nullptr && !m_d.m_overwritePhysics)
+   {
+       obj->m_elasticity = mat->m_fElasticity;
+       obj->m_elasticityFalloff = mat->m_fElasticityFalloff;
+       obj->SetFriction(mat->m_fFriction);
+       obj->m_scatter = ANGTORAD(mat->m_fScatterAngle);
    }
    else
    {
-       obj->m_elasticity = m_ptable->m_elasticity;
-       obj->m_elasticityFalloff = m_ptable->m_elasticityFalloff;
-       obj->SetFriction(m_ptable->m_friction);
-       obj->m_scatter = ANGTORAD(m_ptable->m_scatter);
-       obj->m_enabled = true;
+       obj->m_elasticity = m_d.m_elasticity;
+       obj->m_elasticityFalloff = m_d.m_elasticityFalloff;
+       obj->SetFriction(m_d.m_friction);
+       obj->m_scatter = ANGTORAD(m_d.m_scatter);
    }
+
+   obj->m_enabled = m_d.m_collidable;
    obj->m_threshold = m_d.m_threshold;
    obj->m_ObjType = ePrimitive;
    obj->m_obj = (IFireEvents *)this;

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -13,6 +13,7 @@ FEATURES:
 
 - add additive blending to primitives (same as flashers)
 - support HDR textures on primitives (same as flashers), full high dynamic range is only available if lighting disabled though (otherwise clamped to 0..1)
+- allows playfield_mesh to be not collidable (or a toy). In this case another collidable object must be included for the playfield to avoid ball falling indefinitely.
 
 FIXES:
 


### PR DESCRIPTION
This PR allows to split the visual part of the playfield from its physics part, like it is possible for all other objects. The use case for this is when the visuals for the playfield are not fitted for physics simulation (too high poly, cutholes for all the switches or even GI lights, some beveling,...). In this case, with this PR you would use a playfield_mesh like today (needed to get correct reflections) but disable its physics (mark it as a 'toy'), and add another collidable mesh with only the needed holes by the physics, or if not needed a full PF sized ramp without any hole.

To do so, it takes in account the 'toy' and 'collidable' attributes of the playfield mesh primitive.

This PR may introduce regression if a table creator has put a playfield_mesh, disabled its physics, relying on VPX to not take in account what is in the UI. This is not likely but with the amount of tables out there, it may happen. A table like this will need the physics of the primitive to be reenabled.

Below is a test table that shows it running, with reflection working, on a very highpoly playfield.
[Collidable PF.zip](https://github.com/vpinball/vpinball/files/8490843/Collidable.PF.zip)