### PR TITLE
fix: empty imagename in texture cache

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -7212,7 +7212,7 @@ Texture *PinTable::ImportImage(const string &filename, const string &imagename)
    }
    if (!isUpdate)
    {
-      m_textureMap[ppi->m_szName] = ppi;
+      m_textureMap[imagename.empty() ? ppi->m_szName : imagename] = ppi;
       m_vimage.push_back(ppi);
       if (m_isLiveInstance)
          m_vliveimage.push_back(ppi);


### PR DESCRIPTION
When using LoadTexture, the image name is passed to Import Image. This means the texture name load be loaded from the filename. szName will be empty and the texturecache won't have the correct name.