### PR TITLE
Fade light when visible only through reflections

### DIFF
--- a/light.cpp
+++ b/light.cpp
@@ -371,18 +371,6 @@ void Light::RenderDynamic()
 
    TRACE_FUNCTION();
 
-   if (!m_d.m_visible || m_ptable->m_reflectionEnabled)
-      return;
-
-   if (m_customMoverVBuffer == nullptr) // in case of degenerate light
-      return;
-
-   if (m_backglass && !GetPTable()->GetDecalsEnabled())
-      return;
-
-   if (m_d.m_BulbLight && m_d.m_showBulbMesh && !m_d.m_staticBulbMesh)
-      RenderBulbMesh();
-
    const U32 old_time_msec = (m_d.m_time_msec < g_pplayer->m_time_msec) ? m_d.m_time_msec : g_pplayer->m_time_msec;
    m_d.m_time_msec = g_pplayer->m_time_msec;
    const float diff_time_msec = (float)(g_pplayer->m_time_msec - old_time_msec);
@@ -417,6 +405,18 @@ void Light::RenderDynamic()
             m_d.m_currentIntensity = 0.0f;
       }
    }
+
+   if (!m_d.m_visible || m_ptable->m_reflectionEnabled)
+      return;
+
+   if (m_customMoverVBuffer == nullptr) // in case of degenerate light
+      return;
+
+   if (m_backglass && !GetPTable()->GetDecalsEnabled())
+      return;
+
+   if (m_d.m_BulbLight && m_d.m_showBulbMesh && !m_d.m_staticBulbMesh)
+      RenderBulbMesh();
 
    Texture *offTexel = nullptr;
 


### PR DESCRIPTION
The 2 parts of rendering of lights are controlled:
- by the Visible property, for the halo/modulated image and transmission part,
- by the ShowReflectionOnBall property, for the reflected point on balls (for the 8 nearest lights).

The problem is that, when turning off Visible, reflection are still rendered if enabled, but the fading is no more performed (i.e. the light will be seen in the reflections but not animated anymore).

A lot of tables work around this by moving the lights below the playfield (to hide them from the player) and keep them visible to keep the fading. This works but has a few drawbacks: reflections are relative to the position of the light which is then too low (for GI lights), the lights are still rendered making things complicated if the playfield has holes, there is likely a (very) slight performance impact.

This PR proposes to solve this by keeping the fading code executed in all situations, letting the table creator choose what is visible by using the Visible / ShowReflectionOnBall properties.

Here is a table demonstrating the problem and the fix. It contains 2 blinking lights (can be located by there visible bulb). One should be only directly visible (no reflection on balls), the other only through reflections on ball.
[Light Visibility.zip](https://github.com/vpinball/vpinball/files/8537147/Light.Visibility.zip)

