### PR TITLE
fix(input): only touch motion for motion event

### DIFF
--- a/src/core/pininput.cpp
+++ b/src/core/pininput.cpp
@@ -710,11 +710,6 @@ void PinInput::HandleSDLEvents(DIDEVICEOBJECTDATA* didod)
    int j = 0;
    while (SDL_PollEvent(&e) != 0 && j<32)
    {
-      // We scale motion data since SDL expects DPI scaled points coordinates on Apple device, while it uses pixel coordinates on other devices (see SDL_WINDOWS_DPI_SCALING)
-      // For the time being, VPX always uses pixel coordinates, using setup obtained at window creation time.
-      e.motion.x = (Sint32) ((float) e.motion.x * g_pplayer->m_playfieldWnd->GetHiDPIScale());
-      e.motion.y = (Sint32) ((float) e.motion.y * g_pplayer->m_playfieldWnd->GetHiDPIScale());
-
    #ifdef ENABLE_SDL_VIDEO
       ImGui_ImplSDL2_ProcessEvent(&e);
 
@@ -749,6 +744,11 @@ void PinInput::HandleSDLEvents(DIDEVICEOBJECTDATA* didod)
          break;
       case SDL_MOUSEMOTION:
          {
+            // We scale motion data since SDL expects DPI scaled points coordinates on Apple device, while it uses pixel coordinates on other devices (see SDL_WINDOWS_DPI_SCALING)
+            // For the time being, VPX always uses pixel coordinates, using setup obtained at window creation time.
+            e.motion.x = (Sint32)((float)e.motion.x * g_pplayer->m_playfieldWnd->GetHiDPIScale());
+            e.motion.y = (Sint32)((float)e.motion.y * g_pplayer->m_playfieldWnd->GetHiDPIScale());
+
             static Sint32 m_lastcursorx = 0xfffffff, m_lastcursory = 0xfffffff;
             if (m_lastcursorx != e.motion.x || m_lastcursory != e.motion.y)
             {


### PR DESCRIPTION
6d2ea06e96ed3362a8036f1031376dafc62fb598 was modifying keyboard events causing shift / ctrl keys to no longer workon mac/linux