### PR TITLE
HDR primitive: avoid saturating HDR textures

### DIFF
--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1335,6 +1335,14 @@ void Primitive::RenderDynamic()
            return;
        if (m_ptable->m_reflectionEnabled && !m_d.m_reflectionEnabled)
            return;
+       if (m_d.m_addBlend)
+       {
+          const vec4 color = convertColor(m_d.m_color, m_d.m_alpha * (float)(1.0 / 100.0));
+          if (color.w == 0.f)
+             return;
+          if (color.x == 0.f && color.y == 0.f && color.z == 0.f)
+             return;
+       }
    }
 
    RenderObject();

--- a/shader/Material.fxh
+++ b/shader/Material.fxh
@@ -142,7 +142,7 @@ float3 lightLoop(const float3 pos, float3 N, const float3 V, float3 diffuse, flo
    const float glossyMax = max(glossy.x,max(glossy.y,glossy.z));
    const float specularMax = max(specular.x,max(specular.y,specular.z)); //!! not needed as 2nd layer only so far
    const float sum = diffuseMax + glossyMax /*+ specularMax*/;
-   if (sum > 1.0)
+   if (sum > 1.0 && fDisableLighting_top_below.x < 1.0)
    {
       const float invsum = 1.0/sum;
       diffuse  *= invsum;


### PR DESCRIPTION
Previous PR allowed for HDR texture for primitive, if lighting was disabled. Though, the diffuse color is saturated in the lighting shader, braking the initial intent. This PR disables the saturation if lighting is disabled.

Since stauration happens in the lighting, I think that the saturation in the base technique is not needed and could be removed (I did not removed it). https://github.com/vpinball/vpinball/blob/109634cafb16a98625da4384e7cddc5f5b602193/shader/BasicShader.hlsl#L239


I also included a little fix for primitive that were rendered even when set to additive with a 0 color or opacity (no-op rendering).