### PR TITLE
Including wctypes so it can compile properly under GCC 14.

### DIFF
--- a/standalone/inc/wine/dlls/oleaut32/varformat.c
+++ b/standalone/inc/wine/dlls/oleaut32/varformat.c
@@ -29,6 +29,9 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #include "windef.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/oleaut32/variant.c
+++ b/standalone/inc/wine/dlls/oleaut32/variant.c
@@ -28,6 +28,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #define COBJMACROS
 #include "windef.h"

--- a/standalone/inc/wine/dlls/oleaut32/vartype.c
+++ b/standalone/inc/wine/dlls/oleaut32/vartype.c
@@ -18,6 +18,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
+
 #define COBJMACROS
 #include "wine/debug.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/scrrun/dictionary.c
+++ b/standalone/inc/wine/dlls/scrrun/dictionary.c
@@ -20,6 +20,9 @@
 
 #include <stdarg.h>
 #include <math.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #include "windef.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/scrrun/filesystem.c
+++ b/standalone/inc/wine/dlls/scrrun/filesystem.c
@@ -22,6 +22,9 @@
 #include <limits.h>
 #include <assert.h>
 #include <wchar.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #include "windef.h"
 #include "winbase.h"

--- a/standalone/inc/wine/dlls/vbscript/global.c
+++ b/standalone/inc/wine/dlls/vbscript/global.c
@@ -18,6 +18,9 @@
 
 #include <assert.h>
 #include <math.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #include "vbscript.h"
 #include "vbscript_defs.h"

--- a/standalone/inc/wine/dlls/vbscript/lex.c
+++ b/standalone/inc/wine/dlls/vbscript/lex.c
@@ -19,6 +19,9 @@
 #include <assert.h>
 #include <limits.h>
 #include <math.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #include "vbscript.h"
 #include "parse.h"

--- a/standalone/inc/wine/dlls/vbscript/regexp.c
+++ b/standalone/inc/wine/dlls/vbscript/regexp.c
@@ -32,6 +32,9 @@
  */
 
 #include <assert.h>
+#if defined(__STANDALONE__)
+#include <wctype.h>
+#endif
 
 #include "vbscript.h"
 #include "regexp.h"


### PR DESCRIPTION
With Fedora 40 came GCC14 which treats undefined function as errors. This allows to work under this compiler.
Wrapped it with __STANDALONE__ so it's hopefully easier to update wine in the future.