### PR TITLE
Anaglyph: add dynamic desaturation to luminance filter for optimized retinal rivalry

### DIFF
--- a/LiveUI.cpp
+++ b/LiveUI.cpp
@@ -2016,8 +2016,8 @@ void LiveUI::UpdateVideoOptionsModal()
                }
                if (ImGui::InputText("Name", &name[glassesIndex]))
                   SaveValue(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Name"s), name[glassesIndex]);
-               const char *filter_items[] = { "Luminance", "Deghost", "Dubois", "None" };
-               int anaglyphFilter = LoadValueWithDefault(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Filter"s), 0);
+               const char *filter_items[] = { "None", "Dubois", "Deghost", "Luminance", "Dyn. Desat.", };
+               int anaglyphFilter = LoadValueWithDefault(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Filter"s), 4);
                if (ImGui::Combo("Filter", &anaglyphFilter, filter_items, IM_ARRAYSIZE(filter_items)))
                   SaveValue(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Filter"s), anaglyphFilter);
                // Global anaglyph settings

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -133,6 +133,7 @@ const string Shader::shaderTechniqueNames[SHADER_TECHNIQUE_COUNT]
    SHADER_TECHNIQUE(stereo_Flipped_Int),
    SHADER_TECHNIQUE(Stereo_LinearAnaglyph),
    SHADER_TECHNIQUE(Stereo_DeghostAnaglyph),
+   SHADER_TECHNIQUE(Stereo_DynDesatAnaglyph),
    SHADER_TECHNIQUE(irradiance),
 };
 #undef SHADER_TECHNIQUE
@@ -268,6 +269,8 @@ Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_UNIFORM(SUT_Float4x4, Stereo_RightMat, 1), // Anaglyph Stereo
    SHADER_UNIFORM(SUT_Float4, Stereo_DeghostGamma, 1), // Anaglyph Stereo
    SHADER_UNIFORM(SUT_Float4x4, Stereo_DeghostFilter, 1), // Anaglyph Stereo
+   SHADER_UNIFORM(SUT_Float4, Stereo_LeftLuminance, 1), // Anaglyph Stereo
+   SHADER_UNIFORM(SUT_Float4, Stereo_RightLuminance, 1), // Anaglyph Stereo
 };
 #undef SHADER_UNIFORM
 #undef SHADER_SAMPLER

--- a/Shader.h
+++ b/Shader.h
@@ -128,6 +128,7 @@ enum ShaderTechniques
    SHADER_TECHNIQUE(stereo_Flipped_Int),
    SHADER_TECHNIQUE(Stereo_LinearAnaglyph),
    SHADER_TECHNIQUE(Stereo_DeghostAnaglyph),
+   SHADER_TECHNIQUE(Stereo_DynDesatAnaglyph),
    SHADER_TECHNIQUE(irradiance),
    SHADER_TECHNIQUE_COUNT,
    SHADER_TECHNIQUE_INVALID
@@ -272,6 +273,8 @@ enum ShaderUniforms
    SHADER_UNIFORM(SUT_Float4x4, Stereo_RightMat, 1), // Anaglyph Stereo
    SHADER_UNIFORM(SUT_Float4, Stereo_DeghostGamma, 1), // Anaglyph Stereo
    SHADER_UNIFORM(SUT_Float4x4, Stereo_DeghostFilter, 1), // Anaglyph Stereo
+   SHADER_UNIFORM(SUT_Float4, Stereo_LeftLuminance, 1), // Anaglyph Stereo
+   SHADER_UNIFORM(SUT_Float4, Stereo_RightLuminance, 1), // Anaglyph Stereo
 
    SHADER_UNIFORM_COUNT,
    SHADER_UNIFORM_INVALID

--- a/dialogs/VideoOptionsDialog.cpp
+++ b/dialogs/VideoOptionsDialog.cpp
@@ -520,10 +520,11 @@ BOOL VideoOptionsDialog::OnInitDialog()
 
    hwnd = GetDlgItem(IDC_3D_STEREO_ANAGLYPH_FILTER).GetHwnd();
    SendMessage(hwnd, WM_SETREDRAW, FALSE, 0); // to speed up adding the entries :/
-   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Luminance");
-   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Deghost");
-   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Dubois");
    SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "None");
+   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Dubois");
+   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Deghost");
+   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Luminance");
+   SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM) "Dyn. Desat.");
    SendMessage(hwnd, WM_SETREDRAW, TRUE, 0);
 
    OnCommand(IDC_3D_STEREO, 0L); // Force UI update
@@ -881,7 +882,7 @@ BOOL VideoOptionsDialog::OnCommand(WPARAM wParam, LPARAM lParam)
             GetDlgItem(IDC_3D_STEREO_DESATURATION).EnableWindow(true);
             GetDlgItem(IDC_3D_STEREO_ANAGLYPH_FILTER).EnableWindow(true);
             int glassesIndex = stereo3D - STEREO_ANAGLYPH_1;
-            int anaglyphFilter = LoadValueWithDefault(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Filter"s), 0);
+            int anaglyphFilter = LoadValueWithDefault(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Filter"s), 4);
             SendMessage(GetDlgItem(IDC_3D_STEREO_ANAGLYPH_FILTER), CB_SETCURSEL, anaglyphFilter, 0);
          }
       }
@@ -1045,7 +1046,7 @@ void VideoOptionsDialog::OnOK()
       int glassesIndex = stereo3D - STEREO_ANAGLYPH_1;
       LRESULT anaglyphFilter = SendMessage(GetDlgItem(IDC_3D_STEREO_ANAGLYPH_FILTER).GetHwnd(), CB_GETCURSEL, 0, 0);
       if (anaglyphFilter == LB_ERR)
-         anaglyphFilter = 0;
+         anaglyphFilter = 4;
       SaveValue(regKey[RegName::Player], "Anaglyph"s.append(std::to_string(glassesIndex + 1)).append("Filter"s), (int) anaglyphFilter);
    }
 

--- a/shader/StereoShader.glfx
+++ b/shader/StereoShader.glfx
@@ -77,6 +77,16 @@ void main()
 }
 
 
+////ps_main_stereo_dyndesat_anaglyph
+void main()
+{
+   float3 lCol, rCol, lColDesat, rColDesat;
+   gatherLeftRightColors(tex0, lCol, rCol);
+   DynamicDesatAnaglyph(lCol, rCol, lColDesat, rColDesat);
+   color = float4(LinearAnaglyph(lColDesat, rColDesat), 1.0);
+}
+
+
 ////TECHNIQUES
 
 stereo_SBS:P0:vs_main_no_trafo():ps_main_sbs()
@@ -85,3 +95,4 @@ stereo_Int:P0:vs_main_no_trafo():ps_main_int()
 stereo_Flipped_Int:P0:vs_main_no_trafo():ps_main_flipped_int()
 Stereo_LinearAnaglyph:P0:vs_main_no_trafo():ps_main_stereo_linear_anaglyph()
 Stereo_DeghostAnaglyph:P0:vs_main_no_trafo():ps_main_stereo_deghost_anaglyph()
+Stereo_DynDesatAnaglyph:P0:vs_main_no_trafo():ps_main_stereo_dyndesat_anaglyph()

--- a/shader/StereoShader.hlsl
+++ b/shader/StereoShader.hlsl
@@ -84,6 +84,15 @@ float4 ps_main_stereo_deghost_anaglyph(const in VS_OUTPUT_2D IN) : COLOR
     return float4(DeghostAnaglyph(lCol, rCol), 1.0);
 }
 
+float4 ps_main_stereo_dyndesat_anaglyph(const in VS_OUTPUT_2D IN) : COLOR
+{
+    float3 lCol, rCol, lColDesat, rColDesat;
+    gatherLeftRightColors(IN.tex0, lCol, rCol);
+    DynamicDesatAnaglyph(lCol, rCol, lColDesat, rColDesat);
+    return float4(LinearAnaglyph(lColDesat, rColDesat), 1.0);
+}
+
+
 
 ////TECHNIQUES
 
@@ -93,3 +102,4 @@ technique stereo_Int { pass P0 { VertexShader = compile vs_3_0 vs_main_no_trafo(
 technique stereo_Flipped_Int { pass P0 { VertexShader = compile vs_3_0 vs_main_no_trafo(); PixelShader = compile ps_3_0 ps_main_flipped_int(); } }
 technique Stereo_LinearAnaglyph { pass P0 { VertexShader = compile vs_3_0 vs_main_no_trafo(); PixelShader = compile ps_3_0 ps_main_stereo_linear_anaglyph(); } }
 technique Stereo_DeghostAnaglyph { pass P0 { VertexShader = compile vs_3_0 vs_main_no_trafo(); PixelShader = compile ps_3_0 ps_main_stereo_deghost_anaglyph(); } }
+technique Stereo_DynDesatAnaglyph { pass P0 { VertexShader = compile vs_3_0 vs_main_no_trafo(); PixelShader = compile ps_3_0 ps_main_stereo_dyndesat_anaglyph(); } }


### PR DESCRIPTION
 (also reverse filter order)