### PR TITLE
Sync: simplify to be more resilient

### DIFF
--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -91,7 +91,6 @@ public:
    SDL_Window* m_sdl_playfieldHwnd = nullptr;
    SDL_GLContext m_sdl_context = nullptr;
    IDXGIOutput* m_DXGIOutput = nullptr;
-   int m_swapInterval;
 
 #else
    enum PrimitiveTypes
@@ -111,7 +110,7 @@ public:
       TRANSFORMSTATE_PROJECTION
    };
 
-   RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, const VideoSyncMode syncMode, const int maxFrameRate, const float AAfactor,
+   RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, const VideoSyncMode syncMode, const float AAfactor,
       const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl, const bool useNvidiaApi, const bool disable_dwm, const int BWrendering);
    ~RenderDevice();
    void CreateDevice(int &refreshrate, UINT adapterIndex = D3DADAPTER_DEFAULT);
@@ -134,15 +133,7 @@ public:
    void LogNextFrame() { m_logNextFrame = true; }
    bool IsLogNextFrame() const { return m_logNextFrame; }
    void FlushRenderFrame();
-   void Flip(const int flipSchedule);
-   bool SupportsDynamicFlipSchedule() const
-   {
-      #ifdef ENABLE_SDL // OpenGL
-	  return true;
-	  #else // DirectX 9
-	  return m_pD3DDeviceEx != nullptr;
-	  #endif
-   }
+   void Flip();
    void WaitForVSync(const bool asynchronous);
 
    bool SetMaximumPreRenderedFrames(const DWORD frames);
@@ -245,7 +236,6 @@ public:
    bool          m_fullscreen;
    int           m_colorDepth;
    VideoSyncMode m_videoSyncMode;
-   int           m_maxFrameRate;
    StereoMode    m_stereo3D;
    float         m_AAfactor;
    bool          m_ssRefl;

--- a/pin/player.h
+++ b/pin/player.h
@@ -374,7 +374,6 @@ public:
    bool m_lastFrameSyncOnFPS;
    bool m_curFrameSyncOnVBlank = false;
    bool m_curFrameSyncOnFPS = false;
-   bool m_resyncOnVBlank = false;
 
 #pragma endregion
 

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -415,7 +415,7 @@ BaseTexture* EnvmapPrecalc(const Texture* envTex, const unsigned int rad_env_xre
    return radTex;
 }
 
-HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int& refreshrate, const VideoSyncMode syncMode, const int maxFrameRate, const float AAfactor,
+HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int& refreshrate, const VideoSyncMode syncMode, const float AAfactor,
    const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl)
 {
    const int display = g_pvp->m_primaryDisplay ? 0 : LoadValueWithDefault(regKey[RegName::Player], "Display"s, 0);
@@ -426,7 +426,7 @@ HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int& ref
       if (display == dispConf->display)
          adapter = dispConf->adapter;
 
-   m_pd3dPrimaryDevice = new RenderDevice(g_pplayer->GetHwnd(), m_viewPort.Width, m_viewPort.Height, fullScreen, colordepth, syncMode, maxFrameRate, AAfactor, stereo3D, FXAA, sharpen, ss_refl,
+   m_pd3dPrimaryDevice = new RenderDevice(g_pplayer->GetHwnd(), m_viewPort.Width, m_viewPort.Height, fullScreen, colordepth, syncMode, AAfactor, stereo3D, FXAA, sharpen, ss_refl,
       g_pplayer->m_useNvidiaApi, g_pplayer->m_disableDWM, g_pplayer->m_BWrendering);
    try {
       m_pd3dPrimaryDevice->CreateDevice(refreshrate, adapter);
@@ -475,7 +475,7 @@ HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int& ref
 }
 
 HRESULT Pin3D::InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int& refreshrate, const VideoSyncMode syncMode,
-   const int maxFrameRate, const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl)
+   const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl)
 {
    m_stereo3D = stereo3D;
    m_mvp = new ModelViewProj(m_stereo3D == STEREO_OFF ? 1 : 2);
@@ -489,7 +489,7 @@ HRESULT Pin3D::InitPin3D(const bool fullScreen, const int width, const int heigh
    m_viewPort.MinZ = 0.0f;
    m_viewPort.MaxZ = 1.0f;
 
-   if (FAILED(InitPrimary(fullScreen, colordepth, refreshrate, syncMode, maxFrameRate, AAfactor, stereo3D, FXAA, sharpen, ss_refl)))
+   if (FAILED(InitPrimary(fullScreen, colordepth, refreshrate, syncMode, AAfactor, stereo3D, FXAA, sharpen, ss_refl)))
       return E_FAIL;
 
    m_pd3dSecondaryDevice = m_pd3dPrimaryDevice; //!! for now, there is no secondary device :/

--- a/pin3d.h
+++ b/pin3d.h
@@ -96,7 +96,7 @@ public:
    ~Pin3D();
 
    HRESULT InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const VideoSyncMode syncMode, 
-      const int maxFrameRate, const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl);
+      const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl);
 
    void InitLayout(const float xpixoff = 0.f, const float ypixoff = 0.f);
 
@@ -121,7 +121,7 @@ private:
    void InitRenderState(RenderDevice * const pd3dDevice);
    void InitPrimaryRenderState();
    void InitSecondaryRenderState();
-   HRESULT InitPrimary(const bool fullScreen, const int colordepth, int& refreshrate, const VideoSyncMode syncMode, const int maxFrameRate, const float AAfactor, const StereoMode stereo3D,
+   HRESULT InitPrimary(const bool fullScreen, const int colordepth, int& refreshrate, const VideoSyncMode syncMode, const float AAfactor, const StereoMode stereo3D,
       const unsigned int FXAA, const bool sharpen, const bool ss_refl);
 
    StereoMode m_stereo3D;

--- a/wintimer.h
+++ b/wintimer.h
@@ -164,23 +164,6 @@ public:
       return count == 0 ? 0. : (double)sum / (double)count;
    }
 
-   double GetAvgFrameLength(unsigned int defaultFrameLength) const
-   {
-      unsigned int pos = (m_profileIndex + N_SAMPLES - 1) % N_SAMPLES; // Start from last frame
-      unsigned int sum = 0u;
-      unsigned int count = 0u;
-      constexpr unsigned int navg = 5;
-      for (unsigned int i = 0u; i < navg; i++)
-      {
-         if (count >= m_frameIndex)
-            break;
-         count++;
-         sum += m_profileData[pos][ProfileSection::PROFILE_FRAME];
-         pos = (pos + N_SAMPLES - 1) % N_SAMPLES;
-      }
-      return ((count < navg ? (navg - count) : 0) * (double)defaultFrameLength + (double)sum) / (double)navg;
-   }
-
    double GetSlidingInputLag(const bool isMax) const
    {
       unsigned int pos = (m_processInputIndex + N_SAMPLES - 1) % N_SAMPLES; // Start from last frame


### PR DESCRIPTION
- do not use D3D9Ex flipex since it breaks on Windows 11 fullscreen
- do not support syncing to higher speed than framerate unless sync mode is None (like before)
- do not perform dynamic throttling of frame pacing when the computer can not keep up, in this situation just defaults to adaptive sync (with higher input latency)
- evaluate TableAdaptiveSync on startup and not after since it was not supported anyway