### PR TITLE
Improve flex asset loading error message

### DIFF
--- a/standalone/inc/flexdmd/AssetManager.cpp
+++ b/standalone/inc/flexdmd/AssetManager.cpp
@@ -252,7 +252,7 @@ void* AssetManager::Open(AssetSrc* pSrc)
    }
 
    if (!pAsset) {
-      PLOGW.printf("Asset not loaded: %s", pSrc->GetPath().c_str());
+      PLOGW.printf("Asset not loaded: %s - %s", pSrc->GetPath().c_str(), SDL_GetError());
    }
 
    return pAsset;


### PR DESCRIPTION
before
```
2024-04-16 23:19:36.580 WARN  [115461] [AssetManager::Open@255] Asset not loaded: d_border
```

after
```
2024-04-16 23:19:36.580 WARN  [115461] [AssetManager::Open@255] Asset not loaded: d_border - Unsupported image format
```