### PR TITLE
fix: read nudge settings

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1478,6 +1478,11 @@ void Player::ReadAccelerometerCalibration()
 
    m_accelerometerSensitivity = clamp((float)m_ptable->m_settings.LoadValueWithDefault(Settings::Player, "NudgeSensitivity"s, 500) * (float)(1.0/1000.0), 0.f, 1.f);
 
+   m_accelerometerMax.x = m_ptable->m_settings.LoadValueWithDefault(Settings::Player, "PBWAccelMaxX"s, 100);
+   m_accelerometerMax.y = m_ptable->m_settings.LoadValueWithDefault(Settings::Player, "PBWAccelMaxY"s, 100);
+   m_accelerometerGain.x = m_ptable->m_settings.LoadValueWithDefault(Settings::Player, "PBWAccelGainX"s, 150.0f);
+   m_accelerometerGain.y = m_ptable->m_settings.LoadValueWithDefault(Settings::Player, "PBWAccelGainY"s, 150.0f);
+
    m_pininput.LoadSettings(m_ptable->m_settings);
 }
 


### PR DESCRIPTION
Reading these settings got lost during previous refactorings

Relates to #1204, #1247 and #1302 