### PR TITLE
Fix for edge-case DSound enumeration crash

### DIFF
--- a/audioplayer.cpp
+++ b/audioplayer.cpp
@@ -45,7 +45,14 @@ AudioPlayer::AudioPlayer()
           DSAudioDevices DSads;
           if (!FAILED(DirectSoundEnumerate(DSEnumCallBack, &DSads)))
           {
-              if ((size_t)DSidx >= DSads.size() || DSads[DSidx]->guid != nullptr) // primary device has guid nullptr, so use BASS_idx = -1 in that case
+              if ((size_t)DSidx >= DSads.size())
+              {
+                 for (size_t i = 0; i < DSads.size(); i++)
+                    delete DSads[i];
+                 continue;
+              }
+
+              if (DSads[DSidx]->guid != nullptr) // primary device has guid nullptr, so use BASS_idx = -1 in that case
               {
                   BASS_DEVICEINFO dinfo;
                   for (int i = 1; BASS_GetDeviceInfo(i, &dinfo); i++) // 0 = no sound/no device

--- a/audioplayer.cpp
+++ b/audioplayer.cpp
@@ -45,14 +45,7 @@ AudioPlayer::AudioPlayer()
           DSAudioDevices DSads;
           if (!FAILED(DirectSoundEnumerate(DSEnumCallBack, &DSads)))
           {
-              if ((size_t)DSidx >= DSads.size())
-              {
-                 for (size_t i = 0; i < DSads.size(); i++)
-                    delete DSads[i];
-                 continue;
-              }
-
-              if (DSads[DSidx]->guid != nullptr) // primary device has guid nullptr, so use BASS_idx = -1 in that case
+              if ((size_t)DSidx < DSads.size() && DSads[DSidx]->guid != nullptr) // primary device has guid nullptr, so use BASS_idx = -1 in that case
               {
                   BASS_DEVICEINFO dinfo;
                   for (int i = 1; BASS_GetDeviceInfo(i, &dinfo); i++) // 0 = no sound/no device


### PR DESCRIPTION
If the registry entry for a DSound device is past the end of the enumerated array, the existing code will attempt to dereference anyway and crash. This PR fixes this case.