### PR TITLE
standalone: ignore nvoffset

### DIFF
--- a/scripts/core.vbs
+++ b/scripts/core.vbs
@@ -3045,6 +3045,10 @@ End Sub
 
 'added thanks to Koadic
 Sub NVOffset(version) ' version 2 for dB2S compatibility
+	if PlatformOS <> "windows" then
+		MsgBox "NVOffset is not supported on standalone versions of Visual Pinball. Similar functionality can be achieved by putting the rom in pinmame/roms next to the table file."
+		Exit Sub
+	End If
 	Dim check,nvcheck,v,vv,nvpath,rom
 	Set check = CreateObject("Scripting.FileSystemObject")
 	Set nvcheck = CreateObject("WScript.Shell")


### PR DESCRIPTION
This would remove the need to patch:
* https://github.com/jsm174/vpx-standalone-scripts/blob/4a9e0a1b3f30b7ff92f4f28c051afe573c336664/TRON%20Classic%20(Original%202022)%20v2.1/TRON%20Classic%20(Original%202022)%20v2.1.vbs.patch#L8
* https://github.com/jsm174/vpx-standalone-scripts/blob/4a9e0a1b3f30b7ff92f4f28c051afe573c336664/Attack%20and%20Revenge%20from%20Mars%20v4.3/Attack%20and%20Revenge%20from%20Mars%20v4.3.vbs.patch#L8

closes #1188 