### PR TITLE
scripts: fix replace &H000000001 with &H00000001

### DIFF
--- a/scripts/ALI.vbs
+++ b/scripts/ALI.vbs
@@ -46,7 +46,7 @@ Private Sub ALIDips
 		With vpmDips
 			.AddForm  80, 60, "DIP Switches"
 			.AddFrame  0,0, 60,"Sound", 0,_
-		       Array("DIP 1",&H000000001,"DIP 2",&H00000002)
+		       Array("DIP 1",&H00000001,"DIP 2",&H00000002)
 			.AddFrame  0,45, 60,"Game", 0,_
 		       Array("DIP M8",&H00000100,"DIP M7",&H00000200,"DIP M6",&H00000400,"DIP M5",&H00000800,_
 			       "DIP M4",&H00001000,"DIP M3",&H00002000,"DIP M2",&H00004000,"DIP M1",32768,_

--- a/scripts/s4.vbs
+++ b/scripts/s4.vbs
@@ -55,7 +55,7 @@ Private Sub s4ShowDips
 		With vpmDips
 			.AddForm  80, 290, "DIP Switches"
 			.AddFrame  0,0, 100,"Sound", 0,_
-			  Array("Dip 1",&H000000001,"Synth Sound",&H00000002)
+			  Array("Dip 1",&H00000001,"Synth Sound",&H00000002)
 			.AddFrame  0,50, 100,"Function / Data", 0,_
 				    Array("DIP F8 (1)" ,&H00000100,"DIP F7 (2)",&H00000200,"DIP F6 (4)",&H00000400,"DIP F5 (8)",&H00000800,_
 	    			      "DIP F4 (16)",&H00001000,"DIP F3",&H00002000,"DIP F2",&H00004000,"DIP F1",32768,_

--- a/scripts/s6.vbs
+++ b/scripts/s6.vbs
@@ -56,7 +56,7 @@ Private Sub s6ShowDips
 		With vpmDips
 			.AddForm  80, 290, "DIP Switches"
 			.AddFrame  0,0, 60,"Sound", 0,_
-			  Array("DIP 1",&H000000001,"DIP 2",&H00000002)
+			  Array("DIP 1",&H00000001,"DIP 2",&H00000002)
 			.AddFrame  0,45, 60,"Game", 0,_
 				    Array("DIP M8",&H00000100,"DIP M7",&H00000200,"DIP M6",&H00000400,"DIP M5",&H00000800,_
 	    			      "DIP M4",&H00001000,"DIP M3",&H00002000,"DIP M2",&H00004000,"DIP M1",32768,_

--- a/scripts/s7.vbs
+++ b/scripts/s7.vbs
@@ -54,7 +54,7 @@ Private Sub s7ShowDips
 		With vpmDips
 			.AddForm  80, 60, "DIP Switches"
 			.AddFrame  0,0, 60,"Sound", 0,_
-		       Array("DIP 1",&H000000001,"DIP 2",&H00000002)
+		       Array("DIP 1",&H00000001,"DIP 2",&H00000002)
 			.AddFrame  0,45, 60,"Game", 0,_
 		       Array("DIP M8",&H00000100,"DIP M7",&H00000200,"DIP M6",&H00000400,"DIP M5",&H00000800,_
 			       "DIP M4",&H00001000,"DIP M3",&H00002000,"DIP M2",&H00004000,"DIP M1",32768,_


### PR DESCRIPTION
This replaces the 9 character hex literal H000000001 with an 8 character hex literal H00000001.

Fixes https://github.com/vpinball/vpinball/issues/306