### PR TITLE
Play a table if it's the only argument passed to the executable

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -521,7 +521,16 @@ public:
          }
 
          //
-
+#ifdef __STANDALONE__
+         // If the only parameter passed is a vpx table we play it automatically.
+         const bool launchfile = (!valid_param) && (nArgs == 2) && (i==1) && strstr(szArglist[i], ".vpx") == (&szArglist[i][strlen(szArglist[i]) - 4]);
+         if(launchfile)
+         {
+            valid_param = true;
+            // Backtrack so the rest of the loop sees the table path as the next argument
+            i = 0;
+         }
+#endif
          if (!valid_param
             || compare_option(szArglist[i], OPTION_H)
             || compare_option(szArglist[i], OPTION_HELP)
@@ -754,7 +763,7 @@ public:
          if (ini || tableIni || editfile || playfile || povEdit || extractpov || extractscript || tournament)
 #else
 #ifndef __ANDROID__
-         if (prefPath || ini || tableIni || editfile || playfile || povEdit || extractpov || extractscript || tournament)
+         if (prefPath || ini || tableIni || editfile || playfile || launchfile || povEdit || extractpov || extractscript || tournament)
 #else
          if (editfile || playfile || povEdit || extractpov || extractscript || tournament)
 #endif
@@ -849,6 +858,9 @@ public:
                   exit(1);
                }
                m_play = playfile || povEdit;
+#ifdef __STANDALONE__
+               m_play = m_play || launchfile; 
+#endif
                m_extractPov = extractpov;
                m_extractScript = extractscript;
                m_vpinball.m_povEdit = povEdit;

--- a/standalone/inc/wine/dlls/oleaut32/varformat.c
+++ b/standalone/inc/wine/dlls/oleaut32/varformat.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <wctype.h>
 
 #include "windef.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/oleaut32/variant.c
+++ b/standalone/inc/wine/dlls/oleaut32/variant.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <wctype.h>
 
 #define COBJMACROS
 #include "windef.h"

--- a/standalone/inc/wine/dlls/oleaut32/vartype.c
+++ b/standalone/inc/wine/dlls/oleaut32/vartype.c
@@ -17,6 +17,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
+ 
+#include <wctype.h>
 
 #define COBJMACROS
 #include "wine/debug.h"

--- a/standalone/inc/wine/dlls/scrrun/dictionary.c
+++ b/standalone/inc/wine/dlls/scrrun/dictionary.c
@@ -20,6 +20,7 @@
 
 #include <stdarg.h>
 #include <math.h>
+#include <wctype.h>
 
 #include "windef.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/scrrun/filesystem.c
+++ b/standalone/inc/wine/dlls/scrrun/filesystem.c
@@ -22,6 +22,7 @@
 #include <limits.h>
 #include <assert.h>
 #include <wchar.h>
+#include <wctype.h>
 
 #include "windef.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/vbscript/global.c
+++ b/standalone/inc/wine/dlls/vbscript/global.c
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <math.h>
+#include <wctype.h>
 
 #include "vbscript.h"
 #include "vbscript_defs.h"

--- a/standalone/inc/wine/dlls/vbscript/lex.c
+++ b/standalone/inc/wine/dlls/vbscript/lex.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <math.h>
+#include <wctype.h>
 
 #include "vbscript.h"
 #include "parse.h"

--- a/standalone/inc/wine/dlls/vbscript/regexp.c
+++ b/standalone/inc/wine/dlls/vbscript/regexp.c
@@ -32,6 +32,7 @@
  */
 
 #include <assert.h>
+#include <wctype.h>
 
 #include "vbscript.h"
 #include "regexp.h"


### PR DESCRIPTION
If the only parameter passed to the executable is the path of a vpx table we default to playing the table. This allows to assign .vpx extensions to VPinballX and launch a table in desktop mode simply by clicking on its icon.