### PR TITLE
Remove non-ascii characters from WPC.vbs

### DIFF
--- a/scripts/WPC.vbs
+++ b/scripts/WPC.vbs
@@ -2,7 +2,7 @@
 
 'sw116 and sw118 are commonly used for UL and UR flippers(in most WPC pins),
 'while in IJ (i think the only one that has it different?!) these are the ramp switches.
-'Everytime you press the flipper keys those switches are “on”, so one did use the cSingleLFlip variable to prevent that.
+'Everytime you press the flipper keys those switches are "on", so one did use the cSingleLFlip variable to prevent that.
 'Nowadays cSingleLFlip has been replaced by the separate keyStagedFlipperL.
 
 Option Explicit


### PR DESCRIPTION
fixes #1666

These characters are not `UTF8`, `ASCII` compatible and seem to be coming from `Windows-1252`

This should also be applied to 10.8.1