### PR TITLE
Fix prop panels

### DIFF
--- a/dialogs/Properties/DragpointVisualsProperty.cpp
+++ b/dialogs/Properties/DragpointVisualsProperty.cpp
@@ -72,22 +72,27 @@ void DragpointVisualsProperty::UpdateProperties(const int dispid)
         switch (dispid)
         {
             case 1:
-                CHECK_UPDATE_ITEM(dpoint->m_v.x, PropertyDialog::GetFloatTextbox(m_posXEdit), dpoint);
+                if (m_posXEdit.IsWindow() && !m_posXEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_v.x, PropertyDialog::GetFloatTextbox(m_posXEdit), dpoint);
                 break;
             case 2:
-                CHECK_UPDATE_ITEM(dpoint->m_v.y, PropertyDialog::GetFloatTextbox(m_posYEdit), dpoint);
+                if (m_posYEdit.IsWindow() && !m_posYEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_v.y, PropertyDialog::GetFloatTextbox(m_posYEdit), dpoint);
                 break;
             case 4:
                 CHECK_UPDATE_ITEM(dpoint->m_autoTexture, PropertyDialog::GetCheckboxState(::GetDlgItem(GetHwnd(), 4)), dpoint);
                 break;
             case 5:
-                CHECK_UPDATE_ITEM(dpoint->m_texturecoord, PropertyDialog::GetFloatTextbox(m_textureCoordEdit), dpoint);
+                if (m_textureCoordEdit.IsWindow() && !m_textureCoordEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_texturecoord, PropertyDialog::GetFloatTextbox(m_textureCoordEdit), dpoint);
                 break;
             case 6:
-                CHECK_UPDATE_ITEM(dpoint->m_v.z, PropertyDialog::GetFloatTextbox(m_heightOffsetEdit), dpoint);
+                if (m_heightOffsetEdit.IsWindow() && !m_heightOffsetEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_v.z, PropertyDialog::GetFloatTextbox(m_heightOffsetEdit), dpoint);
                 break;
             case IDC_CALC_HEIGHT_EDIT:
-                CHECK_UPDATE_ITEM(dpoint->m_calcHeight, PropertyDialog::GetFloatTextbox(m_realHeightEdit), dpoint);
+                if (m_realHeightEdit.IsWindow() && !m_realHeightEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_calcHeight, PropertyDialog::GetFloatTextbox(m_realHeightEdit), dpoint);
                 break;
             default:
                 break;

--- a/dialogs/Properties/PropertyDialog.cpp
+++ b/dialogs/Properties/PropertyDialog.cpp
@@ -411,13 +411,20 @@ void PropertyDialog::DeleteAllTabs()
 
 void PropertyDialog::UpdateTextureComboBox(const vector<Texture *>& contentList, const CComboBox &combo, const string &selectName)
 {
-    bool texelFound = false;
-    for (const auto texel : contentList)
+    bool need_reset = combo.GetCount() != contentList.size() + 1; // Not the same number of items
+    need_reset |= combo.FindStringExact(1, selectName.c_str()) == CB_ERR; // Selection is not part of combo
+    if (!need_reset)
     {
-        if (strncmp(texel->m_szName.c_str(), selectName.c_str(), MAXTOKEN) == 0) //!! _stricmp?
-            texelFound = true;
+        bool texelFound = false;
+        for (const auto texel : contentList)
+        {
+            if (strncmp(texel->m_szName.c_str(), selectName.c_str(), MAXTOKEN) == 0) //!! _stricmp?
+                texelFound = true;
+            need_reset |= combo.FindStringExact(1, texel->m_szName.c_str()) == CB_ERR; // Combo does not contain an image from the image list
+        }
+        need_reset |= !texelFound; // Selection is not part of image list
     }
-    if (combo.FindStringExact(1, selectName.c_str()) == CB_ERR || !texelFound)
+    if (need_reset)
     {
         combo.ResetContent();
         combo.AddString(_T("<None>"));


### PR DESCRIPTION
Little fix for annoying bugs:
- update image list combo box after importing/deleting images
- don't set point coordinates to 2 when multiple points are selected and the control is unselected (like when tabbing through them)