### PR TITLE
Fix Missing ownTexture initialized leading to DX resource leak

### DIFF
--- a/Sampler.cpp
+++ b/Sampler.cpp
@@ -5,9 +5,11 @@
 Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb)
 {
    m_rd = rd;
+   m_dirty = false;
+   m_isMSAA = false;
+   m_ownTexture = true;
    m_width = surf->width();
    m_height = surf->height();
-   m_dirty = false;
 #ifdef ENABLE_SDL
    colorFormat format;
    if (surf->m_format == BaseTexture::SRGBA)
@@ -62,27 +64,29 @@ Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_lin
 Sampler::Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb)
 {
    m_rd = rd;
+   m_dirty = false;
+   m_isMSAA = isMSAA;
    m_ownTexture = ownTexture;
    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &m_width);
    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &m_height);
    int internal_format;
    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
    m_isLinear = !((internal_format == SRGB) && (internal_format == SRGBA) && (internal_format == SDXT5) && (internal_format == SBC7)) || force_linear_rgb;
-   m_isMSAA = isMSAA;
    m_texture = glTexture;
 }
 #else
 Sampler::Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb)
 {
    m_rd = rd;
+   m_dirty = false;
+   m_isMSAA = false;
+   m_ownTexture = ownTexture;
    D3DSURFACE_DESC desc;
    dx9Texture->GetLevelDesc(0, &desc);
-   m_ownTexture = ownTexture;
-   m_texture = dx9Texture;
    m_width = desc.Width;
    m_height = desc.Height;
-   m_dirty = false;
    m_isLinear = desc.Format == D3DFMT_A16B16G16R16F || desc.Format == D3DFMT_A32B32G32R32F || force_linear_rgb;
+   m_texture = dx9Texture;
 }
 #endif
 


### PR DESCRIPTION
Hopefully fix https://github.com/vpinball/vpinball/issues/73

I could not reproduce the leak described in https://github.com/vpinball/vpinball/issues/73 (the refcount on my side is ok) so I made a review of the code and it appears I had forgotten the field that tells if a Sampler must be released or not. I think this is likely the cause of the bug depending on how the memory is initialized, since on my computer it is 0x0c0c0c0c so considered as true, but if uninitialized memory is 0x00000000 it will be considered as false and the Sampler won't get released leading to resource leak.

Anyway, this field must be initialized so this fix should be merged (I have also reorganized the initialization order in the 3 constructors to be the same for better readability).