### PR TITLE
VPX <-> VPVR sync

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1630,6 +1630,26 @@ void RenderDevice::SetTextureAddressMode(const DWORD texUnit, const TextureAddre
    SetSamplerState(texUnit, D3DSAMP_ADDRESSV, mode);
 }
 
+void RenderDevice::CreateVertexDeclaration(const VertexElement * const element, VertexDeclaration ** declaration)
+{
+#ifndef ENABLE_SDL
+   CHECKD3D(m_pD3DDevice->CreateVertexDeclaration(element, declaration));
+#endif
+}
+
+void RenderDevice::SetVertexDeclaration(VertexDeclaration * declaration)
+{
+#ifndef ENABLE_SDL
+   if (declaration != currentDeclaration)
+   {
+      CHECKD3D(m_pD3DDevice->SetVertexDeclaration(declaration));
+      currentDeclaration = declaration;
+
+      m_curStateChanges++;
+   }
+#endif
+}
+
 void RenderDevice::DrawPrimitive(const PrimitiveTypes type, const DWORD fvf, const void* vertices, const DWORD vertexCount)
 {
 #ifndef ENABLE_SDL

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1771,238 +1771,41 @@ void RenderDevice::GetTransform(const TransformStateType p1, D3DMATRIX* p2)
 
 void RenderDevice::Clear(const DWORD flags, const D3DCOLOR color, const D3DVALUE z, const DWORD stencil)
 {
+#ifdef ENABLE_SDL
+   static float clear_r=0.f, clear_g = 0.f, clear_b = 0.f, clear_a = 0.f, clear_z=1.f;//Default OpenGL Values
+   static GLint clear_s=0;
+
+   if (clear_s != stencil) { clear_s = stencil;  glClearStencil(stencil); }
+   if (clear_z != z) { clear_z = z;  glClearDepthf(z); }
+   const float r = (float)( color & 0xff) / 255.0f;
+   const float g = (float)((color & 0xff00) >> 8) / 255.0f;
+   const float b = (float)((color & 0xff0000) >> 16) / 255.0f;
+   const float a = (float)((color & 0xff000000) >> 24) / 255.0f;
+   if ((r != clear_r) || (g != clear_g) || (b != clear_b) || (a != clear_a)) { clear_z = z;  glClearColor(r,g,b,a); }
+   glClear(flags);
+#else
    CHECKD3D(m_pD3DDevice->Clear(0, nullptr, flags, color, z, stencil));
+#endif
 }
+
+#ifdef ENABLE_SDL
+static ViewPort viewPort;
+#endif
 
 void RenderDevice::SetViewport(const ViewPort* p1)
 {
+#ifdef ENABLE_SDL
+   memcpy(&viewPort, p1, sizeof(ViewPort));
+#else
    CHECKD3D(m_pD3DDevice->SetViewport((D3DVIEWPORT9*)p1));
+#endif
 }
 
 void RenderDevice::GetViewport(ViewPort* p1)
 {
+#ifdef ENABLE_SDL
+   memcpy(p1, &viewPort, sizeof(ViewPort));
+#else
    CHECKD3D(m_pD3DDevice->GetViewport((D3DVIEWPORT9*)p1));
-}
-
-//
-//
-//
-
-Shader::Shader(RenderDevice *renderDevice) : currentMaterial(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX,
-                                                             0xCCCCCCCC, 0xCCCCCCCC, 0xCCCCCCCC, false, false, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX)
-{
-   m_renderDevice = renderDevice;
-   m_shader = nullptr;
-   for (unsigned int i = 0; i < TEXTURESET_STATE_CACHE_SIZE; ++i)
-      currentTexture[i] = nullptr;
-   currentAlphaTestValue = -FLT_MAX;
-   currentDisableLighting =
-   currentFlasherData =
-   currentFlasherData2 =
-   currentFlasherColor =
-   currentLightColor =
-   currentLightColor2 =
-   currentLightData = vec4(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX);
-   currentLightImageMode = ~0u;
-   currentLightBackglassMode = ~0u;
-   currentTechnique[0] = '\0';
-}
-
-Shader::~Shader()
-{
-   if (m_shader)
-   {
-      this->Unload();
-   }
-}
-
-// loads an HLSL effect file
-// if fromFile is true the shaderName should point to the full filename (with path) to the .fx file
-// if fromFile is false the shaderName should be the resource name not the IDC_XX_YY value. Search vpinball_eng.rc for ".fx" to see an example
-bool Shader::Load(const BYTE* shaderCodeName, UINT codeSize)
-{
-   LPD3DXBUFFER pBufferErrors;
-   constexpr DWORD dwShaderFlags = 0; //D3DXSHADER_SKIPVALIDATION // these do not have a measurable effect so far (also if used in the offline fxc step): D3DXSHADER_PARTIALPRECISION, D3DXSHADER_PREFER_FLOW_CONTROL/D3DXSHADER_AVOID_FLOW_CONTROL
-   HRESULT hr;
-   /*
-       if(fromFile)
-       {
-       dwShaderFlags = D3DXSHADER_DEBUG|D3DXSHADER_SKIPOPTIMIZATION;
-       hr = D3DXCreateEffectFromFile(m_renderDevice->GetCoreDevice(),		// pDevice
-       shaderName,			// pSrcFile
-       nullptr,				// pDefines
-       nullptr,				// pInclude
-       dwShaderFlags,		// Flags
-       nullptr,				// pPool
-       &m_shader,			// ppEffect
-       &pBufferErrors);		// ppCompilationErrors
-       }
-       else
-       {
-       hr = D3DXCreateEffectFromResource(m_renderDevice->GetCoreDevice(),		// pDevice
-       nullptr,
-       shaderName,			// resource name
-       nullptr,				// pDefines
-       nullptr,				// pInclude
-       dwShaderFlags,		// Flags
-       nullptr,				// pPool
-       &m_shader,			// ppEffect
-       &pBufferErrors);		// ppCompilationErrors
-
-       }
-       */
-   hr = D3DXCreateEffect(m_renderDevice->GetCoreDevice(), shaderCodeName, codeSize, nullptr, nullptr, dwShaderFlags, nullptr, &m_shader, &pBufferErrors);
-   if (FAILED(hr))
-   {
-      if (pBufferErrors)
-      {
-         const LPVOID pCompileErrors = pBufferErrors->GetBufferPointer();
-         g_pvp->MessageBox((const char*)pCompileErrors, "Compile Error", MB_OK | MB_ICONEXCLAMATION);
-      }
-      else
-         g_pvp->MessageBox("Unknown Error", "Compile Error", MB_OK | MB_ICONEXCLAMATION);
-
-      return false;
-   }
-   return true;
-}
-
-void Shader::Unload()
-{
-   SAFE_RELEASE(m_shader);
-}
-
-void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, Texture* texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb)
-{
-   const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
-   assert(idx < TEXTURESET_STATE_CACHE_SIZE);
-
-   if (!texel || !texel->m_pdsBuffer) {
-      currentTexture[idx] = nullptr; // invalidate the cache
-
-      CHECKD3D(m_shader->SetTexture(texelName, nullptr));
-
-      m_renderDevice->m_curTextureChanges++;
-
-      return;
-   }
-
-   if (texel->m_pdsBuffer != currentTexture[idx])
-   {
-      currentTexture[idx] = texel->m_pdsBuffer;
-      CHECKD3D(m_shader->SetTexture(texelName, m_renderDevice->m_texMan.LoadTexture(texel->m_pdsBuffer, filter, clampU, clampV, force_linear_rgb)->GetCoreTexture()));
-
-      m_renderDevice->m_curTextureChanges++;
-   }
-}
-
-void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, Sampler* texel)
-{
-   const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
-   assert(idx < TEXTURESET_STATE_CACHE_SIZE);
-
-   currentTexture[idx] = nullptr; // direct set of device tex invalidates the cache
-
-   CHECKD3D(m_shader->SetTexture(texelName, texel->GetCoreTexture()));
-
-   m_renderDevice->m_curTextureChanges++;
-}
-
-void Shader::SetTextureNull(const SHADER_UNIFORM_HANDLE texelName)
-{
-   const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
-   const bool cache = (idx < TEXTURESET_STATE_CACHE_SIZE);
-
-   if (cache)
-      currentTexture[idx] = nullptr; // direct set of device tex invalidates the cache
-
-   CHECKD3D(m_shader->SetTexture(texelName, nullptr));
-
-   m_renderDevice->m_curTextureChanges++;
-}
-
-void Shader::SetMaterial(const Material * const mat)
-{
-   COLORREF cBase, cGlossy, cClearcoat;
-   float fWrapLighting, fRoughness, fGlossyImageLerp, fThickness, fEdge, fEdgeAlpha, fOpacity;
-   bool bIsMetal, bOpacityActive;
-
-   if (mat)
-   {
-      fWrapLighting = mat->m_fWrapLighting;
-      fRoughness = exp2f(10.0f * mat->m_fRoughness + 1.0f); // map from 0..1 to 2..2048
-      fGlossyImageLerp = mat->m_fGlossyImageLerp;
-      fThickness = mat->m_fThickness;
-      fEdge = mat->m_fEdge;
-      fEdgeAlpha = mat->m_fEdgeAlpha;
-      fOpacity = mat->m_fOpacity;
-      cBase = mat->m_cBase;
-      cGlossy = mat->m_cGlossy;
-      cClearcoat = mat->m_cClearcoat;
-      bIsMetal = mat->m_bIsMetal;
-      bOpacityActive = mat->m_bOpacityActive;
-   }
-   else
-   {
-      fWrapLighting = 0.0f;
-      fRoughness = exp2f(10.0f * 0.0f + 1.0f); // map from 0..1 to 2..2048
-      fGlossyImageLerp = 1.0f;
-      fThickness = 0.05f;
-      fEdge = 1.0f;
-      fEdgeAlpha = 1.0f;
-      fOpacity = 1.0f;
-      cBase = g_pvp->m_dummyMaterial.m_cBase;
-      cGlossy = 0;
-      cClearcoat = 0;
-      bIsMetal = false;
-      bOpacityActive = false;
-   }
-
-   // bIsMetal is nowadays handled via a separate technique! (so not in here)
-
-   if (fRoughness != currentMaterial.m_fRoughness ||
-       fEdge != currentMaterial.m_fEdge ||
-       fWrapLighting != currentMaterial.m_fWrapLighting ||
-       fThickness != currentMaterial.m_fThickness)
-   {
-      const vec4 rwem(fRoughness, fWrapLighting, fEdge, fThickness);
-      SetVector(SHADER_Roughness_WrapL_Edge_Thickness, &rwem);
-      currentMaterial.m_fRoughness = fRoughness;
-      currentMaterial.m_fWrapLighting = fWrapLighting;
-      currentMaterial.m_fEdge = fEdge;
-      currentMaterial.m_fThickness = fThickness;
-   }
-
-   const float alpha = bOpacityActive ? fOpacity : 1.0f;
-   if (cBase != currentMaterial.m_cBase || alpha != currentMaterial.m_fOpacity)
-   {
-      const vec4 cBaseF = convertColor(cBase, alpha);
-      SetVector(SHADER_cBase_Alpha, &cBaseF);
-      currentMaterial.m_cBase = cBase;
-      currentMaterial.m_fOpacity = alpha;
-   }
-
-   if (!bIsMetal) // Metal has no glossy
-      if (cGlossy != currentMaterial.m_cGlossy ||
-          fGlossyImageLerp != currentMaterial.m_fGlossyImageLerp)
-      {
-         const vec4 cGlossyF = convertColor(cGlossy, fGlossyImageLerp);
-         SetVector(SHADER_cGlossy_ImageLerp, &cGlossyF);
-         currentMaterial.m_cGlossy = cGlossy;
-         currentMaterial.m_fGlossyImageLerp = fGlossyImageLerp;
-      }
-
-   if (cClearcoat != currentMaterial.m_cClearcoat ||
-      (bOpacityActive && fEdgeAlpha != currentMaterial.m_fEdgeAlpha))
-   {
-      const vec4 cClearcoatF = convertColor(cClearcoat, fEdgeAlpha);
-      SetVector(SHADER_cClearcoat_EdgeAlpha, &cClearcoatF);
-      currentMaterial.m_cClearcoat = cClearcoat;
-      currentMaterial.m_fEdgeAlpha = fEdgeAlpha;
-   }
-
-   if (bOpacityActive /*&& (alpha < 1.0f)*/)
-      g_pplayer->m_pin3d.EnableAlphaBlend(false);
-   else
-      g_pplayer->m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE);
+#endif
 }

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -979,8 +979,14 @@ bool RenderDevice::LoadShaders()
    // Now that shaders are compiled, set static textures for SMAA postprocessing shader
    if (m_FXAA == Quality_SMAA)
    {
+#ifdef ENABLE_SDL
+      FBShader->SetTexture(SHADER_areaTex2D, m_SMAAareaTexture);
+      FBShader->SetTexture(SHADER_searchTex2D, m_SMAAsearchTexture);
+#else
+      // FIXME Shader rely on texture to be named with a leading texture unit. SetTexture will fail otherwise...
       CHECKD3D(FBShader->Core()->SetTexture(SHADER_areaTex2D, m_SMAAareaTexture->GetCoreTexture()));
       CHECKD3D(FBShader->Core()->SetTexture(SHADER_searchTex2D, m_SMAAsearchTexture->GetCoreTexture()));
+#endif
    }
 
    // Initialize uniform to default value
@@ -1025,27 +1031,28 @@ void RenderDevice::FreeShader()
 {
    if (basicShader)
    {
-      CHECKD3D(basicShader->Core()->SetTexture(SHADER_Texture0, nullptr));
-      CHECKD3D(basicShader->Core()->SetTexture(SHADER_Texture1, nullptr));
-      CHECKD3D(basicShader->Core()->SetTexture(SHADER_Texture2, nullptr));
-      CHECKD3D(basicShader->Core()->SetTexture(SHADER_Texture3, nullptr));
-      CHECKD3D(basicShader->Core()->SetTexture(SHADER_Texture4, nullptr));
+      basicShader->SetTextureNull(SHADER_Texture0);
+      basicShader->SetTextureNull(SHADER_Texture1);
+      basicShader->SetTextureNull(SHADER_Texture2);
+      basicShader->SetTextureNull(SHADER_Texture3);
+      basicShader->SetTextureNull(SHADER_Texture4);
       delete basicShader;
       basicShader = 0;
    }
    if (DMDShader)
    {
-      CHECKD3D(DMDShader->Core()->SetTexture(SHADER_Texture0, nullptr));
+      DMDShader->SetTextureNull(SHADER_Texture0);
       delete DMDShader;
       DMDShader = 0;
    }
    if (FBShader)
    {
-      CHECKD3D(FBShader->Core()->SetTexture(SHADER_Texture0, nullptr));
-      CHECKD3D(FBShader->Core()->SetTexture(SHADER_Texture1, nullptr));
-      CHECKD3D(FBShader->Core()->SetTexture(SHADER_Texture3, nullptr));
-      CHECKD3D(FBShader->Core()->SetTexture(SHADER_Texture4, nullptr));
+      FBShader->SetTextureNull(SHADER_Texture0);
+      FBShader->SetTextureNull(SHADER_Texture1);
+      FBShader->SetTextureNull(SHADER_Texture3);
+      FBShader->SetTextureNull(SHADER_Texture4);
 
+      // FIXME Shader rely on texture to be named with a leading texture unit. SetTextureNull will fail otherwise...
       CHECKD3D(FBShader->Core()->SetTexture(SHADER_areaTex2D, nullptr));
       CHECKD3D(FBShader->Core()->SetTexture(SHADER_searchTex2D, nullptr));
 
@@ -1054,8 +1061,8 @@ void RenderDevice::FreeShader()
    }
    if (flasherShader)
    {
-      CHECKD3D(flasherShader->Core()->SetTexture(SHADER_Texture0, nullptr));
-      CHECKD3D(flasherShader->Core()->SetTexture(SHADER_Texture1, nullptr));
+      flasherShader->SetTextureNull(SHADER_Texture0);
+      flasherShader->SetTextureNull(SHADER_Texture1);
       delete flasherShader;
       flasherShader = 0;
    }
@@ -1067,9 +1074,9 @@ void RenderDevice::FreeShader()
 #ifdef SEPARATE_CLASSICLIGHTSHADER
    if (classicLightShader)
    {
-      CHECKD3D(classicLightShader->Core()->SetTexture(SHADER_Texture0, nullptr));
-      CHECKD3D(classicLightShader->Core()->SetTexture(SHADER_Texture1, nullptr));
-      CHECKD3D(classicLightShader->Core()->SetTexture(SHADER_Texture2, nullptr));
+      classicLightShader->SetTextureNull(SHADER_Texture0);
+      classicLightShader->SetTextureNull(SHADER_Texture1);
+      classicLightShader->SetTextureNull(SHADER_Texture2);
       delete classicLightShader;
       classicLightShader=0;
    }

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1749,9 +1749,9 @@ void RenderDevice::GetTransform(const TransformStateType p1, D3DMATRIX* p2)
    CHECKD3D(m_pD3DDevice->GetTransform((D3DTRANSFORMSTATETYPE)p1, p2));
 }
 
-void RenderDevice::Clear(const DWORD numRects, const D3DRECT* rects, const DWORD flags, const D3DCOLOR color, const D3DVALUE z, const DWORD stencil)
+void RenderDevice::Clear(const DWORD flags, const D3DCOLOR color, const D3DVALUE z, const DWORD stencil)
 {
-   CHECKD3D(m_pD3DDevice->Clear(numRects, rects, flags, color, z, stencil));
+   CHECKD3D(m_pD3DDevice->Clear(0, nullptr, flags, color, z, stencil));
 }
 
 void RenderDevice::SetViewport(const ViewPort* p1)

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -264,7 +264,7 @@ public:
    RenderTarget* GetBackBufferTmpTexture() const { return m_pOffscreenBackBufferTmpTexture; } // stereo/FXAA only
    RenderTarget* GetBackBufferTmpTexture2() const { return m_pOffscreenBackBufferTmpTexture2; } // SMAA only
 #ifdef ENABLE_SDL
-   Sampler* GetNonMSAABlitTexture(int m_MSAASamples) const { return m_MSAASamples == 1 ? m_pOffscreenBackBufferTexture->GetColorSampler() : m_pOffscreenNonMSAABlitTexture; }
+   RenderTarget* GetNonMSAABlitTexture(int m_MSAASamples) const { return m_MSAASamples == 1 ? m_pOffscreenBackBufferTexture : m_pOffscreenNonMSAABlitTexture; }
    RenderTarget* GetOffscreenVR(int eye) const { return eye == 0 ? m_pOffscreenVRLeft : m_pOffscreenVRRight; }
 #endif
    RenderTarget* GetMirrorTmpBufferTexture() const { return m_pMirrorTmpBufferTexture; }
@@ -313,6 +313,7 @@ public:
 
    //VR stuff
 #ifdef ENABLE_VR
+   bool IsVRReady() const { return m_pHMD != nullptr; }
    void SetTransformVR();
    void UpdateVRPosition();
    void tableUp();
@@ -337,26 +338,25 @@ public:
 
    void FreeShader();
 
-   void CreateVertexDeclaration(const VertexElement * const element, VertexDeclaration ** declaration)
+   void CreateVertexDeclaration(const VertexElement * const element, VertexDeclaration ** declaration);
+   void SetVertexDeclaration(VertexDeclaration * declaration);
+
+#ifdef ENABLE_SDL
+   void* GetCoreDevice() const
    {
-      CHECKD3D(m_pD3DDevice->CreateVertexDeclaration(element, declaration));
+      return nullptr;
    }
 
-   void SetVertexDeclaration(VertexDeclaration * declaration)
+   int getGLVersion() const
    {
-      if (declaration != currentDeclaration)
-      {
-         CHECKD3D(m_pD3DDevice->SetVertexDeclaration(declaration));
-         currentDeclaration = declaration;
-
-         m_curStateChanges++;
-      }
+      return m_GLversion;
    }
-
+#else
    IDirect3DDevice9* GetCoreDevice() const
    {
       return m_pD3DDevice;
    }
+#endif
 
    HWND         m_windowHwnd;
    int          m_width;

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -255,7 +255,7 @@ public:
    void BeginScene();
    void EndScene();
 
-   void Clear(const DWORD numRects, const D3DRECT* rects, const DWORD flags, const D3DCOLOR color, const D3DVALUE z, const DWORD stencil);
+   void Clear(const DWORD flags, const D3DCOLOR color, const D3DVALUE z, const DWORD stencil);
    void Flip(const bool vsync);
 
    bool SetMaximumPreRenderedFrames(const DWORD frames);

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -488,5 +488,3 @@ public:
    //static VertexDeclaration* m_pVertexNormalTexelTexelDeclaration;
    static VertexDeclaration* m_pVertexTrafoTexelDeclaration;
 };
-
-#include "Shader.h"

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -1,0 +1,217 @@
+#include "stdafx.h"
+#include "Shader.h"
+#include "typedefs3D.h"
+#include "RenderDevice.h"
+
+
+//
+//
+//
+
+Shader::Shader(RenderDevice* renderDevice)
+   : currentMaterial(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, 0xCCCCCCCC, 0xCCCCCCCC, 0xCCCCCCCC, false, false, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX)
+{
+   m_renderDevice = renderDevice;
+   m_shader = nullptr;
+   for (unsigned int i = 0; i < TEXTURESET_STATE_CACHE_SIZE; ++i)
+      currentTexture[i] = nullptr;
+   currentAlphaTestValue = -FLT_MAX;
+   currentDisableLighting = currentFlasherData = currentFlasherData2 = currentFlasherColor = currentLightColor = currentLightColor2 = currentLightData
+      = vec4(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX);
+   currentLightImageMode = ~0u;
+   currentLightBackglassMode = ~0u;
+   currentTechnique[0] = '\0';
+}
+
+Shader::~Shader()
+{
+   if (m_shader)
+   {
+      this->Unload();
+   }
+}
+
+// loads an HLSL effect file
+// if fromFile is true the shaderName should point to the full filename (with path) to the .fx file
+// if fromFile is false the shaderName should be the resource name not the IDC_XX_YY value. Search vpinball_eng.rc for ".fx" to see an example
+bool Shader::Load(const BYTE* shaderCodeName, UINT codeSize)
+{
+   LPD3DXBUFFER pBufferErrors;
+   constexpr DWORD dwShaderFlags
+      = 0; //D3DXSHADER_SKIPVALIDATION // these do not have a measurable effect so far (also if used in the offline fxc step): D3DXSHADER_PARTIALPRECISION, D3DXSHADER_PREFER_FLOW_CONTROL/D3DXSHADER_AVOID_FLOW_CONTROL
+   HRESULT hr;
+   /*
+       if(fromFile)
+       {
+       dwShaderFlags = D3DXSHADER_DEBUG|D3DXSHADER_SKIPOPTIMIZATION;
+       hr = D3DXCreateEffectFromFile(m_renderDevice->GetCoreDevice(),		// pDevice
+       shaderName,			// pSrcFile
+       nullptr,				// pDefines
+       nullptr,				// pInclude
+       dwShaderFlags,		// Flags
+       nullptr,				// pPool
+       &m_shader,			// ppEffect
+       &pBufferErrors);		// ppCompilationErrors
+       }
+       else
+       {
+       hr = D3DXCreateEffectFromResource(m_renderDevice->GetCoreDevice(),		// pDevice
+       nullptr,
+       shaderName,			// resource name
+       nullptr,				// pDefines
+       nullptr,				// pInclude
+       dwShaderFlags,		// Flags
+       nullptr,				// pPool
+       &m_shader,			// ppEffect
+       &pBufferErrors);		// ppCompilationErrors
+
+       }
+       */
+   hr = D3DXCreateEffect(m_renderDevice->GetCoreDevice(), shaderCodeName, codeSize, nullptr, nullptr, dwShaderFlags, nullptr, &m_shader, &pBufferErrors);
+   if (FAILED(hr))
+   {
+      if (pBufferErrors)
+      {
+         const LPVOID pCompileErrors = pBufferErrors->GetBufferPointer();
+         g_pvp->MessageBox((const char*)pCompileErrors, "Compile Error", MB_OK | MB_ICONEXCLAMATION);
+      }
+      else
+         g_pvp->MessageBox("Unknown Error", "Compile Error", MB_OK | MB_ICONEXCLAMATION);
+
+      return false;
+   }
+   return true;
+}
+
+void Shader::Unload() { SAFE_RELEASE(m_shader); }
+
+void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, Texture* texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb)
+{
+   const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
+   assert(idx < TEXTURESET_STATE_CACHE_SIZE);
+
+   if (!texel || !texel->m_pdsBuffer)
+   {
+      currentTexture[idx] = nullptr; // invalidate the cache
+
+      CHECKD3D(m_shader->SetTexture(texelName, nullptr));
+
+      m_renderDevice->m_curTextureChanges++;
+
+      return;
+   }
+
+   if (texel->m_pdsBuffer != currentTexture[idx])
+   {
+      currentTexture[idx] = texel->m_pdsBuffer;
+      CHECKD3D(m_shader->SetTexture(texelName, m_renderDevice->m_texMan.LoadTexture(texel->m_pdsBuffer, filter, clampU, clampV, force_linear_rgb)->GetCoreTexture()));
+
+      m_renderDevice->m_curTextureChanges++;
+   }
+}
+
+void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, Sampler* texel)
+{
+   const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
+   assert(idx < TEXTURESET_STATE_CACHE_SIZE);
+
+   currentTexture[idx] = nullptr; // direct set of device tex invalidates the cache
+
+   CHECKD3D(m_shader->SetTexture(texelName, texel->GetCoreTexture()));
+
+   m_renderDevice->m_curTextureChanges++;
+}
+
+void Shader::SetTextureNull(const SHADER_UNIFORM_HANDLE texelName)
+{
+   const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
+   const bool cache = (idx < TEXTURESET_STATE_CACHE_SIZE);
+
+   if (cache)
+      currentTexture[idx] = nullptr; // direct set of device tex invalidates the cache
+
+   CHECKD3D(m_shader->SetTexture(texelName, nullptr));
+
+   m_renderDevice->m_curTextureChanges++;
+}
+
+void Shader::SetMaterial(const Material* const mat)
+{
+   COLORREF cBase, cGlossy, cClearcoat;
+   float fWrapLighting, fRoughness, fGlossyImageLerp, fThickness, fEdge, fEdgeAlpha, fOpacity;
+   bool bIsMetal, bOpacityActive;
+
+   if (mat)
+   {
+      fWrapLighting = mat->m_fWrapLighting;
+      fRoughness = exp2f(10.0f * mat->m_fRoughness + 1.0f); // map from 0..1 to 2..2048
+      fGlossyImageLerp = mat->m_fGlossyImageLerp;
+      fThickness = mat->m_fThickness;
+      fEdge = mat->m_fEdge;
+      fEdgeAlpha = mat->m_fEdgeAlpha;
+      fOpacity = mat->m_fOpacity;
+      cBase = mat->m_cBase;
+      cGlossy = mat->m_cGlossy;
+      cClearcoat = mat->m_cClearcoat;
+      bIsMetal = mat->m_bIsMetal;
+      bOpacityActive = mat->m_bOpacityActive;
+   }
+   else
+   {
+      fWrapLighting = 0.0f;
+      fRoughness = exp2f(10.0f * 0.0f + 1.0f); // map from 0..1 to 2..2048
+      fGlossyImageLerp = 1.0f;
+      fThickness = 0.05f;
+      fEdge = 1.0f;
+      fEdgeAlpha = 1.0f;
+      fOpacity = 1.0f;
+      cBase = g_pvp->m_dummyMaterial.m_cBase;
+      cGlossy = 0;
+      cClearcoat = 0;
+      bIsMetal = false;
+      bOpacityActive = false;
+   }
+
+   // bIsMetal is nowadays handled via a separate technique! (so not in here)
+
+   if (fRoughness != currentMaterial.m_fRoughness || fEdge != currentMaterial.m_fEdge || fWrapLighting != currentMaterial.m_fWrapLighting || fThickness != currentMaterial.m_fThickness)
+   {
+      const vec4 rwem(fRoughness, fWrapLighting, fEdge, fThickness);
+      SetVector(SHADER_Roughness_WrapL_Edge_Thickness, &rwem);
+      currentMaterial.m_fRoughness = fRoughness;
+      currentMaterial.m_fWrapLighting = fWrapLighting;
+      currentMaterial.m_fEdge = fEdge;
+      currentMaterial.m_fThickness = fThickness;
+   }
+
+   const float alpha = bOpacityActive ? fOpacity : 1.0f;
+   if (cBase != currentMaterial.m_cBase || alpha != currentMaterial.m_fOpacity)
+   {
+      const vec4 cBaseF = convertColor(cBase, alpha);
+      SetVector(SHADER_cBase_Alpha, &cBaseF);
+      currentMaterial.m_cBase = cBase;
+      currentMaterial.m_fOpacity = alpha;
+   }
+
+   if (!bIsMetal) // Metal has no glossy
+      if (cGlossy != currentMaterial.m_cGlossy || fGlossyImageLerp != currentMaterial.m_fGlossyImageLerp)
+      {
+         const vec4 cGlossyF = convertColor(cGlossy, fGlossyImageLerp);
+         SetVector(SHADER_cGlossy_ImageLerp, &cGlossyF);
+         currentMaterial.m_cGlossy = cGlossy;
+         currentMaterial.m_fGlossyImageLerp = fGlossyImageLerp;
+      }
+
+   if (cClearcoat != currentMaterial.m_cClearcoat || (bOpacityActive && fEdgeAlpha != currentMaterial.m_fEdgeAlpha))
+   {
+      const vec4 cClearcoatF = convertColor(cClearcoat, fEdgeAlpha);
+      SetVector(SHADER_cClearcoat_EdgeAlpha, &cClearcoatF);
+      currentMaterial.m_cClearcoat = cClearcoat;
+      currentMaterial.m_fEdgeAlpha = fEdgeAlpha;
+   }
+
+   if (bOpacityActive /*&& (alpha < 1.0f)*/)
+      g_pplayer->m_pin3d.EnableAlphaBlend(false);
+   else
+      g_pplayer->m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE);
+}

--- a/VisualPinball.net2015.vcxproj
+++ b/VisualPinball.net2015.vcxproj
@@ -488,6 +488,7 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="RenderDevice.cpp" />
     <ClCompile Include="RenderTarget.cpp" />
     <ClCompile Include="Sampler.cpp" />
+    <ClCompile Include="Shader.cpp" />
     <ClCompile Include="slintf.cpp" />
     <ClCompile Include="spinner.cpp" />
     <ClCompile Include="StackTrace.cpp" />

--- a/VisualPinball.net2017.vcxproj
+++ b/VisualPinball.net2017.vcxproj
@@ -666,6 +666,7 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="RenderDevice.cpp" />
     <ClCompile Include="RenderTarget.cpp" />
     <ClCompile Include="Sampler.cpp" />
+    <ClCompile Include="Shader.cpp" />
     <ClCompile Include="slintf.cpp" />
     <ClCompile Include="spinner.cpp" />
     <ClCompile Include="StackTrace.cpp" />

--- a/VisualPinball.net2019.vcxproj
+++ b/VisualPinball.net2019.vcxproj
@@ -487,6 +487,7 @@ copy "$(TargetPath)" "%25VPIN_DIR%25"
     <ClCompile Include="regutil.cpp" />
     <ClCompile Include="RenderDevice.cpp" />
     <ClCompile Include="Sampler.cpp" />
+    <ClCompile Include="Shader.cpp" />
     <ClCompile Include="slintf.cpp" />
     <ClCompile Include="spinner.cpp" />
     <ClCompile Include="StackTrace.cpp" />

--- a/VisualPinball.net2019.vcxproj.filters
+++ b/VisualPinball.net2019.vcxproj.filters
@@ -294,6 +294,7 @@
     <ClCompile Include="TextureManager.cpp" />
     <ClCompile Include="RenderTarget.cpp" />
     <ClCompile Include="Sampler.cpp" />
+    <ClCompile Include="Shader.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="vpinball.rc">

--- a/cmake/CMakeLists_win-x64.txt
+++ b/cmake/CMakeLists_win-x64.txt
@@ -455,6 +455,7 @@ add_executable(vpinball WIN32
    rubber.h
    Sampler.cpp
    Sampler.h
+   Shader.cpp
    Shader.h
    slintf.cpp
    slintf.h

--- a/cmake/CMakeLists_win-x86.txt
+++ b/cmake/CMakeLists_win-x86.txt
@@ -456,6 +456,7 @@ add_executable(vpinball WIN32
    rubber.h
    Sampler.cpp
    Sampler.h
+   Shader.cpp
    Shader.h
    slintf.cpp
    slintf.h

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -11,6 +11,10 @@
  #include "imgui/imgui_impl_win32.h"
  #include "imgui/implot/implot.h"
 
+#ifdef ENABLE_SDL
+#include "sdl2/SDL_syswm.h"
+#endif
+
 // utility structure for realtime plot //!! cleanup
 class ScrollingData {
 private:
@@ -470,6 +474,88 @@ void Player::PreCreate(CREATESTRUCT& cs)
     cs.lpszClass = "VPPlayer"; // leave as-is as e.g. VPM relies on this
 }
 
+void Player::CreateWnd(HWND parent /* = 0 */)
+{
+#ifdef ENABLE_SDL
+   // SDL needs to create the window (as of SDL 2.0.22, SDL_CreateWindowFrom does not support OpenGL contexts) so we create it through SDL and attach it to win32++
+   WNDCLASS wc;
+   ZeroMemory(&wc, sizeof(wc));
+
+   CREATESTRUCT cs;
+   ZeroMemory(&cs, sizeof(cs));
+
+   // Set the WNDCLASS parameters
+   PreRegisterClass(wc);
+   /* TODO use the VPX window class
+   if (wc.lpszClassName)
+   {
+      RegisterClass(wc);
+      cs.lpszClass = wc.lpszClassName;
+   }
+   else
+      cs.lpszClass = _T("Win32++ Window");
+   SDL_RegisterApp(wc.lpszClassName, 0, g_pvp->theInstance); */
+
+   // Set a reasonable default window style.
+   DWORD dwOverlappedStyle = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+   cs.style = WS_VISIBLE | ((parent) ? WS_CHILD : dwOverlappedStyle);
+
+   // Set a reasonable default window position
+   if (0 == parent)
+   {
+      cs.x = CW_USEDEFAULT;
+      cs.cx = CW_USEDEFAULT;
+      cs.y = CW_USEDEFAULT;
+      cs.cy = CW_USEDEFAULT;
+   }
+
+   // Allow the CREATESTRUCT parameters to be modified.
+   PreCreate(cs);
+
+   DWORD style = cs.style & ~WS_VISIBLE;
+
+   const int colordepth = LoadValueIntWithDefault(regKey[RegName::Player], "ColorDepth"s, 32);
+   bool video10bit = LoadValueBoolWithDefault(regKey[RegName::Player], "Render10Bit"s, false);
+   int channelDepth = video10bit ? 10 : ((colordepth == 16) ? 5 : 8);
+   // FIXME this will fail for 10 bits output
+   SDL_GL_SetAttribute(SDL_GL_RED_SIZE, channelDepth);
+   SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, channelDepth);
+   SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, channelDepth);
+   SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
+
+   // Multisampling is performed on the offscreen buffers, not the window framebuffer
+   SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 0);
+   SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
+
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+   //SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+   // Create the window.
+   m_sdl_playfieldHwnd = SDL_CreateWindow("Visual Pinball Player SDL", cs.x, cs.y, cs.cx, cs.cy, SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS | SDL_WINDOW_HIDDEN | (m_fullScreen ? SDL_WINDOW_FULLSCREEN : 0));
+   SDL_SysWMinfo wmInfo;
+   SDL_VERSION(&wmInfo.version);
+   SDL_GetWindowWMInfo(m_sdl_playfieldHwnd, &wmInfo);
+
+   // Attach it (raise a WM_CREATE which in turns call OnInitialUpdate)
+   Attach(wmInfo.info.win.window);
+
+   const VRPreviewMode vrPreview = (VRPreviewMode)LoadValueIntWithDefault(regKey[RegName::PlayerVR], "VRPreview"s, VRPREVIEW_LEFT);
+   if (cs.style & WS_VISIBLE && ((m_stereo3D != STEREO_VR) || (vrPreview != VRPREVIEW_DISABLED)))
+   {
+      if (cs.style & WS_MAXIMIZE)
+         ShowWindow(SW_MAXIMIZE);
+      else if (cs.style & WS_MINIMIZE)
+         ShowWindow(SW_MINIMIZE);
+      else
+         ShowWindow();
+   }
+#else
+   Create();
+#endif // ENABLE_SDL
+}
+
 void Player::OnInitialUpdate()
 {
     // Check for Touch support
@@ -553,6 +639,10 @@ void Player::OnInitialUpdate()
 
 void Player::Shutdown()
 {
+#ifdef ENABLE_SDL
+   Detach();
+#endif
+
 #ifdef USE_IMGUI
  #ifdef ENABLE_SDL
    ImGui_ImplOpenGL3_Shutdown();
@@ -1044,7 +1134,11 @@ void Player::UpdateBallShaderMatrix()
 void Player::InitBallShader()
 {
    m_ballShader = new Shader(m_pin3d.m_pd3dPrimaryDevice);
+ #ifdef ENABLE_SDL
+   m_ballShader->Load("ballShader.glfx", 0);
+ #else
    m_ballShader->Load(g_ballShaderCode, sizeof(g_ballShaderCode));
+ #endif
 
    UpdateBallShaderMatrix();
 
@@ -1245,61 +1339,8 @@ HRESULT Player::Init()
       return hr;
    }
 
-#ifdef ENABLE_SDL
-   // SDL Window appears after InitPin3D, set window default position and flags
-
-   int x = 0;
-   int y = 0;
-
-   int display = LoadValueIntWithDefault((m_stereo3D == STEREO_VR) ? regKey[RegName::PlayerVR] : regKey[RegName::Player], "Display"s, -1);
-   display = (display < getNumberOfDisplays()) ? display : -1;
-
-   getDisplaySetupByID(display, x, y, m_screenwidth, m_screenheight);
-   if (m_fullScreen)
-      SetWindowPos(nullptr, x, y, m_screenwidth, m_screenheight, SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE);
-   else
-   {
-      m_refreshrate = 0; // The default
-
-      // constrain window to screen
-      if (m_width > m_screenwidth)
-      {
-         m_width = m_screenwidth;
-         m_height = m_width * 9 / 16;
-      }
-
-      if (m_height > m_screenheight)
-      {
-         m_height = m_screenheight;
-         m_width = m_height * 16 / 9;
-      }
-      int xPos = x + (m_screenwidth - m_width) / 2;
-      int yPos = y + (m_screenheight - m_height) / 2;
-
-      // is this a non-fullscreen window? -> get previously saved window position
-      if ((m_height != m_screenheight) || (m_width != m_screenwidth))
-      {
-         const int xTemp = LoadValueIntWithDefault((m_stereo3D == STEREO_VR) ? regKey[RegName::PlayerVR] : regKey[RegName::Player], "WindowPosX"s, xPos); //!! does this handle multi-display correctly like this?
-         const int yTemp = LoadValueIntWithDefault((m_stereo3D == STEREO_VR) ? regKey[RegName::PlayerVR] : regKey[RegName::Player], "WindowPosY"s, yPos);
-         if (xTemp >= x && (xTemp + m_width < x + m_screenwidth) && yTemp >= y && (yTemp + m_height < y + m_screenheight)) {//Absolute Window position is on screen
-            xPos = xTemp;
-            yPos = yTemp;
-         }
-         else if (xTemp >= 0 && xTemp < (m_screenwidth- m_width) && yTemp >=0 && yTemp < (m_screenheight- m_height)) {//Relative window Position is on screen
-            xPos = x+xTemp;
-            yPos = y+yTemp;
-         }
-         m_showWindowedCaption = false;
-         const int windowflags = WS_POPUP;
-         SetWindowLong(GetHwnd(), GWL_STYLE, windowflags);
-         SetWindowPos(HWND_TOP, xPos, yPos, m_width, m_height, SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-         ShowWindow(SW_SHOWNORMAL);
-      }
-   }
-#else
    if (m_fullScreen)
       SetWindowPos(nullptr, 0, 0, m_width, m_height, SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE);
-#endif
 
    m_pininput.Init(GetHwnd());
 
@@ -1328,7 +1369,7 @@ HRESULT Player::Init()
    else
        m_toogle_DTFS = false;
 
-   m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS);
+   m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, m_ptable->GetMaxSeparation());
 #ifdef USE_IMGUI
    IMGUI_CHECKVERSION();
    ImGui::CreateContext();
@@ -1688,7 +1729,7 @@ HRESULT Player::Init()
 //
 // for the dynamic objects:
 //  1. use the previous mirror depthbuffer
-//  2. switch to a temporary mirror texture and render all dynamic elements into that buffer 
+//  2. switch to a temporary mirror texture and render all dynamic elements into that buffer
 //  3. switch back to normal back buffer
 //  4. render the dynamic mirror texture over the scene
 //  5. render all dynamic objects as normal
@@ -2100,7 +2141,7 @@ void Player::InitStatic()
 
       RenderTarget* tmpDepth = m_pin3d.m_pddsStatic->Duplicate();
       m_pin3d.m_pddsStatic->CopyTo(tmpDepth);
-      
+
       m_pin3d.m_pddsBackBuffer->CopyTo(m_pin3d.m_pddsStatic); // Restore saved Z buffer and render (cannot be called inside BeginScene -> EndScene cycle)
 
       m_pin3d.m_pd3dPrimaryDevice->BeginScene();
@@ -4924,7 +4965,7 @@ void Player::Render()
    // Update camera point of view
    if (m_cameraMode)
    {
-      m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS);
+      m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, m_ptable->GetMaxSeparation());
    }
 
    if (!RenderStaticOnly())
@@ -5126,6 +5167,9 @@ void Player::Render()
 
          if (option == ID_QUIT)
          {
+#ifdef ENABLE_SDL
+            StopPlayer();
+#endif
             if (g_pvp->m_open_minimized && !g_pvp->m_disable_pause_menu)
                SendMessage(g_pvp->GetHwnd(), WM_COMMAND, ID_FILE_EXIT, NULL);
             m_ptable->SendMessage(WM_COMMAND, ID_TABLE_STOP_PLAY, 0);

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1563,7 +1563,7 @@ HRESULT Player::Init()
          }
    }
    // Direct all renders to the back buffer.
-   m_pin3d.m_pddsBackBuffer->Activate(true);
+   m_pin3d.m_pddsBackBuffer->Activate(false);
 
    m_ptable->m_progressDialog.SetProgress(90);
 
@@ -1698,7 +1698,7 @@ void Player::RenderStaticMirror(const bool onlyBalls)
 {
    // Direct all renders to the temporary mirror buffer (plus the static z-buffer)
    m_pin3d.m_pd3dPrimaryDevice->GetMirrorTmpBufferTexture()->Activate(true);
-   m_pin3d.m_pd3dPrimaryDevice->Clear(0, nullptr, clearType::TARGET, 0, 1.0f, 0L);
+   m_pin3d.m_pd3dPrimaryDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);
 
    if (!onlyBalls)
    {
@@ -1763,7 +1763,7 @@ void Player::RenderDynamicMirror(const bool onlyBalls)
 {
    // render into temp mirror back buffer 
    m_pin3d.m_pd3dPrimaryDevice->GetMirrorTmpBufferTexture()->Activate(true);
-   m_pin3d.m_pd3dPrimaryDevice->Clear(0, nullptr, clearType::TARGET, 0, 1.0f, 0L);
+   m_pin3d.m_pd3dPrimaryDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);
 
    D3DMATRIX viewMat;
    m_pin3d.m_pd3dPrimaryDevice->GetTransform(TRANSFORMSTATE_VIEW, &viewMat);
@@ -1908,7 +1908,7 @@ void Player::InitStatic()
    if (iter == 0)
       assert(u1 == 0.5f && u2 == 0.5f);
 
-   // Setup Camera,etc matrices for each iteration. 
+   // Setup Camera,etc matrices for each iteration.
    m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, u1 - 0.5f, u2 - 0.5f);
 
    // Now begin rendering of static buffer
@@ -2113,7 +2113,7 @@ void Player::InitStatic()
       m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZENABLE, RenderDevice::RS_FALSE);
 
       m_pin3d.m_pddsAOBackTmpBuffer->Activate(false);
-      m_pin3d.m_pd3dPrimaryDevice->Clear(0, nullptr, clearType::TARGET, 0, 1.0f, 0L);
+      m_pin3d.m_pd3dPrimaryDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);
 
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture3, tmpDepth->GetDepthSampler());
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture4, &m_pin3d.m_aoDitherTexture, TextureFilter::TEXTURE_MODE_NONE, false, false, true);
@@ -3371,7 +3371,7 @@ void Player::DrawBulbLightBuffer()
 {
    // switch to 'bloom' output buffer to collect all bulb lights
    m_pin3d.m_pd3dPrimaryDevice->GetBloomBufferTexture()->Activate(true);
-   m_pin3d.m_pd3dPrimaryDevice->Clear(0, nullptr, clearType::TARGET, 0, 1.0f, 0L);
+   m_pin3d.m_pd3dPrimaryDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);
 
    // check if any bulb specified at all
    bool do_renderstage = false;
@@ -3694,7 +3694,7 @@ void Player::Bloom()
    {
       // need to reset content from (optional) bulb light abuse of the buffer
       /*m_pin3d.m_pd3dDevice->GetBloomBufferTexture()->Activate(false);
-      m_pin3d.m_pd3dDevice->Clear(0, nullptr, clearType::TARGET, 0, 1.0f, 0L);*/
+      m_pin3d.m_pd3dDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);*/
 
       return;
    }

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -571,17 +571,15 @@ void Player::Shutdown()
 
    SAFE_BUFFER_RELEASE(m_ballVertexBuffer);
    SAFE_BUFFER_RELEASE(m_ballIndexBuffer);
-#ifndef ENABLE_SDL
    if (m_ballShader)
    {
-      CHECKD3D(m_ballShader->Core()->SetTexture(SHADER_Texture0, nullptr));
-      CHECKD3D(m_ballShader->Core()->SetTexture(SHADER_Texture1, nullptr));
-      CHECKD3D(m_ballShader->Core()->SetTexture(SHADER_Texture2, nullptr));
-      CHECKD3D(m_ballShader->Core()->SetTexture(SHADER_Texture3, nullptr));
+      m_ballShader->SetTextureNull(SHADER_Texture0);
+      m_ballShader->SetTextureNull(SHADER_Texture1);
+      m_ballShader->SetTextureNull(SHADER_Texture2);
+      m_ballShader->SetTextureNull(SHADER_Texture3);
       delete m_ballShader;
       m_ballShader = nullptr;
    }
-#endif
 #ifdef DEBUG_BALL_SPIN
    SAFE_BUFFER_RELEASE(m_ballDebugPoints);
 #endif

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1948,7 +1948,7 @@ void Player::InitStatic()
       assert(u1 == 0.5f && u2 == 0.5f);
 
    // Setup Camera,etc matrices for each iteration.
-   m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, u1 - 0.5f, u2 - 0.5f);
+   m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, m_ptable->GetMaxSeparation(), u1 - 0.5f, u2 - 0.5f);
 
    // Now begin rendering of static buffer
    m_pin3d.m_pd3dPrimaryDevice->BeginScene();
@@ -4963,10 +4963,27 @@ void Player::Render()
       m_pin3d.m_gpu_profiler.BeginFrame(m_pin3d.m_pd3dPrimaryDevice->GetCoreDevice());
 
    // Update camera point of view
+#ifdef ENABLE_VR
+   if (m_stereo3D == STEREO_VR)
+   {
+      if (m_pin3d.m_pd3dPrimaryDevice->IsVRReady())
+         m_pin3d.m_pd3dPrimaryDevice->UpdateVRPosition();
+      else
+         m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, m_ptable->GetMaxSeparation());
+   }
+   else
+#endif
    if (m_cameraMode)
    {
       m_pin3d.InitLayout(m_ptable->m_BG_enable_FSS, m_ptable->GetMaxSeparation());
    }
+#ifdef ENABLE_BAM
+   else if ((m_stereo3D != STEREO_VR) && m_headTracking)
+   {
+      // #ravarcade: UpdateBAMHeadTracking will set proj/view matrix to add BAM view and head tracking
+      m_pin3d.UpdateBAMHeadTracking();
+   }
+#endif
 
    if (!RenderStaticOnly())
    {

--- a/pin/player.h
+++ b/pin/player.h
@@ -10,6 +10,14 @@
 
 constexpr int DBG_SPRITE_SIZE = 1024;
 
+enum VRPreviewMode
+{
+   VRPREVIEW_DISABLED,
+   VRPREVIEW_LEFT,
+   VRPREVIEW_RIGHT,
+   VRPREVIEW_BOTH
+};
+
 // NOTE that the following four definitions need to be in sync in their order!
 enum EnumAssignKeys
 {
@@ -259,6 +267,7 @@ public:
    Player(const bool cameraMode, PinTable * const ptable);
    virtual ~Player();
 
+   void CreateWnd(HWND parent = 0);
    virtual void PreRegisterClass(WNDCLASS& wc) override;
    virtual void PreCreate(CREATESTRUCT& cs) override;
    virtual void OnInitialUpdate() override;

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -498,6 +498,8 @@ HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int &ref
 
 HRESULT Pin3D::InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl)
 {
+   m_stereo3D = stereo3D;
+
    // set the viewport for the newly created device
    m_viewPort.X = 0;
    m_viewPort.Y = 0;
@@ -861,7 +863,7 @@ void Pin3D::InitLayoutFS()
 // here is where the tables camera / rotation / scale is setup
 // flashers are ignored in the calculation of boundaries to center the
 // table in the view
-void Pin3D::InitLayout(const bool FSS_mode, const float xpixoff, const float ypixoff)
+void Pin3D::InitLayout(const bool FSS_mode, const float max_separation, const float xpixoff, const float ypixoff)
 {
    TRACE_FUNCTION();
 
@@ -873,12 +875,14 @@ void Pin3D::InitLayout(const bool FSS_mode, const float xpixoff, const float ypi
    for (size_t i = 0; i < g_pplayer->m_ptable->m_vedit.size(); ++i)
       g_pplayer->m_ptable->m_vedit[i]->GetBoundingVertices(vvertex3D);
 
+   int buf_width = m_stereo3D == STEREO_VR ? m_viewPort.Width / 2 : m_viewPort.Width;
+
    m_proj.m_rcviewport.left = 0;
    m_proj.m_rcviewport.top = 0;
-   m_proj.m_rcviewport.right = m_viewPort.Width;
+   m_proj.m_rcviewport.right = buf_width;
    m_proj.m_rcviewport.bottom = m_viewPort.Height;
 
-   const float aspect = ((float)m_viewPort.Width) / ((float)m_viewPort.Height); //(float)(4.0/3.0);
+   const float aspect = ((float)buf_width) / ((float)m_viewPort.Height); //(float)(4.0/3.0);
 
    // next 4 def values for layout portrait(game vert) in landscape(screen horz)
    // for FSS, force an offset to camy which drops the table down 1/3 of the way.

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -639,7 +639,7 @@ void Pin3D::DrawBackground()
       : nullptr;
    if (pin)
    {
-      m_pd3dPrimaryDevice->Clear(0, nullptr, clearType::ZBUFFER, 0, 1.0f, 0L);
+      m_pd3dPrimaryDevice->Clear(clearType::ZBUFFER, 0, 1.0f, 0L);
 
       m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
       m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZENABLE, RenderDevice::RS_FALSE);
@@ -660,7 +660,7 @@ void Pin3D::DrawBackground()
    else
    {
       const D3DCOLOR d3dcolor = COLORREF_to_D3DCOLOR(ptable->m_colorbackdrop);
-      m_pd3dPrimaryDevice->Clear(0, nullptr, clearType::TARGET | clearType::ZBUFFER, d3dcolor, 1.0f, 0L);
+      m_pd3dPrimaryDevice->Clear(clearType::TARGET | clearType::ZBUFFER, d3dcolor, 1.0f, 0L);
    }
 }
 

--- a/pin3d.h
+++ b/pin3d.h
@@ -75,7 +75,7 @@ public:
    HRESULT InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
 
    void InitLayoutFS();
-   void InitLayout(const bool FSS_mode, const float xpixoff = 0.f, const float ypixoff = 0.f);
+   void InitLayout(const bool FSS_mode, const float max_separation, const float xpixoff = 0.f, const float ypixoff = 0.f);
 
    void TransformVertices(const Vertex3D_NoTex2 * const __restrict rgv, const WORD * const __restrict rgi, const int count, Vertex2D * const __restrict rgvout) const;
 
@@ -105,6 +105,8 @@ private:
    void InitPrimaryRenderState();
    void InitSecondaryRenderState();
    HRESULT InitPrimary(const bool fullScreen, const int colordepth, int &refreshrate, const int VSync, const bool useAA, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
+
+   StereoMode m_stereo3D;
 
    // Data members
 public:

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -2072,24 +2072,7 @@ void PinTable::Play(const bool cameraMode)
       // create Player and init that one
 
       g_pplayer = new Player(cameraMode, this);
-#ifdef ENABLE_SDL
-      WNDCLASS wc = {};
-      CREATESTRUCT cs = {};
-      PreRegisterClass(wc);
-      g_pplayer->PreCreate(cs);
-      if (g_pplayer->PreInit() != S_OK)
-      {
-         delete g_pplayer;
-         g_pplayer = nullptr;
-
-         HandleLoadFailure();
-         return;
-      }
-      g_pplayer->Attach(g_pplayer->m_pin3d.m_pd3dPrimaryDevice ? g_pplayer->m_pin3d.m_pd3dPrimaryDevice->getHwnd() : 0);
-#else
-      g_pplayer->Create();
-#endif
-
+      g_pplayer->CreateWnd();
       const float minSlope = (m_overridePhysics ? m_fOverrideMinSlope : m_angletiltMin);
       const float maxSlope = (m_overridePhysics ? m_fOverrideMaxSlope : m_angletiltMax);
       const float slope = minSlope + (maxSlope - minSlope) * m_globalDifficulty;


### PR DESCRIPTION
Cleanup to continue the merge process, as well as sync to the latest merged [PR](https://github.com/vpinball/vpvr/pull/27) on VPVR, mainly:
- New device initialization,
- RenderDevice->Clear, 
- Stereo mode RenderTarget setup for VPVR
- Move shader code out of RenderDevice.cpp to its own cpp file for further cleanup
- Avoid SetTexture direct DX call 