### PR TITLE
refactored plog so it can be initialized from multiple places

### DIFF
--- a/build/CMakeLists_bgfx-win-x64.txt
+++ b/build/CMakeLists_bgfx-win-x64.txt
@@ -417,6 +417,8 @@ add_executable(vpinball WIN32
    src/utils/BlackBox.h
    src/utils/CrashHandler.cpp
    src/utils/CrashHandler.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    src/ui/vpinball.rc
    vpinball.idl

--- a/build/CMakeLists_bgfx-win-x86.txt
+++ b/build/CMakeLists_bgfx-win-x86.txt
@@ -418,6 +418,8 @@ add_executable(vpinball WIN32
    src/utils/BlackBox.h
    src/utils/CrashHandler.cpp
    src/utils/CrashHandler.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    src/ui/vpinball.rc
    vpinball.idl

--- a/build/CMakeLists_dx9-win-x64.txt
+++ b/build/CMakeLists_dx9-win-x64.txt
@@ -461,6 +461,8 @@ add_executable(vpinball WIN32
    src/utils/BlackBox.h
    src/utils/CrashHandler.cpp
    src/utils/CrashHandler.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    src/ui/vpinball.rc
    vpinball.idl

--- a/build/CMakeLists_dx9-win-x86.txt
+++ b/build/CMakeLists_dx9-win-x86.txt
@@ -462,6 +462,8 @@ add_executable(vpinball WIN32
    src/utils/BlackBox.h
    src/utils/CrashHandler.cpp
    src/utils/CrashHandler.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    src/ui/vpinball.rc
    vpinball.idl

--- a/build/CMakeLists_gl-win-x64.txt
+++ b/build/CMakeLists_gl-win-x64.txt
@@ -427,6 +427,8 @@ add_executable(vpinball WIN32
    src/utils/BlackBox.h
    src/utils/CrashHandler.cpp
    src/utils/CrashHandler.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    src/ui/vpinball.rc
    vpinball.idl

--- a/build/CMakeLists_gl-win-x86.txt
+++ b/build/CMakeLists_gl-win-x86.txt
@@ -428,6 +428,8 @@ add_executable(vpinball WIN32
    src/utils/BlackBox.h
    src/utils/CrashHandler.cpp
    src/utils/CrashHandler.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    src/ui/vpinball.rc
    vpinball.idl

--- a/src/core/main.h
+++ b/src/core/main.h
@@ -247,9 +247,6 @@ class ColorButton { };
 class SCNotification { };
 #endif
 
-#define PLOG_OMIT_LOG_DEFINES 
-#define PLOG_NO_DBG_OUT_INSTANCE_ID 1
-#include <plog/Log.h>
 
 #ifdef __STANDALONE__
 #include "standalone/inc/atl/atldef.h"

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cfloat>
+#include "utils/logger.h"
 
 // 2D vector
 class alignas(8) Vertex2D

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -1,0 +1,89 @@
+#include "logger.h"
+
+#include <string>
+#include <plog/Init.h>
+#include <plog/Appenders/RollingFileAppender.h>
+
+#ifdef __STANDALONE__
+#ifndef __ANDROID__
+#include <plog/Appenders/ColorConsoleAppender.h>
+#else
+#include <plog/Appenders/AndroidAppender.h>
+#endif
+#endif
+
+#include "core/main.h"
+
+void InitLogger()
+{
+    static bool initialized = false;
+
+    if (!initialized) 
+    {
+        initialized = true;
+        plog::init<PLOG_DEFAULT_INSTANCE_ID>();
+        plog::init<PLOG_NO_DBG_OUT_INSTANCE_ID>(); // Logger that do not show in the debug window to avoid duplicated messages
+    }
+}
+
+class DebugAppender : public plog::IAppender
+{
+public:
+   virtual void write(const plog::Record &record) PLOG_OVERRIDE
+   {
+      if (g_pvp == nullptr || g_pplayer == nullptr)
+         return;
+      auto table = g_pvp->GetActiveTable();
+      if (table == nullptr)
+         return;
+      #ifdef _WIN32
+      // Convert from wchar* to char* on Win32
+      auto msg = record.getMessage();
+      const int len = (int)lstrlenW(msg);
+      char *const szT = new char[len + 1];
+      WideCharToMultiByteNull(CP_ACP, 0, msg, -1, szT, len + 1, nullptr, nullptr);
+      table->m_pcv->AddToDebugOutput(szT);
+      delete [] szT;
+      #else
+      table->m_pcv->AddToDebugOutput(record.getMessage());
+      #endif
+   }
+};
+
+void SetupLogger(const bool enable)
+{
+   plog::Severity maxLogSeverity = plog::none;
+   if (enable)
+   {
+      static bool initialized = false;
+      if (!initialized)
+      {
+         initialized = true;
+         std::string szLogPath = g_pvp->m_szMyPrefPath + "vpinball.log";
+         static plog::RollingFileAppender<plog::TxtFormatter> fileAppender(szLogPath.c_str(), 1024 * 1024 * 5, 1);
+         static DebugAppender debugAppender;
+         plog::Logger<PLOG_DEFAULT_INSTANCE_ID>::getInstance()->addAppender(&debugAppender);
+         plog::Logger<PLOG_DEFAULT_INSTANCE_ID>::getInstance()->addAppender(&fileAppender);
+         plog::Logger<PLOG_NO_DBG_OUT_INSTANCE_ID>::getInstance()->addAppender(&fileAppender);
+
+#ifdef __STANDALONE__
+#ifndef __ANDROID__
+         static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
+         plog::Logger<PLOG_DEFAULT_INSTANCE_ID>::getInstance()->addAppender(&consoleAppender);
+         plog::Logger<PLOG_NO_DBG_OUT_INSTANCE_ID>::getInstance()->addAppender(&consoleAppender);
+#else
+         static plog::AndroidAppender<plog::TxtFormatter> androidAppender("vpinball");
+         plog::Logger<PLOG_DEFAULT_INSTANCE_ID>::getInstance()->addAppender(&androidAppender);
+         plog::Logger<PLOG_NO_DBG_OUT_INSTANCE_ID>::getInstance()->addAppender(&androidAppender);
+#endif
+#endif
+      }
+      #ifdef _DEBUG
+      maxLogSeverity = plog::debug;
+      #else
+      maxLogSeverity = plog::info;
+      #endif
+   }
+   plog::Logger<PLOG_DEFAULT_INSTANCE_ID>::getInstance()->setMaxSeverity(maxLogSeverity);
+   plog::Logger<PLOG_NO_DBG_OUT_INSTANCE_ID>::getInstance()->setMaxSeverity(maxLogSeverity);
+}

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <plog/Log.h>
+#include <plog/Formatters/TxtFormatter.h>
+
+#define PLOG_OMIT_LOG_DEFINES 
+#define PLOG_NO_DBG_OUT_INSTANCE_ID 1
+
+void InitLogger();
+void SetupLogger(const bool enable);

--- a/src/utils/wintimer.h
+++ b/src/utils/wintimer.h
@@ -5,6 +5,7 @@
 #endif
 
 #include "robin_hood.h"
+#include "logger.h"
 
 // call if msec,usec or uSleep, etc. should be more precise
 void set_lowest_possible_win_timer_resolution();

--- a/standalone/cmake/CMakeLists_bgfx-android-arm64-v8a.txt
+++ b/standalone/cmake/CMakeLists_bgfx-android-arm64-v8a.txt
@@ -265,6 +265,8 @@ add_library(vpinball SHARED
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_bgfx-ios-arm64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-ios-arm64.txt
@@ -270,6 +270,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_bgfx-linux-aarch64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-linux-aarch64.txt
@@ -278,6 +278,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_bgfx-linux-x64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-linux-x64.txt
@@ -266,6 +266,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_bgfx-macos-arm64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-macos-arm64.txt
@@ -269,6 +269,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_bgfx-macos-x64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-macos-x64.txt
@@ -269,6 +269,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-android-arm64-v8a.txt
+++ b/standalone/cmake/CMakeLists_gl-android-arm64-v8a.txt
@@ -271,6 +271,8 @@ add_library(vpinball SHARED
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-ios-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-ios-arm64.txt
@@ -279,6 +279,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-linux-aarch64.txt
+++ b/standalone/cmake/CMakeLists_gl-linux-aarch64.txt
@@ -284,6 +284,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-linux-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-linux-x64.txt
@@ -271,6 +271,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-macos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-arm64.txt
@@ -274,6 +274,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-macos-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-x64.txt
@@ -274,6 +274,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp

--- a/standalone/cmake/CMakeLists_gl-tvos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-tvos-arm64.txt
@@ -279,6 +279,8 @@ add_executable(vpinball
    src/utils/hash.h
    src/utils/objloader.cpp
    src/utils/objloader.h
+   src/utils/logger.cpp
+   src/utils/logger.h
 
    third-party/include/imgui/imconfig.h
    third-party/include/imgui/imgui.cpp


### PR DESCRIPTION
Simply moved the plog initialization out of main.cpp and into utils/logger.cpp. I adjusted all references and CMake build files to use it.

This is necessary so the web server can initialize plog when running in the Android app. The Android app will start/stop the web server before any table is launched. The independent web server control in the Android app is in a pending PR waiting for this to be integrated.