### PR TITLE
fix: improve tweak ui increment

### DIFF
--- a/src/ui/LiveUI.cpp
+++ b/src/ui/LiveUI.cpp
@@ -1611,7 +1611,7 @@ void LiveUI::OnTweakModeEvent(const int keyEvent, const int keycode)
             {
                auto opt = customOptions[activeTweakSetting - BS_Custom];
                float nTotalSteps = (opt.maxValue - opt.minValue) / opt.step;
-               int nMsecPerStep = nTotalSteps < 20.f ? 500 : max(5, 30 - (int)(msec() - startOfPress) / 500); // discrete vs continuous sliding
+               int nMsecPerStep = nTotalSteps < 20.f ? 500 : max(5, 250 - (int)(msec() - startOfPress) / 10); // discrete vs continuous sliding
                int nSteps = (msec() - m_lastTweakKeyDown) / nMsecPerStep;
                if (keyEvent == 1)
                {


### PR DESCRIPTION
fixes #1696

This is a specific issue for custom settings with more than 20 items. The base speed was way too high.