### PR TITLE
Fixed native crashes with the new Android launcher

### DIFF
--- a/pininput.cpp
+++ b/pininput.cpp
@@ -1054,7 +1054,11 @@ void PinInput::Init(const HWND hwnd)
    SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC);
    string path = g_pvp->m_szMyPrefPath + "gamecontrollerdb.txt";
    if (!std::filesystem::exists(path))
+#ifndef __ANDROID__
       std::filesystem::copy(g_pvp->m_szMyPath + "assets" + PATH_SEPARATOR_CHAR + "Default gamecontrollerdb.txt", path);
+#else
+      std::filesystem::copy(g_pvp->m_szMyPath + "assets" + PATH_SEPARATOR_CHAR + "Default_gamecontrollerdb.txt", path);
+#endif
    int count = SDL_GameControllerAddMappingsFromFile(path.c_str());
    if (count > 0) {
       PLOGI.printf("Game controller mappings added: count=%d, path=%s", count, path.c_str());

--- a/src/core/Settings.cpp
+++ b/src/core/Settings.cpp
@@ -43,7 +43,11 @@ bool Settings::LoadFromFile(const string& path, const bool createDefault)
       PLOGI << "Settings file was not found at '" << path << "' creating a default one";
 
       // Load failed: initialize from the default setting file
+#ifndef __ANDROID__
       std::filesystem::copy(g_pvp->m_szMyPath + "assets" + PATH_SEPARATOR_CHAR + "Default VPinballX.ini", path);
+#else
+      std::filesystem::copy(g_pvp->m_szMyPath + "assets" + PATH_SEPARATOR_CHAR + "Default_VPinballX.ini", path);
+#endif
       if (!file.read(m_ini))
       {
          PLOGE << "Loading of default settings file failed";

--- a/standalone/android/android-project/app/src/main/java/org/vpinball/app/VpxLauncherActivity.kt
+++ b/standalone/android/android-project/app/src/main/java/org/vpinball/app/VpxLauncherActivity.kt
@@ -252,8 +252,8 @@ class VpxLauncherActivity : ComponentActivity() {
 
             try {
                 val inputStream = assets.open(srcPath)
-                dstFile = dstDir.createFile("application/octet-stream", filename)!!
-                Log.v(TAG, "Copying $srcPath to $dstFile")
+                dstFile = dstDir.createFile("application/octet-stream", filename.replace(' ', '_'))!!
+                Log.v(TAG, "Copying $srcPath to '${dstFile.name}'")
                 copyFile(inputStream, dstFile)
             } catch (e: FileNotFoundException) {
                 // Create the directory if it doesn't exist
@@ -385,7 +385,7 @@ fun PinballTables(tablesList: SnapshotStateList<String>) {
             modifier = Modifier
                 .padding(8.dp)
                 .fillMaxWidth()) {
-            ElevatedButton(onClick = { activity.openVpxDirectory(true) }) {
+            ElevatedButton(onClick = { activity.openVpxDirectory(false) }) {
                 Text(stringResource(R.string.button_refresh))
             }
 


### PR DESCRIPTION
Two main changes:

- SAF doesn't like spaces in filenames so copies from assets/ were creating files with wrong names
- looking up the directory name from the SAF file descriptor needed additional processing, namely anything mapped to /sdcard can't use the physical location returned by readlink. I added logic to replace the path with /sdcard when appropriate

I tested it on both a Pixel phone and a Galaxy Tab. 