### PR TITLE
fix(ui): go back to game instead of live editor

### DIFF
--- a/src/ui/LiveUI.cpp
+++ b/src/ui/LiveUI.cpp
@@ -3488,7 +3488,7 @@ void LiveUI::UpdateMainSplashModal()
       // Key shortcut: click on the button, or press escape key (react on key released, otherwise, it would immediately reopen the UI,...)
       int keyShortcut = 0;
       if (enableKeyboardShortcuts && (ImGui::IsKeyReleased(ImGuiKey_Escape) || ((ImGui::IsKeyReleased(dikToImGuiKeys[m_player->m_rgKeys[eEscape]]) && !m_disable_esc))))
-         keyShortcut = m_ShowUI ? 3 : m_tweakMode ? 2 : 1;
+         keyShortcut = m_ShowUI ? 1 : m_tweakMode ? 2 : 1;
 
       ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
       if (ImGui::Button("Resume Game", size) || (keyShortcut == 1))


### PR DESCRIPTION
fixes #1646

Not sure I understand all these flags but this fixes the issue I have where double `esc` brings you to the live editor instead of back to the game.

_There is still some weirdness in the live editor where you first need to select something before you can use `esc` to exit it._