### PR TITLE
pup: log warnings on duplicate playlist / screen

### DIFF
--- a/standalone/inc/pup/PUPPinDisplay.cpp
+++ b/standalone/inc/pup/PUPPinDisplay.cpp
@@ -40,13 +40,12 @@ STDMETHODIMP PUPPinDisplay::playlistadd(LONG ScreenNum, BSTR folder, LONG sort, 
       return S_OK;
    }
 
-   const string sFolder = MakeString(folder);
-   if (pScreen->GetPlaylist(sFolder)) {
-      PLOGW.printf("Playlist already exists: screenNum=%d, folder=%s", ScreenNum, sFolder.c_str());
+   if (pScreen->GetPlaylist(MakeString(folder))) {
+      PLOGW.printf("Playlist already exists: screenNum=%d, folder=%s", ScreenNum, MakeString(folder).c_str());
       return S_OK;
    }
 
-   pScreen->AddPlaylist(new PUPPlaylist(sFolder, "", sort, restSeconds, 100, 1));
+   pScreen->AddPlaylist(new PUPPlaylist(MakeString(folder), "", sort, restSeconds, 100, 1));
 
    return S_OK;
 }

--- a/standalone/inc/pup/PUPPinDisplay.cpp
+++ b/standalone/inc/pup/PUPPinDisplay.cpp
@@ -23,6 +23,10 @@ PUPPinDisplay::~PUPPinDisplay()
 
 STDMETHODIMP PUPPinDisplay::Init(LONG ScreenNum, BSTR RootDir)
 {
+   if (PUPManager::GetInstance()->HasScreen(ScreenNum)) {
+      PLOGW.printf("Screen already exists: screenNum=%d", ScreenNum);
+      return S_OK;
+   }
    m_pManager->AddScreen(PUPScreen::CreateDefault(ScreenNum));
 
    return S_OK;
@@ -31,11 +35,18 @@ STDMETHODIMP PUPPinDisplay::Init(LONG ScreenNum, BSTR RootDir)
 STDMETHODIMP PUPPinDisplay::playlistadd(LONG ScreenNum, BSTR folder, LONG sort, LONG restSeconds)
 {
    PUPScreen* pScreen = m_pManager->GetScreen(ScreenNum);
-   if (pScreen)
-      pScreen->AddPlaylist(new PUPPlaylist(MakeString(folder), "", sort, restSeconds, 100, 1));
-   else {
+   if (!pScreen) {
       PLOGE.printf("Screen not found: screenNum=%d");
+      return S_OK;
    }
+
+   const string sFolder = MakeString(folder);
+   if (pScreen->GetPlaylist(sFolder)) {
+      PLOGW.printf("Playlist already exists: screenNum=%d, folder=%s", ScreenNum, sFolder.c_str());
+      return S_OK;
+   }
+
+   pScreen->AddPlaylist(new PUPPlaylist(sFolder, "", sort, restSeconds, 100, 1));
 
    return S_OK;
 }

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -141,8 +141,12 @@ PUPScreen* PUPScreen::CreateFromCSV(const string& line)
       mode = PUP_SCREEN_MODE_FORCE_POP_BACK;
    else if (string_compare_case_insensitive(parts[5], "MusicOnly"))
       mode = PUP_SCREEN_MODE_MUSIC_ONLY;
-   else
+   else if (string_compare_case_insensitive(parts[5], "Off"))
       mode = PUP_SCREEN_MODE_OFF;
+   else{
+      PLOGW.printf("Invalid screen mode: %s for ", parts[5].c_str());
+      mode = PUP_SCREEN_MODE_OFF;
+   }
 
    return new PUPScreen(
       mode,

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -144,7 +144,7 @@ PUPScreen* PUPScreen::CreateFromCSV(const string& line)
    else if (string_compare_case_insensitive(parts[5], "Off"))
       mode = PUP_SCREEN_MODE_OFF;
    else{
-      PLOGW.printf("Invalid screen mode: %s for ", parts[5].c_str());
+      PLOGW.printf("Invalid screen mode: %s", parts[5].c_str());
       mode = PUP_SCREEN_MODE_OFF;
    }
 

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -143,7 +143,7 @@ PUPScreen* PUPScreen::CreateFromCSV(const string& line)
       mode = PUP_SCREEN_MODE_MUSIC_ONLY;
    else if (string_compare_case_insensitive(parts[5], "Off"))
       mode = PUP_SCREEN_MODE_OFF;
-   else{
+   else {
       PLOGW.printf("Invalid screen mode: %s", parts[5].c_str());
       mode = PUP_SCREEN_MODE_OFF;
    }


### PR DESCRIPTION
This happens when the old way of setting up playlists and screens is mixed with the screens.pup and playlists.pup.