### PR TITLE
Set GIT_REVISION default value to 9999 for local compile

### DIFF
--- a/.github/workflows/vpinball.yml
+++ b/.github/workflows/vpinball.yml
@@ -71,7 +71,7 @@ jobs:
           path: DXSDK
           key: cache-dxsdk
       - run: |
-          perl -i -pe"s/0/${{ needs.version.outputs.revision }}/g" git_version.h
+          perl -i -pe"s/9999/${{ needs.version.outputs.revision }}/g" git_version.h
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha7 }}/g" git_version.h
       - name: Build
         run: |
@@ -118,7 +118,7 @@ jobs:
           path: DXSDK
           key: cache-dxsdk
       - run: |
-          perl -i -pe"s/0/${{ needs.version.outputs.revision }}/g" git_version.h
+          perl -i -pe"s/9999/${{ needs.version.outputs.revision }}/g" git_version.h
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha7 }}/g" git_version.h
       - name: Build
         run: |

--- a/git_version.h
+++ b/git_version.h
@@ -1,7 +1,7 @@
 #ifndef _GIT_VERSION_H_
 #define _GIT_VERSION_H_
 
-#define GIT_REVISION 0
+#define GIT_REVISION 9999
 #define GIT_SHA      "unknown"
 
 #endif

--- a/vpversion.h
+++ b/vpversion.h
@@ -2,6 +2,7 @@
 
 #include "git_version.h"
 
+// Update VERSION_START_SHA in .github\workflows\vpinball.yml to point to the latest commit.
 #define VP_VERSION_MAJOR    10 // X Digits
 #define VP_VERSION_MINOR    8  // Max 2 Digits
 #define VP_VERSION_REV      0  // Max 1 Digit


### PR DESCRIPTION
As in my last pull request, we discussed what happens when compiling locally with the GIT_REVISION set to zero.
Therefore I have set it to 9999 in git_version.h and updated the git action to replace 9999 with the git revision.

I have also added a comment to update VERSION_START_SHA in .github\workflows\vpinball.yml on version changes