### PR TITLE
Adds NSOpenPanel when app is double-clicked

### DIFF
--- a/standalone/macos-arm64/main.mm
+++ b/standalone/macos-arm64/main.mm
@@ -1,57 +1,48 @@
 #import <Cocoa/Cocoa.h>
-#import <Foundation/Foundation.h>
 
 extern "C" char **g_argv;
 extern "C" int g_argc;
 extern "C" int WinMain(void*, void*, void*, int);
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
+- (void)makeWindowExit;
 @end
 
 @implementation AppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-   if (g_argc == 1) {
-      NSAlert* alert = [[NSAlert alloc] init];
-      [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
-      [alert addButtonWithTitle:@"OK"];
-      [alert setAlertStyle:NSAlertStyleWarning];
-      [alert runModal];
-   }
+    if (g_argc == 1) {
+        NSOpenPanel *panel = [NSOpenPanel openPanel];
+        panel.message = @"Select a Visual Pinball Table File:";
+        panel.allowsMultipleSelection = NO;
+        panel.canChooseDirectories = NO;
 
-   int status = WinMain(NULL, NULL, NULL, 0);
-   exit(status);
-}
+        [panel beginWithCompletionHandler:^(NSInteger result) {
+            if (result == NSModalResponseOK) {
+                NSURL *theDoc = panel.URLs[0];
+                NSString *filename = [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
 
-- (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename
-{
-   if (g_argc == 1 && (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"])) {
-      char **new_argv = (char**)malloc(3 * sizeof(char *));
+                if (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"]) {
+                    char **new_argv = (char **)malloc(4 * sizeof(char *));
+                    new_argv[0] = g_argv[0];
+                    new_argv[1] = strdup("-DisableTrueFullscreen");
+                    new_argv[2] = strdup("-play");
+                    new_argv[3] = strdup([filename UTF8String]);
 
-      new_argv[0] = g_argv[0];
-      new_argv[1] = strdup("-play");
-      new_argv[2] = strdup([filename UTF8String]);
-
-      g_argc = 3;
-      g_argv = new_argv;
+                    g_argc = 4;
+                    g_argv = new_argv;
+                }
+            } else {
+                NSAlert *alert = [[NSAlert alloc] init];
+                [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
+                [alert addButtonWithTitle:@"OK"];
+                [alert setAlertStyle:NSAlertStyleWarning];
+                [alert runModal];
+            }
+            [self makeWindowExit];
+        }];
     }
-
-    return YES;
 }
 
 @end
-
-int main(int argc, const char * argv[])
-{
-   @autoreleasepool {
-      g_argc = argc;
-      g_argv = (char**)argv;
-
-      [NSApplication sharedApplication];
-      AppDelegate *delegate = [[AppDelegate alloc] init];
-      [NSApp setDelegate:delegate];
-      [NSApp run];
-   }
-   return 0;
-}

--- a/standalone/macos-arm64/main.mm
+++ b/standalone/macos-arm64/main.mm
@@ -1,6 +1,6 @@
 #import <Cocoa/Cocoa.h>
 
-extern "C" char **g_argv;
+extern "C" char** g_argv;
 extern "C" int g_argc;
 extern "C" int WinMain(void*, void*, void*, int);
 
@@ -10,39 +10,88 @@ extern "C" int WinMain(void*, void*, void*, int);
 
 @implementation AppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
+- (void)applicationDidFinishLaunching:(NSNotification*)notification
 {
-    if (g_argc == 1) {
-        NSOpenPanel *panel = [NSOpenPanel openPanel];
-        panel.message = @"Select a Visual Pinball Table File:";
-        panel.allowsMultipleSelection = NO;
-        panel.canChooseDirectories = NO;
+  if (g_argc == 1) {
 
-        [panel beginWithCompletionHandler:^(NSInteger result) {
-            if (result == NSModalResponseOK) {
-                NSURL *theDoc = panel.URLs[0];
-                NSString *filename = [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
 
-                if (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"]) {
-                    char **new_argv = (char **)malloc(4 * sizeof(char *));
-                    new_argv[0] = g_argv[0];
-                    new_argv[1] = strdup("-DisableTrueFullscreen");
-                    new_argv[2] = strdup("-play");
-                    new_argv[3] = strdup([filename UTF8String]);
+    panel.message = @"Select a Visual Pinball Table File:";
+    panel.allowsMultipleSelection = NO;
+    panel.canChooseDirectories = NO;
 
-                    g_argc = 4;
-                    g_argv = new_argv;
-                }
-            } else {
-                NSAlert *alert = [[NSAlert alloc] init];
-                [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
-                [alert addButtonWithTitle:@"OK"];
-                [alert setAlertStyle:NSAlertStyleWarning];
-                [alert runModal];
-            }
-            [self makeWindowExit];
-        }];
-    }
+    [panel beginWithCompletionHandler:^(NSInteger result) {
+        if (result == NSModalResponseOK) {
+
+          NSURL* theDoc = panel.URLs[0]; 
+          NSString* filename =
+              [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
+
+          if (filename && filename.length > 0 &&
+              [[filename.lowercaseString pathExtension]
+                  isEqualToString:@"vpx"]) {
+            char** new_argv = (char**)malloc(4 * sizeof(char*));
+
+            new_argv[0] = g_argv[0];
+            new_argv[1] = strdup("-DisableTrueFullscreen");
+            new_argv[2] = strdup("-play");
+            new_argv[3] = strdup([filename UTF8String]);
+
+            g_argc = 4;
+            g_argv = new_argv;
+          }
+        } else {
+          NSAlert* alert = [[NSAlert alloc] init];
+          [alert setMessageText:
+                     @"VPinballX_GL\n\nThis app must be run using command line "
+                     @"arguments or double clicking a \".vpx\" file."];
+          [alert addButtonWithTitle:@"OK"];
+          [alert setAlertStyle:NSAlertStyleWarning];
+          [alert runModal];
+        }
+        [self makeWindowExit];
+    }];
+
+  } else if (g_argc > 1) {
+    [self makeWindowExit];
+  }
+}
+- (void)makeWindowExit
+{
+  int status = WinMain(NULL, NULL, NULL, 0);
+  exit(status);
+}
+
+- (BOOL)application:(NSApplication*)sender openFile:(NSString*)filename
+{
+  if (g_argc == 1
+      && (filename && filename.length > 0 &&
+          [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"])) {
+    char** new_argv = (char**)malloc(3 * sizeof(char*));
+
+    new_argv[0] = g_argv[0];
+    new_argv[1] = strdup("-play");
+    new_argv[2] = strdup([filename UTF8String]);
+
+    g_argc = 3;
+    g_argv = new_argv;
+  }
+  [self makeWindowExit];
+  return YES;
 }
 
 @end
+
+int main(int argc, const char* argv[])
+{
+  @autoreleasepool {
+    g_argc = argc;
+    g_argv = (char**)argv;
+
+    [NSApplication sharedApplication];
+    AppDelegate* delegate = [[AppDelegate alloc] init];
+    [NSApp setDelegate:delegate];
+    [NSApp run];
+  }
+  return 0;
+}

--- a/standalone/macos-x64/main.mm
+++ b/standalone/macos-x64/main.mm
@@ -1,11 +1,13 @@
 #import <Cocoa/Cocoa.h>
 #import <Foundation/Foundation.h>
+#import <CoreServices/CoreServices.h>
 
 extern "C" char **g_argv;
 extern "C" int g_argc;
 extern "C" int WinMain(void*, void*, void*, int);
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
+-(void)makeWindowExit;
 @end
 
 @implementation AppDelegate
@@ -13,15 +15,58 @@ extern "C" int WinMain(void*, void*, void*, int);
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
    if (g_argc == 1) {
-      NSAlert* alert = [[NSAlert alloc] init];
+
+      NSOpenPanel*    panel = [NSOpenPanel openPanel];
+      // UTType* vpxType = [UTType typeWithFilenameExtension:@"vpx"];
+      // NSArray* vpxTypes =  @[vpxType];
+      // [panel allowedTypes:vpxTypes];
+      // [panel allowsMultipleSelection:NO];
+      // [panel canChooseDirectories:NO];
+      panel.message = @"Select a Visual Pinball Table File:";
+      panel.allowsMultipleSelection = NO;
+      panel.canChooseDirectories = NO;
+    
+
+      [panel beginWithCompletionHandler:^(NSInteger result){
+      if (result == NSModalResponseOK) {
+         
+         NSURL*  theDoc = panel.URLs[0];//[[panel URLs] objectAtIndex:0];
+         NSString* filename = [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
+         
+          if (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"]) {
+      char **new_argv = (char**)malloc(4 * sizeof(char *));
+
+      new_argv[0] = g_argv[0];
+      new_argv[1] = strdup("-DisableTrueFullscreen");
+      new_argv[2] = strdup("-play");
+      new_argv[3] = strdup([filename UTF8String]);
+      
+
+      g_argc = 4;
+      g_argv = new_argv;
+     
+    }
+      }else{
+        NSAlert* alert = [[NSAlert alloc] init];
       [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
       [alert addButtonWithTitle:@"OK"];
       [alert setAlertStyle:NSAlertStyleWarning];
       [alert runModal];
-   }
 
-   int status = WinMain(NULL, NULL, NULL, 0);
-   exit(status);
+      }
+     [self makeWindowExit];
+ 
+   }];
+   
+   } else if (g_argc > 1){
+        [self makeWindowExit];
+   }
+  
+   
+}
+-(void)makeWindowExit {
+    int status = WinMain(NULL, NULL, NULL, 0);
+        exit(status);
 }
 
 - (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename
@@ -35,8 +80,9 @@ extern "C" int WinMain(void*, void*, void*, int);
 
       g_argc = 3;
       g_argv = new_argv;
+       
     }
-
+[self makeWindowExit];
     return YES;
 }
 

--- a/standalone/macos-x64/main.mm
+++ b/standalone/macos-x64/main.mm
@@ -1,103 +1,48 @@
 #import <Cocoa/Cocoa.h>
-#import <Foundation/Foundation.h>
-#import <CoreServices/CoreServices.h>
 
 extern "C" char **g_argv;
 extern "C" int g_argc;
 extern "C" int WinMain(void*, void*, void*, int);
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
--(void)makeWindowExit;
+- (void)makeWindowExit;
 @end
 
 @implementation AppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-   if (g_argc == 1) {
+    if (g_argc == 1) {
+        NSOpenPanel *panel = [NSOpenPanel openPanel];
+        panel.message = @"Select a Visual Pinball Table File:";
+        panel.allowsMultipleSelection = NO;
+        panel.canChooseDirectories = NO;
 
-      NSOpenPanel*    panel = [NSOpenPanel openPanel];
-      // UTType* vpxType = [UTType typeWithFilenameExtension:@"vpx"];
-      // NSArray* vpxTypes =  @[vpxType];
-      // [panel allowedTypes:vpxTypes];
-      // [panel allowsMultipleSelection:NO];
-      // [panel canChooseDirectories:NO];
-      panel.message = @"Select a Visual Pinball Table File:";
-      panel.allowsMultipleSelection = NO;
-      panel.canChooseDirectories = NO;
-    
+        [panel beginWithCompletionHandler:^(NSInteger result) {
+            if (result == NSModalResponseOK) {
+                NSURL *theDoc = panel.URLs[0];
+                NSString *filename = [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
 
-      [panel beginWithCompletionHandler:^(NSInteger result){
-      if (result == NSModalResponseOK) {
-         
-         NSURL*  theDoc = panel.URLs[0];//[[panel URLs] objectAtIndex:0];
-         NSString* filename = [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
-         
-          if (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"]) {
-      char **new_argv = (char**)malloc(4 * sizeof(char *));
+                if (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"]) {
+                    char **new_argv = (char **)malloc(4 * sizeof(char *));
+                    new_argv[0] = g_argv[0];
+                    new_argv[1] = strdup("-DisableTrueFullscreen");
+                    new_argv[2] = strdup("-play");
+                    new_argv[3] = strdup([filename UTF8String]);
 
-      new_argv[0] = g_argv[0];
-      new_argv[1] = strdup("-DisableTrueFullscreen");
-      new_argv[2] = strdup("-play");
-      new_argv[3] = strdup([filename UTF8String]);
-      
-
-      g_argc = 4;
-      g_argv = new_argv;
-     
+                    g_argc = 4;
+                    g_argv = new_argv;
+                }
+            } else {
+                NSAlert *alert = [[NSAlert alloc] init];
+                [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
+                [alert addButtonWithTitle:@"OK"];
+                [alert setAlertStyle:NSAlertStyleWarning];
+                [alert runModal];
+            }
+            [self makeWindowExit];
+        }];
     }
-      }else{
-        NSAlert* alert = [[NSAlert alloc] init];
-      [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
-      [alert addButtonWithTitle:@"OK"];
-      [alert setAlertStyle:NSAlertStyleWarning];
-      [alert runModal];
-
-      }
-     [self makeWindowExit];
- 
-   }];
-   
-   } else if (g_argc > 1){
-        [self makeWindowExit];
-   }
-  
-   
-}
--(void)makeWindowExit {
-    int status = WinMain(NULL, NULL, NULL, 0);
-        exit(status);
-}
-
-- (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename
-{
-   if (g_argc == 1 && (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"])) {
-      char **new_argv = (char**)malloc(3 * sizeof(char *));
-
-      new_argv[0] = g_argv[0];
-      new_argv[1] = strdup("-play");
-      new_argv[2] = strdup([filename UTF8String]);
-
-      g_argc = 3;
-      g_argv = new_argv;
-       
-    }
-[self makeWindowExit];
-    return YES;
 }
 
 @end
-
-int main(int argc, const char * argv[])
-{
-   @autoreleasepool {
-      g_argc = argc;
-      g_argv = (char**)argv;
-
-      [NSApplication sharedApplication];
-      AppDelegate *delegate = [[AppDelegate alloc] init];
-      [NSApp setDelegate:delegate];
-      [NSApp run];
-   }
-   return 0;
-}

--- a/standalone/macos-x64/main.mm
+++ b/standalone/macos-x64/main.mm
@@ -1,6 +1,6 @@
 #import <Cocoa/Cocoa.h>
 
-extern "C" char **g_argv;
+extern "C" char** g_argv;
 extern "C" int g_argc;
 extern "C" int WinMain(void*, void*, void*, int);
 
@@ -10,39 +10,88 @@ extern "C" int WinMain(void*, void*, void*, int);
 
 @implementation AppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
+- (void)applicationDidFinishLaunching:(NSNotification*)notification
 {
-    if (g_argc == 1) {
-        NSOpenPanel *panel = [NSOpenPanel openPanel];
-        panel.message = @"Select a Visual Pinball Table File:";
-        panel.allowsMultipleSelection = NO;
-        panel.canChooseDirectories = NO;
+  if (g_argc == 1) {
 
-        [panel beginWithCompletionHandler:^(NSInteger result) {
-            if (result == NSModalResponseOK) {
-                NSURL *theDoc = panel.URLs[0];
-                NSString *filename = [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
 
-                if (filename && filename.length > 0 && [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"]) {
-                    char **new_argv = (char **)malloc(4 * sizeof(char *));
-                    new_argv[0] = g_argv[0];
-                    new_argv[1] = strdup("-DisableTrueFullscreen");
-                    new_argv[2] = strdup("-play");
-                    new_argv[3] = strdup([filename UTF8String]);
+    panel.message = @"Select a Visual Pinball Table File:";
+    panel.allowsMultipleSelection = NO;
+    panel.canChooseDirectories = NO;
 
-                    g_argc = 4;
-                    g_argv = new_argv;
-                }
-            } else {
-                NSAlert *alert = [[NSAlert alloc] init];
-                [alert setMessageText:@"VPinballX_GL\n\nThis app must be run using command line arguments or double clicking a \".vpx\" file."];
-                [alert addButtonWithTitle:@"OK"];
-                [alert setAlertStyle:NSAlertStyleWarning];
-                [alert runModal];
-            }
-            [self makeWindowExit];
-        }];
-    }
+    [panel beginWithCompletionHandler:^(NSInteger result) {
+        if (result == NSModalResponseOK) {
+
+          NSURL* theDoc = panel.URLs[0]; 
+          NSString* filename =
+              [NSString stringWithUTF8String:[theDoc fileSystemRepresentation]];
+
+          if (filename && filename.length > 0 &&
+              [[filename.lowercaseString pathExtension]
+                  isEqualToString:@"vpx"]) {
+            char** new_argv = (char**)malloc(4 * sizeof(char*));
+
+            new_argv[0] = g_argv[0];
+            new_argv[1] = strdup("-DisableTrueFullscreen");
+            new_argv[2] = strdup("-play");
+            new_argv[3] = strdup([filename UTF8String]);
+
+            g_argc = 4;
+            g_argv = new_argv;
+          }
+        } else {
+          NSAlert* alert = [[NSAlert alloc] init];
+          [alert setMessageText:
+                     @"VPinballX_GL\n\nThis app must be run using command line "
+                     @"arguments or double clicking a \".vpx\" file."];
+          [alert addButtonWithTitle:@"OK"];
+          [alert setAlertStyle:NSAlertStyleWarning];
+          [alert runModal];
+        }
+        [self makeWindowExit];
+    }];
+
+  } else if (g_argc > 1) {
+    [self makeWindowExit];
+  }
+}
+- (void)makeWindowExit
+{
+  int status = WinMain(NULL, NULL, NULL, 0);
+  exit(status);
+}
+
+- (BOOL)application:(NSApplication*)sender openFile:(NSString*)filename
+{
+  if (g_argc == 1
+      && (filename && filename.length > 0 &&
+          [[filename.lowercaseString pathExtension] isEqualToString:@"vpx"])) {
+    char** new_argv = (char**)malloc(3 * sizeof(char*));
+
+    new_argv[0] = g_argv[0];
+    new_argv[1] = strdup("-play");
+    new_argv[2] = strdup([filename UTF8String]);
+
+    g_argc = 3;
+    g_argv = new_argv;
+  }
+  [self makeWindowExit];
+  return YES;
 }
 
 @end
+
+int main(int argc, const char* argv[])
+{
+  @autoreleasepool {
+    g_argc = argc;
+    g_argv = (char**)argv;
+
+    [NSApplication sharedApplication];
+    AppDelegate* delegate = [[AppDelegate alloc] init];
+    [NSApp setDelegate:delegate];
+    [NSApp run];
+  }
+  return 0;
+}


### PR DESCRIPTION
Simply adds a standard macOS "Open File:" panel when the app is launched by double-clicking the app's icon. Tables open this way, versus the command line, or double-clicking a .vpx file, open full screen, per the current default behavior(s).