### PR TITLE
BGFX: move all CPU-GPU interaction to a single render thread

### DIFF
--- a/src/core/player.h
+++ b/src/core/player.h
@@ -301,11 +301,10 @@ private:
    bool m_curFrameSyncOnFPS = false;
    U64 m_startFrameTick; // System time in us when render frame was started (beginning of frame animation then collect,...)
    unsigned int m_onPrepareFrameEventId;
-   unsigned int m_syncLengths[512];
 
-   void MultithreadedGameLoop(std::function<void(bool)> sync);
-   void FramePacingGameLoop(std::function<void(bool)> sync);
-   void GPUQueueStuffingGameLoop(std::function<void(bool)> sync);
+   void MultithreadedGameLoop(std::function<void()> sync);
+   void FramePacingGameLoop(std::function<void()> sync);
+   void GPUQueueStuffingGameLoop(std::function<void()> sync);
 
 #pragma endregion
 

--- a/src/physics/PhysicsEngine.cpp
+++ b/src/physics/PhysicsEngine.cpp
@@ -688,8 +688,8 @@ void PhysicsEngine::UpdatePhysics()
    } // end while (m_curPhysicsFrameTime < initial_time_usec)
 
    // The physics is emulated by PHYSICS_STEPTIME, but the overall emulation time is more precise
-   g_pplayer->m_time_sec = (double)(min(initial_time_usec, m_curPhysicsFrameTime) - m_StartTime_usec) / 1000000.0;
-   // g_pplayer->m_time_msec = (U32)((min(initial_time_usec, m_curPhysicsFrameTime) - m_StartTime_usec) / 1000); // Not needed since PHYSICS_STEPTIME happens to be 1ms
+   g_pplayer->m_time_sec = (double)(max(initial_time_usec, m_curPhysicsFrameTime) - m_StartTime_usec) / 1000000.0;
+   // g_pplayer->m_time_msec = (U32)((max(initial_time_usec, m_curPhysicsFrameTime) - m_StartTime_usec) / 1000); // Not needed since PHYSICS_STEPTIME happens to be 1ms
 
    g_frameProfiler.ExitProfileSection();
 }

--- a/src/renderer/RenderProbe.cpp
+++ b/src/renderer/RenderProbe.cpp
@@ -363,11 +363,6 @@ void RenderProbe::PreRenderStaticReflectionProbe()
       m_rd->m_FBShader->SetTextureNull(SHADER_tex_fb_unfiltered);
 
       m_rd->SubmitRenderFrame(); // Submit to avoid stacking up all prerender passes in a huge render frame
-      #if defined(ENABLE_BGFX)
-      // BGFX will only process the submitted render frame when the render surface is presented
-      m_rd->Flip();
-      #endif
-
    }
    m_rd->m_curDrawnTriangles += nTris;
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -1135,12 +1135,6 @@ void Renderer::PrepareFrame()
 
 }
 
-void Renderer::SubmitFrame()
-{
-   // Submit to GPU render queue
-   m_pd3dPrimaryDevice->SubmitRenderFrame();
-}
-
 void Renderer::DrawBulbLightBuffer()
 {
    RenderDevice* p3dDevice = m_pd3dPrimaryDevice;
@@ -1377,10 +1371,6 @@ void Renderer::RenderStaticPrepass()
       }
 
       m_pd3dPrimaryDevice->SubmitRenderFrame(); // Submit to avoid stacking up all prerender passes in a huge render frame
-      #if defined(ENABLE_BGFX)
-      // BGFX will only process the submitted render frame when the render surface is presented
-      m_pd3dPrimaryDevice->Flip();
-      #endif
    }
 
    if (accumulationSurface)
@@ -1482,10 +1472,6 @@ void Renderer::RenderStaticPrepass()
       m_pd3dPrimaryDevice->AddEndOfFrameCmd([initialPreRender]() { delete initialPreRender; });
    }
    m_pd3dPrimaryDevice->SubmitRenderFrame(); // Submit frame as other rendering will not declare a dependency on the created passes and therefore they would be discarded
-   #if defined(ENABLE_BGFX)
-   // BGFX will only process the submitted render frame when the render surface is presented
-   m_pd3dPrimaryDevice->Flip();
-   #endif
 
    if (IsUsingStaticPrepass())
    {

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -38,7 +38,6 @@ public:
    void RenderStaticPrepass();
 
    void PrepareFrame();
-   void SubmitFrame();
 
    void DrawStatics();
    void DrawDynamics(bool onlyBalls);

--- a/src/renderer/Sampler.h
+++ b/src/renderer/Sampler.h
@@ -88,6 +88,8 @@ private:
    SamplerFilter m_filter;
 
 #if defined(ENABLE_BGFX)
+   string m_name;
+   bgfx::TextureFormat::Enum m_bgfx_format = bgfx::TextureFormat::Enum::Count;
    bgfx::TextureHandle m_texture = BGFX_INVALID_HANDLE;
    bgfx::TextureHandle m_mips_texture = BGFX_INVALID_HANDLE;
    bgfx::FrameBufferHandle m_mips_framebuffer = BGFX_INVALID_HANDLE;

--- a/src/utils/wintimer.h
+++ b/src/utils/wintimer.h
@@ -181,6 +181,10 @@ public:
 
    void NewFrame(U32 gametime)
    {
+      #ifdef ENABLE_BGFX
+      // BGFX FIXME make profiler multithreaded
+      return;
+      #endif
       assert(m_profileSectionStackPos == 0);
       m_frameIndex++;
       m_profileTimeStamp = usec();
@@ -229,6 +233,10 @@ public:
 
    void SetProfileSection(ProfileSection section)
    {
+      #ifdef ENABLE_BGFX
+      // BGFX FIXME make profiler multithreaded
+      return;
+      #endif
       assert(0 <= section && section < PROFILE_COUNT);
       const unsigned long long ts = usec();
       m_profileData[m_profileIndex][m_profileSection] += (unsigned int) (ts - m_profileTimeStamp);
@@ -238,6 +246,10 @@ public:
 
    void EnterProfileSection(ProfileSection section)
    {
+      #ifdef ENABLE_BGFX
+      // BGFX FIXME make profiler multithreaded
+      return;
+      #endif
       assert(0 <= section && section < PROFILE_COUNT);
       assert(m_profileSectionStackPos < STACK_SIZE);
       m_profileSectionStack[m_profileSectionStackPos] = m_profileSection;
@@ -247,6 +259,10 @@ public:
 
    void ExitProfileSection()
    {
+      #ifdef ENABLE_BGFX
+      // BGFX FIXME make profiler multithreaded
+      return;
+      #endif
       assert(m_profileSectionStackPos >= 0);
       m_profileSectionStackPos--;
       SetProfileSection(m_profileSectionStack[m_profileSectionStackPos]);
@@ -254,6 +270,10 @@ public:
 
    void EnterScriptSection(DISPID id, const char* timer_name = nullptr)
    {
+      #ifdef ENABLE_BGFX
+      // BGFX FIXME make profiler multithreaded
+      return;
+      #endif
       EnterProfileSection(PROFILE_SCRIPT);
       m_scriptEventDispID = id;
       // For the time being, just store a list of the timer called during the script profile section
@@ -276,6 +296,10 @@ public:
 
    void ExitScriptSection(const char* timer_name = nullptr)
    {
+      #ifdef ENABLE_BGFX
+      // BGFX FIXME make profiler multithreaded
+      return;
+      #endif
       unsigned long long profileTimeStamp = m_profileTimeStamp;
       ExitProfileSection();
       EventTick& et = m_scriptEventData[m_scriptEventDispID];


### PR DESCRIPTION
This PR implements the target threading model for BGFX:
- a logic thread that only performs IO/Physic/Controller sync/script and when needed prepare render frames
- a render thread that process the frame, submit to GPU and sync on the display

Beside the performance benefit of parallelization, this allows to decouple the emulation from the rendering and especially from the display synchronization, leading to more stable game play (bound to CPU) independently of stability of render (bound to GPU). This also allows to maintain a very short VPM - VPX round trip (usually far below 1ms, depending on the table script, and the length of preparing the frame, which is not yet optimized at all).

This MSVC Concurrency Viewer shows the syncronization for an heavy table ('VPW's Jurassic Park) running at 144Hz on a GTX970:
![image](https://github.com/vpinball/vpinball/assets/2796036/32f0cfb2-935c-41fc-8249-aeae6f58e1b5)

First 'Worker thread' is VPX emulating mostly on sync with main thread: except during prepare which 1.5ms, the round trip is always way below 1ms.
Bottom 'Workker thread' is the render thread, mostly waiting for GPU & Display and submitting frames when it is ready.

Next steps should be to (re)add some embedded profiling as they have been disabled (they are not relevant & thread safe for the time being), and optimize frame preparation (do not recreate the render commands for each frame, but lazily as properties of parts change).