### PR TITLE
Adding a Settings page to the Android app

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -68,6 +68,25 @@
 #endif
 #endif
 
+#ifdef __ANDROID__
+#include "jni.h"
+#include <android/log.h>
+
+#define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,"VPX",__VA_ARGS__)
+
+static WebServer android_webServer;
+
+extern "C" JNIEXPORT void JNICALL Java_org_vpinball_app_VPXViewModel_webserver(JNIEnv* env, jobject obj, jboolean state) {
+   if (state) 
+      //android_webServer.Start();
+      LOGE("-> Start Web Server");
+   else
+      //android_webServer.Stop();
+      LOGE("-> Stop Web Server");
+}
+
+#endif
+
 Player::Player(PinTable *const editor_table, PinTable *const live_table, const int playMode)
    : m_pEditorTable(editor_table)
    , m_ptable(live_table)

--- a/standalone/android-arm64-v8a/android-project/app/build.gradle
+++ b/standalone/android-arm64-v8a/android-project/app/build.gradle
@@ -25,6 +25,9 @@ android {
         }
     }
 
+    aaptOptions {
+        ignoreAssetsPattern ''
+    }
 
     buildTypes {
         release {

--- a/standalone/android-arm64-v8a/android-project/app/build.gradle
+++ b/standalone/android-arm64-v8a/android-project/app/build.gradle
@@ -25,9 +25,6 @@ android {
         }
     }
 
-    aaptOptions {
-        ignoreAssetsPattern ''
-    }
 
     buildTypes {
         release {
@@ -43,9 +40,6 @@ android {
         }
     }
 
-    lintOptions {
-        abortOnError false
-    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -64,21 +58,33 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    androidResources {
+        ignoreAssetsPattern ''
+    }
+    lint {
+        abortOnError false
+    }
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.core:core-ktx:+'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.0'
-    implementation platform('androidx.compose:compose-bom:2023.08.00')
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation platform('androidx.compose:compose-bom:2024.03.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation 'androidx.compose.material3:material3-android:1.2.0'
-    androidTestImplementation platform('androidx.compose:compose-bom:2023.08.00')
+    implementation 'androidx.compose.material3:material3-android:1.2.1'
+    implementation 'androidx.datastore:datastore-core:1.0.0'
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.03.00')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    implementation "androidx.navigation:navigation-compose:2.7.7"
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.7.0"
+    implementation("com.github.alorma.compose-settings:ui-tiles:2.1.0")
+    implementation("com.github.alorma.compose-settings:ui-tiles-extended:2.1.0")
 }

--- a/standalone/android-arm64-v8a/android-project/app/src/main/AndroidManifest.xml
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/AndroidManifest.xml
@@ -87,6 +87,16 @@
             </intent-filter>
             -->
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="org.vpinball"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/Navigation.kt
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/Navigation.kt
@@ -1,0 +1,36 @@
+package org.vpinball.app
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+
+enum class Screen {
+    TABLES,
+    DIR_SELECTION,
+    SETTINGS
+}
+
+sealed class NavigationItem(val route: String) {
+    data object Tables : NavigationItem(Screen.TABLES.name)
+    data object Settings : NavigationItem(Screen.SETTINGS.name)
+    data object DirSelection : NavigationItem(Screen.DIR_SELECTION.name)
+}
+
+@Composable
+fun Navigator(
+    modifier: Modifier = Modifier,
+    controller: NavHostController,
+    model: VPXViewModel
+) {
+    NavHost(
+        modifier = modifier,
+        navController = controller,
+        startDestination = if (model.isConfigured.value) NavigationItem.Tables.route else NavigationItem.DirSelection.route
+    ) {
+        composable(NavigationItem.Tables.route) { Tables(controller, model) }
+        composable(NavigationItem.Settings.route) { Settings(controller) }
+        composable(NavigationItem.DirSelection.route) { VPXDirSelection(controller) }
+    }
+}

--- a/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/Settings.kt
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/Settings.kt
@@ -1,0 +1,151 @@
+package org.vpinball.app
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.core.content.FileProvider
+import androidx.core.net.toUri
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavHostController
+import com.alorma.compose.settings.ui.SettingsMenuLink
+import com.alorma.compose.settings.ui.SettingsSwitch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import java.io.File
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+// From https://stackoverflow.com/questions/6064510/how-to-get-ip-address-of-the-device-from-code
+fun getIpv4HostAddress(): String {
+    NetworkInterface.getNetworkInterfaces()?.toList()?.map { networkInterface ->
+        networkInterface.inetAddresses?.toList()?.find {
+            !it.isLoopbackAddress && it is Inet4Address
+        }?.let { return it.hostAddress }
+    }
+    return ""
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun Settings(controller: NavHostController) {
+    val activity = LocalContext.current as VpxLauncherActivity
+//    var webServerState = activity.dataStore.data
+//        .map { it[booleanPreferencesKey("webserver")] ?: false }
+//        .collectAsStateWithLifecycle(true)
+
+    var webServerState = activity.model.webServerState.collectAsStateWithLifecycle(false)
+
+    Scaffold(
+        topBar = { TopAppBar(
+            title = { Text(stringResource(R.string.settings))},
+            navigationIcon = {
+                IconButton(onClick = { controller.navigateUp() }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        ) },
+        content = { paddingValues ->
+            Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+
+                // Web Server toggle
+                SettingsSwitch(
+                    enabled = false, // Disabled until the c++ web server can be made to run standalone
+                    state = webServerState.value,
+                    onCheckedChange = { state ->
+                        activity.lifecycleScope.launch {
+                            activity.dataStore.edit {
+                                it[booleanPreferencesKey("webserver")] = state
+                            }
+                        }
+                    },
+                    title = { Text(text = "Web Server") },
+                    subtitle = { Text(text = if (webServerState.value) "${getIpv4HostAddress()}:2112" else "Off") },
+                    icon = { Icon(imageVector = Icons.Outlined.Home, contentDescription = null) },
+                )
+
+                // Button to send a copy of the VPX log to another Android app
+                SettingsMenuLink(
+                    title = { Text(stringResource(R.string.share_logs)) },
+                    icon = { Icon(imageVector = Icons.Outlined.Share, contentDescription = null) },
+                    subtitle = { Text(stringResource(R.string.share_logs_subtext)) },
+                    onClick = { },
+                    action = {
+                        Button(
+                            onClick = {
+                                activity.copyVPXLog()?.let {
+                                    val logUri =
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                                            FileProvider.getUriForFile(
+                                                activity,
+                                                "org.vpinball",
+                                                it
+                                            )
+                                        } else {
+                                            Uri.fromFile(it)
+                                        }
+
+                                    val sendIntent = Intent().apply {
+                                        action = Intent.ACTION_SEND
+                                        putExtra(Intent.EXTRA_STREAM, logUri)
+                                        type = "text/plain"
+                                        flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                    }
+                                    val shareIntent = Intent.createChooser(sendIntent, "VPX Logs")
+                                    activity.startActivity(shareIntent)
+                                }
+                            },
+                            enabled = true,
+                            content = { Text(stringResource(R.string.logs_button)) }
+                        )
+                    }
+                )
+
+                // Option for changing the VPX directory
+                SettingsMenuLink(
+                    title = { Text(stringResource(R.string.new_dir_selection)) },
+                    icon = { Icon(imageVector = Icons.Outlined.Edit, contentDescription = null) },
+                    subtitle = { Text(stringResource(R.string.new_dir_explanation)) },
+                    onClick = { },
+                    action = {
+                        Button(
+                            onClick = {
+                                val suggestedVpxDir =
+                                    File(Environment.getExternalStorageDirectory(), "vpx").toUri()
+                                activity.askUserForVpxDirectory(suggestedVpxDir)
+                            },
+                            enabled = true,
+                            content = { Text(stringResource(R.string.button_new_dir)) }
+                        )
+                    }
+                )
+
+            }
+        }
+    )
+}

--- a/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/TableSelection.kt
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/TableSelection.kt
@@ -1,0 +1,94 @@
+package org.vpinball.app
+
+import android.content.Intent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun Tables(controller: NavHostController, model: VPXViewModel) {
+    PinballTables(model.tablesList, controller)
+}
+
+
+// Rudimentary presentation of all tables on a list.
+// It works but it's ugly. Hopefully to be replaced with a nice looking UI.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PinballTables(tablesList: SnapshotStateList<String>, controller: NavHostController) {
+    val tables = remember { tablesList }
+    val activity = LocalContext.current as VpxLauncherActivity
+
+    Scaffold(
+        topBar = { TopAppBar(title = {Text(stringResource(R.string.main_title))}) },
+
+        content = { paddingValues ->
+            Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp)
+                ) {
+                    tables.forEach { table ->
+                        Text(text = table,
+                            modifier = Modifier.fillMaxWidth().clickable {
+                                val intent = Intent(activity, VPinballActivity::class.java).apply {
+                                    putExtra("table", "$table.vpx")
+                                    putExtra("dirFd", activity.vpxDirFd!!.detachFd())
+                                }
+                                activity.startActivity(intent)
+                            })
+
+                        HorizontalDivider()
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    modifier = Modifier
+                        .padding(8.dp)
+                        .fillMaxWidth()
+                ) {
+                    ElevatedButton(onClick = { activity.openVpxDirectory(false) }) {
+                        Text(stringResource(R.string.button_refresh))
+                    }
+
+                    ElevatedButton(onClick = {
+                        controller.navigate(NavigationItem.Settings.route)
+                    }) {
+                        Text(stringResource(R.string.settings))
+                    }
+                }
+
+            }
+        }
+    )
+}

--- a/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/VPXDirectorySelection.kt
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/VPXDirectorySelection.kt
@@ -1,0 +1,47 @@
+package org.vpinball.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun VPXDirSelection(controller: NavHostController) {
+    val activity = LocalContext.current as VpxLauncherActivity
+
+    Column(modifier = Modifier.padding(horizontal = 14.dp)) {
+
+        Column(modifier = Modifier.weight(1f).fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+            Spacer(modifier = Modifier.height(48.dp))
+            Text(stringResource(R.string.select_dir_msg))
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Button(
+                    onClick = {
+                        // Try to open the VPX directory
+                        activity.openVpxDirectory(true)
+                    }
+                ) {
+                    Text(stringResource(R.string.button_select_dir))
+                }
+            }
+        }
+
+        Text(text = stringResource(R.string.permissions_msg),
+            fontStyle = FontStyle.Italic,
+            modifier = Modifier.padding(vertical = 24.dp))
+    }
+}

--- a/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/VPXViewModel.kt
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/VPXViewModel.kt
@@ -1,0 +1,86 @@
+package org.vpinball.app
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.ContextCompat
+import androidx.core.content.edit
+import androidx.core.net.toUri
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class VPXViewModelFactory(private val application: Application, private val dataStore: DataStore<Preferences>): ViewModelProvider.NewInstanceFactory() {
+    override fun <T:ViewModel> create(modelClass: Class<T>): T = VPXViewModel(application, dataStore) as T
+}
+
+class VPXViewModel(application: Application, dataStore: DataStore<Preferences>): AndroidViewModel(application) {
+    var vpxDir: Uri? = null
+    val isConfigured = mutableStateOf(false)
+    val tablesList = mutableStateListOf("")
+    var webServerState = dataStore.data
+        .map { it[booleanPreferencesKey("webserver")] ?: false }
+
+    init {
+        System.loadLibrary("vpinball")
+
+        // Retrieve the previously selected VPX directory from preferences
+        vpxDir = application.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE).let {
+            it.getString(VPX_DIR_KEY, null)?.toUri()
+        }
+
+        // The launcher will not display the initial warning page if there is a configured
+        // VPX directory and the user has granted storage permissions
+        isConfigured.value = (vpxDir != null) && checkStoragePermissions()
+
+        // Start/Stop the webserver according to the settings value
+        MainScope().launch {
+            webServerState.collect {
+                webserver(it)
+            }
+        }
+    }
+
+    private external fun webserver(state: Boolean)
+
+    fun checkStoragePermissions(): Boolean {
+        val context = getApplication<Application>().applicationContext
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Environment.isExternalStorageManager()
+        } else {
+            val write = ContextCompat.checkSelfPermission(context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+            val read = ContextCompat.checkSelfPermission(context,
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            )
+            read == PackageManager.PERMISSION_GRANTED && write == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    fun updateVPXDir(uri: Uri) {
+        val context = getApplication<Application>().applicationContext
+        context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE).edit {
+            this.putString(VPX_DIR_KEY, uri.toString())
+        }
+        vpxDir = uri
+    }
+
+    companion object {
+        private const val TAG = "VPXViewModel"
+        private const val VPX_DIR_KEY = "VPXMainDir"
+        private const val PREFS_FILE = "vpx"
+    }
+}

--- a/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/VPinballActivity.kt
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/java/org/vpinball/app/VPinballActivity.kt
@@ -1,7 +1,6 @@
 package org.vpinball.app
 
 import android.os.Bundle
-import android.util.Log
 import org.libsdl.app.SDLActivity
 
 /**
@@ -37,7 +36,6 @@ class VPinballActivity : SDLActivity() {
             "zedmd",
             "serum",
             "dmdutil",
-            "pupdmd",
             "dof",
             "sockpp",
             "vpinball"

--- a/standalone/android-arm64-v8a/android-project/app/src/main/res/values/strings.xml
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/res/values/strings.xml
@@ -8,6 +8,12 @@
     <string name="button_select_dir">Select VPX directory</string>
     <string name="main_title">Visual Pinball Tables</string>
     <string name="button_refresh">Refresh</string>
-    <string name="button_new_dir">Switch Table Dir</string>
+    <string name="new_dir_selection">VPX directory</string>
+    <string name="new_dir_explanation">Switch VPX directory</string>
+    <string name="button_new_dir">Choose Dir</string>
     <string name="copying_assets_message">Copying all required files to the VPX directory. This can take a minute. Please wait.</string>
+    <string name="settings">Settings</string>
+    <string name="share_logs">Share Logs</string>
+    <string name="share_logs_subtext">Send VPX logs to another app</string>
+    <string name="logs_button">Logs</string>
 </resources>

--- a/standalone/android-arm64-v8a/android-project/app/src/main/res/xml/provider_paths.xml
+++ b/standalone/android-arm64-v8a/android-project/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-cache-path name="logs" path="."/>
+</paths>

--- a/standalone/android-arm64-v8a/android-project/build.gradle
+++ b/standalone/android-arm64-v8a/android-project/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/standalone/android-arm64-v8a/android-project/gradle/wrapper/gradle-wrapper.properties
+++ b/standalone/android-arm64-v8a/android-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 11 18:20:34 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The new Settings page will host a number of configuration options. For now there are two active settings:

- Send the VPX log to another Android app via the Share Sheet
- Change the VPX directory

The setting to start/stop is currently disabled. It requires further changes to the native web server. I will be working on that next.