### PR TITLE
Fix wrong stereo mode constants

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -616,7 +616,7 @@ typedef HRESULT(STDAPICALLTYPE *pDEC)(UINT uCompositionAction);
 static pDEC mDwmEnableComposition = nullptr;
 #endif
 
-RenderDevice::RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, int VSync, const bool useAA, const bool stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl, const bool useNvidiaApi, const bool disable_dwm, const int BWrendering)
+RenderDevice::RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl, const bool useNvidiaApi, const bool disable_dwm, const int BWrendering)
     : m_windowHwnd(hwnd), m_width(width), m_height(height), m_fullscreen(fullscreen), 
       m_colorDepth(colordepth), m_vsync(VSync), m_useAA(useAA), m_stereo3D(stereo3D),
       m_ssRefl(ss_refl), m_disableDwm(disable_dwm), m_sharpen(sharpen), m_FXAA(FXAA), m_BWrendering(BWrendering), m_texMan(*this)
@@ -917,7 +917,7 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
    m_pBloomTmpBufferTexture = new RenderTarget(this, m_width / 4, m_height / 4, render_format, false, false, m_stereo3D, "Fatal Error: unable to create blur buffer!");
 
    // alloc temporary buffer for stereo3D/post-processing AA/sharpen
-   if ((m_stereo3D) || (m_FXAA > 0) || m_sharpen)
+   if ((m_stereo3D != STEREO_OFF) || (m_FXAA > 0) || m_sharpen)
       m_pOffscreenBackBufferTmpTexture = new RenderTarget(this, m_width, m_height, video10bit ? colorFormat::RGBA10 : colorFormat::RGBA8, false, false, m_stereo3D,
          "Fatal Error: unable to create stereo3D/post-processing AA/sharpen buffer!");
    else

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -84,6 +84,8 @@ enum UsageFlags {
 #endif
 };
 
+enum StereoMode;
+
 class Shader;
 
 class RenderDevice
@@ -245,7 +247,7 @@ public:
 #endif
 
 
-   RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, int VSync, const bool useAA, const bool stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl, const bool useNvidiaApi, const bool disable_dwm, const int BWrendering);
+   RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl, const bool useNvidiaApi, const bool disable_dwm, const int BWrendering);
    ~RenderDevice();
    void CreateDevice(int &refreshrate, UINT adapterIndex = D3DADAPTER_DEFAULT);
    bool LoadShaders();
@@ -363,7 +365,7 @@ public:
    int          m_colorDepth;
    int          m_vsync;
    bool         m_useAA;
-   bool         m_stereo3D;
+   StereoMode   m_stereo3D;
    bool         m_ssRefl;
    bool         m_disableDwm;
    bool         m_sharpen;

--- a/pin/player.h
+++ b/pin/player.h
@@ -420,7 +420,7 @@ public:
 
    bool m_stereo3Denabled;
    bool m_stereo3DY;
-   int m_stereo3D; // 0=off, 1=top/down, 2=interlaced/LG, 3=interlaced/LG (flipped), 4=sidebyside, else anaglyph: 5=Red/Cyan, 6=Green/Magenta, 7=Dubois Red/Cyan, 8=Dubois Green/Magenta, 9=Deghosted Red/Cyan, 10=Deghosted Green/Magenta, 11=Blue/Amber
+   StereoMode m_stereo3D;
    float m_global3DContrast;
    float m_global3DDesaturation;
 

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -443,7 +443,7 @@ BaseTexture* EnvmapPrecalc(const Texture* envTex, const unsigned int rad_env_xre
    return radTex;
 }
 
-HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const bool stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl)
+HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl)
 {
    const int display = g_pvp->m_primaryDisplay ? 0 : LoadValueIntWithDefault("Player", "Display", 0);
    std::vector<DisplayConfig> displays;
@@ -496,7 +496,7 @@ HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int &ref
    return S_OK;
 }
 
-HRESULT Pin3D::InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const bool stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl)
+HRESULT Pin3D::InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl)
 {
    // set the viewport for the newly created device
    m_viewPort.X = 0;

--- a/pin3d.h
+++ b/pin3d.h
@@ -15,6 +15,30 @@ enum TextureFilter
    TEXTURE_MODE_ANISOTROPIC		// Anisotropic texture filtering. 
 };
 
+enum StereoMode
+{
+   STEREO_OFF = 0, // Disabled
+   STEREO_TB = 1, // TB (Top / Bottom)
+   STEREO_INT = 2, // Interlaced (e.g. LG TVs)
+   STEREO_FLIPPED_INT = 3, // Flipped Interlaced (e.g. LG TVs)
+   STEREO_SBS = 4, // SBS (Side by Side)
+   STEREO_ANAGLYPH_RC = 5, // Anaglyph Red/Cyan
+   STEREO_ANAGLYPH_GM = 6, // Anaglyph Green/Magenta
+   STEREO_ANAGLYPH_DUBOIS_RC = 7, // Anaglyph Dubois Red/Cyan
+   STEREO_ANAGLYPH_DUBOIS_GM = 8, // Anaglyph Dubois Green/Magenta
+   STEREO_ANAGLYPH_DEGHOSTED_RC = 9, // Anaglyph Deghosted Red/Cyan
+   STEREO_ANAGLYPH_DEGHOSTED_GM = 10, // Anaglyph Deghosted Green/Magenta
+   STEREO_ANAGLYPH_BA = 11, // Anaglyph Blue/Amber
+   STEREO_ANAGLYPH_CR = 12, // Anaglyph Cyan/Red
+   STEREO_ANAGLYPH_MR, // Anaglyph Magenta/Green
+   STEREO_ANAGLYPH_DUBOIS_CR = 14, // Anaglyph Dubois Cyan/Red
+   STEREO_ANAGLYPH_DUBOIS_MG = 15, // Anaglyph Dubois Magenta/Green
+   STEREO_ANAGLYPH_DEGHOSTED_CR = 16, // Anaglyph Deghosted Cyan/Red
+   STEREO_ANAGLYPH_DEGHOSTED_MG = 17, // Anaglyph Deghosted Magenta/Green
+   STEREO_ANAGLYPH_AB = 18, // Anaglyph Amber/Blue
+   STEREO_VR = 19, // Hardware VR set (not supported by DX9)
+};
+
 class PinProjection
 {
 public:
@@ -48,7 +72,7 @@ public:
    Pin3D();
    ~Pin3D();
 
-   HRESULT InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const bool stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
+   HRESULT InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
 
    void InitLayoutFS();
    void InitLayout(const bool FSS_mode, const float xpixoff = 0.f, const float ypixoff = 0.f);
@@ -80,7 +104,7 @@ private:
    void InitRenderState(RenderDevice * const pd3dDevice);
    void InitPrimaryRenderState();
    void InitSecondaryRenderState();
-   HRESULT InitPrimary(const bool fullScreen, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const bool stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
+   HRESULT InitPrimary(const bool fullScreen, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
 
    // Data members
 public:

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -1116,7 +1116,7 @@ STDMETHODIMP ScriptGlobalTable::GetSerialDevices(VARIANT *pVal)
 
 STDMETHODIMP ScriptGlobalTable::get_RenderingMode(int *pVal)
 {
-   *pVal = ((g_pplayer->m_stereo3D != 0) && g_pplayer->m_stereo3Denabled) ? 1 : 0; // 0 = Normal 2D, 1 = Stereo 3D, 2 = VR
+   *pVal = ((g_pplayer->m_stereo3D != STEREO_OFF) && g_pplayer->m_stereo3Denabled) ? 1 : 0; // 0 = Normal 2D, 1 = Stereo 3D, 2 = VR
    return S_OK;
 }
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -98,12 +98,6 @@
 
 //VR Support
 
-#define STEREO_OFF 0
-#define STEREO_TB  1
-#define STEREO_INT 2
-#define STEREO_SBS 3
-#define STEREO_VR  4
-
 #ifdef ENABLE_SDL
 //No VR support with DX9 possible, only with DX11 and OpenGL
 #define ENABLE_VR


### PR DESCRIPTION
This PR replace the various bool/int stereo variable by a shared enum. 

The reason is that right now the values are defined in multiple places leading to errors:
- in stdafx but they are wrong (they were not updated after anaglyph feature inclusion). Only VPVR uses them (and therefore has a bug on that),
- directly in the code for player.cpp in StereoFXAA as int values,
- as literal in comments.

This PR is not strictly needed, but I think it should be harmless to merge and helps cleaning up and bringing VPVR and VPX together.