### PR TITLE
InGame UI: refactor of table startup/close, redesign of the live ui accordingly

### DIFF
--- a/LiveUI.cpp
+++ b/LiveUI.cpp
@@ -531,7 +531,10 @@ LiveUI::LiveUI(RenderDevice* const rd)
    m_StartTime_usec = usec();
    m_app = g_pvp;
    m_player = g_pplayer;
+   // FIXME update with the new startup/live table system
+   // m_table = g_pplayer->m_pEditorTable;
    m_table = g_pplayer->m_ptable;
+   m_live_table = g_pplayer->m_ptable;
    m_pininput = &(g_pplayer->m_pininput);
    m_pin3d = &(g_pplayer->m_pin3d);
    m_disable_esc = LoadValueBoolWithDefault(regKey[RegName::Player], "DisableESC"s, m_disable_esc);

--- a/LiveUI.cpp
+++ b/LiveUI.cpp
@@ -636,6 +636,24 @@ void LiveUI::Render()
 #endif
 }
 
+void LiveUI::OpenMainUI()
+{
+   // Opens the main UI. This will only open the main splash modal which allows to go further in the live UI.
+   if (!m_ShowUI && !m_ShowSplashModal)
+   {
+      m_ShowUI = false;
+      m_ShowBAMModal = false;
+      m_ShowSplashModal = true;
+      m_OpenUITime = msec();
+      PausePlayer(true);
+   }
+}
+
+void LiveUI::ToggleFPS()
+{
+   m_show_fps = (m_show_fps + 1) % 3;
+}
+
 void LiveUI::Update()
 {
    // For the time being, the UI is only available inside a running player
@@ -650,7 +668,7 @@ void LiveUI::Update()
    ImGui_ImplWin32_NewFrame();
    ImGui::NewFrame();
 
-   if (m_ShowUI)
+   if (m_ShowUI || m_ShowSplashModal)
    {
       // Main UI
       m_rotate = 0;
@@ -860,30 +878,11 @@ void LiveUI::ExitEditMode()
    SetupImGuiStyle(1.0f);
 }
 
-void LiveUI::OpenMainUI()
-{
-   if (!m_ShowUI)
-   {
-      m_ShowUI = true;
-      m_ShowBAMModal = false;
-      m_ShowSplashModal = true;
-      m_OpenUITime = msec();
-      PausePlayer(true);
-   }
-}
-
-void LiveUI::ToggleFPS()
-{
-   m_show_fps = (m_show_fps + 1) % 3;
-}
-
 void LiveUI::HideUI()
 { 
-   if (m_ShowUI) 
-   {
-      m_ShowUI = false;
-      PausePlayer(false);
-   }
+   m_ShowSplashModal = false;
+   m_ShowUI = false;
+   PausePlayer(false);
 }
 
 void LiveUI::UpdateMainUI()
@@ -899,7 +898,7 @@ void LiveUI::UpdateMainUI()
    bool popup_audio_settings = false;
    bool popup_renderer_inspection = false;
 
-   bool hide_parts = false;
+   bool hide_parts = !m_ShowUI;
    if (ImGui::IsPopupOpen(ID_RENDERER_INSPECTION))
    {
       hide_parts = true;
@@ -1259,6 +1258,7 @@ void LiveUI::UpdateMainSplashModal()
       }
       if (ImGui::Button("Live Editor", size))
       {
+         m_ShowUI = true;
          m_ShowSplashModal = false;
          ImGui::CloseCurrentPopup();
          EnterEditMode();

--- a/LiveUI.h
+++ b/LiveUI.h
@@ -2,6 +2,8 @@
 
 #include "stdafx.h"
 
+#include "imgui/imgui.h"
+
 class LiveUI
 {
 public:
@@ -31,15 +33,25 @@ private:
    void UpdateRendererInspectionModal();
 
    // UI Selection & properties
-   void CameraProperties();
-   void MaterialProperties();
-   void FlasherProperties();
-   void LightProperties();
-   void PrimitiveProperties();
-   void RampProperties();
-   void RubberProperties();
-   void SurfaceProperties();
-   void TableProperties();
+   void CameraProperties(bool is_live);
+   void MaterialProperties(bool is_live);
+   void TableProperties(bool is_live);
+   void FlasherProperties(bool is_live, Flasher *startup_obj, Flasher *live_obj);
+   void LightProperties(bool is_live, Light *startup_obj, Light *live_obj);
+   void PrimitiveProperties(bool is_live, Primitive *startup_obj, Primitive *live_obj);
+   void RampProperties(bool is_live, Ramp *startup_obj, Ramp *live_obj);
+   void RubberProperties(bool is_live, Rubber *startup_obj, Rubber *live_obj);
+   void SurfaceProperties(bool is_live, Surface *startup_obj, Surface *live_obj);
+
+   // Helpers for property edition
+   typedef std::function<void(LiveUI*, float prev, float v)> OnFloatPropChange;
+   void PropSeparator(const char *label = nullptr);
+   void PropCheckbox(const char *label, bool is_live, bool *startup_v, bool *live_v);
+   void PropFloat(const char *label, bool is_live, float *startup_v, float *live_v, float step, float step_fast, const char *format = "%.3f",
+      ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsDecimal, OnFloatPropChange chg_callback = nullptr);
+   void PropInt(const char *label, bool is_live, int *startup_v, int *live_v);
+   void PropRGB(const char *label, bool is_live, COLORREF *startup_v, COLORREF *live_v, ImGuiColorEditFlags flags = 0);
+   void PropVec3(const char *label, bool is_live, Vertex3Ds *startup_v, Vertex3Ds *live_v, const char *format = "%.3f", ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsDecimal);
 
    // Enter/Exit edit mode (manage table backup, dynamic mode,...)
    void HideUI();
@@ -51,12 +63,13 @@ private:
    VPinball *m_app;
    Player *m_player;
    PinTable *m_table; // The edited table
-   PinTable *m_live_table; // The live copy of the edited being played by the player
+   PinTable *m_live_table; // The live copy of the edited table being played by the player (all properties can be changed at any time by the script)
    PinInput *m_pininput;
    Pin3D *m_pin3d;
    struct Selection
    {
       enum SelectionType { S_NONE, S_CAMERA, S_MATERIAL, S_EDITABLE } type = S_NONE;
+      bool is_live;
       union
       {
          int camera;

--- a/LiveUI.h
+++ b/LiveUI.h
@@ -50,7 +50,8 @@ private:
    // UI Context
    VPinball *m_app;
    Player *m_player;
-   PinTable *m_table;
+   PinTable *m_table; // The edited table
+   PinTable *m_live_table; // The live copy of the edited being played by the player
    PinInput *m_pininput;
    Pin3D *m_pin3d;
    struct Selection

--- a/LiveUI.h
+++ b/LiveUI.h
@@ -13,6 +13,7 @@ public:
    bool HasMouseCapture() const;
 
    void OpenMainUI();
+   void ToggleFPS();
 
 private:
    // Interactive Camera Mode

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -31,6 +31,21 @@ Bumper::~Bumper()
    EndPlay();
 }
 
+Bumper *Bumper::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Bumper> *dst;
+   CComObject<Bumper>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 HRESULT Bumper::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/bumper.h
+++ b/bumper.h
@@ -107,6 +107,8 @@ public:
 
    void WriteRegDefaults() final;
 
+   Bumper *CopyForPlay(PinTable *live_table);
+
    BumperData m_d;
 
    BumperHitCircle *m_pbumperhitcircle;

--- a/decal.cpp
+++ b/decal.cpp
@@ -26,6 +26,26 @@ Decal::~Decal()
    delete m_meshBuffer;
 }
 
+Decal *Decal::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Decal> *dst;
+   CComObject<Decal>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Decal specific copy
+   dst->m_backglass = m_backglass;
+   dst->m_pIFont = m_pIFont;
+   dst->m_pIFont->AddRef();
+   dst->EnsureSize();
+   return dst;
+}
+
 HRESULT Decal::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/decal.h
+++ b/decal.h
@@ -87,6 +87,8 @@ public:
 
    void EnsureSize();
 
+   Decal *CopyForPlay(PinTable *live_table);
+
    DecalData m_d;
    IFont *m_pIFont;
 

--- a/dispreel.cpp
+++ b/dispreel.cpp
@@ -5,6 +5,22 @@ DispReel::DispReel()
 {
 }
 
+DispReel *DispReel::CopyForPlay(PinTable *live_table)
+{
+   CComObject<DispReel> *dst;
+   CComObject<DispReel>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // DispReel specific copy
+   return dst;
+}
+
 // This function is called when ever a new instance of this object is created
 // (along with the constructor (above))
 //

--- a/dispreel.h
+++ b/dispreel.h
@@ -145,6 +145,8 @@ public:
        m_d.m_updateinterval = max((int)5, interval);
    }
 
+   DispReel *CopyForPlay(PinTable *live_table);
+
    DispReelData m_d;
 
 private:

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -32,6 +32,30 @@ Flasher::~Flasher()
    }
 }
 
+Flasher *Flasher::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Flasher> *dst;
+   CComObject<Flasher>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Flasher specific copy
+   for (size_t i = 0; i < dst->m_vdpoint.size(); i++)
+      dst->m_vdpoint[i]->Release(); // Remove default points
+   dst->m_vdpoint.clear();
+   for (size_t i = 0; i < m_vdpoint.size(); i++)
+   {
+      m_vdpoint[i]->AddRef();
+      dst->m_vdpoint.push_back(m_vdpoint[i]);
+   }
+   return dst;
+}
+
 void Flasher::InitShape()
 {
    if (m_vdpoint.empty())

--- a/flasher.h
+++ b/flasher.h
@@ -137,6 +137,8 @@ public:
 
    void setInPlayState(const bool newVal);
 
+   Flasher *CopyForPlay(PinTable *live_table);
+
    FlasherData m_d;
 
    bool m_lockedByLS;

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -93,6 +93,21 @@ Flipper::~Flipper()
    delete m_meshBuffer;
 }
 
+Flipper *Flipper::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Flipper> *dst;
+   CComObject<Flipper>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 HRESULT Flipper::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/flipper.h
+++ b/flipper.h
@@ -171,6 +171,8 @@ public:
           m_d.m_FlipperRadiusMin = max(value,0.0f);
       }
 
+      Flipper *CopyForPlay(PinTable *live_table);
+
       FlipperData m_d;
       PinTable *m_ptable;
 

--- a/gate.cpp
+++ b/gate.cpp
@@ -21,6 +21,21 @@ Gate::Gate()
    m_numVertices = 0;
 }
 
+Gate *Gate::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Gate> *dst;
+   CComObject<Gate>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 void Gate::SetGateType(GateType type)
 {
     switch (m_d.m_type)

--- a/gate.h
+++ b/gate.h
@@ -96,6 +96,8 @@ public:
    float GetCloseAngle() const;
    void SetCloseAngle(const float angle);
 
+   Gate *CopyForPlay(PinTable *live_table);
+
    GateData m_d;
 
 private:

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -48,6 +48,23 @@ HitTarget::~HitTarget()
    delete m_meshBuffer;
 }
 
+HitTarget *HitTarget::CopyForPlay(PinTable *live_table)
+{
+   CComObject<HitTarget> *dst;
+   CComObject<HitTarget>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // HitTarget specific
+   dst->m_hitEvent = m_hitEvent;
+   return dst;
+}
+
 void HitTarget::SetMeshType(const TargetType type)
 {
     if (type == DropTargetBeveled)

--- a/hittarget.h
+++ b/hittarget.h
@@ -175,7 +175,9 @@ public:
    void SetMeshType(const TargetType type);
    void UpdateStatusBarInfo() final;
 
-   HitTargetData    m_d;
+   HitTarget *CopyForPlay(PinTable *live_table);
+
+   HitTargetData m_d;
 
    bool             m_hitEvent;
 

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -27,6 +27,21 @@ Kicker::~Kicker()
    delete m_plateMeshBuffer;
 }
 
+Kicker *Kicker::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Kicker> *dst;
+   CComObject<Kicker>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 void Kicker::UpdateStatusBarInfo()
 {
    char tbuf[128];

--- a/kicker.h
+++ b/kicker.h
@@ -85,6 +85,8 @@ public:
 
    void WriteRegDefaults() final;
 
+   Kicker *CopyForPlay(PinTable *live_table);
+
    KickerData m_d;
 
    vector<Vertex3Ds> m_hitMesh;
@@ -145,7 +147,7 @@ public:
    STDMETHOD(get_Legacy)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_Legacy)(/*[in]*/ VARIANT_BOOL newVal);
    STDMETHOD(get_LastCapturedBall)(/*[out, retval]*/ IBall **pVal);
-   };
+};
 
 class KickerHitCircle : public HitCircle
 {

--- a/light.cpp
+++ b/light.cpp
@@ -23,6 +23,44 @@ Light::~Light()
    FreeBuffers();
 }
 
+Light *Light::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Light> *dst;
+   CComObject<Light>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Light specific copy
+   dst->m_surfaceHeight = m_surfaceHeight;
+   dst->m_inPlayState = m_inPlayState;
+   dst->m_lockedByLS = m_lockedByLS;
+   dst->m_rgblinkpattern = m_rgblinkpattern;
+   dst->m_blinkinterval = m_blinkinterval;
+   dst->m_duration = m_duration;
+   dst->m_finalLightState = m_finalLightState;
+   dst->m_surfaceMaterial = m_surfaceMaterial;
+   dst->m_surfaceTexture = m_surfaceTexture;
+   dst->m_lightcenter = m_lightcenter;
+   dst->m_initSurfaceHeight = m_initSurfaceHeight;
+   dst->m_maxDist = m_maxDist;
+   dst->m_updateBulbLightHeight = m_updateBulbLightHeight;
+   dst->m_roundLight = m_roundLight;
+   for (size_t i = 0; i < dst->m_vdpoint.size(); i++)
+      dst->m_vdpoint[i]->Release(); // Remove default points
+   dst->m_vdpoint.clear();
+   for (size_t i = 0; i < m_vdpoint.size(); i++)
+   {
+      m_vdpoint[i]->AddRef();
+      dst->m_vdpoint.push_back(m_vdpoint[i]);
+   }
+   return dst;
+}
+
 HRESULT Light::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/light.h
+++ b/light.h
@@ -158,6 +158,8 @@ public:
 
    void RenderBulbMesh();
 
+   Light *CopyForPlay(PinTable *live_table);
+
    LightData m_d;
 
    float m_inPlayState; // 0..1 is modulated from off to on, 2 is blinking

--- a/lightseq.cpp
+++ b/lightseq.cpp
@@ -8,6 +8,23 @@ LightSeq::~LightSeq()
 {
 }
 
+LightSeq *LightSeq::CopyForPlay(PinTable *live_table)
+{
+   CComObject<LightSeq> *dst;
+   CComObject<LightSeq>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // LightSeq specific copy
+   dst->m_backglass = m_backglass;
+   return dst;
+}
+
 HRESULT LightSeq::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/lightseq.h
+++ b/lightseq.h
@@ -182,6 +182,8 @@ public:
    long     GetUpdateInterval() const { return m_d.m_updateinterval; }
    void     SetUpdateInterval(const long value) { m_d.m_updateinterval = max((long)1, value); }
 
+   LightSeq *CopyForPlay(PinTable *live_table);
+
    LightSeqData m_d;
 
 private:

--- a/pin/player.h
+++ b/pin/player.h
@@ -308,7 +308,7 @@ struct TimerOnOff
 class Player : public CWnd
 {
 public:
-   Player(const bool cameraMode, PinTable * const ptable);
+   Player(const bool cameraMode, PinTable *const editor_table, PinTable *const live_table);
    virtual ~Player();
 
    void CreateWnd(HWND parent = 0);
@@ -398,7 +398,8 @@ public:
    bool m_dynamicMode;
    bool m_cameraMode;
    int m_backdropSettingActive;
-   PinTable *m_ptable;
+   PinTable * const m_pEditorTable; // The untouched version of the table, as it is in the editor (The Player needs it to interact with the UI)
+   PinTable * const m_ptable; // The played table, which can be modified by the script
 
    Pin3D m_pin3d;
 

--- a/pininput.cpp
+++ b/pininput.cpp
@@ -1264,12 +1264,12 @@ void PinInput::Joy(const unsigned int n, const int updown, const bool start)
    if (m_joyexitgamekey == n)
    {
       if (DISPID_GameEvents_KeyDown == updown)
-         g_pplayer->ShowUI();
+         g_pplayer->m_liveUI->OpenMainUI();
    }
    if (m_joyframecount == n)
    {
       if (DISPID_GameEvents_KeyDown == updown)
-         g_pplayer->ShowUI();
+         g_pplayer->m_liveUI->ToggleFPS();
    }
    if (m_joyvolumeup == n)   FireKeyEvent(updown, g_pplayer->m_rgKeys[eVolumeUp]);
    if (m_joyvolumedown == n) FireKeyEvent(updown, g_pplayer->m_rgKeys[eVolumeDown]);
@@ -1477,7 +1477,7 @@ void PinInput::ProcessJoystick(const DIDEVICEOBJECTDATA * __restrict input, int 
             if (((uShockType == USHOCKTYPE_PBWIZARD) || (uShockType == USHOCKTYPE_VIRTUAPIN)) && !m_override_default_buttons) // pause menu
             {
                if (DISPID_GameEvents_KeyDown == updown)
-                  g_pplayer->ShowUI();
+                  g_pplayer->m_liveUI->OpenMainUI();
             }
             else if ((uShockType == USHOCKTYPE_ULTRACADE) && !m_override_default_buttons) // volume down
                 FireKeyEvent(updown, g_pplayer->m_rgKeys[eVolumeDown]);
@@ -1953,7 +1953,7 @@ void PinInput::ProcessKeys(/*const U32 curr_sim_msec,*/ int curr_time_msec) // l
          if (input->dwOfs == (DWORD)g_pplayer->m_rgKeys[eFrameCount])
          {
             if ((input->dwData & 0x80) != 0)
-               g_pplayer->ShowUI();
+               g_pplayer->m_liveUI->ToggleFPS();
          }
          else if (input->dwOfs == (DWORD)g_pplayer->m_rgKeys[eEnable3D])
          {
@@ -1990,7 +1990,7 @@ void PinInput::ProcessKeys(/*const U32 curr_sim_msec,*/ int curr_time_msec) // l
             if (started() || !g_pplayer->m_ptable->m_tblAutoStartEnabled)
             {
                if (input->dwData & 0x80)
-                  g_pplayer->ShowUI();
+                  g_pplayer->m_liveUI->OpenMainUI();
             }
          }
          else

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -2254,7 +2254,12 @@ void PinTable::Play(const bool cameraMode)
       dst->m_BG_image[i] = src->m_BG_image[i];
    }
    for (size_t i = 0; i < src->m_materials.size(); i++)
-      dst->m_materials.push_back(new Material(src->m_materials[i]));
+   {
+      Material *mat = new Material(src->m_materials[i]);
+      dst->m_materials.push_back(mat);
+      dst->m_startupToLive[src->m_materials[i]] = mat;
+      dst->m_liveToStartup[mat] = src->m_materials[i];
+   }
 
    // Don't perform deep copy for these parts that can't be modified by the script
    for (size_t i = 0; i < src->m_vimage.size(); i++)
@@ -2288,14 +2293,15 @@ void PinTable::Play(const bool cameraMode)
       case eItemTextbox:   edit_dst = ((Textbox *)  src->m_vedit[i])->CopyForPlay(live_table); break;
       case eItemTimer:     edit_dst = ((Timer *)    src->m_vedit[i])->CopyForPlay(live_table); break;
       case eItemTrigger:   edit_dst = ((Trigger *)  src->m_vedit[i])->CopyForPlay(live_table); break;
+      default: assert(false); // Unexpected table part
       }
       if (edit_dst != nullptr)
       {
          live_table->m_vedit.push_back(edit_dst);
          if (edit_dst->GetScriptable())
             live_table->m_pcv->AddItem(edit_dst->GetScriptable(), false);
-         m_startupToLive[src->m_vedit[i]] = edit_dst;
-         m_liveToStartup[edit_dst] = src->m_vedit[i];
+         dst->m_startupToLive[src->m_vedit[i]] = edit_dst;
+         dst->m_liveToStartup[edit_dst] = src->m_vedit[i];
       }
    }
 
@@ -2310,9 +2316,9 @@ void PinTable::Play(const bool cameraMode)
       pcol->m_groupElements = m_vcollection[i].m_groupElements;
       for (int j = 0; j < m_vcollection[i].m_visel.size(); ++j)
       {
-         if (m_startupToLive.find(m_vcollection[i].m_visel[j].GetIEditable()) != m_startupToLive.end())
+         if (dst->m_startupToLive.find(m_vcollection[i].m_visel[j].GetIEditable()) != dst->m_startupToLive.end())
          {
-            auto edit_item = m_startupToLive[m_vcollection[i].m_visel[j].GetIEditable()];
+            auto edit_item = (IEditable*) dst->m_startupToLive[m_vcollection[i].m_visel[j].GetIEditable()];
             edit_item->m_vCollection.push_back(pcol);
             edit_item->m_viCollection.push_back(pcol->m_visel.size());
             pcol->m_visel.push_back(edit_item->GetISelect());

--- a/pintable.h
+++ b/pintable.h
@@ -357,11 +357,10 @@ public:
    void FireKeyEvent(int dispid, int keycode);
 
    void HandleLoadFailure();
-
-   // also creates Player instance
-   void Play(const bool cameraMode);
-   // called before Player instance gets deleted
-   void StopPlaying();
+   
+   void Play(const bool cameraMode); // Duplicate table into a live instance, create a player to run it, suspend edit mode
+   void OnPlayerStopped(); // Called after player has stopped, to get back to edit state
+   void StopPlaying(); // Called on a live instance of the table (copy for playing) before Player instance gets deleted
 
    void ImportSound(const HWND hwndListView, const string &filename);
    void ReImportSound(const HWND hwndListView, PinSound *const pps, const string &filename);
@@ -588,6 +587,8 @@ public:
 
    string m_szFileName;
    string m_szTitle;
+
+   bool is_live_instance = false; // true for live shallow copy of a table
 
    // editor viewport
    Vertex2D m_offset;
@@ -841,7 +842,6 @@ public:
 
    virtual void OnInitialUpdate() override;
    virtual LRESULT WndProc(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
-   virtual BOOL OnCommand(WPARAM wparam, LPARAM lparam) override;
    virtual BOOL OnEraseBkgnd(CDC &dc) override;
 
    void SetMouseCursor();
@@ -891,7 +891,7 @@ public:
    CString GetNotesText() const { return m_notesText; }
 
 private:
-   PinTableMDI *m_mdiTable;
+   PinTableMDI *m_mdiTable = nullptr;
    CString m_notesText;
    robin_hood::unordered_map<string, Texture *, StringHashFunctor, StringComparator> m_textureMap; // hash table to speed up texture lookup by name
    robin_hood::unordered_map<string, Material *, StringHashFunctor, StringComparator> m_materialMap; // hash table to speed up material lookup by name

--- a/pintable.h
+++ b/pintable.h
@@ -589,8 +589,8 @@ public:
    string m_szTitle;
 
    bool m_isLiveInstance = false; // true for live shallow copy of a table
-   std::unordered_map<IEditable *, IEditable *> m_startupToLive; // For live table, maps back and forth to startup table editable parts
-   std::unordered_map<IEditable *, IEditable *> m_liveToStartup;
+   std::unordered_map<void *, void *> m_startupToLive; // For live table, maps back and forth to startup table editable parts, materials,...
+   std::unordered_map<void *, void *> m_liveToStartup;
 
    // editor viewport
    Vertex2D m_offset;

--- a/pintable.h
+++ b/pintable.h
@@ -588,7 +588,9 @@ public:
    string m_szFileName;
    string m_szTitle;
 
-   bool is_live_instance = false; // true for live shallow copy of a table
+   bool m_isLiveInstance = false; // true for live shallow copy of a table
+   std::unordered_map<IEditable *, IEditable *> m_startupToLive; // For live table, maps back and forth to startup table editable parts
+   std::unordered_map<IEditable *, IEditable *> m_liveToStartup;
 
    // editor viewport
    Vertex2D m_offset;

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -11,6 +11,21 @@ Plunger::~Plunger()
    delete m_meshBuffer;
 }
 
+Plunger* Plunger::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Plunger> *dst;
+   CComObject<Plunger>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 HRESULT Plunger::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/plunger.h
+++ b/plunger.h
@@ -152,14 +152,16 @@ public:
    // ISupportsErrorInfo
    STDMETHOD(InterfaceSupportsErrorInfo)(REFIID riid);
 
+   Plunger* CopyForPlay(PinTable *live_table);
+
    PlungerData m_d;
 
 private:
-   PinTable *m_ptable;
+   PinTable *m_ptable = nullptr;
 
    MeshBuffer *m_meshBuffer = nullptr;
 
-   HitPlunger *m_phitplunger;
+   HitPlunger *m_phitplunger = nullptr;
 
    //
    // Plunger animation details.  We calculate these in RenderSetup()
@@ -167,13 +169,13 @@ private:
    //
 
    // number of animation frames
-   int m_cframes;
+   int m_cframes = 0;
 
    // number of vertices per animation frame
-   int m_vtsPerFrame;
+   int m_vtsPerFrame = 0;
 
    // number of triangle indices per frame
-   int m_indicesPerFrame;
+   int m_indicesPerFrame = 0;
 
 // IPlunger
 public:

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -201,6 +201,23 @@ Primitive::~Primitive()
    delete m_meshBuffer;
 }
 
+Primitive *Primitive::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Primitive> *dst;
+   CComObject<Primitive>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Primitive specific fields
+   dst->m_mesh = m_mesh;
+   return dst;
+}
+
 void Primitive::CreateRenderGroup(const Collection * const collection)
 {
    if (!collection->m_groupElements)

--- a/primitive.h
+++ b/primitive.h
@@ -306,6 +306,8 @@ public:
 
    void setInPlayState(const bool newVal);
 
+   Primitive *CopyForPlay(PinTable *live_table);
+
    static INT_PTR CALLBACK ObjImportProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
    Mesh m_mesh;

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -28,6 +28,30 @@ Ramp::~Ramp()
       delete[] m_rgheightInit;
 }
 
+Ramp *Ramp::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Ramp> *dst;
+   CComObject<Ramp>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Ramp specific copy
+   for (size_t i = 0; i < dst->m_vdpoint.size(); i++)
+      dst->m_vdpoint[i]->Release(); // Remove default points
+   dst->m_vdpoint.clear();
+   for (size_t i = 0; i < m_vdpoint.size(); i++)
+   {
+      m_vdpoint[i]->AddRef();
+      dst->m_vdpoint.push_back(m_vdpoint[i]);
+   }
+   return dst;
+}
+
 void Ramp::UpdateStatusBarInfo()
 {
    char tbuf[128];

--- a/ramp.h
+++ b/ramp.h
@@ -116,6 +116,8 @@ public:
    float GetSurfaceHeight(float x, float y) const;
    bool isHabitrail() const;
 
+   Ramp *CopyForPlay(PinTable *live_table);
+
    RampData m_d;
 
 private:

--- a/resource.h
+++ b/resource.h
@@ -1401,8 +1401,6 @@
 #define ID_EXPORT_TABLEMESH             33002
 #define ID_ADD_CTRL_POINT               33003
 #define ID_ADD_SMOOTH_CTRL_POINT        33004
-#define ID_TABLE_STOP_PLAY              33005
-#define ID_TABLE_PLAYER_STOPPED         33006
 #define ID_ASSIGN_TO_LAYER1             41000
 #define ID_ASSIGN_TO_LAYER2             41001
 #define ID_ASSIGN_TO_LAYER3             41002

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -24,6 +24,30 @@ Rubber::~Rubber()
    delete m_meshBuffer;
 }
 
+Rubber *Rubber::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Rubber> *dst;
+   CComObject<Rubber>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Rubber specific copy
+   for (size_t i = 0; i < dst->m_vdpoint.size(); i++)
+      dst->m_vdpoint[i]->Release(); // Remove default points
+   dst->m_vdpoint.clear();
+   for (size_t i = 0; i < m_vdpoint.size(); i++)
+   {
+      m_vdpoint[i]->AddRef();
+      dst->m_vdpoint.push_back(m_vdpoint[i]);
+   }
+   return dst;
+}
+
 void Rubber::UpdateStatusBarInfo()
 {
    char tbuf[128];

--- a/rubber.h
+++ b/rubber.h
@@ -106,6 +106,7 @@ public:
 #if 0
    float GetSurfaceHeight(float x, float y) const;
 #endif
+   Rubber *CopyForPlay(PinTable *live_table);
 
    RubberData m_d;
 

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -18,6 +18,21 @@ Spinner::~Spinner()
    delete m_plateMeshBuffer;
 }
 
+Spinner *Spinner::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Spinner> *dst;
+   CComObject<Spinner>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 void Spinner::UpdateStatusBarInfo()
 {
    char tbuf[128];

--- a/spinner.h
+++ b/spinner.h
@@ -88,6 +88,8 @@ public:
    float GetAngleMin() const;
    void  SetAngleMin(const float angle);
 
+   Spinner *CopyForPlay(PinTable *live_table);
+
    SpinnerData m_d;
 
 private:

--- a/surface.cpp
+++ b/surface.cpp
@@ -22,6 +22,33 @@ Surface::~Surface()
    FreeBuffers();
 }
 
+Surface *Surface::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Surface> *dst;
+   CComObject<Surface>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Surface specific copy
+   dst->m_isWall = m_isWall;
+   dst->m_isDynamic = m_isDynamic;
+   dst->m_isDropped = m_isDropped;
+   for (size_t i = 0; i < dst->m_vdpoint.size(); i++)
+      dst->m_vdpoint[i]->Release(); // Remove default points
+   dst->m_vdpoint.clear();
+   for (size_t i = 0; i < m_vdpoint.size(); i++)
+   {
+      m_vdpoint[i]->AddRef();
+      dst->m_vdpoint.push_back(m_vdpoint[i]);
+   }
+   return dst;
+}
+
 bool Surface::IsTransparent() const
 {
    bool result = false;

--- a/surface.h
+++ b/surface.h
@@ -129,6 +129,8 @@ public:
 
    bool     StaticRendering() const { return (!m_d.m_droppable && !m_isDynamic); }
 
+   Surface *CopyForPlay(PinTable *live_table);
+
    SurfaceData m_d;
    bool m_disabled;
 

--- a/textbox.cpp
+++ b/textbox.cpp
@@ -14,6 +14,21 @@ Textbox::~Textbox()
    m_pIFont->Release();
 }
 
+Textbox *Textbox::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Textbox> *dst;
+   CComObject<Textbox>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 HRESULT Textbox::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/textbox.h
+++ b/textbox.h
@@ -78,6 +78,8 @@ public:
    char *GetFontName();
    HFONT GetFont();
 
+   Textbox *CopyForPlay(PinTable *live_table);
+
    IFont *m_pIFont;
 
    TextboxData m_d;

--- a/timer.cpp
+++ b/timer.cpp
@@ -8,6 +8,21 @@ Timer::~Timer()
 {
 }
 
+Timer *Timer::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Timer> *dst;
+   CComObject<Timer>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   return dst;
+}
+
 HRESULT Timer::Init(PinTable * const ptable, const float x, const float y, const bool fromMouseClick)
 {
    m_ptable = ptable;

--- a/timer.h
+++ b/timer.h
@@ -88,6 +88,8 @@ public:
    STDMETHOD(get_Enabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_Enabled)(/*[in]*/ VARIANT_BOOL newVal);
 
+   Timer *CopyForPlay(PinTable *live_table);
+
    TimerData m_d;
 
 private:

--- a/trigger.cpp
+++ b/trigger.cpp
@@ -34,6 +34,30 @@ Trigger::~Trigger()
    }
 }
 
+Trigger *Trigger::CopyForPlay(PinTable *live_table)
+{
+   CComObject<Trigger> *dst;
+   CComObject<Trigger>::CreateInstance(&dst);
+   dst->AddRef();
+   dst->Init(live_table, 0.f, 0.f, false);
+   memcpy(dst->m_wzName, m_wzName, MAXNAMEBUFFER * sizeof(m_wzName[0]));
+   dst->m_d = m_d;
+   dst->m_oldLayerIndex = m_oldLayerIndex;
+   dst->m_layerName = m_layerName;
+   dst->m_isVisible = m_isVisible;
+   dst->m_locked = m_locked;
+   // Trigger specific
+   dst->m_hitEnabled = m_hitEnabled;
+   for (size_t i = 0; i < dst->m_vdpoint.size(); i++)
+      dst->m_vdpoint[i]->Release(); // Remove default points
+   dst->m_vdpoint.clear();
+   for (size_t i = 0; i < m_vdpoint.size(); i++)
+   {
+      m_vdpoint[i]->AddRef();
+      dst->m_vdpoint.push_back(m_vdpoint[i]);
+   }
+   return dst;
+}
 
 void Trigger::UpdateStatusBarInfo()
 {

--- a/trigger.h
+++ b/trigger.h
@@ -104,6 +104,8 @@ public:
    void TriggerAnimationHit();
    void TriggerAnimationUnhit();
 
+   Trigger *CopyForPlay(PinTable *live_table);
+
    TriggerData m_d;
 
    bool m_hitEnabled;		// for custom shape triggers


### PR DESCRIPTION
InGame editing was greatly limited by the fact that the player is ran on the edited table which is restored after play (erasing any changes, excepted for camera/light/material through a little hack). Having the player running on the editor's table data was also a problem for multithreaded rendering in the BGFX branch.

So, I refactored it in order that when starting a table, a shallow copy of the editor's table is performed and given to the player. This makes things cleaner and easier to manage, and also allows to inspect/compare/edit both the edited vs running version of the table (somewhat in the manner of Godot with its remote/local node tree view, see: https://docs.godotengine.org/en/stable/tutorials/scripting/nodes_and_scene_instances.html#creating-nodes).

The PR also contains some initial refactoring of the LiveUI:
- Put back F11 for FPS since it is used independently of the other part of the UI
- When opened, just show the basic message box since most user will never use the LiveUI
- Add support for Live / Startup view of the table tree / part properties with editing & syncing capabilities
- Add some more properties
- Cleanup

The PR breaks the 'legacy' debugger UI for material / light. Regarding this, I would like to:
- add the missing properties to the liveUI for lights (volatile state property)
- remove the debugger material / light dialog (opened from the existing debugger dialog)
- remove the debug material / light little hack (copy of objects that used to be commited after play)
- remove the backup for play / restore functions and little hacks around the hash crypt key

but if you prefer, I can hack the existing 'legacy' material/light debug dialogs and get them to work again. And obvisouly the cleanup of the old backup/restore can be postponed.

@toxieainc Just tell me what's your choice!
