### PR TITLE
feat(standalone): ball control

### DIFF
--- a/pininput.h
+++ b/pininput.h
@@ -199,6 +199,7 @@ private:
    bool m_rumbleRunning;
 #endif
 #ifdef ENABLE_SDL_INPUT
+   static void SdlScaleHidpi(Sint32 x, Sint32 y, Sint32 *ox, Sint32 *oy);
 #ifndef ENABLE_SDL_GAMECONTROLLER
    SDL_Joystick* m_inputDeviceSDL;
    SDL_Haptic* m_rumbleDeviceSDL;

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -219,6 +219,11 @@ Player::Player(PinTable *const editor_table, PinTable *const live_table, const i
    m_texdmd = nullptr;
 
    m_implicitPlayfieldMesh = nullptr;
+
+#ifdef ENABLE_SDL_INPUT
+   m_wnd_scale_x=0;
+   m_wnd_scale_y=0;
+#endif
 }
 
 Player::~Player()
@@ -941,6 +946,10 @@ HRESULT Player::Init()
 #ifdef ENABLE_SDL
    SDL_GL_GetDrawableSize(m_sdl_playfieldHwnd, &m_wnd_width, &m_wnd_height);
    PLOGI.printf("Drawable Size: width=%d, height=%d", m_wnd_width, m_wnd_height);
+   int realWindowWidth, realWindowHeight;
+   SDL_GetWindowSize(g_pplayer->m_sdl_playfieldHwnd, &realWindowWidth, &realWindowHeight);
+   m_wnd_scale_x = static_cast<float>(m_wnd_width) / realWindowWidth;
+   m_wnd_scale_y = static_cast<float>(m_wnd_height) / realWindowHeight;
 #endif
 
    // colordepth & refreshrate are only defined if fullscreen is true.

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -408,6 +408,10 @@ public:
 #ifndef __STANDALONE__
    DebuggerDialog m_debuggerDialog;
 #endif
+#ifdef ENABLE_SDL_INPUT
+   float m_wnd_scale_x;
+   float m_wnd_scale_y;
+#endif
    bool m_debugMode;
    HWND m_hwndDebugOutput;
    bool m_showDebugger;


### PR DESCRIPTION
fixes #1281 

To test this modify your ini file to contain the following values

```ini
[Editor]
ThrowBallsAlwaysOn = 0
BallControlAlwaysOn = 1
```

Mind the uppercase `E` in Editor, I had an old version of the ini with lowercase e causing the setting to not be applied.

Then drag your mouse with left mouse button on the playfield to have the ball follow you. For a quick move double click somewhere to have the ball teleport and fall down on that location.