### PR TITLE
standalone: partially revert joystick changes. Add gamecontrollerdb.txt

### DIFF
--- a/src/assets/Default gamecontrollerdb.txt
+++ b/src/assets/Default gamecontrollerdb.txt
@@ -1,0 +1,1 @@
+03000000fafa0000f00000000a000000,mjrnet Pinscape Controller,platform:Mac OS X,crc:804c,leftx:a0~,lefty:a1~

--- a/src/core/pininput.h
+++ b/src/core/pininput.h
@@ -200,10 +200,14 @@ private:
 #endif
 #ifdef ENABLE_SDL_INPUT
    static void SdlScaleHidpi(Sint32 x, Sint32 y, Sint32 *ox, Sint32 *oy);
+#ifdef ENABLE_SDL_GAMECONTROLLER
+   SDL_GameController* m_pSDLGameController;
+   void RefreshSDLGameController();
+#else
    SDL_Joystick* m_pSDLJoystick;
    SDL_Haptic* m_pSDLRumbleDevice;
-   SDL_GameController* m_pSDLGameController;
-   void RefreshSDLJoystickAndGameController();
+   void RefreshSDLJoystick();
+#endif
 #endif
 #ifdef ENABLE_IGAMECONTROLLER
 #endif

--- a/standalone/changelog.md
+++ b/standalone/changelog.md
@@ -4,6 +4,10 @@ To keep up with all the changes in master, and make it easier to rebase, this br
 
 The downside of this approach is not accurately keeping track of history:
 
+* 02/19/24
+    * Revert support for both a joystick and game controller
+    * Add support for game controller mappings via gamecontrollerdb.txt
+
 * 02/18/24
     * Update SDL2, SDL2_image, and SDL2_ttf
     * Add documentation on compiling linux version using Docker

--- a/standalone/cmake/CMakeLists_gl-android-arm64-v8a.txt
+++ b/standalone/cmake/CMakeLists_gl-android-arm64-v8a.txt
@@ -35,6 +35,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-ios-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-ios-arm64.txt
@@ -38,6 +38,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-linux-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-linux-x64.txt
@@ -34,6 +34,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-macos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-arm64.txt
@@ -39,6 +39,7 @@ add_compile_definitions(
   
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-macos-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-x64.txt
@@ -39,6 +39,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-rk3588-aarch64.txt
+++ b/standalone/cmake/CMakeLists_gl-rk3588-aarch64.txt
@@ -36,6 +36,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-rpi-aarch64.txt
+++ b/standalone/cmake/CMakeLists_gl-rpi-aarch64.txt
@@ -36,6 +36,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__

--- a/standalone/cmake/CMakeLists_gl-tvos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-tvos-arm64.txt
@@ -39,6 +39,7 @@ add_compile_definitions(
 
    ENABLE_SDL
    ENABLE_SDL_INPUT
+   ENABLE_SDL_GAMECONTROLLER
    ENABLE_INI_SETTINGS
 
    __WINESRC__


### PR DESCRIPTION
This PR will revert supporting joysticks and game controllers at the same time. I thought both were needed as I wanted to support Pinscape controllers which only appeared as a joystick.

I didn't realize that the preferred way is to add mappings via `SDL_GameControllerAddMappingsFromFile` and a `gamecontrollerdb.txt` file.

This PR will go back to only using joysticks if `ENABLE_SDL_GAMECONTROLLER` is not defined while building.

The `ENABLE_SDL_GAMECONTROLLER` path will now create a default `gamecontrollerdb.txt` in the preferences path.

After this PR, we will be able to add more entries to the `Default gamecontrollerdb.txt` file.