### PR TITLE
Add build number to the COM Version method of VPX #1558

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1152,15 +1152,15 @@ STDMETHODIMP ScriptGlobalTable::get_ActiveTable(ITable **pVal)
    return S_OK;
 }
 
-STDMETHODIMP ScriptGlobalTable::get_Version(int *pVal)
+STDMETHODIMP ScriptGlobalTable::get_Version(DOUBLE *pVal)
 {
-	*pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV;
+	*pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
 	return S_OK;
 }
 
-STDMETHODIMP ScriptGlobalTable::get_VPBuildVersion(int *pVal)
+STDMETHODIMP ScriptGlobalTable::get_VPBuildVersion(DOUBLE *pVal)
 {
-	*pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV;
+	*pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
 	return S_OK;
 }
 
@@ -10379,15 +10379,15 @@ STDMETHODIMP PinTable::QuitPlayer(int CloseType)
    return m_vpinball->QuitPlayer(CloseType);
 }
 
-STDMETHODIMP PinTable::get_Version(int *pVal)
+STDMETHODIMP PinTable::get_Version(DOUBLE *pVal)
 {
-   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV;
+   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
    return S_OK;
 }
 
-STDMETHODIMP PinTable::get_VPBuildVersion(int *pVal)
+STDMETHODIMP PinTable::get_VPBuildVersion(DOUBLE *pVal)
 {
-   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV;
+   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
    return S_OK;
 }
 

--- a/src/parts/pintable.h
+++ b/src/parts/pintable.h
@@ -309,8 +309,8 @@ public:
    STDMETHOD(get_EnvironmentImage)(/*[out, retval]*/ BSTR *pVal);
    STDMETHOD(put_EnvironmentImage)(/*[in]*/ BSTR newVal);
 
-   STDMETHOD(get_Version)(/*[out, retval]*/ int *pVal);
-   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ int *pVal);
+   STDMETHOD(get_Version)(/*[out, retval]*/ DOUBLE *pVal);
+   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ DOUBLE *pVal);
    STDMETHOD(get_VersionMajor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionMinor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionRevision)(/*[out, retval]*/ int *pVal);
@@ -966,8 +966,8 @@ public:
    STDMETHOD(GetElementByName)(/*[in]*/ BSTR name, /*[out, retval]*/ IDispatch **pVal);
    STDMETHOD(get_ActiveTable)(/*[out, retval]*/ ITable **pVal);
 
-   STDMETHOD(get_Version)(/*[out, retval]*/ int *pVal);
-   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ int *pVal);
+   STDMETHOD(get_Version)(/*[out, retval]*/ DOUBLE *pVal);
+   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ DOUBLE *pVal);
    STDMETHOD(get_VersionMajor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionMinor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionRevision)(/*[out, retval]*/ int *pVal);

--- a/txt/CommandReference.txt
+++ b/txt/CommandReference.txt
@@ -193,7 +193,7 @@ MusicVolume(float volume) - 0..1
 EndMusic
 FireKnocker(int Count)
 QuitPlayer(int CloseType)
-Version - returns VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REVISION
+Version - returns VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REVISION + VP_BUILD_NUMBER / 10000
 VPBuildVersion - same, deprecated
 VersionMajor - major VP version number
 VersionMinor - minor VP version number

--- a/vpinball.idl
+++ b/vpinball.idl
@@ -680,11 +680,11 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [propput, id(398), helpstring("property OverwriteAlphaAcc")] HRESULT GlobalAlphaAcc([in] VARIANT_BOOL newVal);
                 [propget, id(588), helpstring("property OverwriteDayNight")] HRESULT GlobalDayNight([out, retval] VARIANT_BOOL *pVal);
                 [propput, id(588), helpstring("property OverwriteDayNight")] HRESULT GlobalDayNight([in] VARIANT_BOOL newVal);
-                [propget, id(219), helpstring("property Version")] HRESULT Version([out, retval] int *pVal);
+                [propget, id(219), helpstring("property Version")] HRESULT Version([out, retval] DOUBLE *pVal);
                 [propget, id(38), helpstring("property VersionMajor")] HRESULT VersionMajor([out, retval] int *pVal);
                 [propget, id(39), helpstring("property VersionMinor")] HRESULT VersionMinor([out, retval] int *pVal);
                 [propget, id(40), helpstring("property VersionRevision")] HRESULT VersionRevision([out, retval] int *pVal);
-                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] int *pVal);
+                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] DOUBLE *pVal);
 
                 [propget, id(230), helpstring("property Option")] HRESULT Option([in] BSTR OptionName, [in] float MinValue, [in] float MaxValue, [in] float Step, [in] float DefaultValue, [in] int Unit, [in, optional] VARIANT values, [out, retval] float *pVal);
                 [propput, id(230), helpstring("property Option")] HRESULT Option([in] BSTR OptionName, [in] float MinValue, [in] float MaxValue, [in] float Step, [in] float DefaultValue, [in] int Unit, [in, optional] VARIANT values, [in] float val);
@@ -768,11 +768,11 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [propput, id(46), helpstring("property DMDPixels")] HRESULT DMDPixels([in] VARIANT pVal);
                 [propput, id(47), helpstring("property DMDColoredPixels")] HRESULT DMDColoredPixels([in] VARIANT pVal);
 
-                [propget, id(219), helpstring("property Version")] HRESULT Version([out, retval] int *pVal);
+                [propget, id(219), helpstring("property Version")] HRESULT Version([out, retval] DOUBLE *pVal);
                 [propget, id(38), helpstring("property VersionMajor")] HRESULT VersionMajor([out, retval] int *pVal);
                 [propget, id(39), helpstring("property VersionMinor")] HRESULT VersionMinor([out, retval] int *pVal);
                 [propget, id(40), helpstring("property VersionRevision")] HRESULT VersionRevision([out, retval] int *pVal);
-                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] int *pVal);
+                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] DOUBLE  *pVal);
 
                 [id(249), helpstring("method GetSerialDevices")] HRESULT GetSerialDevices([out, retval] VARIANT *pVal);
                 [id(250), helpstring("method OpenSerial")] HRESULT OpenSerial([in] BSTR device);


### PR DESCRIPTION
Currently the Version method returns an integer as 10800 for VPX 10.8, it would be an improvement if the build number would be added as decimal value like 10800.1923 (allowing 4 decimal characters), meaning one would have to change the method to return a double instead.