### PR TITLE
Fix window creation

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -309,7 +309,7 @@ Player::Player(PinTable *const editor_table, PinTable *const live_table, const i
    #endif
 #endif
 
-   m_playfieldWnd = new VPX::Window(WIN32_WND_TITLE, "Playfield", display, wnd_width, wnd_height, m_fullScreen, refreshrate, colordepth);
+   m_playfieldWnd = new VPX::Window(WIN32_WND_TITLE, "Playfield", display, wnd_width, wnd_height, m_fullScreen, colordepth, refreshrate);
 
    // Touch screen support
 

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -53,7 +53,7 @@ Window::Window(const string& title, const string& settingsId, const int display,
    {
       bool fsModeExists = false;
       vector<VideoMode> allVideoModes;
-      GetDisplayModes(display, allVideoModes);
+      GetDisplayModes(m_display, allVideoModes);
       for (VideoMode mode : allVideoModes)
       {
          if ((mode.width == m_width) && (mode.height == m_height))


### PR DESCRIPTION
I had the refresh rate configured as 60Hz in my VPinball.ini file. But I found the following log line when launching tables:

> [VPX::Window::Window@77] Requested fullscreen mode 3840x2160 at 32Hz is not available. Switching to windowed mode

This MR fixes two issues:

  + VideoMode was listed for the wrong display (67122625dcefd61923f9a1b851b033ea09985a8e)
  + Window constructor arguments were mixed on call (614b95917896d8474520a190dcd55577a6c04241)