### PR TITLE
Fix Z artefacts in camera mode

### DIFF
--- a/CrashHandler.cpp
+++ b/CrashHandler.cpp
@@ -121,7 +121,11 @@ namespace
 
    void WriteHeader(FILE* f)
    {
+#ifdef ENABLE_SDL
+      fprintf(f, "Crash report VPX GL rev%i (%s)\n============\n", GIT_REVISION, GIT_SHA);
+#else
       fprintf(f, "Crash report VPX rev%i (%s)\n============\n", GIT_REVISION, GIT_SHA);
+#endif
    }
 
    const char* GetExceptionString(DWORD exc)

--- a/VertexBuffer.cpp
+++ b/VertexBuffer.cpp
@@ -154,8 +154,7 @@ void VertexBuffer::UploadData()
       glBindBuffer(GL_ARRAY_BUFFER, Buffer);
    if (size - offsetToLock > 0)
       glBufferSubData(GL_ARRAY_BUFFER, offset * fvfToSize(fvf) + offsetToLock, min(sizeToLock, size - offsetToLock), dataBuffer);
-   glBindBuffer(GL_ARRAY_BUFFER, 0);
-   glBindVertexArray(0);
+   m_curVertexBuffer = this;
    isUploaded = true;
    free(dataBuffer);
    dataBuffer = nullptr;
@@ -211,10 +210,10 @@ void VertexBuffer::UploadBuffers()
       glBindVertexArray(ArrayT);
       glBufferData(GL_ARRAY_BUFFER, countT * fvfToSize(MY_D3DFVF_TEX), nullptr, GL_STATIC_DRAW);
    }
+   glBindBuffer(GL_ARRAY_BUFFER, 0);
+   m_curVertexBuffer = nullptr;
    for (auto it = notUploadedBuffers.begin(); it != notUploadedBuffers.end(); ++it)
       (*it)->UploadData();
-   glBindBuffer(GL_ARRAY_BUFFER, 0);
-   glBindVertexArray(0);
    notUploadedBuffers.clear();
 }
 #endif

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -228,7 +228,7 @@ Player::Player(const bool cameraMode, PinTable * const ptable) : m_cameraMode(ca
                m_decalImage = new Texture(tex);
        }
    }
-   
+
    m_throwBalls = LoadValueBoolWithDefault(regKey[RegName::Editor], "ThrowBallsAlwaysOn"s, false);
    m_ballControl = LoadValueBoolWithDefault(regKey[RegName::Editor], "BallControlAlwaysOn"s, false);
    m_debugBallSize = LoadValueIntWithDefault(regKey[RegName::Editor], "ThrowBallSize"s, 50);
@@ -4837,7 +4837,6 @@ void Player::UpdateCameraModeDisplay()
    }
    }
    DebugPrint(0, 150, szFoo);
-   m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS);
    sprintf_s(szFoo, sizeof(szFoo), "Camera at X: %.2f Y: %.2f Z: %.2f,  Rotation: %.2f", -m_pin3d.m_proj.m_matView._41, (m_ptable->m_BG_current_set == 0 || m_ptable->m_BG_current_set == 2) ? m_pin3d.m_proj.m_matView._42 : -m_pin3d.m_proj.m_matView._42, m_pin3d.m_proj.m_matView._43, g_pplayer->m_ptable->m_BG_rotation[g_pplayer->m_ptable->m_BG_current_set]); // DT & FSS
    DebugPrint(0, 130, szFoo);
    DebugPrint(0, 190, "Navigate around with the Arrow Keys and Left Alt Key (if enabled in the Key settings)");
@@ -4923,6 +4922,12 @@ void Player::Render()
 
    if (ProfilingMode() == 1)
       m_pin3d.m_gpu_profiler.BeginFrame(m_pin3d.m_pd3dPrimaryDevice->GetCoreDevice());
+
+   // Update camera point of view
+   if (m_cameraMode)
+   {
+      m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS);
+   }
 
    if (!RenderStaticOnly())
    {

--- a/pin/player.h
+++ b/pin/player.h
@@ -339,9 +339,8 @@ public:
 #ifdef ENABLE_SDL
    SDL_Window  *m_sdl_playfieldHwnd;
    SDL_Window  *m_sdl_backdropHwnd;
-#else
-   Shader      *m_ballShader;
 #endif
+   Shader      *m_ballShader;
 
    IndexBuffer *m_ballIndexBuffer;
    VertexBuffer *m_ballVertexBuffer;

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1309,9 +1309,9 @@ void PinProjection::ComputeNearFarPlane(const vector<Vertex3Ds>& verts)
    slintf("m_rznear: %f\n", m_rznear);
    slintf("m_rzfar : %f\n", m_rzfar);
 
-   // beware the div-0 problem
-   if (m_rznear < 0.001f)
-      m_rznear = 0.001f;
+   // beware the div-0 problem, also avoid near plane below 1 which result in loss of precision and z rendering artefacts
+   if (m_rznear < 1.0f)
+      m_rznear = 1.0f;
    //m_rznear *= 0.89f; //!! magic, influences also stereo3D code
    m_rzfar *= 1.01f;
 }


### PR DESCRIPTION
In camera mode, if you go too near the objects, the rendering will turn wrong. This is because enar plane is allowed to drop below 1 leading to z buffer imprecision problems.

Beside this fix, 2 small cleanups commits are included:
- in camera mode, the camera matrix update was done in the debug code, I propose to move it in the render method (where VR matrix update or BAM update is called in VPVR)
- a very minimal commit to limit the code diff between the codebase without any impact

This PR was tested (desktop mode, with a few tables) and should be safe to merge