### PR TITLE
Make code line number margin dynamic based on size of script loaded

### DIFF
--- a/codeview.cpp
+++ b/codeview.cpp
@@ -1811,7 +1811,7 @@ void CodeViewer::LoadFromStream(IStream *pistream, const HCRYPTHASH hcrypthash, 
 
 	const int scriptLines = (int)SendMessage(m_hwndScintilla, SCI_GETLINECOUNT, 0, 0);
 	// Get the font size
-	const int fontSize = SendMessage(m_hwndScintilla, SCI_STYLEGETSIZE, 0, 0);
+	const int fontSize = (int)SendMessage(m_hwndScintilla, SCI_STYLEGETSIZE, 0, 0);
 	//Update the margin width to fit the number of characters required to display the line number * font size
     SendMessage(m_hwndScintilla, SCI_SETMARGINWIDTHN, 0, (scriptLines > 0 ? (int)ceil(log10(scriptLines) + 2) : 1) * fontSize);
 }

--- a/codeview.cpp
+++ b/codeview.cpp
@@ -1809,11 +1809,8 @@ void CodeViewer::LoadFromStream(IStream *pistream, const HCRYPTHASH hcrypthash, 
    m_ignoreDirty = false;
    m_sdsDirty = eSaveClean;
 
-	const int scriptLines = (int)SendMessage(m_hwndScintilla, SCI_GETLINECOUNT, 0, 0);
-	// Get the font size
-	const int fontSize = (int)SendMessage(m_hwndScintilla, SCI_STYLEGETSIZE, 0, 0);
-	//Update the margin width to fit the number of characters required to display the line number * font size
-    SendMessage(m_hwndScintilla, SCI_SETMARGINWIDTHN, 0, (scriptLines > 0 ? (int)ceil(log10(scriptLines) + 2) : 1) * fontSize);
+   // Allow updates to take now we know the script size
+   UpdateScinFromPrefs();
 }
 
 void CodeViewer::LoadFromFile(const string& filename)
@@ -3699,6 +3696,10 @@ void CodeViewer::UpdateScinFromPrefs()
 	prefVPcore->ApplyPreferences(m_hwndScintilla, m_prefEverythingElse);
 	SendMessage(m_hwndScintilla, SCI_STYLESETBACK, SCE_B_KEYWORD5, RGB(200,200,200));
 	SendMessage(m_hwndScintilla, SCI_SETKEYWORDS, 4 , (LPARAM)m_wordUnderCaret.lpstrText);
+
+	const int scriptLines = (int)SendMessage(m_hwndScintilla, SCI_GETLINECOUNT, 0, 0);
+   //Update the margin width to fit the number of characters required to display the line number * font size
+   SendMessage(m_hwndScintilla, SCI_SETMARGINWIDTHN, 0, (scriptLines > 0 ? (int)ceil(log10(scriptLines) + 3) : 1) * m_prefEverythingElse->m_pointSize);
 }
 
 void CodeViewer::ResizeScintillaAndLastError()

--- a/codeview.cpp
+++ b/codeview.cpp
@@ -1808,6 +1808,12 @@ void CodeViewer::LoadFromStream(IStream *pistream, const HCRYPTHASH hcrypthash, 
 
    m_ignoreDirty = false;
    m_sdsDirty = eSaveClean;
+
+	const int scriptLines = (int)SendMessage(m_hwndScintilla, SCI_GETLINECOUNT, 0, 0);
+	// Get the font size
+	const int fontSize = SendMessage(m_hwndScintilla, SCI_STYLEGETSIZE, 0, 0);
+	//Update the margin width to fit the number of characters required to display the line number * font size
+    SendMessage(m_hwndScintilla, SCI_SETMARGINWIDTHN, 0, (scriptLines > 0 ? (int)ceil(log10(scriptLines) + 2) : 1) * fontSize);
 }
 
 void CodeViewer::LoadFromFile(const string& filename)


### PR DESCRIPTION
Make margin for line number dynamic based on script size.

Tried with 4 and 3  length script sizes, seems to work. i.e. (000's and 0000's) lines of scripts. 