### PR TITLE
MeshBuffer fixes & implementation

### DIFF
--- a/IndexBuffer.cpp
+++ b/IndexBuffer.cpp
@@ -104,8 +104,8 @@ void MeshBuffer::bind()
          }
       }
       // FIXME this supposes that this mesh buffer is always used with the same attribute layout.
-      // This happens to be true but it would be more clean to fix the attribute layout in the shaders
-      Shader::GetCurrentShader()->setAttributeFormat(m_vertexFormat);
+      // This happens to be true but it would be more clean to enforce the attribute layout in the shaders
+      Shader::GetCurrentShader()->setAttributeFormat(m_vb->m_fvf);
       curVAO = m_vao;
    }
    else 

--- a/IndexBuffer.cpp
+++ b/IndexBuffer.cpp
@@ -14,17 +14,10 @@ vector<MeshBuffer::SharedVAO> MeshBuffer::sharedVAOs;
 #include "Shader.h"
 #include "VertexBuffer.h"
 
-MeshBuffer::MeshBuffer(VertexBuffer* vb, const bool ownBuffers)
-   : MeshBuffer(vb, nullptr, ownBuffers)
-{
-}
-
-MeshBuffer::MeshBuffer(VertexBuffer* vb, IndexBuffer* ib, const bool ownBuffers)
-   : m_vb(vb)
-   , m_ib(ib)
-   , m_ownBuffers(ownBuffers)
+MeshBuffer::MeshBuffer(VertexBuffer* vb, IndexBuffer* ib) : m_vb(vb), m_ib(ib)
 #ifndef ENABLE_SDL
-   , m_vertexDeclaration(vb->m_fvf == MY_D3DFVF_NOTEX2_VERTEX ? m_vb->m_rd->m_pVertexNormalTexelDeclaration :
+   , m_vertexDeclaration(
+      vb->m_fvf == MY_D3DFVF_NOTEX2_VERTEX ? m_vb->m_rd->m_pVertexNormalTexelDeclaration :
       vb->m_fvf == MY_D3DTRANSFORMED_NOTEX2_VERTEX ? m_vb->m_rd->m_pVertexTrafoTexelDeclaration :
       vb->m_fvf == MY_D3DFVF_TEX ? m_vb->m_rd->m_pVertexTexelDeclaration : nullptr)
 #endif
@@ -55,12 +48,9 @@ MeshBuffer::~MeshBuffer()
       glDeleteVertexArrays(1, &m_vao);
       m_vao = 0;
    }
-   #endif
-   if (m_ownBuffers)
-   {
-      delete m_vb;
-      delete m_ib;
-   }
+#endif
+   delete m_vb;
+   delete m_ib;
 }
 
 #ifdef ENABLE_SDL

--- a/IndexBuffer.h
+++ b/IndexBuffer.h
@@ -9,12 +9,10 @@ class IndexBuffer;
 class MeshBuffer final
 {
 public:
-   MeshBuffer(VertexBuffer* vb, const bool ownBuffers);
-   MeshBuffer(VertexBuffer* vb, IndexBuffer* ib, const bool ownBuffers);
+   MeshBuffer(VertexBuffer* vb, IndexBuffer* ib = nullptr);
    ~MeshBuffer();
    void bind();
 
-   const bool m_ownBuffers;
    VertexBuffer* const m_vb;
    IndexBuffer* const m_ib;
 

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -2167,7 +2167,7 @@ void RenderDevice::DrawTexturedQuad(const Vertex3D_TexelOnly* vertices)
    m_quadDynMeshBuffer->m_vb->unlock();
    DrawMesh(m_quadDynMeshBuffer, TRIANGLESTRIP, 0, 4);
 #else
-   // having a VB and lock/copying stuff each time is slower on DX9 :/
+   // having a VB and lock/copying stuff each time is slower on DX9 :/ (is it still true ? looks overly complicated for a very marginal benefit)
    ApplyRenderStates();
    m_stats_drawn_triangles += 2;
    SetVertexDeclaration(m_pVertexTexelDeclaration);
@@ -2212,32 +2212,6 @@ void RenderDevice::DrawMesh(MeshBuffer* mb, const PrimitiveTypes type, const DWO
       CHECKD3D(m_pD3DDevice->DrawIndexedPrimitive((D3DPRIMITIVETYPE)type, 0, 0, mb->m_vb->m_vertexCount, startIndice, np));
 #endif
    }
-   m_curDrawCalls++;
-}
-
-void RenderDevice::DrawIndexedPrimitiveVB(const PrimitiveTypes type, const DWORD fvf, VertexBuffer* vb, const DWORD startVertex, const DWORD vertexCount, IndexBuffer* ib, const DWORD startIndex, const DWORD indexCount)
-{
-   if (vb == nullptr || ib == nullptr) //!! happens for primitives that are grouped on player init render call?!?
-      return;
-
-   ApplyRenderStates();
-
-   const unsigned int np = ComputePrimitiveCount(type, indexCount);
-   m_stats_drawn_triangles += np;
-
-   MeshBuffer mb(vb, ib, false);
-   mb.bind();
-
-#ifdef ENABLE_SDL
-   const int offset = ib->getOffset() + (ib->getIndexFormat() == IndexBuffer::FMT_INDEX16 ? 2 : 4) * startIndex;
-#ifndef __OPENGLES__
-   glDrawElementsBaseVertex(type, indexCount, ib->getIndexFormat() == IndexBuffer::FMT_INDEX16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void*)offset, vb->getOffset() + startVertex);
-#else
-   glDrawElements(type, indexCount, ib->getIndexFormat() == IndexBuffer::FMT_INDEX16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void*)(intptr_t)offset);
-#endif
-#else
-   CHECKD3D(m_pD3DDevice->DrawIndexedPrimitive((D3DPRIMITIVETYPE)type, startVertex, 0, vertexCount, startIndex, np));
-#endif
    m_curDrawCalls++;
 }
 

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1152,11 +1152,11 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
       -1.0f, -1.0f, 0.0f, 0.0f, 1.0f
    };
    VertexBuffer* quadVertexBuffer = new VertexBuffer(this, 4, USAGE_STATIC, MY_D3DFVF_TEX, verts);
-   m_quadMeshBuffer = new MeshBuffer(quadVertexBuffer, true);
+   m_quadMeshBuffer = new MeshBuffer(quadVertexBuffer);
 
 #ifdef ENABLE_SDL
    VertexBuffer* quadDynVertexBuffer = new VertexBuffer(this, 4, USAGE_DYNAMIC, MY_D3DFVF_TEX);
-   m_quadDynMeshBuffer = new MeshBuffer(quadDynVertexBuffer, true);
+   m_quadDynMeshBuffer = new MeshBuffer(quadDynVertexBuffer);
 #endif
 
    //

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -251,11 +251,9 @@ private:
    RenderStateCache m_current_renderstate, m_renderstate;
 
 public:
+   void DrawMesh(MeshBuffer* mb, const PrimitiveTypes type, const DWORD startIndice, const DWORD indexCount);
    void DrawTexturedQuad(const Vertex3D_TexelOnly* vertices);
    void DrawFullscreenTexturedQuad();
-   
-   void DrawIndexedPrimitiveVB(const PrimitiveTypes type, const DWORD fvf, VertexBuffer* vb, const DWORD startVertex, const DWORD vertexCount, IndexBuffer* ib, const DWORD startIndex, const DWORD indexCount);
-   void DrawMesh(MeshBuffer* mb, const PrimitiveTypes type, const DWORD startIndice, const DWORD indexCount);
    
    void DrawGaussianBlur(Sampler* source, RenderTarget* tmp, RenderTarget* dest, float kernel_size);
 

--- a/VertexBuffer.cpp
+++ b/VertexBuffer.cpp
@@ -9,7 +9,7 @@ extern unsigned m_curLockCalls, m_frameLockCalls;
 // Disabled since OpenGL ES does not support glDrawElementsBaseVertex and we need it unless we remap the indices when creating the index buffer (and we should)
 #define COMBINE_BUFFERS 0
 #else
-#define COMBINE_BUFFERS 1
+#define COMBINE_BUFFERS 0
 #endif
 
 static unsigned int fvfToSize(const DWORD fvf)

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -631,7 +631,7 @@ void Bumper::RenderSetup()
       GenerateBaseMesh(buf);
       baseVertexBuffer->unlock();
       delete m_baseMeshBuffer;
-      m_baseMeshBuffer = new MeshBuffer(baseVertexBuffer, baseIndexBuffer, true);
+      m_baseMeshBuffer = new MeshBuffer(baseVertexBuffer, baseIndexBuffer);
    }
 
    if (m_d.m_skirtVisible)
@@ -644,7 +644,7 @@ void Bumper::RenderSetup()
       GenerateSocketMesh(buf);
       socketVertexBuffer->unlock();
       delete m_socketMeshBuffer;
-      m_socketMeshBuffer = new MeshBuffer(socketVertexBuffer, socketIndexBuffer, true);
+      m_socketMeshBuffer = new MeshBuffer(socketVertexBuffer, socketIndexBuffer);
    }
 
    if (m_d.m_ringVisible)
@@ -659,7 +659,7 @@ void Bumper::RenderSetup()
       memcpy(buf, m_ringVertices, bumperRingNumVertices*sizeof(Vertex3D_NoTex2));
       ringVertexBuffer->unlock();
       delete m_ringMeshBuffer;
-      m_ringMeshBuffer = new MeshBuffer(ringVertexBuffer, ringIndexBuffer, true);
+      m_ringMeshBuffer = new MeshBuffer(ringVertexBuffer, ringIndexBuffer);
    }
 
    if (m_d.m_capVisible)
@@ -672,7 +672,7 @@ void Bumper::RenderSetup()
       GenerateCapMesh(buf);
       capVertexBuffer->unlock();
       delete m_capMeshBuffer;
-      m_capMeshBuffer = new MeshBuffer(capVertexBuffer, capIndexBuffer, true);
+      m_capMeshBuffer = new MeshBuffer(capVertexBuffer, capIndexBuffer);
    }
 }
 

--- a/decal.cpp
+++ b/decal.cpp
@@ -516,7 +516,7 @@ void Decal::RenderSetup()
 
    vertexBuffer->unlock();
 
-   m_meshBuffer = new MeshBuffer(vertexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer);
 }
 
 float Decal::GetDepth(const Vertex3Ds& viewDir) const

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -386,7 +386,7 @@ void Flasher::RenderSetup()
    NumVideoBytes += (int)(m_numVertices * sizeof(Vertex3D_TexelOnly));
 
    delete m_meshBuffer;
-   m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+   m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
 
    if (m_vertices)
       delete[] m_vertices;

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -90,10 +90,7 @@ Flipper::Flipper()
 
 Flipper::~Flipper()
 {
-   delete m_batMeshBuffer;
-   m_batMeshBuffer = nullptr;
-   delete m_rubberMeshBuffer;
-   m_rubberMeshBuffer = nullptr;
+   delete m_meshBuffer;
 }
 
 HRESULT Flipper::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
@@ -290,10 +287,8 @@ void Flipper::EndPlay()
 {
    if (m_phitflipper) // Failed player case
       m_phitflipper = nullptr;
-   delete m_batMeshBuffer;
-   m_batMeshBuffer = nullptr;
-   delete m_rubberMeshBuffer;
-   m_rubberMeshBuffer = nullptr;
+   delete m_meshBuffer;
+   m_meshBuffer = nullptr;
    IEditable::EndPlay();
 }
 
@@ -641,7 +636,7 @@ void Flipper::RenderDynamic()
    }
    g_pplayer->UpdateBasicShaderMatrix(matTrafo);
    pd3dDevice->basicShader->Begin();
-   pd3dDevice->DrawMesh(m_batMeshBuffer, RenderDevice::TRIANGLELIST, 0, flipperBaseNumIndices);
+   pd3dDevice->DrawMesh(m_meshBuffer, RenderDevice::TRIANGLELIST, 0, flipperBaseNumIndices);
    pd3dDevice->basicShader->End();
 
    //render rubber
@@ -660,7 +655,7 @@ void Flipper::RenderDynamic()
       }
 
       pd3dDevice->basicShader->Begin();
-      pd3dDevice->DrawMesh(m_rubberMeshBuffer, RenderDevice::TRIANGLELIST, flipperBaseNumIndices, flipperBaseNumIndices);
+      pd3dDevice->DrawMesh(m_meshBuffer, RenderDevice::TRIANGLELIST, flipperBaseNumIndices, flipperBaseNumIndices);
       pd3dDevice->basicShader->End();
    }
    g_pplayer->UpdateBasicShaderMatrix();
@@ -879,9 +874,8 @@ void Flipper::RenderSetup()
    vertexBuffer->lock(0, 0, (void**)&buf, VertexBuffer::WRITEONLY);
    GenerateBaseMesh(buf);
    vertexBuffer->unlock();
-   delete m_batMeshBuffer;
-   m_batMeshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, true);
-   m_rubberMeshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, false);
+   delete m_meshBuffer;
+   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer);
    m_lastAngle = 123486.0f;
 }
 

--- a/flipper.h
+++ b/flipper.h
@@ -181,8 +181,7 @@ private:
 
       void UpdatePhysicsSettings();
 
-      MeshBuffer *m_batMeshBuffer = nullptr;
-      MeshBuffer *m_rubberMeshBuffer = nullptr;
+      MeshBuffer *m_meshBuffer = nullptr;
 
       HitFlipper *m_phitflipper;
       float m_lastAngle;

--- a/gate.cpp
+++ b/gate.cpp
@@ -557,7 +557,7 @@ void Gate::RenderSetup()
    GenerateBracketMesh(buf);
    bracketVertexBuffer->unlock();
    delete m_bracketMeshBuffer;
-   m_bracketMeshBuffer = new MeshBuffer(bracketVertexBuffer, bracketIndexBuffer, true);
+   m_bracketMeshBuffer = new MeshBuffer(bracketVertexBuffer, bracketIndexBuffer);
 
    IndexBuffer *wireIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numIndices, m_indices);
    VertexBuffer *wireVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices, USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX);
@@ -565,7 +565,7 @@ void Gate::RenderSetup()
    GenerateWireMesh(buf);
    wireVertexBuffer->unlock();
    delete m_wireMeshBuffer;
-   m_wireMeshBuffer = new MeshBuffer(wireVertexBuffer, wireIndexBuffer, true);
+   m_wireMeshBuffer = new MeshBuffer(wireVertexBuffer, wireIndexBuffer);
 }
 
 void Gate::UpdateAnimation(const float diff_time_msec)

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -722,7 +722,7 @@ void HitTarget::RenderObject()
    {
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW);
       pd3dDevice->basicShader->Begin();
-      pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numVertices, m_indexBuffer, 0, m_numIndices);
+      pd3dDevice->DrawMesh(m_meshBuffer, RenderDevice::TRIANGLELIST, 0, m_numIndices);
       pd3dDevice->basicShader->End();
    }
 #endif

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -822,7 +822,7 @@ void HitTarget::RenderSetup()
 
    VertexBuffer *vertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, (unsigned int)m_numVertices, USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX, (float *)m_transformedVertices.data());
    IndexBuffer *indexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numIndices, m_indices);
-   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer);
 }
 
 void HitTarget::RenderStatic()

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -417,7 +417,7 @@ void Kicker::RenderSetup()
 
       IndexBuffer *plateIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, kickerPlateNumIndices, kickerPlateIndices);
       VertexBuffer *plateVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, kickerPlateNumVertices, 0, MY_D3DFVF_NOTEX2_VERTEX, (float*)buf);
-      m_plateMeshBuffer = new MeshBuffer(plateVertexBuffer, plateIndexBuffer, true);
+      m_plateMeshBuffer = new MeshBuffer(plateVertexBuffer, plateIndexBuffer);
 
       delete[] buf;
    }
@@ -503,7 +503,7 @@ void Kicker::RenderSetup()
    vertexBuffer->lock(0, 0, (void**)&buf, VertexBuffer::WRITEONLY);
    GenerateMesh(buf);
    vertexBuffer->unlock();
-   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer);
 }
 
 void Kicker::SetDefaultPhysics(const bool fromMouseClick)

--- a/light.cpp
+++ b/light.cpp
@@ -577,7 +577,7 @@ void Light::PrepareMoversCustom()
    const DWORD vertexType = (!m_backglass) ? MY_D3DFVF_NOTEX2_VERTEX : MY_D3DTRANSFORMED_NOTEX2_VERTEX;
    VertexBuffer * customMoverVBuffer = new VertexBuffer(m_backglass ? g_pplayer->m_pin3d.m_pd3dSecondaryDevice : g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_customMoverVertexNum, 0, vertexType);
 
-   m_customMoverMeshBuffer = new MeshBuffer(customMoverVBuffer, customMoverIBuffer, true);
+   m_customMoverMeshBuffer = new MeshBuffer(customMoverVBuffer, customMoverIBuffer);
 
    UpdateCustomMoverVBuffer();
 }
@@ -685,7 +685,7 @@ void Light::RenderSetup()
       delete m_bulbLightMeshBuffer;
       IndexBuffer* bulbLightIndexBuffer = new IndexBuffer(m_backglass ? g_pplayer->m_pin3d.m_pd3dSecondaryDevice : g_pplayer->m_pin3d.m_pd3dPrimaryDevice, bulbLightNumFaces, bulbLightIndices);
       VertexBuffer* bulbLightVBuffer = new VertexBuffer(m_backglass ? g_pplayer->m_pin3d.m_pd3dSecondaryDevice : g_pplayer->m_pin3d.m_pd3dPrimaryDevice, bulbLightNumVertices, 0, MY_D3DFVF_NOTEX2_VERTEX);
-      m_bulbLightMeshBuffer = new MeshBuffer(bulbLightVBuffer, bulbLightIndexBuffer, true);
+      m_bulbLightMeshBuffer = new MeshBuffer(bulbLightVBuffer, bulbLightIndexBuffer);
 
       Vertex3D_NoTex2 *buf;
       bulbLightVBuffer->lock(0, 0, (void**)&buf, VertexBuffer::WRITEONLY);
@@ -705,7 +705,7 @@ void Light::RenderSetup()
       delete m_bulbSocketMeshBuffer;
       IndexBuffer* bulbSocketIndexBuffer = new IndexBuffer(m_backglass ? g_pplayer->m_pin3d.m_pd3dSecondaryDevice : g_pplayer->m_pin3d.m_pd3dPrimaryDevice, bulbSocketNumFaces, bulbSocketIndices);
       VertexBuffer *bulbSocketVBuffer = new VertexBuffer(m_backglass ? g_pplayer->m_pin3d.m_pd3dSecondaryDevice : g_pplayer->m_pin3d.m_pd3dPrimaryDevice, bulbSocketNumVertices, 0, MY_D3DFVF_NOTEX2_VERTEX);
-      m_bulbSocketMeshBuffer = new MeshBuffer(bulbSocketVBuffer, bulbSocketIndexBuffer, true);
+      m_bulbSocketMeshBuffer = new MeshBuffer(bulbSocketVBuffer, bulbSocketIndexBuffer);
 
       bulbSocketVBuffer->lock(0, 0, (void**)&buf, VertexBuffer::WRITEONLY);
       for (unsigned int i = 0; i < bulbSocketNumVertices; i++)

--- a/light.h
+++ b/light.h
@@ -216,12 +216,9 @@ private:
 
    unsigned int m_customMoverVertexNum;
    unsigned int m_customMoverIndexNum;
-   VertexBuffer *m_customMoverVBuffer;
-   IndexBuffer  *m_customMoverIBuffer;
-   VertexBuffer *m_bulbLightVBuffer;
-   IndexBuffer  *m_bulbLightIndexBuffer;
-   VertexBuffer *m_bulbSocketVBuffer;
-   IndexBuffer  *m_bulbSocketIndexBuffer;
+   MeshBuffer *m_customMoverMeshBuffer = nullptr;
+   MeshBuffer *m_bulbSocketMeshBuffer = nullptr;
+   MeshBuffer *m_bulbLightMeshBuffer = nullptr;
    PropertyPane *m_propVisual;
 
    vector<RenderVertex> m_vvertex;

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1296,7 +1296,7 @@ void Player::InitBallShader()
    const bool lowDetailBall = (m_ptable->GetDetailLevel() < 10);
    IndexBuffer* ballIndexBuffer = new IndexBuffer(m_pin3d.m_pd3dPrimaryDevice, lowDetailBall ? basicBallLoNumFaces : basicBallMidNumFaces, lowDetailBall ? basicBallLoIndices : basicBallMidIndices);
    VertexBuffer* ballVertexBuffer = new VertexBuffer(m_pin3d.m_pd3dPrimaryDevice, lowDetailBall ? basicBallLoNumVertices : basicBallMidNumVertices, 0, MY_D3DFVF_NOTEX2_VERTEX, (float*)(lowDetailBall ? basicBallLo : basicBallMid));
-   m_ballMeshBuffer = new MeshBuffer(ballVertexBuffer, ballIndexBuffer, true);
+   m_ballMeshBuffer = new MeshBuffer(ballVertexBuffer, ballIndexBuffer);
 
    vec4 amb_lr = convertColor(m_ptable->m_lightAmbient, m_ptable->m_lightRange);
    amb_lr.x *= m_globalEmissionScale;
@@ -1836,13 +1836,13 @@ HRESULT Player::Init()
 
       assert(m_ballDebugPoints == nullptr);
       VertexBuffer *ballDebugPoints = new VertexBuffer(m_pin3d.m_pd3dPrimaryDevice, (unsigned int)ballDbgVtx.size(), 0, MY_D3DFVF_TEX, (float*) ballDbgVtx.data());
-      m_ballDebugPoints = new MeshBuffer(ballDebugPoints, true);
+      m_ballDebugPoints = new MeshBuffer(ballDebugPoints);
    }
 #endif
 
    assert(m_ballTrailMeshBuffer == nullptr);
    VertexBuffer* ballTrailVertexBuffer = new VertexBuffer(m_pin3d.m_pd3dPrimaryDevice, (MAX_BALL_TRAIL_POS - 2) * 2 + 4, USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX);
-   m_ballTrailMeshBuffer = new MeshBuffer(ballTrailVertexBuffer, true);
+   m_ballTrailMeshBuffer = new MeshBuffer(ballTrailVertexBuffer);
 
    m_ptable->m_progressDialog.SetName("Starting Game Scripts..."s);
 

--- a/pin/player.h
+++ b/pin/player.h
@@ -387,8 +387,7 @@ public:
 #endif
    Shader      *m_ballShader;
 
-   IndexBuffer *m_ballIndexBuffer;
-   VertexBuffer *m_ballVertexBuffer;
+   MeshBuffer *m_ballMeshBuffer = nullptr;
    MeshBuffer *m_ballTrailMeshBuffer = nullptr;
    bool m_antiStretchBall;
 

--- a/pin/player.h
+++ b/pin/player.h
@@ -213,7 +213,7 @@ public:
       if (!m_buffers[m_curIdx])
       {
          VertexBuffer *vb = new VertexBuffer(pd3dDevice, 1024, 0, MY_D3DFVF_NOTEX2_VERTEX);
-         m_buffers[m_curIdx] = new MeshBuffer(vb, true);
+         m_buffers[m_curIdx] = new MeshBuffer(vb);
       }
 
       // idea: locking a static vertex buffer stalls the pipeline if that VB is still

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -851,7 +851,7 @@ void Plunger::RenderSetup()
 
    // Create the mesh buffer
    delete m_meshBuffer;
-   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer);
 
    // done with the index scratch pad
    delete[] indices;

--- a/plunger.h
+++ b/plunger.h
@@ -157,8 +157,7 @@ public:
 private:
    PinTable *m_ptable;
 
-   VertexBuffer *m_vertexBuffer;
-   IndexBuffer *m_indexBuffer;
+   MeshBuffer *m_meshBuffer = nullptr;
 
    HitPlunger *m_phitplunger;
 

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -300,7 +300,7 @@ void Primitive::CreateRenderGroup(const Collection * const collection)
       }
    }
    vertexBuffer->unlock();
-   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer);
 }
 
 HRESULT Primitive::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
@@ -1417,7 +1417,7 @@ void Primitive::RenderSetup()
    bool is_static = m_d.m_staticRendering || m_mesh.m_animationFrames.size() == 0;
    VertexBuffer* vertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, (unsigned int)m_mesh.NumVertices(), is_static ? USAGE_STATIC : USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX);
    IndexBuffer* indexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_mesh.m_indices);
-   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer, indexBuffer);
 
    // Compute and upload mesh to let a chance for renderdevice to share the buffers with other static objects
    RecalculateMatrices();

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -1123,7 +1123,7 @@ void Ramp::PrepareHabitrail()
    {
       IndexBuffer *dynamicIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_meshIndices);
       VertexBuffer *dynamicVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices, USAGE_STATIC, MY_D3DFVF_NOTEX2_VERTEX, (float *)tmpBuf1);
-      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
       break;
    }
    case RampType2Wire:
@@ -1143,7 +1143,7 @@ void Ramp::PrepareHabitrail()
          indices[m_numIndices + i] = indices[i] + m_numVertices;
       IndexBuffer *dynamicIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numIndices * 2, indices);
       VertexBuffer *dynamicVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices * 2, USAGE_STATIC, MY_D3DFVF_NOTEX2_VERTEX, (float *)vertices);
-      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
       m_numVertices *= 2;
       m_numIndices *= 2;
       break;
@@ -1171,7 +1171,7 @@ void Ramp::PrepareHabitrail()
       }
       IndexBuffer *dynamicIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numIndices * 3, indices);
       VertexBuffer *dynamicVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices * 3, USAGE_STATIC, MY_D3DFVF_NOTEX2_VERTEX, (float *)vertices);
-      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
       m_numVertices *= 3;
       m_numIndices *= 3;
       break;
@@ -1202,7 +1202,7 @@ void Ramp::PrepareHabitrail()
       }
       IndexBuffer *dynamicIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numIndices * 4, indices);
       VertexBuffer *dynamicVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices * 4, USAGE_STATIC, MY_D3DFVF_NOTEX2_VERTEX, (float *)vertices);
-      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+      m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
       m_numVertices *= 4;
       m_numIndices *= 4;
       break;
@@ -2462,7 +2462,7 @@ void Ramp::GenerateVertexBuffer()
 
    VertexBuffer* dynamicVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices * 3, 0, MY_D3DFVF_NOTEX2_VERTEX, (float*) tmpBuffer); //!! use USAGE_DYNAMIC if it would actually be "really" dynamic
    IndexBuffer* dynamicIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_meshIndices);
-   m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+   m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
    delete[] tmpBuffer;
 }
 

--- a/ramp.h
+++ b/ramp.h
@@ -135,9 +135,8 @@ private:
 
    vector<HitObject*> m_vhoCollidable; // Objects to that may be collide selectable
 
-   VertexBuffer *m_dynamicVertexBuffer;
-   IndexBuffer *m_dynamicIndexBuffer;
-   VertexBuffer *m_dynamicVertexBuffer2;
+   MeshBuffer *m_meshBuffer1 = nullptr;
+   MeshBuffer *m_meshBuffer2 = nullptr;
    bool m_dynamicVertexBufferRegenerate;
 
    PropertyPane *m_propPhysics;

--- a/ramp.h
+++ b/ramp.h
@@ -135,8 +135,7 @@ private:
 
    vector<HitObject*> m_vhoCollidable; // Objects to that may be collide selectable
 
-   MeshBuffer *m_meshBuffer1 = nullptr;
-   MeshBuffer *m_meshBuffer2 = nullptr;
+   MeshBuffer *m_meshBuffer = nullptr;
    bool m_dynamicVertexBufferRegenerate;
 
    PropertyPane *m_propPhysics;

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1466,7 +1466,7 @@ void Rubber::GenerateVertexBuffer()
 
    VertexBuffer* dynamicVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices, m_d.m_staticRendering ? USAGE_STATIC : USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX, (float*) m_vertices.data());
    IndexBuffer *dynamicIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_ringIndices);
-   m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer, true);
+   m_meshBuffer = new MeshBuffer(dynamicVertexBuffer, dynamicIndexBuffer);
 }
 
 void Rubber::UpdateRubber(const bool updateVB, const float height)

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -408,7 +408,7 @@ void Spinner::RenderSetup()
 
    IndexBuffer *bracketIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, spinnerBracketNumFaces, spinnerBracketIndices);
    VertexBuffer *bracketVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, spinnerBracketNumVertices, 0, MY_D3DFVF_NOTEX2_VERTEX);
-   m_bracketMeshBuffer = new MeshBuffer(bracketVertexBuffer, bracketIndexBuffer, true);
+   m_bracketMeshBuffer = new MeshBuffer(bracketVertexBuffer, bracketIndexBuffer);
 
    m_fullMatrix.RotateZMatrix(ANGTORAD(m_d.m_rotation));
 
@@ -435,7 +435,7 @@ void Spinner::RenderSetup()
 
    IndexBuffer* plateIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, spinnerPlateNumFaces, spinnerPlateIndices);
    VertexBuffer* plateVertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, spinnerPlateNumVertices, USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX);
-   m_plateMeshBuffer = new MeshBuffer(plateVertexBuffer, plateIndexBuffer, true);
+   m_plateMeshBuffer = new MeshBuffer(plateVertexBuffer, plateIndexBuffer);
 
    m_vertexBuffer_spinneranimangle = -FLT_MAX;
    UpdatePlate(nullptr);

--- a/spinner.h
+++ b/spinner.h
@@ -95,10 +95,8 @@ private:
 
    PinTable *m_ptable;
 
-   VertexBuffer *m_bracketVertexBuffer;
-   IndexBuffer *m_bracketIndexBuffer;
-   VertexBuffer *m_plateVertexBuffer;
-   IndexBuffer *m_plateIndexBuffer;
+   MeshBuffer *m_bracketMeshBuffer = nullptr;
+   MeshBuffer *m_plateMeshBuffer = nullptr;
    Matrix3D m_fullMatrix;
 
    float m_posZ;

--- a/surface.cpp
+++ b/surface.cpp
@@ -873,7 +873,7 @@ void Surface::PrepareWallsAtHeight()
    IBuffer->unlock();
 
    delete m_meshBuffer;
-   m_meshBuffer = new MeshBuffer(VBuffer, IBuffer, true);
+   m_meshBuffer = new MeshBuffer(VBuffer, IBuffer);
 }
 
 static constexpr WORD rgiSlingshot[24] = { 0, 4, 3, 0, 1, 4, 1, 2, 5, 1, 5, 4, 4, 8, 5, 4, 7, 8, 3, 7, 4, 3, 6, 7 };
@@ -941,7 +941,7 @@ void Surface::PrepareSlingshots()
    slingIBuffer->unlock();
 
    delete m_slingshotMeshBuffer;
-   m_slingshotMeshBuffer = new MeshBuffer(slingshotVBuffer, slingIBuffer, true);
+   m_slingshotMeshBuffer = new MeshBuffer(slingshotVBuffer, slingIBuffer);
 }
 
 void Surface::RenderSetup()

--- a/trigger.cpp
+++ b/trigger.cpp
@@ -856,7 +856,7 @@ void Trigger::RenderSetup()
    GenerateMesh();
    IndexBuffer *triggerIndexBuffer = new IndexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numIndices, indices);
    VertexBuffer *vertexBuffer = new VertexBuffer(g_pplayer->m_pin3d.m_pd3dPrimaryDevice, m_numVertices, USAGE_DYNAMIC, MY_D3DFVF_NOTEX2_VERTEX, (float*) m_triggerVertices);
-   m_meshBuffer = new MeshBuffer(vertexBuffer, triggerIndexBuffer, true);
+   m_meshBuffer = new MeshBuffer(vertexBuffer, triggerIndexBuffer);
 }
 
 void Trigger::RenderStatic()


### PR DESCRIPTION
This (wide) change do the following:
- instead of directly using vertex buffer and index buffer, object use a Mesh Buffer, which groups the 2 of them
- on OpenGL, this MeshBuffer allows to easily build corresponding Vertex Array Object (for GL, VAO = VB+IB+Vertex format)
- all draw call now use this, allowing to simplify and clean the code a bit
- some objects have been modified to use avoid using base vertex offset, since this is not available for OpenGL ES. In the end, I'm not fully sure this was a great idea, since we can bypass the GLES limitation by using an offest in the vertex attribute pointer, and this leads to somewhat bigger index buffer for plunger and surface (wall). It's still nice since it makes the code simpler but I will evaluate if this has to be reverted
- I took the opportunity to cleanup some vertex/index builds : either just code cleanup, or some improments like for wire ramp which are now rendered in a single draw call

Beside, the aim of fixing VAO and adjusting for GLES, I made this to easier include the RenderQueue I have on my branch (not shared yet). But this makes quite a wide change, so let's test it a bit like this first