### PR TITLE
Add Sampler & RenderTarget classes, use them instead of direct low level API

### DIFF
--- a/RenderTarget.cpp
+++ b/RenderTarget.cpp
@@ -1,0 +1,277 @@
+#include "stdafx.h"
+#include "RenderTarget.h"
+#include "RenderDevice.h"
+
+#ifndef DISABLE_FORCE_NVIDIA_OPTIMUS
+#include "nvapi.h"
+#endif
+
+RenderTarget::RenderTarget(RenderDevice* rd)
+{
+   m_rd = rd;
+   m_stereo = STEREO_OFF;
+   m_is_back_buffer = true;
+   // FIXME we should gather backbuffer informations (but this is not used anywhere)
+   // m_format = ;
+   // m_width = ;
+   // m_height = ;
+   m_has_depth = false;
+   m_use_mSAA = false;
+   m_color_sampler = nullptr;
+   m_depth_sampler = nullptr;
+#ifdef ENABLE_SDL
+   m_framebuffer = 0;
+   glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)(&m_framebuffer)); // Not sure about this (taken from VPVR original implementation). Doesn't the back buffer alays bind to 0 on OpenGL ?
+#else
+   HRESULT hr = m_rd->GetCoreDevice()->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &m_color_surface);
+   if (FAILED(hr))
+      ReportError("Fatal Error: unable to create back buffer!", hr, __FILE__, __LINE__);
+   m_use_alternate_depth = m_rd->m_useNvidiaApi || !m_rd->m_INTZ_support;
+   m_color_tex = nullptr;
+   m_color_sampler = nullptr;
+   m_depth_tex = nullptr;
+   m_depth_surface = nullptr;
+   m_depth_sampler = nullptr;
+#endif
+}
+
+RenderTarget::RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, bool use_MSAA, int stereo, char* failureMessage)
+{
+   m_is_back_buffer = false;
+   m_rd = rd;
+   m_stereo = stereo;
+   m_width = width;
+   m_height = height;
+   m_format = format;
+   m_has_depth = with_depth;
+   m_use_mSAA = use_MSAA;
+#ifdef ENABLE_SDL
+   const GLuint col_type = ((format == RGBA32F) || (format == RGB32F)) ? GL_FLOAT : ((format == RGBA16F) || (format == RGB16F)) ? GL_HALF_FLOAT : GL_UNSIGNED_BYTE;
+   const GLuint col_format = ((format == GREY8) || (format == RED16F))                                                                                                      ? GL_RED
+      : ((format == GREY_ALPHA) || (format == RG16F))                                                                                                                       ? GL_RG
+      : ((format == RGB) || (format == RGB8) || (format == SRGB) || (format == SRGB8) || (format == RGB5) || (format == RGB10) || (format == RGB16F) || (format == RGB32F)) ? GL_RGB
+                                                                                                                                                                              : GL_RGBA;
+   const bool col_is_linear = (format == GREY8) || (format == RED16F) || (format == GREY_ALPHA) || (format == RG16F) || (format == RGB5) || (format == RGB) || (format == RGB8)
+      || (format == RGB10) || (format == RGB16F) || (format == RGB32F) || (format == RGBA16F) || (format == RGBA32F) || (format == RGBA) || (format == RGBA8) || (format == RGBA10)
+      || (format == DXT5) || (format == BC6U) || (format == BC6S) || (format == BC7);
+
+   glGenFramebuffers(1, &m_framebuffer);
+   glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+   glGenTextures(1, &m_color_tex);
+
+   if (g_pplayer->m_MSAASamples > 1 && use_MSAA)
+   {
+      glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, m_color_tex);
+      glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, g_pplayer->m_MSAASamples, format, width, height, GL_TRUE);
+      glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, 0);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, m_color_tex, 0);
+
+      if (with_depth)
+      {
+         glGenRenderbuffers(1, &m_depth_tex);
+         glBindRenderbuffer(GL_RENDERBUFFER, m_depth_tex);
+         glRenderbufferStorageMultisample(GL_RENDERBUFFER, g_pplayer->m_MSAASamples, GL_DEPTH_COMPONENT, width, height);
+         glBindRenderbuffer(GL_RENDERBUFFER, 0);
+         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depth_tex);
+      }
+      else
+      {
+         m_depth_tex = 0;
+      }
+   }
+   else // RENDERTARGET & RENDERTARGET_DEPTH
+   {
+      glBindTexture(GL_TEXTURE_2D, m_color_tex);
+      glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, GL_RGBA, col_type, nullptr);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_color_tex, 0);
+
+      if (with_depth)
+      {
+         glGenRenderbuffers(1, &m_depth_tex);
+         glBindRenderbuffer(GL_RENDERBUFFER, m_depth_tex);
+         glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height);
+         glBindRenderbuffer(GL_RENDERBUFFER, 0);
+         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depth_tex);
+      }
+      else
+      {
+         m_depth_tex = 0;
+      }
+   }
+
+   constexpr GLenum DrawBuffers[1] = { GL_COLOR_ATTACHMENT0 };
+   glDrawBuffers(1, DrawBuffers);
+
+   const int status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+   if (status != GL_FRAMEBUFFER_COMPLETE)
+   {
+      char msg[256];
+      const char* errorCode;
+      switch (status)
+      {
+      case GL_FRAMEBUFFER_UNDEFINED: errorCode = "GL_FRAMEBUFFER_UNDEFINED"; break;
+      case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT: errorCode = "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT"; break;
+      case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: errorCode = "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT"; break;
+      case GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER: errorCode = "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER"; break;
+      case GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER: errorCode = "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER"; break;
+      case GL_FRAMEBUFFER_UNSUPPORTED: errorCode = "GL_FRAMEBUFFER_UNSUPPORTED"; break;
+      case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE: errorCode = "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"; break;
+      case GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS: errorCode = "GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS"; break;
+      default: errorCode = "unknown"; break;
+      }
+      sprintf_s(msg, 256, "glCheckFramebufferStatus returned 0x%0002X %s", glCheckFramebufferStatus(m_framebuffer), errorCode);
+      ShowError(msg);
+      exit(-1);
+   }
+
+   m_color_sampler = new Sampler(m_rd, m_color_tex, false, use_MSAA, true);
+   m_depth_sampler = with_depth ? new Sampler(m_rd, m_depth_tex, false, use_MSAA, true) : nullptr;
+
+#else
+   HRESULT hr = m_rd->GetCoreDevice()->CreateTexture(width, height, 1, D3DUSAGE_RENDERTARGET, (D3DFORMAT)format, (D3DPOOL)memoryPool::DEFAULT, &m_color_tex, nullptr);
+   if (FAILED(hr))
+      ReportError(failureMessage, hr, __FILE__, __LINE__);
+   m_color_tex->GetSurfaceLevel(0, &m_color_surface);
+   m_color_sampler = new Sampler(m_rd, m_color_tex, false, true);
+   m_use_alternate_depth = m_rd->m_useNvidiaApi || !m_rd->m_INTZ_support;
+   if (with_depth)
+   {
+      CHECKD3D(m_rd->GetCoreDevice()->CreateTexture(width, height, 1, D3DUSAGE_DEPTHSTENCIL, (D3DFORMAT)MAKEFOURCC('I', 'N', 'T', 'Z'), (D3DPOOL)memoryPool::DEFAULT, &m_depth_tex, nullptr)); // D3DUSAGE_AUTOGENMIPMAP?
+      if (m_use_alternate_depth)
+      {
+         // Alternate depth path. Depth surface and depth texture are separated, synced with a copy.
+         D3DSURFACE_DESC desc;
+         m_color_surface->GetDesc(&desc);
+         const HRESULT hr = m_rd->GetCoreDevice()->CreateDepthStencilSurface(width, height, D3DFMT_D16 /*D3DFMT_D24X8*/, //!!
+            desc.MultiSampleType, desc.MultiSampleQuality, FALSE, &m_depth_surface, nullptr);
+         if (FAILED(hr))
+            ReportError("Fatal Error: unable to create depth buffer!", hr, __FILE__, __LINE__);
+         CHECKNVAPI(NvAPI_D3D9_RegisterResource(m_depth_surface));
+         CHECKNVAPI(NvAPI_D3D9_RegisterResource(m_depth_tex));
+      }
+      else
+      {
+         CHECKD3D(m_depth_tex->GetSurfaceLevel(0, &m_depth_surface));
+      }
+      m_depth_sampler = new Sampler(m_rd, m_depth_tex, false, true);
+   }
+   else
+   {
+      m_depth_tex = nullptr;
+      m_depth_surface = nullptr;
+      m_depth_sampler = nullptr;
+   }
+#endif
+}
+
+RenderTarget::~RenderTarget()
+{
+#ifdef ENABLE_SDL
+#else
+   if (!m_is_back_buffer) SAFE_RELEASE(m_color_surface);
+   SAFE_RELEASE(m_color_tex);
+   if (m_use_alternate_depth && m_depth_surface != nullptr)
+   {
+      CHECKNVAPI(NvAPI_D3D9_UnregisterResource(m_depth_surface));
+      CHECKNVAPI(NvAPI_D3D9_UnregisterResource(m_depth_tex));
+   }
+   SAFE_RELEASE(m_depth_surface);
+   SAFE_RELEASE(m_depth_tex);
+#endif
+   delete m_color_sampler;
+   delete m_depth_sampler;
+}
+   
+void RenderTarget::UpdateDepthSampler()
+{
+#if !defined(DISABLE_FORCE_NVIDIA_OPTIMUS) && !defined(ENABLE_SDL)
+   if (m_has_depth && m_use_alternate_depth && m_rd->NVAPIinit)
+   {
+      // From IDirect3DSurface9 to IDirect3DTexture9
+      // CHECKNVAPI(NvAPI_D3D9_AliasSurfaceAsTexture(m_rd->GetCoreDevice(), m_depth_surface, &m_depth_tex, 0));
+      CHECKNVAPI(NvAPI_D3D9_StretchRectEx(m_rd->GetCoreDevice(), m_depth_surface, nullptr, m_depth_tex, nullptr, D3DTEXF_NONE));
+   }
+#endif
+}
+
+RenderTarget* RenderTarget::Duplicate()
+{
+   assert(!m_is_back_buffer);
+   return new RenderTarget(m_rd, m_width, m_height, m_format, m_has_depth, m_use_mSAA, m_stereo, "Failed to duplicate render target");
+}
+
+void RenderTarget::CopyTo(RenderTarget* dest)
+{
+#ifdef ENABLE_SDL
+   // FIXME unimplementd (only used to copy render target for static pass)
+#else
+   CHECKD3D(m_rd->GetCoreDevice()->StretchRect(m_color_surface, nullptr, dest->m_color_surface, nullptr, D3DTEXF_NONE));
+   if (m_has_depth && dest->m_has_depth)
+      CHECKD3D(m_rd->GetCoreDevice()->StretchRect(m_depth_surface, nullptr, dest->m_depth_surface, nullptr, D3DTEXF_NONE));
+#endif
+}
+
+void RenderTarget::Activate(bool ignoreStereo)
+{
+#ifdef ENABLE_SDL
+   static GLfloat viewPorts[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+   static RenderTarget* currentFrameBuffer = nullptr;
+   static int currentStereoMode = -1;
+   if (currentFrameBuffer == this && currentStereoMode == ignoreStereo || m_is_back_buffer ? STEREO_OFF : m_stereo)
+      return;
+   currentFrameBuffer = this;
+   currentStereoMode = ignoreStereo || m_is_back_buffer ? STEREO_OFF : m_stereo;
+   glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+   if (m_is_back_buffer)
+   {
+      glViewport(0, 0, m_width, m_height);
+   }
+   else
+   {
+      Shader::setTextureDirty(m_color_tex);
+      if (m_has_depth)
+         Shader::setTextureDirty(m_depth_tex);
+      if (ignoreStereo)
+      {
+         glViewport(0, 0, m_width, m_height);
+      }
+      else
+      {
+         switch (m_stereo)
+         {
+         case STEREO_OFF:
+            glViewport(0, 0, m_width, m_height);
+            m_rd->lightShader->SetBool(SHADER_ignoreStereo, true); // For non-stereo lightbulb texture, can't use pre-processor for this
+            break;
+         case STEREO_TB:
+         case STEREO_INT:
+            glViewport(0, 0, m_width,
+               m_height / 2); // Set default viewport width/height values of all viewports before we define the array or we get undefined behaviour in shader (flickering viewports).
+            viewPorts[2] = viewPorts[6] = (float)m_width;
+            viewPorts[3] = viewPorts[7] = (float)m_height / 2.0f;
+            viewPorts[4] = 0.0f;
+            viewPorts[5] = (float)m_height / 2.0f;
+            glViewportArrayv(0, 2, viewPorts);
+            m_rd->lightShader->SetBool(SHADER_ignoreStereo, false);
+            break;
+         case STEREO_SBS:
+         case STEREO_VR:
+            glViewport(0, 0, m_width / 2,
+               m_height); // Set default viewport width/height values of all viewports before we define the array or we get undefined behaviour in shader (flickering viewports).
+            viewPorts[2] = viewPorts[6] = (float)m_width / 2.0f;
+            viewPorts[3] = viewPorts[7] = (float)m_height;
+            viewPorts[4] = (float)m_width / 2.0f;
+            viewPorts[5] = 0.0f;
+            glViewportArrayv(0, 2, viewPorts);
+            m_rd->lightShader->SetBool(SHADER_ignoreStereo, false);
+            break;
+         }
+      }
+   }
+#else
+   CHECKD3D(m_rd->GetCoreDevice()->SetRenderTarget(0, m_color_surface));
+   if (m_depth_surface)
+      CHECKD3D(m_rd->GetCoreDevice()->SetDepthStencilSurface(m_depth_surface));
+#endif
+}

--- a/RenderTarget.h
+++ b/RenderTarget.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "typedefs3D.h"
+class RenderDevice;
+
+class RenderTarget
+{
+public:
+   RenderTarget(RenderDevice* rd); // Default output render target
+   RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, bool use_MSAA, int stereo, char* failureMessage);
+   ~RenderTarget();
+
+   void Activate(bool ignoreStereo);
+
+   Sampler* GetColorSampler() { return m_color_sampler; }
+   void UpdateDepthSampler();
+   Sampler* GetDepthSampler() { return m_depth_sampler; }
+
+   RenderTarget* Duplicate();
+   void CopyTo(RenderTarget* dest);
+
+#ifndef ENABLE_SDL
+   IDirect3DSurface9* GetCoreColorSurface() { return m_color_surface; }
+#endif
+
+private:
+   bool m_is_back_buffer;
+   int m_width;
+   int m_height;
+   colorFormat m_format;
+   bool m_has_depth;
+   bool m_use_mSAA;
+   int m_stereo;
+   RenderDevice* m_rd;
+   Sampler* m_color_sampler;
+   Sampler* m_depth_sampler;
+
+#ifdef ENABLE_SDL
+   GLuint m_framebuffer;
+   GLuint m_color_tex;
+   GLuint m_depth_tex;
+#else
+   bool m_use_alternate_depth;
+   IDirect3DSurface9* m_color_surface;
+   IDirect3DTexture9* m_color_tex;
+   IDirect3DSurface9* m_depth_surface;
+   IDirect3DTexture9* m_depth_tex;
+#endif
+};

--- a/Sampler.cpp
+++ b/Sampler.cpp
@@ -1,0 +1,342 @@
+#include "stdafx.h"
+#include "Sampler.h"
+#include "RenderDevice.h"
+
+Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb)
+{
+   m_rd = rd;
+   m_width = surf->width();
+   m_height = surf->height();
+   m_dirty = false;
+#ifdef ENABLE_SDL
+   colorFormat format;
+   if (surf->m_format == BaseTexture::SRGBA)
+      format = colorFormat::SRGBA;
+   else if (surf->m_format == BaseTexture::RGBA)
+      format = colorFormat::RGBA;
+   else if (surf->m_format == BaseTexture::SRGB)
+      format = colorFormat::SRGB;
+   else if (surf->m_format == BaseTexture::RGB)
+      format = colorFormat::RGB;
+   else if (surf->m_format == BaseTexture::RGB_FP16)
+      format = colorFormat::RGB16F;
+   else if (surf->m_format == BaseTexture::RGB_FP32)
+      format = colorFormat::RGB32F;
+   else
+      assert(false); // Unsupported image format
+   if (force_linear_rgb)
+   {
+      if (format == colorFormat::SRGB)
+         format = colorFormat::RGB;
+      else if (format == colorFormat::SRGBA)
+         format = colorFormat::RGBA;
+   }
+   m_texture = CreateTexture(surf->width(), surf->height(), 0, format, surf->data(), 0);
+   m_isLinear = format != colorFormat::SRGB && format != colorFormat::SRGBA;
+#else
+   const BaseTexture::Format basetexformat = surf->m_format;
+
+   colorFormat texformat;
+   IDirect3DTexture9* sysTex = CreateSystemTexture(surf, force_linear_rgb, texformat);
+
+   m_isLinear = texformat == colorFormat::RGBA16F || texformat == colorFormat::RGBA32F || force_linear_rgb;
+
+   HRESULT hr = m_rd->GetCoreDevice()->CreateTexture(m_width, m_height, (texformat != colorFormat::DXT5 && m_rd->m_autogen_mipmap) ? 0 : sysTex->GetLevelCount(),
+      (texformat != colorFormat::DXT5 && m_rd->m_autogen_mipmap) ? textureUsage::AUTOMIPMAP : 0, (D3DFORMAT)texformat, (D3DPOOL)memoryPool::DEFAULT, &m_texture, nullptr);
+   if (FAILED(hr))
+      ReportError("Fatal Error: out of VRAM!", hr, __FILE__, __LINE__);
+
+   m_rd->m_curTextureUpdates++;
+   hr = m_rd->GetCoreDevice()->UpdateTexture(sysTex, m_texture);
+   if (FAILED(hr))
+      ReportError("Fatal Error: uploading texture failed!", hr, __FILE__, __LINE__);
+
+   SAFE_RELEASE(sysTex);
+
+   if (texformat != colorFormat::DXT5 && m_rd->m_autogen_mipmap)
+      m_texture->GenerateMipSubLevels(); // tell driver that now is a good time to generate mipmaps
+#endif
+}
+
+#ifdef ENABLE_SDL
+Sampler::Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb)
+{
+   m_rd = rd;
+   m_ownTexture = ownTexture;
+   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &m_width);
+   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &m_height);
+   int internal_format;
+   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
+   m_isLinear = !((internal_format == SRGB) && (internal_format == SRGBA) && (internal_format == SDXT5) && (internal_format == SBC7)) || force_linear_rgb;
+   m_isMSAA = isMSAA;
+   m_texture = glTexture;
+}
+#else
+Sampler::Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb)
+{
+   m_rd = rd;
+   D3DSURFACE_DESC desc;
+   dx9Texture->GetLevelDesc(0, &desc);
+   m_ownTexture = ownTexture;
+   m_texture = dx9Texture;
+   m_width = desc.Width;
+   m_height = desc.Height;
+   m_dirty = false;
+   m_isLinear = desc.Format == D3DFMT_A16B16G16R16F || desc.Format == D3DFMT_A32B32G32R32F || force_linear_rgb;
+}
+#endif
+
+Sampler::~Sampler()
+{
+#ifdef ENABLE_SDL
+   if (m_ownTexture)
+      glDeleteTextures(1, &m_texture);
+#else
+   if (m_ownTexture)
+      SAFE_RELEASE_TEXTURE(m_texture);
+#endif
+}
+
+void Sampler::UpdateTexture(BaseTexture* const surf, const bool force_linear_rgb)
+{
+#ifdef ENABLE_SDL
+   colorFormat format;
+   if (surf->m_format == BaseTexture::RGBA)
+      format = colorFormat::RGBA;
+   else if (surf->m_format == BaseTexture::SRGBA)
+      format = colorFormat::SRGBA;
+   else if (surf->m_format == BaseTexture::RGB)
+      format = colorFormat::RGB;
+   else if (surf->m_format == BaseTexture::SRGB)
+      format = colorFormat::SRGB;
+   else if (surf->m_format == BaseTexture::RGB_FP16)
+      format = colorFormat::RGB16F;
+   else if (surf->m_format == BaseTexture::RGB_FP32)
+      format = colorFormat::RGB32F;
+   if (force_linear_rgb)
+      if (format == colorFormat::SRGB)
+         format = colorFormat::RGB;
+      else if (format == colorFormat::SRGBA)
+         format = colorFormat::RGBA;
+   const GLuint col_type = ((format == RGBA32F) || (format == RGB32F)) ? GL_FLOAT : ((format == RGBA16F) || (format == RGB16F)) ? GL_HALF_FLOAT : GL_UNSIGNED_BYTE;
+   const GLuint col_format = ((format == GREY8) || (format == RED16F))                                                                                                      ? GL_RED
+      : ((format == GREY_ALPHA) || (format == RG16F))                                                                                                                       ? GL_RG
+      : ((format == RGB) || (format == RGB8) || (format == SRGB) || (format == SRGB8) || (format == RGB5) || (format == RGB10) || (format == RGB16F) || (format == RGB32F)) ? GL_RGB
+                                                                                                                                                                            : GL_RGBA;
+   glBindTexture(GL_TEXTURE_2D, m_texture);
+   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, surf->width(), surf->height(), col_format, col_type, surf->data());
+   glGenerateMipmap(GL_TEXTURE_2D); // Generate mip-maps
+   glBindTexture(GL_TEXTURE_2D, 0);
+#else
+   colorFormat texformat;
+   IDirect3DTexture9* sysTex = CreateSystemTexture(surf, force_linear_rgb, texformat);
+   m_rd->m_curTextureUpdates++;
+   CHECKD3D(m_rd->GetCoreDevice()->UpdateTexture(sysTex, m_texture));
+   SAFE_RELEASE(sysTex);
+#endif
+}
+
+
+#ifdef ENABLE_SDL
+GLuint Sampler::CreateTexture(UINT Width, UINT Height, UINT Levels, colorFormat Format, void* data, int stereo)
+{
+   const GLuint col_type = ((Format == RGBA32F) || (Format == RGB32F)) ? GL_FLOAT : ((Format == RGBA16F) || (Format == RGB16F)) ? GL_HALF_FLOAT : GL_UNSIGNED_BYTE;
+   const GLuint col_format = ((Format == GREY8) || (Format == RED16F))                                                                                                      ? GL_RED
+      : ((Format == GREY_ALPHA) || (Format == RG16F))                                                                                                                       ? GL_RG
+      : ((Format == RGB) || (Format == RGB8) || (Format == SRGB) || (Format == SRGB8) || (Format == RGB5) || (Format == RGB10) || (Format == RGB16F) || (Format == RGB32F)) ? GL_RGB
+                                                                                                                                                                            : GL_RGBA;
+   const bool col_is_linear = (Format == GREY8) || (Format == RED16F) || (Format == GREY_ALPHA) || (Format == RG16F) || (Format == RGB5) || (Format == RGB) || (Format == RGB8)
+      || (Format == RGB10) || (Format == RGB16F) || (Format == RGB32F) || (Format == RGBA16F) || (Format == RGBA32F) || (Format == RGBA) || (Format == RGBA8) || (Format == RGBA10)
+      || (Format == DXT5) || (Format == BC6U) || (Format == BC6S) || (Format == BC7);
+
+   GLuint texture;
+   glGenTextures(1, &texture);
+   glBindTexture(GL_TEXTURE_2D, texture);
+
+   if (Format == GREY8)
+   { //Hack so that GL_RED behaves as GL_GREY
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA);
+      Format = RGB8;
+   }
+   else if (Format == GREY_ALPHA)
+   { //Hack so that GL_RG behaves as GL_GREY_ALPHA
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_GREEN);
+      Format = RGB8;
+   }
+   else
+   { //Default
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_GREEN);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_BLUE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA);
+
+      // Anisotropic filtering
+      if (m_rd->m_maxaniso > 0)
+         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY, min(max(1.f, m_rd->m_maxaniso), 16.f));
+   }
+
+   colorFormat comp_format = Format;
+   if (m_rd->m_compress_textures && ((Width & 3) == 0) && ((Height & 3) == 0) && (Width > 256) && (Height > 256))
+   {
+      if (col_type == GL_FLOAT || col_type == GL_HALF_FLOAT)
+      {
+         if (GLAD_GL_ARB_texture_compression_bptc)
+            comp_format = colorFormat::BC6S; // We should use unsigned BC6 but this needs to know beforehand if the texture is only positive
+      }
+      else if (GLAD_GL_ARB_texture_compression_bptc)
+         comp_format = col_is_linear ? colorFormat::BC7 : colorFormat::SBC7;
+      else
+         comp_format = col_is_linear ? colorFormat::DXT5 : colorFormat::SDXT5;
+   }
+
+   const int num_mips = (int)std::log2(float(max(Width, Height))) + 1;
+   if (m_rd->getGLVersion() >= 403)
+      glTexStorage2D(GL_TEXTURE_2D, num_mips, comp_format, Width, Height);
+   else
+   { // should never be triggered nowadays
+      GLsizei w = Width;
+      GLsizei h = Height;
+      for (int i = 0; i < num_mips; i++)
+      {
+         glTexImage2D(GL_TEXTURE_2D, i, comp_format, w, h, 0, col_format, col_type, nullptr);
+         w = max(1, (w / 2));
+         h = max(1, (h / 2));
+      }
+   }
+
+   if (data)
+   {
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, Width, Height, col_format, col_type, data);
+      glGenerateMipmap(GL_TEXTURE_2D); // Generate mip-maps, when using TexStorage will generate same amount as specified in TexStorage, otherwise good idea to limit by GL_TEXTURE_MAX_LEVEL
+   }
+   return texture;
+}
+
+#else
+
+IDirect3DTexture9* Sampler::CreateSystemTexture(BaseTexture* const surf, const bool force_linear_rgb, colorFormat& texformat)
+{
+   const unsigned int texwidth = surf->width();
+   const unsigned int texheight = surf->height();
+   const BaseTexture::Format basetexformat = surf->m_format;
+
+   if (basetexformat == BaseTexture::RGB_FP16)
+   {
+      texformat = colorFormat::RGBA16F;
+   }
+   else if (basetexformat == BaseTexture::RGB_FP32)
+   {
+      texformat = colorFormat::RGBA32F;
+   }
+   else
+   {
+      texformat = colorFormat::RGBA8;
+      if (m_rd->m_compress_textures && ((texwidth & 3) == 0) && ((texheight & 3) == 0) && (texwidth > 256) && (texheight > 256))
+         texformat = colorFormat::DXT5;
+   }
+
+   IDirect3DTexture9* sysTex;
+   HRESULT hr;
+   hr = m_rd->GetCoreDevice()->CreateTexture(
+      texwidth, texheight, (texformat != colorFormat::DXT5 && m_rd->m_autogen_mipmap) ? 1 : 0, 0, (D3DFORMAT)texformat, (D3DPOOL)memoryPool::SYSTEM, &sysTex, nullptr);
+   if (FAILED(hr))
+   {
+      ReportError("Fatal Error: unable to create texture!", hr, __FILE__, __LINE__);
+   }
+
+   // copy data into system memory texture
+   if (basetexformat == BaseTexture::RGB_FP32 && texformat == colorFormat::RGBA32F)
+   {
+      D3DLOCKED_RECT locked;
+      CHECKD3D(sysTex->LockRect(0, &locked, nullptr, 0));
+
+      float* const __restrict pdest = (float*)locked.pBits;
+      const float* const __restrict psrc = (float*)(surf->data());
+      for (unsigned int i = 0; i < texwidth * texheight; ++i)
+      {
+         pdest[i * 4 + 0] = psrc[i * 3 + 0];
+         pdest[i * 4 + 1] = psrc[i * 3 + 1];
+         pdest[i * 4 + 2] = psrc[i * 3 + 2];
+         pdest[i * 4 + 3] = 1.f;
+      }
+
+      CHECKD3D(sysTex->UnlockRect(0));
+   }
+   else if (basetexformat == BaseTexture::RGB_FP16 && texformat == colorFormat::RGBA16F)
+   {
+      D3DLOCKED_RECT locked;
+      CHECKD3D(sysTex->LockRect(0, &locked, nullptr, 0));
+
+      unsigned short* const __restrict pdest = (unsigned short*)locked.pBits;
+      const unsigned short* const __restrict psrc = (unsigned short*)(surf->data());
+      const unsigned short one16 = float2half(1.f);
+      for (unsigned int i = 0; i < texwidth * texheight; ++i)
+      {
+         pdest[i * 4 + 0] = psrc[i * 3 + 0];
+         pdest[i * 4 + 1] = psrc[i * 3 + 1];
+         pdest[i * 4 + 2] = psrc[i * 3 + 2];
+         pdest[i * 4 + 3] = one16;
+      }
+
+      CHECKD3D(sysTex->UnlockRect(0));
+   }
+   else if ((basetexformat == BaseTexture::RGB || basetexformat == BaseTexture::SRGB) && texformat == colorFormat::RGBA8)
+   {
+      D3DLOCKED_RECT locked;
+      CHECKD3D(sysTex->LockRect(0, &locked, nullptr, 0));
+
+      BYTE* const __restrict pdest = (BYTE*)locked.pBits;
+      const BYTE* const __restrict psrc = (BYTE*)(surf->data());
+      for (unsigned int i = 0; i < texwidth * texheight; ++i)
+      {
+         pdest[i * 4 + 0] = psrc[i * 3 + 2];
+         pdest[i * 4 + 1] = psrc[i * 3 + 1];
+         pdest[i * 4 + 2] = psrc[i * 3 + 0];
+         pdest[i * 4 + 3] = 255u;
+      }
+
+      CHECKD3D(sysTex->UnlockRect(0));
+   }
+   else if ((basetexformat == BaseTexture::RGBA || basetexformat == BaseTexture::SRGBA) && texformat == colorFormat::RGBA8)
+   {
+      D3DLOCKED_RECT locked;
+      CHECKD3D(sysTex->LockRect(0, &locked, nullptr, 0));
+
+      BYTE* const __restrict pdest = (BYTE*)locked.pBits;
+      const BYTE* const __restrict psrc = (BYTE*)(surf->data());
+      for (unsigned int i = 0; i < texwidth * texheight; ++i)
+      {
+         pdest[i * 4 + 0] = psrc[i * 4 + 2];
+         pdest[i * 4 + 1] = psrc[i * 4 + 1];
+         pdest[i * 4 + 2] = psrc[i * 4 + 0];
+         pdest[i * 4 + 3] = psrc[i * 4 + 3];
+      }
+
+      CHECKD3D(sysTex->UnlockRect(0));
+      /* IDirect3DSurface9* sysSurf;
+      CHECKD3D(sysTex->GetSurfaceLevel(0, &sysSurf));
+      RECT sysRect;
+      sysRect.top = 0;
+      sysRect.left = 0;
+      sysRect.right = texwidth;
+      sysRect.bottom = texheight;
+      CHECKD3D(D3DXLoadSurfaceFromMemory(sysSurf, nullptr, nullptr, surf->data(), (D3DFORMAT)colorFormat::RGBA8, surf->pitch(), nullptr, &sysRect, D3DX_FILTER_NONE, 0));
+      SAFE_RELEASE_NO_RCC(sysSurf);*/
+   }
+
+   if (!(texformat != colorFormat::DXT5 && m_rd->m_autogen_mipmap))
+      // normal maps or float textures are already in linear space!
+      CHECKD3D(D3DXFilterTexture(sysTex, nullptr, D3DX_DEFAULT,
+         (texformat == colorFormat::RGBA16F || texformat == colorFormat::RGBA32F || force_linear_rgb) ? D3DX_FILTER_TRIANGLE : (D3DX_FILTER_TRIANGLE | D3DX_FILTER_SRGB)));
+
+   return sysTex;
+}
+#endif

--- a/Sampler.h
+++ b/Sampler.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "typedefs3D.h"
+class RenderDevice;
+
+enum SamplerFilter
+{
+   SF_NONE, // No mipmapping
+   SF_POINT, // Point sampled (aka nearest mipmap) texture filtering.
+   SF_BILINEAR, // Bilinar texture filtering.
+   SF_TRILINEAR, // Trilinar texture filtering.
+   SF_ANISOTROPIC // Anisotropic texture filtering.
+};
+
+enum SamplerAddressMode
+{
+#ifdef ENABLE_SDL
+   SA_WRAP = GL_REPEAT,
+   SA_CLAMP = GL_CLAMP_TO_EDGE,
+   SA_MIRROR = GL_MIRRORED_REPEAT
+#else
+   SA_WRAP,
+   SA_CLAMP,
+   SA_MIRROR
+#endif
+};
+
+class Sampler
+{
+public:
+   Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb);
+#ifdef ENABLE_SDL
+   Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb);
+   GLuint GetCoreTexture() { return m_texture; }
+#else
+   Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb);
+   IDirect3DTexture9* GetCoreTexture() { return m_texture;  }
+#endif
+   ~Sampler();
+
+   void UpdateTexture(BaseTexture* const surf, const bool force_linear_rgb);
+   bool IsLinear() { return m_isLinear; }
+   bool IsMSAA() { return m_isMSAA; }
+   int GetWidth() { return m_width; }
+   int GetHeight() { return m_height; }
+
+public:
+   bool m_dirty;
+
+private:
+   bool m_ownTexture;
+   RenderDevice* m_rd;
+   int m_width;
+   int m_height;
+   bool m_isLinear;
+   bool m_isMSAA;
+#ifdef ENABLE_SDL
+   GLuint m_texture = 0;
+   GLuint CreateTexture(UINT Width, UINT Height, UINT Levels, colorFormat Format, void* data, int stereo);
+#else
+   IDirect3DTexture9* m_texture;
+   IDirect3DTexture9* CreateSystemTexture(BaseTexture* const surf, const bool force_linear_rgb, colorFormat& texformat);
+#endif
+};

--- a/Shader.h
+++ b/Shader.h
@@ -235,7 +235,7 @@ public:
    }
 
    void SetTexture(const SHADER_UNIFORM_HANDLE texelName, Texture *texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb); //!! clampU/clampV/filter unimplemented
-   void SetTexture(const SHADER_UNIFORM_HANDLE texelName, D3DTexture* texel);
+   void SetTexture(const SHADER_UNIFORM_HANDLE texelName, Sampler *texel);
    void SetTextureNull(const SHADER_UNIFORM_HANDLE texelName);
    void SetMaterial(const Material * const mat);
 

--- a/TextureManager.h
+++ b/TextureManager.h
@@ -2,8 +2,9 @@
 
 #include <inc/robin_hood.h>
 
-#include "Texture.h"
 #include "stdafx.h"
+#include "Texture.h"
+#include "Sampler.h"
 #include "typedefs3D.h"
 
 class RenderDevice;
@@ -20,21 +21,13 @@ public:
       UnloadAll();
    }
 
-   D3DTexture* LoadTexture(BaseTexture* memtex, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);
+   Sampler* LoadTexture(BaseTexture* memtex, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);
    void SetDirty(BaseTexture* memtex);
    void UnloadTexture(BaseTexture* memtex);
    void UnloadAll();
 
 private:
-   struct TexInfo
-   {
-      D3DTexture* d3dtex;
-      int texWidth;
-      int texHeight;
-      bool dirty;
-   };
-
    RenderDevice& m_rd;
-   robin_hood::unordered_map<BaseTexture*, TexInfo> m_map;
-   typedef robin_hood::unordered_map<BaseTexture*, TexInfo>::iterator Iter;
+   robin_hood::unordered_map<BaseTexture*, Sampler*> m_map;
+   typedef robin_hood::unordered_map<BaseTexture*, Sampler*>::iterator Iter;
 };

--- a/VisualPinball.net2015.vcxproj
+++ b/VisualPinball.net2015.vcxproj
@@ -486,6 +486,8 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="ramp.cpp" />
     <ClCompile Include="regutil.cpp" />
     <ClCompile Include="RenderDevice.cpp" />
+    <ClCompile Include="RenderTarget.cpp" />
+    <ClCompile Include="Sampler.cpp" />
     <ClCompile Include="slintf.cpp" />
     <ClCompile Include="spinner.cpp" />
     <ClCompile Include="StackTrace.cpp" />
@@ -902,8 +904,10 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClInclude Include="ramp.h" />
     <ClInclude Include="regutil.h" />
     <ClInclude Include="RenderDevice.h" />
+    <ClInclude Include="RenderTarget.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="rubber.h" />
+    <ClInclude Include="Sampler.h" />
     <ClInclude Include="Shader.h" />
     <ClInclude Include="slintf.h" />
     <ClInclude Include="spinner.h" />

--- a/VisualPinball.net2015.vcxproj.filters
+++ b/VisualPinball.net2015.vcxproj.filters
@@ -292,6 +292,8 @@
     <ClCompile Include="IndexBuffer.cpp" />
     <ClCompile Include="VertexBuffer.cpp" />
     <ClCompile Include="TextureManager.cpp" />
+    <ClCompile Include="RenderTarget.cpp" />
+    <ClCompile Include="Sampler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="vpinball.rc">
@@ -1479,6 +1481,12 @@
       <Filter>headers</Filter>
     </ClInclude>
     <ClInclude Include="TextureManager.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderTarget.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Sampler.h">
       <Filter>headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/VisualPinball.net2017.vcxproj
+++ b/VisualPinball.net2017.vcxproj
@@ -664,6 +664,8 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="ramp.cpp" />
     <ClCompile Include="regutil.cpp" />
     <ClCompile Include="RenderDevice.cpp" />
+    <ClCompile Include="RenderTarget.cpp" />
+    <ClCompile Include="Sampler.cpp" />
     <ClCompile Include="slintf.cpp" />
     <ClCompile Include="spinner.cpp" />
     <ClCompile Include="StackTrace.cpp" />
@@ -1092,8 +1094,10 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClInclude Include="ramp.h" />
     <ClInclude Include="regutil.h" />
     <ClInclude Include="RenderDevice.h" />
+    <ClInclude Include="RenderTarget.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="rubber.h" />
+    <ClInclude Include="Sampler.h" />
     <ClInclude Include="Shader.h" />
     <ClInclude Include="slintf.h" />
     <ClInclude Include="spinner.h" />

--- a/VisualPinball.net2017.vcxproj.filters
+++ b/VisualPinball.net2017.vcxproj.filters
@@ -292,6 +292,8 @@
     <ClCompile Include="IndexBuffer.cpp" />
     <ClCompile Include="VertexBuffer.cpp" />
     <ClCompile Include="TextureManager.cpp" />
+    <ClCompile Include="RenderTarget.cpp" />
+    <ClCompile Include="Sampler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="vpinball.rc">
@@ -1476,6 +1478,12 @@
       <Filter>headers</Filter>
     </ClInclude>
     <ClInclude Include="TextureManager.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderTarget.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Sampler.h">
       <Filter>headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/VisualPinball.net2019.vcxproj
+++ b/VisualPinball.net2019.vcxproj
@@ -434,6 +434,7 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="IndexBuffer.cpp" />
     <ClCompile Include="math\math.cpp" />
     <ClCompile Include="MemoryStatus.cpp" />
+    <ClCompile Include="RenderTarget.cpp" />
     <ClCompile Include="rubber.cpp" />
     <ClCompile Include="hash.cpp" />
     <ClCompile Include="kdtree.cpp" />
@@ -485,6 +486,7 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="ramp.cpp" />
     <ClCompile Include="regutil.cpp" />
     <ClCompile Include="RenderDevice.cpp" />
+    <ClCompile Include="Sampler.cpp" />
     <ClCompile Include="slintf.cpp" />
     <ClCompile Include="spinner.cpp" />
     <ClCompile Include="StackTrace.cpp" />
@@ -901,8 +903,10 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClInclude Include="ramp.h" />
     <ClInclude Include="regutil.h" />
     <ClInclude Include="RenderDevice.h" />
+    <ClInclude Include="RenderTarget.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="rubber.h" />
+    <ClInclude Include="Sampler.h" />
     <ClInclude Include="Shader.h" />
     <ClInclude Include="slintf.h" />
     <ClInclude Include="spinner.h" />

--- a/VisualPinball.net2019.vcxproj.filters
+++ b/VisualPinball.net2019.vcxproj.filters
@@ -292,6 +292,8 @@
     <ClCompile Include="IndexBuffer.cpp" />
     <ClCompile Include="VertexBuffer.cpp" />
     <ClCompile Include="TextureManager.cpp" />
+    <ClCompile Include="RenderTarget.cpp" />
+    <ClCompile Include="Sampler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="vpinball.rc">
@@ -1481,6 +1483,8 @@
     <ClInclude Include="TextureManager.h">
       <Filter>headers</Filter>
     </ClInclude>
+    <ClInclude Include="RenderTarget.h" />
+    <ClInclude Include="Sampler.h" />
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="shader\BallShader.hlsl">

--- a/cmake/CMakeLists_win-x64.txt
+++ b/cmake/CMakeLists_win-x64.txt
@@ -449,8 +449,12 @@ add_executable(vpinball WIN32
    regutil.h
    RenderDevice.cpp
    RenderDevice.h
+   RenderTarget.cpp
+   RenderTarget.h
    resource.h
    rubber.h
+   Sampler.cpp
+   Sampler.h
    Shader.h
    slintf.cpp
    slintf.h

--- a/cmake/CMakeLists_win-x86.txt
+++ b/cmake/CMakeLists_win-x86.txt
@@ -450,8 +450,12 @@ add_executable(vpinball WIN32
    regutil.h
    RenderDevice.cpp
    RenderDevice.h
+   RenderTarget.cpp
+   RenderTarget.h
    resource.h
    rubber.h
+   Sampler.cpp
+   Sampler.h
    Shader.h
    slintf.cpp
    slintf.h

--- a/pin/player.h
+++ b/pin/player.h
@@ -334,7 +334,7 @@ public:
    void DMDdraw(const float DMDposx, const float DMDposy, const float DMDwidth, const float DMDheight, const COLORREF DMDcolor, const float intensity);
 #endif
    void Spritedraw(const float posx, const float posy, const float width, const float height, const COLORREF color, Texture* const tex, const float intensity, const bool backdrop=false);
-   void Spritedraw(const float posx, const float posy, const float width, const float height, const COLORREF color, D3DTexture* const tex, const float intensity, const bool backdrop=false);
+   void Spritedraw(const float posx, const float posy, const float width, const float height, const COLORREF color, Sampler* const tex, const float intensity, const bool backdrop=false);
 
 #ifdef ENABLE_SDL
    SDL_Window  *m_sdl_playfieldHwnd;

--- a/pin3d.h
+++ b/pin3d.h
@@ -60,22 +60,6 @@ public:
 
    void Flip(const bool vsync);
 
-#ifdef ENABLE_SDL
-   void SetRenderTarget(RenderDevice * const pd3dDevice, RenderTarget* pddsSurface, void* unused) const;
-   void SetPrimaryRenderTarget(RenderTarget* pddsSurface, void* unused) const;
-   void SetSecondaryRenderTarget(RenderTarget* pddsSurface, void* unused) const;
-#else
-   void SetRenderTarget(RenderDevice * const pd3dDevice, RenderTarget* pddsSurface, RenderTarget* pddsZ) const;
-   void SetRenderTarget(RenderDevice * const pd3dDevice, RenderTarget* pddsSurface, D3DTexture* pddsZ) const;
-   void SetRenderTarget(RenderDevice * const pd3dDevice, RenderTarget* pddsSurface, void* pddsZ) const;
-   void SetPrimaryRenderTarget(RenderTarget* pddsSurface, RenderTarget* pddsZ) const;
-   void SetPrimaryRenderTarget(RenderTarget* pddsSurface, D3DTexture* pddsZ) const;
-   void SetPrimaryRenderTarget(RenderTarget* pddsSurface, void* pddsZ) const;
-   void SetSecondaryRenderTarget(RenderTarget* pddsSurface, RenderTarget* pddsZ) const;
-   void SetSecondaryRenderTarget(RenderTarget* pddsSurface, void* pddsZ) const;
-   void SetSecondaryRenderTarget(RenderTarget* pddsSurface, D3DTexture* pddsZ) const;
-#endif
-
    void SetTextureFilter(RenderDevice * const pd3dDevice, const int TextureNum, const int Mode) const;
    void SetPrimaryTextureFilter(const int TextureNum, const int Mode) const;
    void SetSecondaryTextureFilter(const int TextureNum, const int Mode) const;
@@ -104,19 +88,13 @@ public:
 
    RenderDevice* m_pd3dPrimaryDevice;
    RenderDevice* m_pd3dSecondaryDevice;
+
+   RenderTarget* m_pddsAOBackBuffer;
+   RenderTarget* m_pddsAOBackTmpBuffer;
+
    RenderTarget* m_pddsBackBuffer;
 
-   D3DTexture* m_pddsAOBackBuffer;
-   D3DTexture* m_pddsAOBackTmpBuffer;
-
-   D3DTexture* m_pdds3DZBuffer;
-
-   void* m_pddsZBuffer; // D3DTexture* or RenderTarget*, depending on HW support
-
-#ifndef ENABLE_SDL
    RenderTarget* m_pddsStatic;
-   void* m_pddsStaticZ; // D3DTexture* or RenderTarget*, depending on HW support
-#endif
 
    Texture m_pinballEnvTexture; // loaded from Resources
    Texture m_builtinEnvTexture; // loaded from Resources

--- a/typedefs3D.h
+++ b/typedefs3D.h
@@ -68,17 +68,6 @@ enum textureUsage {
    DYNAMIC = 1
 };
 
-struct RenderTarget {
-   colorFormat format;
-   textureUsage usage;
-   GLuint texture = 0, zTexture = 0, framebuffer = 0, zBuffer = 0;
-   GLuint width = 0, height = 0;
-   //GLint slot = -1;//Current slot for caching
-   int stereo = 0;
-};
-
-typedef RenderTarget D3DTexture;//It's easier to have them equal than saving 8 bytes and have a lot of trouble.
-
 struct ViewPort  {
    union {
       struct {
@@ -120,9 +109,7 @@ enum clearType {
 #else
 
 typedef LPD3DXFONT FontHandle;
-typedef IDirect3DTexture9 D3DTexture;
 typedef D3DVIEWPORT9 ViewPort;
-typedef IDirect3DSurface9 RenderTarget;
 typedef D3DVERTEXELEMENT9 VertexElement;
 typedef IDirect3DVertexDeclaration9 VertexDeclaration;
 


### PR DESCRIPTION
This PR is a consequence of the work made on VPX/VPVR to have the 2 codebases converge. While working on it, it appeared that all the sampler and render target management code was spread along the codebases, with mixed in between these 2 different concepts. Therefore, I performed a full review and reimplemented this:
- by creating a Sampler class that hosts all the sampler methods (texture creation, update,...)
- by creating a Render Target class that hosts all the render target methods, especially display framebuffer, color render target management, color/depth buffer management and if needed copies to get readback access to depth buffer.
- adding clean access to render target buffers as samplers (they are exposed as a color / depth sampler)
- updating the code that depends on it.

This leads up to a quite extensive cleanup. Especially, since I did not kept the multiple unused methods for mixed in copies between DX9 surface/texture (they are fairly basic, and it seemed cleaner to keep them in the git history instead of the code as commented out/deprecated unused code).

Beside, I also made a full review of the depth buffer copies since there was a useless depth buffer copy (source and target being the same buffer) and checked it using the normal or alternative (NVidia API) depth buffer.

I did make quite a lot of tests on this (static AO, dynamic AO, different antialiasing, normal/alternative depth buffer,...) and did not find any issue, but, as always, since the change is quite large, I may have missed something.

This PR does not fix anything (beside the useless copy) or add any feature, but I think it is worth merging since it results in a cleaner/easier to maintain codebase, and helps to move VPVR and VPX toward a common ground.