### PR TITLE
Change VPBuildVersion to DOUBLE and return GIT_REVISION as decimal #1558

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1168,9 +1168,9 @@ STDMETHODIMP ScriptGlobalTable::get_Version(int *pVal)
 	return S_OK;
 }
 
-STDMETHODIMP ScriptGlobalTable::get_VPBuildVersion(DOUBLE *pVal)
+STDMETHODIMP ScriptGlobalTable::get_VPBuildVersion(double *pVal)
 {
-   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
+   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0;
 	return S_OK;
 }
 
@@ -10391,9 +10391,9 @@ STDMETHODIMP PinTable::get_Version(int *pVal)
    return S_OK;
 }
 
-STDMETHODIMP PinTable::get_VPBuildVersion(DOUBLE *pVal)
+STDMETHODIMP PinTable::get_VPBuildVersion(double *pVal)
 {
-   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
+   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0;
    return S_OK;
 }
 

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1168,9 +1168,9 @@ STDMETHODIMP ScriptGlobalTable::get_Version(int *pVal)
 	return S_OK;
 }
 
-STDMETHODIMP ScriptGlobalTable::get_VPBuildVersion(int *pVal)
+STDMETHODIMP ScriptGlobalTable::get_VPBuildVersion(DOUBLE *pVal)
 {
-	*pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV;
+   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
 	return S_OK;
 }
 
@@ -10391,9 +10391,9 @@ STDMETHODIMP PinTable::get_Version(int *pVal)
    return S_OK;
 }
 
-STDMETHODIMP PinTable::get_VPBuildVersion(int *pVal)
+STDMETHODIMP PinTable::get_VPBuildVersion(DOUBLE *pVal)
 {
-   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV;
+   *pVal = VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REV + GIT_REVISION / 10000.0f;
    return S_OK;
 }
 

--- a/src/parts/pintable.h
+++ b/src/parts/pintable.h
@@ -310,7 +310,7 @@ public:
    STDMETHOD(put_EnvironmentImage)(/*[in]*/ BSTR newVal);
 
    STDMETHOD(get_Version)(/*[out, retval]*/ int *pVal);
-   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ int *pVal);
+   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ DOUBLE *pVal);
    STDMETHOD(get_VersionMajor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionMinor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionRevision)(/*[out, retval]*/ int *pVal);
@@ -968,7 +968,7 @@ public:
    STDMETHOD(get_ActiveTable)(/*[out, retval]*/ ITable **pVal);
 
    STDMETHOD(get_Version)(/*[out, retval]*/ int *pVal);
-   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ int *pVal);
+   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ DOUBLE *pVal);
    STDMETHOD(get_VersionMajor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionMinor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionRevision)(/*[out, retval]*/ int *pVal);

--- a/src/parts/pintable.h
+++ b/src/parts/pintable.h
@@ -310,7 +310,7 @@ public:
    STDMETHOD(put_EnvironmentImage)(/*[in]*/ BSTR newVal);
 
    STDMETHOD(get_Version)(/*[out, retval]*/ int *pVal);
-   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ DOUBLE *pVal);
+   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ double *pVal);
    STDMETHOD(get_VersionMajor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionMinor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionRevision)(/*[out, retval]*/ int *pVal);
@@ -968,7 +968,7 @@ public:
    STDMETHOD(get_ActiveTable)(/*[out, retval]*/ ITable **pVal);
 
    STDMETHOD(get_Version)(/*[out, retval]*/ int *pVal);
-   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ DOUBLE *pVal);
+   STDMETHOD(get_VPBuildVersion)(/*[out, retval]*/ double *pVal);
    STDMETHOD(get_VersionMajor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionMinor)(/*[out, retval]*/ int *pVal);
    STDMETHOD(get_VersionRevision)(/*[out, retval]*/ int *pVal);

--- a/txt/CommandReference.txt
+++ b/txt/CommandReference.txt
@@ -196,7 +196,7 @@ EndMusic
 FireKnocker(int Count)
 QuitPlayer(int CloseType)
 Version - returns VP_VERSION_MAJOR * 1000 + VP_VERSION_MINOR * 100 + VP_VERSION_REVISION
-VPBuildVersion - same, deprecated
+VPBuildVersion - same as Version but with build number as decimal
 VersionMajor - major VP version number
 VersionMinor - minor VP version number
 VersionRevision - VP version revision

--- a/vpinball.idl
+++ b/vpinball.idl
@@ -684,7 +684,7 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [propget, id(38), helpstring("property VersionMajor")] HRESULT VersionMajor([out, retval] int *pVal);
                 [propget, id(39), helpstring("property VersionMinor")] HRESULT VersionMinor([out, retval] int *pVal);
                 [propget, id(40), helpstring("property VersionRevision")] HRESULT VersionRevision([out, retval] int *pVal);
-                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] DOUBLE *pVal);
+                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] double *pVal);
 
                 [propget, id(230), helpstring("property Option")] HRESULT Option([in] BSTR OptionName, [in] float MinValue, [in] float MaxValue, [in] float Step, [in] float DefaultValue, [in] int Unit, [in, optional] VARIANT values, [out, retval] float *pVal);
                 [propput, id(230), helpstring("property Option")] HRESULT Option([in] BSTR OptionName, [in] float MinValue, [in] float MaxValue, [in] float Step, [in] float DefaultValue, [in] int Unit, [in, optional] VARIANT values, [in] float val);
@@ -773,7 +773,7 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [propget, id(38), helpstring("property VersionMajor")] HRESULT VersionMajor([out, retval] int *pVal);
                 [propget, id(39), helpstring("property VersionMinor")] HRESULT VersionMinor([out, retval] int *pVal);
                 [propget, id(40), helpstring("property VersionRevision")] HRESULT VersionRevision([out, retval] int *pVal);
-                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] DOUBLE *pVal);
+                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] double *pVal);
 
                 [id(249), helpstring("method GetSerialDevices")] HRESULT GetSerialDevices([out, retval] VARIANT *pVal);
                 [id(250), helpstring("method OpenSerial")] HRESULT OpenSerial([in] BSTR device);

--- a/vpinball.idl
+++ b/vpinball.idl
@@ -684,7 +684,7 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [propget, id(38), helpstring("property VersionMajor")] HRESULT VersionMajor([out, retval] int *pVal);
                 [propget, id(39), helpstring("property VersionMinor")] HRESULT VersionMinor([out, retval] int *pVal);
                 [propget, id(40), helpstring("property VersionRevision")] HRESULT VersionRevision([out, retval] int *pVal);
-                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] int *pVal);
+                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] DOUBLE *pVal);
 
                 [propget, id(230), helpstring("property Option")] HRESULT Option([in] BSTR OptionName, [in] float MinValue, [in] float MaxValue, [in] float Step, [in] float DefaultValue, [in] int Unit, [in, optional] VARIANT values, [out, retval] float *pVal);
                 [propput, id(230), helpstring("property Option")] HRESULT Option([in] BSTR OptionName, [in] float MinValue, [in] float MaxValue, [in] float Step, [in] float DefaultValue, [in] int Unit, [in, optional] VARIANT values, [in] float val);
@@ -773,7 +773,7 @@ typedef [uuid(D09B9F0E-C1AE-40dd-84D6-B1F74053AA8E)]
                 [propget, id(38), helpstring("property VersionMajor")] HRESULT VersionMajor([out, retval] int *pVal);
                 [propget, id(39), helpstring("property VersionMinor")] HRESULT VersionMinor([out, retval] int *pVal);
                 [propget, id(40), helpstring("property VersionRevision")] HRESULT VersionRevision([out, retval] int *pVal);
-                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] int *pVal);
+                [propget, id(24), helpstring("property VPBuildVersion")] HRESULT VPBuildVersion([out, retval] DOUBLE *pVal);
 
                 [id(249), helpstring("method GetSerialDevices")] HRESULT GetSerialDevices([out, retval] VARIANT *pVal);
                 [id(250), helpstring("method OpenSerial")] HRESULT OpenSerial([in] BSTR device);


### PR DESCRIPTION
I have now reactivated VPBuildVersion (it was stated to be deprecated) but have changed it to return a double instead of integer.
The git build number is now the decimal of the returned value.