### PR TITLE
fix: sdl input

### DIFF
--- a/src/core/pininput.cpp
+++ b/src/core/pininput.cpp
@@ -842,6 +842,7 @@ void PinInput::HandleSDLEvents(DIDEVICEOBJECTDATA* didod)
             break;
          }
          break;
+      }
    #endif
 
    #ifdef ENABLE_SDL_INPUT
@@ -939,7 +940,7 @@ void PinInput::HandleSDLEvents(DIDEVICEOBJECTDATA* didod)
          }
          break;
       #endif
-      }
+
       #ifdef ENABLE_SDL_GAMECONTROLLER
       case SDL_CONTROLLERDEVICEADDED:
       case SDL_CONTROLLERDEVICEREMOVED:


### PR DESCRIPTION
was broken by 8b5554a00fbd6add2f5a8237d3088f45de9288de

On standalone/sdl any key/controller input was not being handled because a large part of the code was not triggered.