### PR TITLE
standalone: update/disable b2s polling if vbscript calls after timer counter

### DIFF
--- a/standalone/inc/b2s/Server.h
+++ b/standalone/inc/b2s/Server.h
@@ -173,6 +173,10 @@ public:
 
 private:
    void TimerElapsed(VP::Timer* pTimer);
+   HRESULT GetChangedLamps(VARIANT *pRetVal);
+   HRESULT GetChangedSolenoids(VARIANT *pRetVal);
+   HRESULT GetChangedGIStrings(VARIANT *pRetVal);
+   HRESULT GetChangedLEDs(VARIANT mask2, VARIANT mask1, VARIANT mask3, VARIANT mask4, VARIANT *pRetVal);
    void CheckGetMech(int number, int mech);
    void CheckLamps(SAFEARRAY* psa);
    void CheckSolenoids(SAFEARRAY* psa);


### PR DESCRIPTION
If a vbscript doesn't request solenoids prior to the B2S polling timer counter expiring, it's stuck in polling forever.

As the table startup process keeps getting tweaked, I'm seeing issues where if a machine isn't fast enough, solenoid calls are accessed a little later after the polling is determined. 

This code will allow for polling to be changed after the counter, which will fix sporatic flipper sticking.