### PR TITLE
standalone: bump SDL2, SDL2_image, SDL2_ttf, and libpinmame

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -866,6 +866,15 @@ public:
                      << " (refreshRate=" << displayMode.refresh_rate << ")";
             }
          }
+
+         PLOGI << "Available external window renderers:";
+         int numRenderers = SDL_GetNumRenderDrivers();
+         for (int renderer = 0; renderer < SDL_GetNumRenderDrivers(); renderer++) {
+            SDL_RendererInfo rendererInfo;
+            if (!SDL_GetRenderDriverInfo(renderer, &rendererInfo)) {
+               PLOGI << "Renderer " << renderer << ": " << rendererInfo.name;
+            }
+         }
       }
 
       if (m_listSnd) {

--- a/standalone/android/android-project/app/proguard-rules.pro
+++ b/standalone/android/android-project/app/proguard-rules.pro
@@ -15,7 +15,3 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
--keep class org.vpinball.app.SerialPort {
-    public *;
-}

--- a/standalone/android/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
+++ b/standalone/android/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
@@ -273,6 +273,7 @@ public class HIDDeviceManager {
         final int XB1_IFACE_SUBCLASS = 71;
         final int XB1_IFACE_PROTOCOL = 208;
         final int[] SUPPORTED_VENDORS = {
+            0x03f0, // HP
             0x044f, // Thrustmaster
             0x045e, // Microsoft
             0x0738, // Mad Catz
@@ -284,6 +285,7 @@ public class HIDDeviceManager {
             0x24c6, // PowerA
             0x2dc8, // 8BitDo
             0x2e24, // Hyperkin
+            0x3537, // GameSir
         };
 
         if (usbInterface.getId() == 0 &&
@@ -356,6 +358,12 @@ public class HIDDeviceManager {
 
     private void initializeBluetooth() {
         Log.d(TAG, "Initializing Bluetooth");
+
+        if (Build.VERSION.SDK_INT >= 31 /* Android 12  */ &&
+            mContext.getPackageManager().checkPermission(android.Manifest.permission.BLUETOOTH_CONNECT, mContext.getPackageName()) != PackageManager.PERMISSION_GRANTED) {
+            Log.d(TAG, "Couldn't initialize Bluetooth, missing android.permission.BLUETOOTH_CONNECT");
+            return;
+        }
 
         if (Build.VERSION.SDK_INT <= 30 /* Android 11.0 (R) */ &&
             mContext.getPackageManager().checkPermission(android.Manifest.permission.BLUETOOTH, mContext.getPackageName()) != PackageManager.PERMISSION_GRANTED) {

--- a/standalone/android/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/standalone/android/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -60,8 +60,8 @@ import java.util.Locale;
 public class SDLActivity extends Activity implements View.OnSystemUiVisibilityChangeListener {
     private static final String TAG = "SDL";
     private static final int SDL_MAJOR_VERSION = 2;
-    private static final int SDL_MINOR_VERSION = 28;
-    private static final int SDL_MICRO_VERSION = 5;
+    private static final int SDL_MINOR_VERSION = 30;
+    private static final int SDL_MICRO_VERSION = 0;
 /*
     // Display InputType.SOURCE/CLASS of events and devices
     //

--- a/standalone/android/external.sh
+++ b/standalone/android/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -103,7 +103,7 @@ cp libs/arm64-v8a/libSDL2.so ../external/lib
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 
 MK_ADDON=$'include $(CLEAR_VARS)\\\n'
 MK_ADDON+=$'LOCAL_MODULE := SDL2\\\n'

--- a/standalone/changelog.md
+++ b/standalone/changelog.md
@@ -4,6 +4,12 @@ To keep up with all the changes in master, and make it easier to rebase, this br
 
 The downside of this approach is not accurately keeping track of history:
 
+* 02/18/24
+    * Update SDL2, SDL2_image, and SDL2_ttf
+    * Add documentation on compiling linux version using Docker
+    * Simplified MacOS dylibs in CMakeLists and CPack
+    * Add analog input support for game controllers (@TheToon)
+
 * 02/09/24
     * Added ball control support (@francisdb)
 

--- a/standalone/cmake/CMakeLists_gl-macos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-arm64.txt
@@ -653,9 +653,9 @@ target_link_directories(vpinball PUBLIC
 
 target_link_libraries(vpinball PUBLIC
    glad
-   SDL2-2.0.0
-   SDL2_image-2.0.3.0.0
-   SDL2_ttf-2.0.15.0.0
+   SDL2
+   SDL2_image
+   SDL2_ttf
    FreeImage
    bass
    pinmame.3.6
@@ -697,16 +697,7 @@ add_custom_command(TARGET vpinball POST_BUILD
    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/shader/Stereo.fxh" "$<TARGET_FILE_DIR:vpinball>/../Resources/shader${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REV}"
    COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_SOURCE_DIR}/standalone/inc/flexdmd/resources" "$<TARGET_FILE_DIR:vpinball>/../Resources/flexdmd"
    COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libbass.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libSDL2-2.0.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libSDL2_image-2.0.3.0.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libSDL2_ttf-2.0.15.0.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libpinmame.3.6.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libaltsound.0.1.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libzedmd.0.5.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libserum.1.6.2.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libdmdutil.0.2.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/libserialport.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
+   COMMAND cp -P "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/external/lib/*.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/VPinballX_GL.icns" "$<TARGET_FILE_DIR:vpinball>/../Resources"
    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-arm64/Info.plist" "$<TARGET_FILE_DIR:vpinball>/.."
    COMMAND /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${CMAKE_PROJECT_VERSION}" $<TARGET_FILE_DIR:vpinball>/../Info.plist
@@ -714,21 +705,22 @@ add_custom_command(TARGET vpinball POST_BUILD
 )
 
 if(OPT_CODESIGN)
+   set(SCRIPT_PATH "${CMAKE_BINARY_DIR}/codesign.sh")
+
+   file(WRITE ${SCRIPT_PATH} "#!/bin/sh\n")
+   file(APPEND ${SCRIPT_PATH} "find \"$1/Contents/Frameworks\" -name \"*.dylib\" | while read -r file; do\n")
+   file(APPEND ${SCRIPT_PATH} "  if [ ! -L \"$file\" ]; then\n")
+   file(APPEND ${SCRIPT_PATH} "    codesign --sign \"$2\" --timestamp --options runtime \"$file\"\n")
+   file(APPEND ${SCRIPT_PATH} "  fi\n")
+   file(APPEND ${SCRIPT_PATH} "done\n")
+   file(APPEND ${SCRIPT_PATH} "codesign --sign \"$2\" --timestamp --options runtime \"$1\"\n")
+   file(CHMOD ${SCRIPT_PATH} PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
+
    set(PATH_APP "${CMAKE_BINARY_DIR}/${APP_NAME}.app")
    set(PATH_APP_ZIPPED "${PATH_APP}.zip")
 
    add_custom_command(TARGET vpinball POST_BUILD
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libbass.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libSDL2-2.0.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libSDL2_image-2.0.3.0.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libSDL2_ttf-2.0.15.0.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libpinmame.3.6.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libaltsound.0.1.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libzedmd.0.5.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libserum.1.6.2.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libdmdutil.0.2.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libserialport.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}
+      COMMAND /bin/sh ${SCRIPT_PATH} ${PATH_APP} ${CODESIGN_DEVELOPER_ID}
       COMMAND ditto -c -k --keepParent ${PATH_APP} ${PATH_APP_ZIPPED}
       COMMAND xcrun notarytool submit ${PATH_APP_ZIPPED} --wait --apple-id "${CODESIGN_APPLE_ID}" --password "${CODESIGN_PASSWORD}" --team-id "${CODESIGN_TEAM_ID}"
    )

--- a/standalone/cmake/CMakeLists_gl-macos-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-x64.txt
@@ -654,9 +654,9 @@ target_link_directories(vpinball PUBLIC
 
 target_link_libraries(vpinball PUBLIC
    glad
-   SDL2-2.0.0
-   SDL2_image-2.0.3.0.0
-   SDL2_ttf-2.0.15.0.0
+   SDL2
+   SDL2_image
+   SDL2_ttf
    FreeImage
    bass
    pinmame.3.6
@@ -698,16 +698,7 @@ add_custom_command(TARGET vpinball POST_BUILD
    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/shader/Stereo.fxh" "$<TARGET_FILE_DIR:vpinball>/../Resources/shader${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REV}"
    COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_SOURCE_DIR}/standalone/inc/flexdmd/resources" "$<TARGET_FILE_DIR:vpinball>/../Resources/flexdmd"
    COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libbass.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libSDL2-2.0.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libSDL2_image-2.0.3.0.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libSDL2_ttf-2.0.15.0.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libpinmame.3.6.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libaltsound.0.1.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libzedmd.0.5.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libserum.1.6.2.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libdmdutil.0.2.0.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
-   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/libserialport.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
+   COMMAND cp -P "${CMAKE_SOURCE_DIR}/standalone/macos-x64/external/lib/*.dylib" "$<TARGET_FILE_DIR:vpinball>/../Frameworks"
    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/VPinballX_GL.icns" "$<TARGET_FILE_DIR:vpinball>/../Resources"
    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos-x64/Info.plist" "$<TARGET_FILE_DIR:vpinball>/.."
    COMMAND /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${CMAKE_PROJECT_VERSION}" $<TARGET_FILE_DIR:vpinball>/../Info.plist
@@ -715,21 +706,22 @@ add_custom_command(TARGET vpinball POST_BUILD
 )
 
 if(OPT_CODESIGN)
+   set(SCRIPT_PATH "${CMAKE_BINARY_DIR}/codesign.sh")
+
+   file(WRITE ${SCRIPT_PATH} "#!/bin/sh\n")
+   file(APPEND ${SCRIPT_PATH} "find \"$1/Contents/Frameworks\" -name \"*.dylib\" | while read -r file; do\n")
+   file(APPEND ${SCRIPT_PATH} "  if [ ! -L \"$file\" ]; then\n")
+   file(APPEND ${SCRIPT_PATH} "    codesign --sign \"$2\" --timestamp --options runtime \"$file\"\n")
+   file(APPEND ${SCRIPT_PATH} "  fi\n")
+   file(APPEND ${SCRIPT_PATH} "done\n")
+   file(APPEND ${SCRIPT_PATH} "codesign --sign \"$2\" --timestamp --options runtime \"$1\"\n")
+   file(CHMOD ${SCRIPT_PATH} PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
+
    set(PATH_APP "${CMAKE_BINARY_DIR}/${APP_NAME}.app")
    set(PATH_APP_ZIPPED "${PATH_APP}.zip")
 
    add_custom_command(TARGET vpinball POST_BUILD
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libbass.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libSDL2-2.0.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libSDL2_image-2.0.3.0.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libSDL2_ttf-2.0.15.0.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libpinmame.3.6.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libaltsound.0.1.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libzedmd.0.5.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libserum.1.6.2.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libdmdutil.0.2.0.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}/Contents/Frameworks/libserialport.dylib
-      COMMAND codesign --sign "${CODESIGN_DEVELOPER_ID}" --timestamp --options runtime ${PATH_APP}
+      COMMAND /bin/sh ${SCRIPT_PATH} ${PATH_APP} ${CODESIGN_DEVELOPER_ID}
       COMMAND ditto -c -k --keepParent ${PATH_APP} ${PATH_APP_ZIPPED}
       COMMAND xcrun notarytool submit ${PATH_APP_ZIPPED} --wait --apple-id "${CODESIGN_APPLE_ID}" --password "${CODESIGN_PASSWORD}" --team-id "${CODESIGN_TEAM_ID}"
    )

--- a/standalone/docker/Dockerfile
+++ b/standalone/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get upgrade -y 
+
+# Upgrade CMake
+
+RUN apt-get install -y ca-certificates gpg wget
+RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+RUN apt-get update && apt-get install -y kitware-archive-keyring
+
+# Install Oh My Zsh
+
+RUN apt-get install -y zsh git curl && chsh -s $(which zsh)
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# Install Dependencies
+
+RUN apt-get install -y git unzip vim rsync build-essential autoconf automake libtool cmake bison curl zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libudev-dev libx11-dev libxrandr-dev
+
+RUN mkdir -p /home/ubuntu && \
+    { \
+    echo '#!/bin/bash'; \
+    echo 'set -e'; \
+    echo 'USER=vpinball'; \
+    echo 'BRANCH=standalone'; \
+    echo 'git clone -b $BRANCH https://github.com/$USER/vpinball'; \
+    echo 'cd vpinball/standalone/linux'; \
+    echo './external.sh'; \
+    echo 'cd ../..'; \
+    echo 'cp standalone/cmake/CMakeLists_gl-linux-x64.txt CMakeLists.txt'; \
+    echo 'cmake -DCMAKE_BUILD_TYPE=Release -B build'; \
+    echo 'cmake --build build -- -j$(nproc)'; \
+    } > /home/ubuntu/build.sh && chmod +x /home/ubuntu/build.sh
+
+WORKDIR /home/ubuntu

--- a/standalone/docker/docker.md
+++ b/standalone/docker/docker.md
@@ -1,0 +1,23 @@
+# Docker
+
+To build the Linux version of Visual Pinball Standalone using a docker container:
+
+```
+docker buildx build --platform linux/amd64 . -t vpx-standalone-ubuntu:22.04
+docker run -it --platform linux/amd64 --rm vpx-standalone-ubuntu:22.04
+
+./build.sh
+```
+
+The supplied `Dockerfile` is based on Ubuntu 22.04, and includes Oh My Zsh, and the latest CMake. 
+
+If you would like to do development, you can use Visual Studio Code and connect it to the container.
+
+Install the C++ Extension Pack, and you should be all set.
+
+You can then transfer to a Linux host distro such as Batocera using `rsync`:
+
+```
+cd /home/ubuntu/vpinball/build
+rsync -avz --progress --exclude "CMake*" --exclude "cmake*" --exclude "Makefile" --exclude "*.a" --exclude ".cmake" --exclude "tables" --exclude "docs" --exclude "compile_commands.json" . root@192.168.1.201:/usr/bin/vpinball
+```

--- a/standalone/ios/external.sh
+++ b/standalone/ios/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -77,7 +77,7 @@ cp sdl-build/libSDL2.a ../external/lib
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 
 xcrun xcodebuild -project "SDL2_image-${SDL2_IMAGE_VERSION}/Xcode/SDL_image.xcodeproj" -target "Static Library" -sdk iphoneos -configuration Release clean build CONFIGURATION_BUILD_DIR="$(pwd)/sdl_image-build"
 cp sdl_image-build/libSDL2_image.a ../external/lib

--- a/standalone/linux/external.sh
+++ b/standalone/linux/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -83,7 +83,7 @@ cd ..
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 cd SDL2_image-${SDL2_IMAGE_VERSION}
 touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \

--- a/standalone/macos-arm64/external.sh
+++ b/standalone/macos-arm64/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -75,7 +75,9 @@ cmake -DSDL_SHARED=ON \
    -DCMAKE_BUILD_TYPE=Release \
    -B build
 cmake --build build -- -j${NUM_PROCS}
-cp build/libSDL2-2.0.0.dylib ../../external/lib
+# cmake does not make a symbolic link for libSDL2.dylib
+ln -s libSDL2-2.0.0.dylib build/libSDL2.dylib
+cp -P build/*.dylib ../../external/lib
 cd ..
 
 #
@@ -84,19 +86,19 @@ cd ..
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 cd SDL2_image-${SDL2_IMAGE_VERSION}
 touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \
    -DSDL2IMAGE_SAMPLES=OFF \
    -DSDL2_INCLUDE_DIR=$(pwd)/../SDL2-${SDL2_VERSION}/include \
-   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2-2.0.0.dylib \
+   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2.dylib \
    -DCMAKE_OSX_ARCHITECTURES=arm64 \
    -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
    -DCMAKE_BUILD_TYPE=Release \
    -B build
 cmake --build build -- -j${NUM_PROCS}
-cp build/libSDL2_image-2.0.3.0.0.dylib ../../external/lib
+cp -P build/*.dylib ../../external/lib
 cd ..
 
 #
@@ -111,7 +113,7 @@ touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \
    -DSDL2TTF_SAMPLES=OFF \
    -DSDL2_INCLUDE_DIR=$(pwd)/../SDL2-${SDL2_VERSION}/include \
-   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2-2.0.0.dylib \
+   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2.dylib \
    -DSDL2TTF_VENDORED=ON \
    -DSDL2TTF_HARFBUZZ=ON \
    -DCMAKE_OSX_ARCHITECTURES=arm64 \
@@ -119,7 +121,7 @@ cmake -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_BUILD_TYPE=Release \
    -B build
 cmake --build build -- -j${NUM_PROCS}
-cp build/libSDL2_ttf-2.0.15.0.0.dylib ../../external/lib
+cp -P build/*.dylib ../../external/lib
 cd ..
 
 #

--- a/standalone/macos-x64/external.sh
+++ b/standalone/macos-x64/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -74,7 +74,9 @@ cmake -DSDL_SHARED=ON \
    -DCMAKE_BUILD_TYPE=Release \
    -B build
 cmake --build build -- -j${NUM_PROCS}
-cp build/libSDL2-2.0.0.dylib ../../external/lib
+# cmake does not make a symbolic link for libSDL2.dylib
+ln -s libSDL2-2.0.0.dylib build/libSDL2.dylib
+cp -P build/*.dylib ../../external/lib
 cd ..
 
 #
@@ -83,19 +85,19 @@ cd ..
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 cd SDL2_image-${SDL2_IMAGE_VERSION}
 touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \
    -DSDL2IMAGE_SAMPLES=OFF \
    -DSDL2_INCLUDE_DIR=$(pwd)/../SDL2-${SDL2_VERSION}/include \
-   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2-2.0.0.dylib \
+   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2.dylib \
    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
    -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
    -DCMAKE_BUILD_TYPE=Release \
    -B build
 cmake --build build -- -j${NUM_PROCS}
-cp build/libSDL2_image-2.0.3.0.0.dylib ../../external/lib
+cp -P build/*.dylib ../../external/lib
 cd ..
 
 #
@@ -110,7 +112,7 @@ touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \
    -DSDL2TTF_SAMPLES=OFF \
    -DSDL2_INCLUDE_DIR=$(pwd)/../SDL2-${SDL2_VERSION}/include \
-   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2-2.0.0.dylib \
+   -DSDL2_LIBRARY=$(pwd)/../SDL2-${SDL2_VERSION}/build/libSDL2.dylib \
    -DSDL2TTF_VENDORED=ON \
    -DSDL2TTF_HARFBUZZ=ON \
    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
@@ -118,7 +120,7 @@ cmake -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_BUILD_TYPE=Release \
    -B build
 cmake --build build -- -j${NUM_PROCS}
-cp build/libSDL2_ttf-2.0.15.0.0.dylib ../../external/lib
+cp -P build/*.dylib ../../external/lib
 cd ..
 
 #

--- a/standalone/rk3588/external.sh
+++ b/standalone/rk3588/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -85,7 +85,7 @@ cd ..
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 cd SDL2_image-${SDL2_IMAGE_VERSION}
 touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \

--- a/standalone/rpi/external.sh
+++ b/standalone/rpi/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -85,7 +85,7 @@ cd ..
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 cd SDL2_image-${SDL2_IMAGE_VERSION}
 touch cmake/FindSDL2.cmake # force cmake to use the SDL2 we just built
 cmake -DBUILD_SHARED_LIBS=ON \

--- a/standalone/tvos/external.sh
+++ b/standalone/tvos/external.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SDL2_VERSION=2.28.5
-SDL2_IMAGE_VERSION=2.6.3
-SDL2_TTF_VERSION=2.20.2
+SDL2_VERSION=2.30.0
+SDL2_IMAGE_VERSION=2.8.2
+SDL2_TTF_VERSION=2.22.0
 
-PINMAME_SHA=4a2a21c6bec1c2227af20418278dd7c6dacd61fa
+PINMAME_SHA=90d5d1ae96fb43fc7e01ff49a2bf43deb1e2add0
 LIBALTSOUND_SHA=9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBDMDUTIL_SHA=342f687a9067f4f3ae2fb7863ef296b3f44253e0
 
@@ -80,7 +80,7 @@ cp sdl-build/libSDL2.a ../external/lib
 
 curl -sL https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/SDL2_image-${SDL2_IMAGE_VERSION}.zip -o SDL2_image-${SDL2_IMAGE_VERSION}.zip
 unzip SDL2_image-${SDL2_IMAGE_VERSION}.zip
-cp -r SDL2_image-${SDL2_IMAGE_VERSION}/SDL_image.h ../external/include/SDL2
+cp SDL2_image-${SDL2_IMAGE_VERSION}/include/SDL_image.h ../external/include/SDL2
 
 xcrun xcodebuild -project "SDL2_image-${SDL2_IMAGE_VERSION}/Xcode/SDL_image.xcodeproj" -target "Static Library" -sdk appletvos -configuration Release clean build CONFIGURATION_BUILD_DIR="$(pwd)/sdl_image-build"
 cp sdl_image-build/libSDL2_image.a ../external/lib


### PR DESCRIPTION
In addition to updating SDL2, SDL2_image, SDL2_ttf, and libpinmame, we also simplified the .dylib logic on macos