### PR TITLE
build(standalone): Asahi linux

### DIFF
--- a/standalone/README.md
+++ b/standalone/README.md
@@ -256,6 +256,20 @@ cmake -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 ```
 
+### Linux (Fedora Asahi Remix 41)
+In a terminal execute the following:
+```
+sudo dnf install @development-tools
+sudo dnf install gcc-c++ autoconf automake libtool cmake nasm bison curl systemd-devel libX11-devel mesa-libGL-devel libXext-devel zlib-ng-compat-static zlib-ng-compat-devel wayland-devel
+git clone -b standalone https://github.com/vpinball/vpinball
+cd vpinball/standalone/linux-x64
+./external.sh
+cd ../..
+cp standalone/cmake/CMakeLists_bgfx-linux-aarch64.txt CMakeLists.txt
+cmake -DCMAKE_BUILD_TYPE=Release -B build
+cmake --build build -- -j$(nproc)
+```
+
 ### RK3588 (Armbian)
 
 Start with a [Armbian 23.02 Jammy LI](https://www.armbian.com/orangepi-5/) image and execute the following:

--- a/standalone/cmake/CMakeLists_gl-linux-aarch64.txt
+++ b/standalone/cmake/CMakeLists_gl-linux-aarch64.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 99)
 
 add_library(glad
-   third-party/include/glad/src/gles2.c
+   third-party/include/glad/src/gl.c
 )
 
 target_include_directories(glad PUBLIC
@@ -35,7 +35,6 @@ bison_target(vbsparser ${CMAKE_SOURCE_DIR}/standalone/inc/wine/dlls/vbscript/par
 
 add_compile_definitions(
    __STANDALONE__
-   __OPENGLES__
 
    ENABLE_OPENGL
    ENABLE_SDL_VIDEO


### PR DESCRIPTION
This promotes the BGFX build as it runs great. GL compiles and starts but does not render my test tables properly on Asahi Linux. It might however still be interesting to have for other ARM linux environments.