### PR TITLE
Nudge/plunger input model enhancements

### DIFF
--- a/dialogs/KeysConfigDialog.cpp
+++ b/dialogs/KeysConfigDialog.cpp
@@ -317,6 +317,7 @@ void KeysConfigDialog::AddStringAxis(const string &name, const int idc, const in
    ::SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM)"rZ Axis");
    ::SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM)"Slider 1");
    ::SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM)"Slider 2");
+   ::SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM)"OpenPinDev");
    ::SendMessage(hwnd, CB_SETCURSEL, selected, 0);
    ::SendMessage(hwnd, WM_SETREDRAW, TRUE, 0);
 }

--- a/dialogs/KeysConfigDialog.cpp
+++ b/dialogs/KeysConfigDialog.cpp
@@ -353,6 +353,9 @@ BOOL KeysConfigDialog::OnInitDialog()
     int key = g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "PBWRotationValue"s, 0);
     SetDlgItemInt( IDC_GLOBALROTATION, key, FALSE);
 
+    on = g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "AccelVelocityInput"s, false);
+    SendDlgItemMessage(IDC_CBGLOBALACCVEL, BM_SETCHECK, on ? BST_CHECKED : BST_UNCHECKED, 0);
+
     on = g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "TiltSensCB"s, false);
     SendDlgItemMessage(IDC_CBGLOBALTILT, BM_SETCHECK, on ? BST_CHECKED : BST_UNCHECKED, 0);
 
@@ -391,6 +394,9 @@ BOOL KeysConfigDialog::OnInitDialog()
 
     key = g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "PBWAccelMaxY"s, 100);
     SetDlgItemInt( IDC_YMAX_EDIT, key, FALSE);
+
+    key = g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "PlungerSpeedScale"s, 100);
+    SetDlgItemInt(IDC_PLUNGERSPEEDSCALE, key, FALSE);
 
     on = g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "EnableMouseInPlayer"s, true);
     SendDlgItemMessage(IDC_ENABLE_MOUSE_PLAYER, BM_SETCHECK, on ? BST_CHECKED : BST_UNCHECKED, 0);
@@ -488,6 +494,7 @@ BOOL KeysConfigDialog::OnInitDialog()
     AddStringAxis("PlungerAxis"s, IDC_PLUNGERAXIS, 3); // assume Z Axis as standard
     AddStringAxis("LRAxis"s, IDC_LRAXISCOMBO, 1); // assume X Axis as standard
     AddStringAxis("UDAxis"s, IDC_UDAXISCOMBO, 2); // assume Y Axis as standard
+    AddStringAxis("PlungerSpeedAxis"s, IDC_PLUNGERSPEEDAXIS, 0);  // not assigned by default
 
     for (unsigned int i = 0; i < eCKeys; ++i)
       if (regkey_idc[i] != -1 && GetDlgItem(regkey_idc[i]) && GetDlgItem(regkey_idc[i]).IsWindow())
@@ -714,6 +721,7 @@ void KeysConfigDialog::OnOK()
     SetValue(IDC_JOYDEBUGGERCOMBO, Settings::Player, "JoyDebuggerKey"s);
     SetValue(IDC_JOYLOCKBARCOMBO, Settings::Player, "JoyLockbarKey"s);
     SetValue(IDC_PLUNGERAXIS, Settings::Player, "PlungerAxis"s);
+    SetValue(IDC_PLUNGERSPEEDAXIS, Settings::Player, "PlungerSpeedAxis"s);
     SetValue(IDC_LRAXISCOMBO, Settings::Player, "LRAxis"s);
     SetValue(IDC_UDAXISCOMBO, Settings::Player, "UDAxis"s);
     SetValue(IDC_JOYPAUSECOMBO, Settings::Player, "JoyPauseKey"s);
@@ -728,6 +736,9 @@ void KeysConfigDialog::OnOK()
 
     newvalue = max((int)GetDlgItemInt(IDC_UDAXISGAIN, nothing, TRUE), 0);
     g_pvp->m_settings.SaveValue(Settings::Player, "PBWAccelGainY"s, newvalue);
+
+    newvalue = max((int)GetDlgItemInt(IDC_PLUNGERSPEEDSCALE, nothing, TRUE), 0);
+    g_pvp->m_settings.SaveValue(Settings::Player, "PlungerSpeedScale"s, newvalue);
 
     newvalue = clamp((int)GetDlgItemInt(IDC_DEADZONEAMT, nothing, TRUE), 0, 100);
     g_pvp->m_settings.SaveValue(Settings::Player, "DeadZone"s, newvalue);
@@ -767,6 +778,9 @@ void KeysConfigDialog::OnOK()
 
     newvalue = GetDlgItemInt(IDC_GLOBALROTATION, nothing, TRUE);
     g_pvp->m_settings.SaveValue(Settings::Player, "PBWRotationValue"s, newvalue);
+
+    newvalue = IsDlgButtonChecked(IDC_CBGLOBALACCVEL);
+    g_pvp->m_settings.SaveValue(Settings::Player, "AccelVelocityInput"s, newvalue);
 
     const bool tscb = (IsDlgButtonChecked(IDC_CBGLOBALTILT)!= 0);
     g_pvp->m_settings.SaveValue(Settings::Player, "TiltSensCB"s, tscb);

--- a/docs/Accelerometer Velocity Input Tech Note.md
+++ b/docs/Accelerometer Velocity Input Tech Note.md
@@ -1,0 +1,410 @@
+# Accelerometer Velocity Input Technical Note
+
+Visual Pinball can simulate nudging based on input from an
+accelerometer, via the USB HID joystick interface.  This is a key
+feature for virtual pin cab users, since it seamlessly replicates the
+kind of physical interaction you can engage in with a mechanical
+pinball machine.
+
+This technical note describes a new enhancement to VP's accelerometer
+input model that's designed to improve the playing experience and the
+realism of the simulation.  To use the new system, the USB device
+supplying the accelerometer input must also be equipped with the new
+mechanism.  This is purely a supplement to the traditional input
+model, so it doesn't affect users with existing devices; it's just a
+new alternative available to users with devices that provide the new
+input data.  The new system is easy to implement on the device side;
+details for device developers are included later in this tech note.
+
+
+## Background: The accelerometer device-level interface
+
+VP doesn't accept accelerometer input directly, since there aren't
+any accelerometers that you can directly connect to a PC.  Instead,
+the accelerometer itself is connected to some kind of intermediary
+device, typically a microcontroller (such as an Arduino, KL25Z, 
+or Raspberry Pi Pico), which in turn connects to the PC via USB.
+VP's access to the accelerometer is by way of the USB interace,
+specifically the USB HID joystick interface.  VP can be configured
+to accept two axes of accelerometer input, representing the X and Y
+axes in the horizontal plane of the virtual playfield, via any pair
+of standard gamepad joystick axes.
+
+This approach was invented by a couple of early "virtual pinball
+controller" products, and was copied by all of the later commercial
+and open-source controllers, since it's easy to implement in a
+microcontroller, and is already supported in the simulators.
+
+
+## The traditional simulator input model: Raw accelerations
+
+In the traditional USB HID joystick interface that VP and other
+simulators implement, the microcontroller simply passes along the
+acceleration samples read from the accelerometer, with little or no
+processing.  The device typically scales the readings to fit the USB
+HID joystick axis range, and provides some kind of automatic
+calibration to subtract out the physical tilt bias that's almost
+always present (since it's nearly impossible to install an
+accelerometer sensor such that it's perfectly level).  Otherwise,
+the readings sent to the simulator are just the readings taken
+from the accelerometer: a series of discrete-time digitized
+acceleration samples.
+
+Internally, VP applies these instantaneous accelerations to the
+simulation by accelerating each moving object by the amount read from
+the accelerometer, for one time step in the simulation.  The
+expression of this concept in the C++ code is equally straightforward:
+VP literally adds the instantaneous acceleration on each time step to
+each movable object's velocity.  
+
+To be correct in a physics sense, the instantaneous acceleration must
+be multiplied by the amount of time in a time step, to yield the
+incremental velocity for one time step.  The VP code has a comment
+that this is missing and should be added someday, but it's really not
+missing after all: it's just hidden in plain sight, by virtue of being
+rolled into the user-adjustable "Gain" setting.  Each acceleration
+reading from the USB device is multiplied by the Gain to yield the
+amount added to the velocities, so the Gain implicitly contains the
+time step factor.  If you've ever wondered why you needed to reduce
+the gain by a factor of 10 between VP9 and VP10, it's because VP10's
+time step is 1/10 of VP9's, thus the component of the gain that
+represents the time step had to be reduced by 10x.
+
+
+## The new alternative simulator input model: Integrated velocities
+
+The new input model passes **velocities**, instead of accelerations,
+through the USB interface.
+
+Readers will recall from high-school physics classes that velocity is
+the integral over time of acceleration.  To perform a numerical
+integration over time with a series of discrete-time samples, such as
+our accelerometer readings, you just add up the samples, multiplying
+each by the time step per sample.
+
+To implement the new "integrated velocity" model, the microcontroller
+collects the individual acceleration samples from the accelerometer as
+usual, and then adds them up, scaling by the time per sample, to
+obtain the velocity at each step.  It reports the integrated velocity
+in each USB HID joystick report in place of (or alongside) the
+instantaneous acceleration reading.
+
+Applying the velocity-based inputs in VP is about as straightforward
+to implement as the original acceleration-based model, at least in
+terms of the C++ code, although perhaps a little harder to
+conceptualize.  The key to thinking about this is to think of each
+moving object's current velocity as the sum of two components: its
+velocity relative to the inertial rest frame, and its velocity
+relative to the playfield.  The second type comes from the nudge
+input, because the nudge input represents the motion of the playfield
+relative to the inertial rest frame.  Since VP's convention is that
+the playfield defines the coordinate system, adding velocity to the
+playfield is a matter of adding the opposite velocity to all of the
+moving objects, so that the playfield remains at rest relative to the
+coordinate system.  
+
+To express all of this in C++ code, we add a new pair of variables
+representing the current X/Y "nudge velocity".  What these really
+represent physically is the velocity of the playfield relative to the
+inertial rest frame.  On each time step, we calculate the new velocity
+for each moving object by adding the **difference** between the **new
+instantaneous accelerometer velocity reading** and the **old nudge
+velocity** variables.  We then update the nudge velocity variables to
+equal the new instantaneous device reading.  This calculation effectively
+gives every moving object on every time step a total velocity equal to its
+intrinsic velocity (relative to the inertial rest frame) plus the
+current instantaneous playfield velocity.  There's no need for the
+moving objects to maintain two separate velocities - it's all done
+with the simple accounting trick - so nothing else in the simulation
+is affected.  In particular, hit testing and collision processing
+are completely unchanged.
+
+Note that VPX already has a similar concept for its internal *simulated*
+nudging system, which applies a nudge from scripting or by keyboard
+activation by modeling an imaginary cabinet as a damped oscillator.  VPX
+calculates the motion of this imaginary damped oscillator, and applies
+the differential velocity to the ball speeds on each physics time step.
+The new accelerometer input handling applies the externally supplied
+velocity input the same way.
+
+
+## Compatibility with games *not* using the new model
+
+For compatibility with other pinball games that only accept the
+traditional acceleration-based input, the microcontroller can report
+**both** the accelerations and the velocities, using different pairs
+of axes for each type of value.  For example, it could report the
+instantaneous accelerations on the traditional joystick X and Y axes,
+and simultaneously report the velocities on joystick RX/RY.  For each
+simulator, the user selects the appropriate pair of axes in the game's
+joystick setup dialog, according to what kind of input the simulator
+accepts.  This allows the microcontroller to work with multiple
+pinball simulators without any need for "mode switching" when changing
+games.  The device simply reports both kinds of data, and the
+simulator reads the type it's interested in and ignores the rest.
+
+
+
+## What's wrong with the traditional model
+
+The motivation for this new feature is that the original
+acceleration-based model has some significant, inherent limitations
+that negatively affect its realism.
+
+The fundamental, unfixable problem with the traditional model is that
+a PC-based simulator doesn't have synchronous access to the
+accelerometer.  The access is mediated through the USB HID mechanism
+(and, in the case of VP, further mediated by the DirectInput layer in
+Windows).  USB HID doesn't provide reliable message delivery or a
+consistent time base.  This means that the simulator and the
+accelerometer can't synchronize their discrete time steps.  Both work
+in terms of discrete time, but *different* discrete time cycles.  As a
+result, VP is effectively resampling a discrete-time signal
+asynchronously, which injects a great deal of noise and distortion
+into the signal.  
+
+It's easiest to understand this in practical terms with an example.
+Suppose that the accelerometer emits this series of acceleration
+samples:
+
+```7 100 200 1000 300 -50 -200 -600 -400 -60 10 -7 15 8 -8...```
+
+The problem occurs when VP *reads* these sample.  VP doesn't have
+synchronous access to the sample stream, so when it reads a new
+sample, it just gets whichever sample came through the USB connection
+most recently.  To illustrate, let's suppose that VP's input reading
+cycle lines up with the samples as shown below, where "*" is a VP
+read operation:
+
+```
+7 100 200 1000 -500 -100 600 -200 -60 10 -7 15 8 -8...
+* *   *   * *        *   * *       *   * *    *  *  *...
+```
+
+We're fine for the first few samples, but look at what happens when we
+get the "1000" sample: VP reads it *twice* - and then skips the next
+sample entirely.  So that extra-large acceleration of 1000 units gets
+applied to the simulation for two time steps in a row, yielding twice
+the amount of acceleration that it should in the simulation.  And the
+next gets missed entirely, so we lose the considerable negative
+acceleration it would have applied.
+
+Since over- and under-sampling is inherently stochastic (in that it
+arises from the mutually asynchronous time bases of the simulator and
+accelerometer), we could equally well see the opposite problem with
+this same data stream, where VP never sees *any* instances of the
+"1000" reading.  That would be unfortunate for the player because it
+means that her attempt to keep the ball from draining with that
+particularly hard nudge is completely lost in the simulation.  This
+makes the strength of each nudge as reflected in the simulation appear
+to be rather random to users.  They'll be frustrated trying to find a
+Gain setting that gives them the effect they want, because there's so
+little consistency in how VP interprets a given physical nudge.  If
+you happen to hit a streak where VP is missing all of the peak
+numbers, you'll start cranking the gain up super high because you're
+annoyed at how little effect it's having, and then suddenly the
+slightest touch makes the ball jump halfway across the screen.
+
+This might sound contrived, but in the actual testing I've done, this
+is exactly what the situation looks like.  The over- and
+under-counting isn't even rare.  The actual occurrence I've observed
+is something like 10%.  This really shouldn't be surprising when you
+consider that VP and the accelerometer are operating on similar
+discrete time scales.  The two cycles are constantly going in and out
+of phase with each other, so things will frequently line up where a VP
+cycle misses a whole accelerometer cycle or overlaps two or more.  And
+we know from much discussion on the forums that users in practice do
+find Gain tuning to be frustratingly random.  The problem isn't just
+academic.
+
+The over- and under-counting causes a serious additional problem,
+apart from the obvious inconsistency in responsiveness to nudging.  If
+you stop to think about the big picture of what VP's really doing here -
+it's adding each discrete acceleration sample into each moving
+object's velocity on each time step - you see that we have an almost
+inherently divergent calculation.  **If** the acceleration inputs
+happen to all add up to zero over time, the sum stays finite.  But if
+there's even a slight bias in the readings, it will accumulate and
+steadily grow over time until the velocities overflow the "floats"
+they're stored in.  And this is indeed exactly what happens in
+practice.  It's the whole reason that we had to add the "Nudge
+Filter" a long time ago to suppress the divergent accumulated
+accelerations.  That filter suppresses the infinities, but it adds
+artifacts of its own, since it only has the flawed USB data stream
+to work with.
+
+## Why device-side velocity integration fixes this
+
+In a nutshell, it's because the device has synchronous access to the
+acceleration data.  For the same reason that VP **can't** accurately
+integrate the accelerations over time, the device **can**.
+
+Perhaps even more importantly, the velocity model eliminates all of
+the problems that arise from the incongruous sampling rates.  The VP
+side no longer has to integrate the samples, so if it misses one, it
+doesn't matter!  VP still gets the correct instantaneous velocity
+reading every time it looks.  If VP misses six samples in a row, it
+makes no difference to the running total, because VP isn't calculating
+a running total: when VP finally gets around to asking for another
+sample after missing six, it instantly gets the exactly correct
+current velocity, and everything in the simulation is instantly
+brought up to date with the correct current velocity.  If VP looks
+too frequently, and keeps getting the same sample six times in a
+row, it *still* doesn't matter, because it's actually *correct*
+to keep applying that same current velocity to the simulation as
+long as it's current on the USB connection.  Again, there's no
+running total to miscalculate because there is no running
+total.  There's only what the USB device is reporting right now.
+
+As an added bonus, the pinball I/O controller not only can do the
+calculation *correctly*, but it can also do it at a higher level of
+detail than the simulator can.  The simulator is limited to the USB
+polling rate.  The I/O controller, in contrast, has direct access to
+the sensor, so it can easily read the sensor at its highest native
+rate.  Most of the current consumer accelerometer chips have maximum
+sampling rates around 1000 Hz - about 10x faster than the HID polling
+cycle.  Sampling at the higher rate provides a more accurate
+reconstruction of the actual motion.  The simulator still benefits
+from this higher sampling rate on the device side, even though the
+simulator is still limited to the slower USB rate, because the
+simulator is only interested in the cumulative (integrated) effect of
+the readings - the velocity.  The velocity reported
+at each USB polling cycle reflects the integration of the many samples
+collected since the last polling cycle, so the ability to take many
+sensor samples between USB reports yields better quality numbers for
+the USB reports.
+
+
+## Device-side filtering
+
+In practice, the device will still need to apply some correction to
+the integrated velocity data, because the consumer-grade
+accelerometers we use in pin cabs are very noisy.  The device is in a
+much better position to do this than the simulator, though, since it
+has a more accurate view of the raw data stream.
+
+To be clear, VP doesn't need or use any of the filtering we're about
+to discuss.  VP simply uses the velocities reported, and leaves any
+desired filtering to the device, so that filtering can be customized
+to the characteristics of the accelerometer being used.  The notes
+below are only meant as an aid to device implementers who wish to add
+velocity-based nudging to their devices.
+
+
+### DC removal filtering
+
+Accelerometers almost always have some fixed bias on each axis.  Part
+of this comes from the near impossibility of installing the device
+perfectly level.  Any slight tilt to one of the horizontal axes will
+show up in the readings as a constant acceleration from the component
+of the Earth's gravity along the tilted axis.  In addition, most
+sensors have some inherent internal DC offset arising from their
+mechanical and electronic construction.  This internal bias can't be
+eliminated the end user, no matter how perfectly they nail the
+positioning.
+
+Almost all of the current pinball I/O controllers already do some kind
+of "calibration" or "centering" to remove the bias, by setting the
+zero point to an average of readings taken at startup or on an ongoing
+basis.  I've found that the bias tends to be fairly dynamic, probably
+because the actual cabinet position changes a bit as the machine gets
+jostled during active play, so it works best to adjust the centering
+point continuously.  One good approach is to use a digital DC removal
+filter, with an adaptation time of perhaps 200 to 500 ms.  Algorithms
+for such filters are published widely on the Web.
+
+
+### Noise filtering
+
+Consumer-grade accelerometers tend to be noisy enough that some kind of
+noise filtering is called for.
+
+Many older pin controllers use a simple-minded dead-zone approach,
+where they simply ignore readings within a certain range of the center
+point.  I don't like the dead-zone model because it has such
+non-linear behavior; a momentary bit of noise that happens to exceed
+the cutoff will cause a sudden burst of reported activity when there
+isn't any actually occurring.
+
+The original KL25Z Pinscape used a sort of hybrid of the dead-zone
+filter that gradually attenuates readings near the zero point, using a
+log-like curve, rather than blocking everything within the center
+range.  Like dead-zone filters, this approach is non-linear, but it
+doesn't have any abrupt cut-off points, which I think makes its
+operation less noticeable and therefore more pleasing.
+
+Pinscape Pico uses hysteresis filtering (which I sometimes call
+"jitter filtering", after the filter used in the KL25Z Pinscape
+plunger sensor reader).  This type of filter uses a sliding window of
+a user-configurable size.  When a reading is within the same window
+bounds as the prior reading, the filter output is the midpoint of the
+current window.  When a reading is outside of the current window, the
+window is repositioned just far enough to incorporate the new reading,
+and then that new midpoint is returned as the result.  This type of
+filter has the advantage that it responds instantly, with no latency,
+to large changes that exceed the window, and minimally attenuates the
+signal.  It also moves fairly smoothly when brief blasts of noise
+occur, unlike dead zone filters.  When the window size is set to, say,
+three or four sigmas worth of noise averaging, the filter is very
+stable during periods of actual mechanical quiet.
+
+Some of the accelerometer manufacturers' application notes discuss
+more sophisticated band-pass filters, with particular attention to the
+dynamic characteristics of the individual sensor models.  MEMs
+accelerometers apparently tend to have some specific noise modes that
+arise from mechanical resonances unique to each sensor's geometry,
+and this seems to call for filters designed to remove those frequencies
+specifically.
+
+
+### Friction filtering
+
+As discussed earlier, one major problem that manifests in VP with its
+traditional acceleration-based input model is the accumulation over
+time of excess velocity, from the accumulation of unbalanced errors in
+the input signal.  Much of the unbalanced error accumulation is due to
+the signal corruption that occurs when VP asynchronously resamples the
+discrete-time accelerometer input, as already discussed.  But even
+with the microcontroller's direct access to the sensor, there might
+still be some unbalanced bias that accumulates over time.
+
+A simple technique to eliminate this is what I call a "friction"
+filter.  This filter applies a slight attenuation to the integrated
+velocity on every time step (i.e., every new acceleration sample).
+This is actually the same basic idea as the "Nudge filter" in VP, but
+that filter has a lot of added complexity that was necessary because
+of VP's more limited view of the underlying data and faster error
+accumulation.  The device-side equivalent doesn't need the same
+complexity and can be a lot gentler, with much less in the way of
+visible artifacts.
+
+The nice thing about a friction filter is that it actually *looks*
+like friction from a user's perspective, which makes it look natural
+in the simulation rather than like an unwanted artifact.  If you model
+the effect of the filter on a ball rolling on a flat, level,
+frictionless surface, and you give the accelerometer a hard nudge that
+leaves some residual unbalanced velocity in the simulation, the
+friction filter will appear to make the ball slow and roll to a stop
+after a few half-life periods.  It looks just like a real ball would
+on a real surface that actually has some friction.  Now, the
+accelerometer is actually measuring the motion of the pin cab, not the
+ball, and the pin cab doesn't have this particular drift-to-a-stop
+behavior (at least, not on such a long time scale).  But from the
+user's perspective, the visible effect is on the way the balls move in
+the simulation, so it's a happy coincidence that the filter produces
+natural-looking effects in that context.
+
+In the Pinscape Pico setup, I've found that a friction filter with a
+half-life of around 2 seconds works well.  ("Half-life" means the time
+it takes to attenuate the velocity by 50%, in the absence
+of further accelerations.)  The implementation of a friction filter
+is simple: just multiply the current velocity by a fixed factor on
+each time step, equal to `pow(0.5, halfLife/sampleRate)`, where
+`halfLife` is the 50% attenuation time in seconds, and `sampleRate`
+is the number of samples per second.
+
+## References
+
+[Improving the Virtual Pin Cab Input Model](http://mjrnet.org/pinscape/OpenPinballDevice/NewPinCabInput.htm):
+A more complete presentation of the ideas here, along with related
+changes for plunger input, aimed at both simulator developers and device developers.

--- a/docs/Accelerometer Velocity Input User Guide.md
+++ b/docs/Accelerometer Velocity Input User Guide.md
@@ -1,0 +1,63 @@
+# Velocity-based Input for Accelerometers - VP Setup Guide
+
+This note describes how to set up a **velocity-based accelerometer**
+in VP.
+
+Traditionally, VP and other simulators accepted accelerometer input in
+"raw" form, reading the instantaneous accelerations reported by the
+sensor.  Newer VP versions support an alternative model where your I/O
+controller device uses the acceleration readings to calculate the
+moment-to-moment velocity of the cabinet's motion, and passes the
+velocity to VP instead of the raw acceleration data.  The advantage of
+this approach is that the device can do this calculation much more
+accurately than the simulator can, thanks to its direct, high-speed
+access to the sensor readings.  The velocity is ultimately the only
+number that matters in the simulation, so better accuracy in the
+velocity calculation should yield a more natural effect in the
+simulation.
+
+
+## When to use
+
+Use the velocity input option **only** with devices that provide
+velocity readings, and **only** if you've configured the option on the
+device.  Compatible devices include:
+
+* Pinscape Controller for KL25Z: To enable the feature in Pinscape, use the
+Pinscape Config Tool to set the joystick axis assignments to "X/Y/Z + RX/RY/RZ".
+This will report the traditional raw accelerations on X/Y, and the velocity
+on RX/RY.
+
+* Pinscape Pico.  To enable the feature on the Pico, configure a pair of joystick
+axes as **nudge.vx** and **nudge.vy**.  Note that you can *also* configure
+a separate pair of axes as acceleration readings, **nudge.x** and **nudge.y**,
+if you're also using other pinball games that only accept the traditional
+acceleration input.
+
+
+## VP setup
+
+Use the "Keys" dialog to set up the accelerometer.  The setup for
+velocity input is almost the same as for any other accelerometer.  The
+only difference is that you check the box labeled **Analog Nudge Input is Velocity**.
+
+* Select the X and Y axis assignments where you've assigned the
+velocity readings in your USB device configuration.  
+
+  * For Pinscape on KL25Z, these are **RX** and **RY**
+  * For Pinscape Pico, these are the axes you've assigned to **nudge.vx** and **nudge.vy**
+
+* Check the box **Enable Analog Nudge**
+
+* Check the box **Normal Mounting Orientation**
+
+* Set the **X and Y Gain** percentages.  You'll have to experiment
+with these to find the appropriate scale for your system.  The
+Nudge Test Table is an easy way to check the effect.
+
+* Check **Analog Nudge Input is Velocity**
+
+* Remember that you must **close all tables in the editor** after changing
+any of these settings before they'll go into effect in the player.
+
+

--- a/docs/Plunger Velocity Input Tech Note.md
+++ b/docs/Plunger Velocity Input Tech Note.md
@@ -1,0 +1,181 @@
+# Plunger Velocity Input Technical Note
+
+Visual Pinball and other simulators can read an external analog sensor
+that tracks the position of a mechanical plunger assembly, using the
+input in the simulation to control a simulated ball shooter.
+
+This technical note describes an extension to the traditional plunger
+sensor input system that includes not only the instantaneous position
+of the mechanical plunger, but also the instantaneous speed at which
+it's moving.  The simulator can use this information to improve the
+simulation accuracy.
+
+## Why it's *useful* to calculate velocity externally
+
+Put simply, it's because the ball shooter moves faster than USB
+reports.
+
+Pinball simulators like VP receive plunger position input via USB HID
+joystick axis reports.  These run at about 10ms polling intervals.  A
+standard pinball ball shooter assembly traverses its whole range of
+travel in about 30ms when the player pulls back the plunger and
+releases it to let the main spring drive it forward.  This means that
+the simulator on the PC only sees one or two position reports across
+the whole travel range.  What's more, the plunger bounces back a
+significant fraction of its travel length when it hits the barrel
+spring, so with USB samples at only 10ms intervals, it's highly likely
+that the host will see "aliasing", where it *appears* that the plunger
+has moved forward since the last reading, but where the plunger
+actually made it all the way to the barrel spring and bounced back
+part of the way.  If the simulator attempts to calculate the speed by
+taking the difference of the two positions and dividing by time, it's
+likely to calculate a speed that's much too low (or even in the wrong
+direction) because it's unaware that the plunger has completed two
+whole legs of travel in opposite directions between the two readings.
+
+These timing characteristics make it impossible for the simulator to
+accurately calculate the plunger's instantaneous speed based on the
+position reports.
+
+VP's plunger code has some heuristics that attempt to work around this
+by detecting patterns of motion that resemble release events, and
+synthetically calculating the speed that would result *if* a release
+is indeed under way.  Like most heuristics, this works well enough in
+typical cases, but it's easy to fool, and it can produce anomalies
+when it guesses wrong.
+
+
+## Why it's *possible* to calculate the velocity externally
+
+Plunger position sensors are never connected directly to a PC.
+They're instead always connected to some kind of external processor,
+typically a microcontroller (Arduino, KL25Z, Raspberry Pi Pico) that
+has the kind of electronic interfaces that sensors can attach to.  The
+external processor is what connects to the PC via USB.
+
+If VP can't calculate the plunger speed accurately, why would we
+expect the intermediary processor to do a better job of it?  Simple:
+the microcontroller isn't constrained by the USB HID polling cycle.
+It can sample the sensor as many times per USB polling cycle as it
+wants, up to the sensor's native rate.  Remember that the problem VP
+has is time resolution: it simply doesn't have access to enough
+samples over the typical 30ms release-motion travel time to get a
+meaningful first derivative.  In contrast, the microcontroller can
+collect plenty of samples over this same time period, thanks to its
+higher speed access to the sensor.
+
+Nearly all of the commonly used position sensors can be sampled at
+intervals of around 2.5ms or faster, which is fast enough for accurate
+speed readings throughout a ball shooter release motion.  The slowest
+commonly used sensor is the VCNL4010 used in the later VirtuaPin
+plunger kits, and that samples at 4ms intervals, which is still fast
+enough for decently accurate speed calculations.  The most commonly
+used sensors - slide potentiometers - can be sampled at ADC rates,
+which can run as fast as a few microseconds per reading.
+
+
+## How I/O controllers can supply speed readings
+
+I/O controllers traditionally send plunger position reports to the PC
+via a joystick axis.  This is most commonly the main joystick Z axis,
+but it's configurable in VP to any of 8 axes (X, Y, Z, RX, RY, RZ,
+or either of two "slider" controls).
+
+The speed reading can be passed to the PC in the same manner,
+alongside the position report, by placing it on any other joystick
+axis not already used for plunger position or accelerometer readings.
+It seems pleasingly symmetrical to adopt RZ as the conventional
+default for the speed data, mirroring the convention of using Z for
+the position report.
+
+Note that the speed reading is **not** a replacement for the position
+report.  The simulator still needs the position reports; the speed is
+only a supplement.
+
+
+## How VP consumes the new speed readings
+
+VP has a new control in the "Keys" setup dialog that lets you select
+a joystick axis to assign as the Plunger Speed input.
+
+VP continues to use the USB position reports to update the on-screen
+plunger animation and the "hit plunger" physics object, exactly as in
+previous versions before speed reports were added.  In fact, VP still
+uses *only* the USB position reports to track the position *and speed*
+of the "hit plunger" object, so that code is essentially unchanged.
+
+The reason **not** to use the speed reading to update the position is
+that we already know the **actual** instantaneous position, from the
+USB reports.  Calculating the position from the velocity would
+effectively integrate the velocity readings over time, which would
+magnify any measurement error component by adding the error into the
+running total (the position) on every time step.  In contrast, the
+position reading is always an instantaneous "state of the world"
+reading, so any measurement error it contains is a one-off that's
+discarded on the next time step.
+
+The place where the external speed reading is applied is in the
+collision processing, to calculate the impulse imparted to the ball.
+Here, it's the external speed that's the instantaneous "state"
+reading, so we use this in preference to the internal speed
+calculation, which is imperfectly calculated from the first
+derivative of position readings over time.
+
+
+### Firing events are suppressed when speed readings are available
+
+"Firing events" are the heuristic that VP uses to improve its speed
+calculations for fast-moving plunger events.  VP declares a firing
+event when it detects two sequential readings that indicate that the
+plunger has moved forward at a high enough speed that it's likely
+being driven forward by the main spring.  A typical mechanical
+plunger takes about 30ms to travel all the way forward after being
+pulled back and released, so VP has good odds of seeing at
+least two USB reports over a firing motion, allowing it to detect
+most of these events.
+
+Two reports isn't enough to accurately calculate speed, for the reasons
+discussed above - the aliasing problem at the bounce-back point, and
+the absence of precise delta-time information.  But two readings *are* enough to 
+tell that some kind of high-speed action occurred, even if we can't determine the speed
+with any precision.  That's why this is a heuristic.  VP assumes from the
+apparent rapid motion that the user did in fact pull back the plunger
+and release it.  So it tries to guess at the actual speed the plunger
+reached *over the course of the forward travel* by looking back over
+recent reports to see how far back the plunger was at its maximum
+excursion.  It's likely that the *retraction* phase, where the user
+was manually operating the plunger, was slow enough that VP has fairly
+detailed readings on the position, so it can figure the apex position
+(or something close) by looking at recent readings and taking the peak
+value.  VP then assumes that the plunger actually was released from
+this position, so it calculates the speed that would occur in an ideal
+system under these conditions.  It then uses that speed to figure the
+ball collision impulse.
+
+The whole point of this heuristic is to get a better estimate of the
+speed for times when VP knows it can't properly calculate the speed
+by taking the first derivative of the position readings.  This is why
+the new system disables the heuristic when external speed readings are
+available.  The external speed readings are presumed to reflect the
+reality of the mechanical system more accurately than the heuristic
+can, so the external speed is used in preference to the heuristically
+synthesized speed.
+
+In addition, it's desirable to disable the firing-event heuristic when
+it's not needed because the heuristic can be fooled pretty easily by
+actions that aren't actually release motions, but which the heuristic
+interprets as such anyway.  If you move the plunger rapidly forward by
+hand and then pull it back, for example, you'll trigger a firing event
+even though you didn't actually release the plunger.  That'll make the
+on-screen plunger go through the full firing travel distance even
+though the actual plunger has already been pulled back, so the
+on-screen motion will diverge from the real motion.  Disabling the
+heuristic when it's not needed keeps it from producing weird results
+when the user accidentally fools it.
+
+## References
+
+[Improving the Virtual Pin Cab Input Model](http://mjrnet.org/pinscape/OpenPinballDevice/NewPinCabInput.htm):
+A more complete presentation of the ideas here, along with related
+changes for accelerometer (nudge) input, aimed at both simulator
+developers and device developers.

--- a/docs/Plunger Velocity Input User Guide.md
+++ b/docs/Plunger Velocity Input User Guide.md
@@ -15,7 +15,6 @@ Since the I/O controller *can* read the speed accurately, it can pass
 the information on to VP alongside the position reading, improving the
 quality of VP's simulation by giving it accurate speed data.
 
-
 ## When to use
 
 Use the plunger velocity input **only** with devices that provide

--- a/docs/Plunger Velocity Input User Guide.md
+++ b/docs/Plunger Velocity Input User Guide.md
@@ -1,0 +1,50 @@
+# Plunger Velocity Input - VP Setup Guide
+
+This note describes how to set up **plunger velocity input** in VP.
+
+Traditionally, I/O controller devices that include mechanical plunger
+input reported only the position of the plunger to simulators like VP.
+Newer versions of VP support an additional input that lets the I/O
+controller also report the *speed* of the plunger from moment to
+moment.  The benefit is that the I/O controller has high-bandwidth
+access to the plunger sensor, which allows it to accurately calculate
+the speed of the plunger at any given moment.  VP can't get a good fix
+on the speed during fast motion, such as when you pull back and
+release the plunger, because the USB reports are simply too slow.
+Since the I/O controller *can* read the speed accurately, it can pass
+the information on to VP alongside the position reading, improving the
+quality of VP's simulation by giving it accurate speed data.
+
+
+## When to use
+
+Use the plunger velocity input **only** with devices that provide
+this information, and **only** if you've configured the option on
+the device.  Compatible devices include:
+
+* Pinscape Controller on KL25Z: In the Pinscape Config Tool, set the
+joystick axis configuration to "X/Y/Z + RX/RY/RZ".  This reports
+the plunger position on the **Z** axis and the plunger speed on **RZ**.
+
+* Pinscape Pico.  To enable the feature, configure a joystick axis
+of your choice as **plunger.z** (position), and a second axis as **plunger.speed**.
+
+## VP setup
+
+Use the "Keys" dialog to set up the plunger.  The procedure is the
+same as the usual plunger setup, except that you also select a Plunger
+Speed axis, in addition to the normal Plunger Position axis.
+
+* In the **Plunger** drop list, select the joystick axis assigned to
+the **plunger position** reading on your I/O controller.
+
+* In the **Speed** drop list immediately below that, select the joystick
+axis assigned to the **plunger speed** reading on your I/O controller.
+
+* Check the **Reverse axis** box if necessary (if you discover that
+the on-screen plunger moves in the opposite direction you expect in
+response to inputs on the physical plunger).
+
+* Remember that you must **close all tables in the editor** after changing
+any of these settings before they'll go into effect in the player.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,9 @@
    4. [View setup](<View Setup.md>)
    5. [Lights](Lights.md)
    6. [Stereo rendering](Stereo.md)
-   7. [Velocity-based accelerometer input](<Accelerometer Velocity Input User Guide.md>) ([Technical notes](<Accelerometer Velocity Input Tech Note.md>))
-   8. [Plunger speed axis input](<Plunger Velocity Input User Guide.md>) ([Technical notes](<Plunger Velocity Input Tech Note.md>))
+   7. [Velocity-based accelerometer input](<Accelerometer Velocity Input User Guide.md>) | [Technical notes](<Accelerometer Velocity Input Tech Note.md>)
+   8. [Plunger speed axis input](<Plunger Velocity Input User Guide.md>) | [Technical notes](<Plunger Velocity Input Tech Note.md>)
+   9. [Open Pinball Device setup](<Open Pinball Device User Guide.md>)
 2. Scripting
    1. [API Reference](<Script API Reference.md>)
 3. Upgrading to new version

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@
    4. [View setup](<View Setup.md>)
    5. [Lights](Lights.md)
    6. [Stereo rendering](Stereo.md)
+   7. [Velocity-based accelerometer input](<Accelerometer Velocity Input User Guide.md>) ([Technical notes](<Accelerometer Velocity Input Tech Note.md>))
+   8. [Plunger speed axis input](<Plunger Velocity Input User Guide.md>) ([Technical notes](<Plunger Velocity Input Tech Note.md>))
 2. Scripting
    1. [API Reference](<Script API Reference.md>)
 3. Upgrading to new version

--- a/main.h
+++ b/main.h
@@ -72,6 +72,7 @@
 #endif
 
 #include <vector>
+#include <list>
 #include <string>
 #include <algorithm>
 #include <commdlg.h>

--- a/pininput.cpp
+++ b/pininput.cpp
@@ -2465,7 +2465,7 @@ void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
          { 0x00000020, -1, DIK_6 }, // Coin 4 (fourth coin chute/dollar bill acceptor)
          { 0x00000040, -1, DIK_2 }, // Extra Ball/Buy-In
          { 0x00000080, ePlungerKey }, // Launch Ball
-         // { 0x00000100, -1, 0 },             // Fire button (lock bar top button) - no standard VPM mapping
+         { 0x00000100, eLockbarKey }, // Fire button (lock bar top button)
          { 0x00000200, eMechanicalTilt }, // Tilt bob
          { 0x00000400, -1, DIK_HOME }, // Slam tilt
          { 0x00000800, -1, DIK_END }, // Coin door switch

--- a/pininput.cpp
+++ b/pininput.cpp
@@ -1,4 +1,6 @@
 #include "stdafx.h"
+#include <cfgmgr32.h>
+#include <SetupAPI.h>
 
 // from dinput.h, modernized to please clang
 #undef DIJOFS_X
@@ -29,6 +31,10 @@
 PinInput::PinInput()
 {
    ZeroMemory(this, sizeof(PinInput));
+
+   // thanks to the ZeroMemory above, we have to explicitly call member
+   // object constructors in-place
+   new (&m_openPinDevs) std::list<OpenPinDev>();
 
 #ifdef _WIN32
    m_pDI = nullptr;
@@ -989,6 +995,9 @@ void PinInput::Init(const HWND hwnd)
    }
 #endif
 
+   // initialize Open Pinball Device HIDs
+   InitOpenPinballDevices();
+
    m_mixerKeyDown = false;
    m_mixerKeyUp = false;
 }
@@ -1894,6 +1903,8 @@ void PinInput::ProcessKeys(/*const U32 curr_sim_msec,*/ int curr_time_msec) // l
 
    GetInputDeviceData(/*curr_time_msec*/);
 
+   ReadOpenPinballDevices(curr_time_msec);
+
    // Camera/Light tweaking mode (F6) incl. fly-around parameters
    if (g_pplayer->m_liveUI->IsTweakMode())
    {
@@ -2194,4 +2205,421 @@ int PinInput::GetNextKey() // return last valid keyboard key
 #endif
 
    return 0;
+}
+
+
+
+// ---------------------------------------------------------------------------
+//
+// Open Pinball Device support
+//
+
+// we require direct access to the Windows HID APIs
+extern "C"
+{
+#include "SetupAPI.h"
+#include "hidsdi.h"
+#include "hidpi.h"
+}
+
+// Initialize the Open Pinball Device interface.  Searches for active
+// devices and adds them to our internal list.
+void PinInput::InitOpenPinballDevices()
+{
+   // initialize a Device Set with all currently connected HID devices
+   GUID hidGuid;
+   HidD_GetHidGuid(&hidGuid);
+   HDEVINFO hdi = SetupDiGetClassDevs(&hidGuid, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+   if (hdi == INVALID_HANDLE_VALUE)
+      return;
+
+   // iterate over the Device Set members
+   SP_DEVICE_INTERFACE_DATA did { sizeof(SP_DEVICE_INTERFACE_DATA) };
+   for (DWORD memberIndex = 0; SetupDiEnumDeviceInterfaces(hdi, NULL, &hidGuid, memberIndex, &did); ++memberIndex)
+   {
+      // retrieve the buffer size needed for device detail
+      DWORD diDetailSize = 0;
+      DWORD err = 0;
+      if (!SetupDiGetDeviceInterfaceDetail(hdi, &did, NULL, 0, &diDetailSize, NULL) && (err = GetLastError()) != ERROR_INSUFFICIENT_BUFFER)
+         break;
+
+      // retrieve the device detail and devinfo data
+      std::unique_ptr<SP_DEVICE_INTERFACE_DETAIL_DATA> diDetail(reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA *>(new BYTE[diDetailSize]));
+      diDetail->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+      SP_DEVINFO_DATA devInfo { sizeof(SP_DEVINFO_DATA) };
+      if (!SetupDiGetDeviceInterfaceDetail(hdi, &did, diDetail.get(), diDetailSize, NULL, &devInfo))
+         break;
+
+      // open the device desc to access the HID
+      HANDLE dev = CreateFile(diDetail->DevicePath, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
+      if (dev != INVALID_HANDLE_VALUE)
+      {
+         // get the preparsed HID data, for details about the report format
+         PHIDP_PREPARSED_DATA ppd;
+         if (HidD_GetPreparsedData(dev, &ppd))
+         {
+            // check for a generic Pinball Device usage (usage page 0x05 "Game
+            // Controls", usage 0x02 "Pinball Device")
+            HIDP_CAPS caps;
+            const USAGE USAGE_PAGE_GAMECONTROLS = 0x05;
+            const USAGE USAGE_GAMECONTROLS_PINBALLDEVICE = 0x02;
+            if (HidP_GetCaps(ppd, &caps) == HIDP_STATUS_SUCCESS && caps.UsagePage == USAGE_PAGE_GAMECONTROLS && caps.Usage == USAGE_GAMECONTROLS_PINBALLDEVICE)
+            {
+               // It's at least a generic Pinball Device.  Check if it's
+               // specifically an Open Pinball Device, by checking for the
+               // custom string descriptor on the first byte array usage.
+               // Windows idiosyncratically represents opaque byte array
+               // usages as "buttons", and Open Pinball Device has exactly
+               // one such "button" array.
+               std::vector<HIDP_BUTTON_CAPS> btnCaps;
+               btnCaps.resize(caps.NumberInputButtonCaps);
+               USHORT nBtnCaps = caps.NumberInputButtonCaps;
+               if (HidP_GetButtonCaps(HIDP_REPORT_TYPE::HidP_Input, btnCaps.data(), &nBtnCaps, ppd) == HIDP_STATUS_SUCCESS && nBtnCaps == 1)
+               {
+                  // check for a string descriptor attached to the usage
+                  USHORT stringIndex = btnCaps[0].NotRange.StringIndex;
+                  WCHAR str[128] { 0 };
+                  if (stringIndex != 0 && HidD_GetIndexedString(dev, stringIndex, str, sizeof(str)) && wcsncmp(str, L"OpenPinballDeviceStruct/", 24) == 0)
+                  {
+                     // matched - add it to the active device list
+                     m_openPinDevs.emplace_back(dev, btnCaps[0].ReportID, caps.InputReportByteLength, &str[24]);
+
+                     // the device list entry owns the handle now - forget it locally
+                     dev = INVALID_HANDLE_VALUE;
+                  }
+               }
+
+               // done with the preparsed data
+               HidD_FreePreparsedData(ppd);
+            }
+         }
+
+         // close the device handle, if we didn't transfer ownership to the device list
+         if (dev != INVALID_HANDLE_VALUE)
+            CloseHandle(dev);
+      }
+   }
+
+   // done with the device list dev
+   SetupDiDestroyDeviceInfoList(hdi);
+}
+
+// Read input from the Open Pinball Device inputs
+void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
+{
+   // Combined report.  In keeping with Visual Pinball's treatment of
+   // multiple gamepads, we merge the input across devices if there are
+   // multiple Pinball Devices sending us data.
+   OpenPinballDeviceReport cr { 0 };
+
+   // read input from each device
+   for (auto &p : m_openPinDevs)
+   {
+      // check for a new report
+      if (!p.ReadReport())
+         continue;
+
+      // Merge the data into the combined struct.  For the accelerometer
+      // and plunger analog quantities, just arbitrarily pick the last
+      // input that's sending non-zero values.  Devices that don't have
+      // those sensors attached will send zeroes, so this strategy yields
+      // sensible results for the sensible case where the user only has
+      // one plunger and one accelerometer, but they're attached to
+      // separate Open Pinball Device microcontrollers.  If the user has
+      // multiple accelerometers in the system, our merge strategy will
+      // arbitrarily pick whichever one enumerated last, which isn't
+      // necessarily a sensible result, but that seems fair enough
+      // because the user's actual configuration isn't sensible either.
+      // I mean, what do they expect us to do with two accelerometer
+      // inputs?  Note that this is a different situation from the
+      // traditional multiple-joysticks case, because in the case of
+      // joysticks, there are plenty of good reasons to have more than
+      // one attached.  One might be set up as a pinball device, and two
+      // more *actual joysticks* might be present as well because the
+      // user also plays some non-pinball video games.  Joysticks are
+      // generic: we can't tell from the HID descriptor if it's an
+      // accelerometer pretending to be a joystick, vs an actual
+      // joystick.  The Pinball Device definition doesn't suffer from
+      // that ambiguity.  We can be sure that an accelerometer there
+      // is an accelerometer, so there aren't any valid use cases where
+      // you'd have two or more of them.
+      //
+      // Merge the buttons by ORing all of the button masks together.
+      // If the user has configured the same button number on more than
+      // one device, they probably actually want the buttons to perform
+      // the same logical function, so ORing them yields the right result.
+      //
+      // Treat the high-time-resolution flipper buttons like the other
+      // analog quantities, since these are more like the analog
+      // quantities than like the other buttons.  As with the plunger
+      // and accelerometer, it's hard to imagine a sensible use case with
+      // multiple devices claiming the same flipper button.
+      auto &r = p.r;
+      if (r.axNudge != 0)
+         cr.axNudge = r.axNudge;
+      if (r.ayNudge != 0)
+         cr.ayNudge = r.ayNudge;
+      if (r.vxNudge != 0)
+         cr.vxNudge = r.vxNudge;
+      if (r.vyNudge != 0)
+         cr.vyNudge = r.vyNudge;
+      if (r.plungerPos != 0)
+         cr.plungerPos = r.plungerPos;
+      if (r.plungerSpeed != 0)
+         cr.plungerSpeed = r.plungerSpeed;
+      if (r.llFlipper != 0)
+         cr.llFlipper = r.llFlipper;
+      if (r.lrFlipper != 0)
+         cr.lrFlipper = r.lrFlipper;
+      if (r.ulFlipper != 0)
+         cr.ulFlipper = r.ulFlipper;
+      if (r.urFlipper != 0)
+         cr.urFlipper = r.urFlipper;
+      cr.genericButtons |= r.genericButtons;
+      cr.pinballButtons |= r.pinballButtons;
+   }
+
+   // Axis scaling factor.  All Open Pinball Device analog axes are
+   // INT16's (-32768..+32767).  The VP functional axes are designed
+   // for joystick input, so we must rescale to VP's joystick scale.
+   int scaleFactor = (JOYRANGEMX - JOYRANGEMN) / 65536;
+
+   // Process the analog axis inputs.  Each VP functional axis has a
+   // Keys dialog mapping to a joystick or OpenPinDev axis.  Axes 1-8
+   // are the generic joystick axes (X, Y, Z, RX, RY, RZ, Slider1,
+   // Slider2, respectively).  Axis 9 is the OpenPinDev device, and
+   // maps to the OpenPinDev input that corresponds to the same VP
+   // functional axis.  For example, m_lr_axis is the VP functional
+   // axis for Nudge X, so if m_lr_axis == 9, it maps to the Open Pin
+   // Dev Nudge X axis.
+   //
+   // For passing the input to the player, we can simply pretend that
+   // we're joystick #0.  A function assigned to OpenPinDev can't also
+   // be assigned to a joystick axis, so there won't be any conflicting
+   // input from an actual joystick to the same function, hence we can
+   // take on the role of the joystick.  We should probably do a little
+   // variable renaming in a few places to clarify that the "joystick"
+   // number is more like a "device number", which can be a joystick if
+   // joysticks are assigned or a PinDev if PinDevs are assigned.
+   if (m_lr_axis == 9)
+   {
+      // Nudge X input - use velocity or acceleration input, according to the user preferences
+      int val = (g_pplayer->m_accelInputIsVelocity ? cr.vxNudge : cr.axNudge) * scaleFactor;
+      g_pplayer->NudgeX(m_lr_axis_reverse == 0 ? -val : val, 0);
+   }
+   if (m_ud_axis == 9)
+   {
+      // Nudge Y input - use velocity or acceleration input, according to the user preferences
+      int val = (g_pplayer->m_accelInputIsVelocity ? cr.vyNudge : cr.ayNudge) * scaleFactor;
+      g_pplayer->NudgeY(m_ud_axis_reverse == 0 ? -val : val, 0);
+   }
+   if (m_plunger_axis == 9)
+   {
+      // Plunger position input
+      int val = cr.plungerPos * scaleFactor;
+      g_pplayer->MechPlungerIn(m_plunger_reverse == 0 ? -val : val, 0);
+   }
+   if (m_plunger_speed_axis == 9)
+   {
+      // Plunger speed input
+      int val = cr.plungerSpeed * scaleFactor;
+      g_pplayer->MechPlungerSpeedIn(m_plunger_reverse == 0 ? -val : val, 0);
+   }
+
+   // Weird special logic for the Start button, to handle auto-start timers,
+   // per the regular joystick button input processor
+   const bool start = ((cur_time_msec - m_firedautostart) > g_pplayer->m_ptable->m_tblAutoStart) || m_pressed_start || Started();
+
+   // Check for button state changes.  If there are any, generate
+   // key up/down events for the button changes.
+   if (cr.genericButtons != m_openPinDev_generic_buttons)
+   {
+      // Visit each button.  VP's internal joystick buttons are
+      // numbered #1 to #32.
+      for (int buttonNum = 1, bit = 1; buttonNum <= 32; ++buttonNum, bit <<= 1)
+      {
+         // check for a state change
+         DISPID isDown = (cr.genericButtons & bit) != 0 ? DISPID_GameEvents_KeyDown : DISPID_GameEvents_KeyUp;
+         DISPID wasDown = (m_openPinDev_generic_buttons & bit) != 0 ? DISPID_GameEvents_KeyDown : DISPID_GameEvents_KeyUp;
+         if (isDown != wasDown)
+            Joy(buttonNum, isDown, start);
+      }
+
+      // remember the new button state
+      cr.genericButtons = m_openPinDev_generic_buttons;
+   }
+   if (cr.pinballButtons != m_openPinDev_pinball_buttons)
+   {
+      // mapping from Open Pinball Device mask bits to VP/VPM keys
+      static const struct KeyMap
+      {
+         uint32_t mask; // bit for the key in OpenPinballDeviceReportStruct::pinballButtons
+         int rgKeyIndex; // g_pplayer->m_rgKeys[] index, or -1 if a direct VPM key is used instead
+         BYTE vpmKey; // DIK_xxx key ID of VPM key, or 0 if an m_rgKeys assignment is used instead
+      } keyMap[] = {
+         { 0x00000001, eStartGameKey }, // Start (start game)
+         { 0x00000002, eExitGame }, // Exit (end game)
+         { 0x00000004, eAddCreditKey }, // Coin 1 (left coin chute)
+         { 0x00000008, eAddCreditKey2 }, // Coin 2 (middle coin chute)
+         { 0x00000010, -1, DIK_5 }, // Coin 3 (right coin chute)
+         { 0x00000020, -1, DIK_6 }, // Coin 4 (fourth coin chute/dollar bill acceptor)
+         { 0x00000040, -1, DIK_2 }, // Extra Ball/Buy-In
+         { 0x00000080, ePlungerKey }, // Launch Ball
+         // { 0x00000100, -1, 0 },             // Fire button (lock bar top button) - no standard VPM mapping
+         { 0x00000200, eMechanicalTilt }, // Tilt bob
+         { 0x00000400, -1, DIK_HOME }, // Slam tilt
+         { 0x00000800, -1, DIK_END }, // Coin door switch
+         { 0x00001000, -1, DIK_7 }, // Service panel Cancel
+         { 0x00002000, -1, DIK_8 }, // Service panel Down
+         { 0x00004000, -1, DIK_9 }, // Service panel Up
+         { 0x00008000, -1, DIK_0 }, // Service panel Enter
+         { 0x00010000, eLeftMagnaSave }, // MagnaSave left
+         { 0x00020000, eRightMagnaSave }, // MagnaSave right
+         { 0x00040000, eLeftTiltKey }, // Left Nudge
+         { 0x00080000, eCenterTiltKey }, // Forward Nudge
+         { 0x00100000, eRightTiltKey }, // Right Nudge
+         { 0x00200000, eVolumeUp }, // Audio volume up
+         { 0x00400000, eVolumeDown }, // Audio volume down
+      };
+
+      // Flipper buttons.  Fold upper and lower into a combined field,
+      // and fold the button duty cycle information into a simple on/off.
+      //
+      // If the simulator is upgraded in the future to accept more detailed
+      // timing information, we can convert the duty cycle into a suitable
+      // amount of simulation time, using the real time between consecutive
+      // HID inputs as the basis, and feed the event into the simulator as
+      // a button press for the corresponding number of physics frames.  This
+      // is irrelevant to VP 9, which has a physics frame time of 10ms,
+      // roughly equal to the HID polling time.  But VP 10 has 1ms frames,
+      // so it should be possible to profitably use the timing info there.
+      bool newFlipperLeft = cr.llFlipper != 0 || cr.ulFlipper != 0;
+      bool newFlipperRight = cr.lrFlipper != 0 || cr.urFlipper != 0;
+      if (newFlipperLeft != m_openPinDev_flipper_l)
+         FireKeyEvent(m_openPinDev_flipper_l = newFlipperLeft, g_pplayer->m_rgKeys[eLeftFlipperKey]);
+      if (newFlipperRight != m_openPinDev_flipper_r)
+         FireKeyEvent(m_openPinDev_flipper_r = newFlipperRight, g_pplayer->m_rgKeys[eRightFlipperKey]);
+
+      // Visit each pre-assigned button
+      const KeyMap *m = keyMap;
+      for (size_t i = 0; i < _countof(keyMap); ++i, ++m)
+      {
+         // check for a state change
+         uint32_t mask = m->mask;
+         DISPID isDown = (cr.pinballButtons & mask) != 0 ? DISPID_GameEvents_KeyDown : DISPID_GameEvents_KeyUp;
+         DISPID wasDown = (m_openPinDev_pinball_buttons & mask) != 0 ? DISPID_GameEvents_KeyDown : DISPID_GameEvents_KeyUp;
+         if (isDown != wasDown)
+            FireKeyEvent(isDown, m->rgKeyIndex != -1 ? g_pplayer->m_rgKeys[m->rgKeyIndex] : m->vpmKey);
+      }
+
+      // remember the new button state
+      cr.pinballButtons = m_openPinDev_pinball_buttons;
+   }
+}
+
+PinInput::OpenPinDev::OpenPinDev(HANDLE hDevice, BYTE reportID, DWORD reportSize, const wchar_t *deviceStructVersionString)
+   : hDevice(hDevice)
+   , reportID(reportID)
+   , reportSize(reportSize)
+{
+   // Parse the device struct version string into a DWORD, with the major
+   // version in the high word and the minor version in the low word.
+   // This format can be compared against a reference version with a
+   // simple DWORD comparison: deviceStructVersion > 0x00020005 tests
+   // for something newer than 2.5.
+   const wchar_t *dot = wcschr(deviceStructVersionString, L'.');
+   deviceStructVersion = (_wtoi(deviceStructVersionString) << 16) | (dot != nullptr ? _wtoi(dot + 1) : 0);
+
+   // allocate space for the report
+   buf.resize(reportSize);
+
+   // Zero our internal report copy - this will clear out any newer
+   // fields that aren't in the version of the structure that the
+   // device sends us.
+   memset(&r, 0, sizeof(r));
+
+   // kick off the first overlapped read - we always keep one read
+   // outstanding, so that we don't have to wait when we're ready to
+   // process a report
+   StartRead();
+}
+
+PinInput::OpenPinDev::~OpenPinDev()
+{
+   // close handles
+   CloseHandle(hDevice);
+   CloseHandle(hIOEvent);
+}
+
+bool PinInput::OpenPinDev::ReadReport()
+{
+   // Read reports until the buffer is empty, to be sure we have the latest.
+   // The reason we loop as long as new reports are available is that the HID
+   // driver buffers a number of reports, and returns one on each request.  So
+   // if we just read the reports sequentially, we'd always have a lag time of
+   // (number of internally buffered reports) * (time per report).  The default
+   // buffer is 32 reports, and the HID polling time is usually about 10ms, so
+   // we'd always see input that's about 1/3 of a second old, which is quite
+   // noticeable on a human scale.  So we always hoover up all available reports
+   // until a read blocks, at which point we know that we have the latest one.
+   // While looping, we keep track of whether or not we've seen any new reports
+   // at all, since it's possible that we're still waiting for the final read
+   // that we started on the last polling cycle.
+   bool newReport = false;
+   for (;;)
+   {
+      // Check the status on the last read.  If the read completed synchronously,
+      // or it was queued with pending status and has since completed, we have
+      // a new report ready.  Otherwise the pipe is empty.
+      if (readStatus == ERROR_SUCCESS || (readStatus == ERROR_IO_PENDING && GetOverlappedResult(hDevice, &ov, &bytesRead, FALSE)))
+      {
+         // Read completed - extract the Open Pinball Device struct from
+         // the HID report byte block.  Copy the smaller of the actual
+         // report data sent from the device or our version of the struct.
+         // If the device reports a NEWER struct than the one we're compiled
+         // against, it will have extra fields at the end, which we will
+         // ignore by virtue of copying only the struct size we know about.
+         // If the device reports an OLDER struct than the one we use, we'll
+         // only populate the portion of our struct that the device provides,
+         // leaving the other fields zeroed.
+         memcpy(&r, &buf[1], std::min(reportSize, sizeof(r)));
+         newReport = true;
+
+         // start the next read - we always maintain one outstanding read
+         StartRead();
+      }
+      else if (readStatus == ERROR_IO_PENDING)
+      {
+         // still waiting for the last read to complete - stop here
+         return newReport;
+      }
+      else
+      {
+         // Error other than pending status - start a new read, and stop here.
+         // We could check for immediate completion, but that could get us into
+         // an infinite loop if the handle has a persistent error (e.g., the
+         // device has been disconnected), since we'd be right back here with
+         // another error for the new read.  Returning ensures that we don't get
+         // stuck.  The caller will still keep trying to poll the device in
+         // such a case, but each new read will just fail immediately, so it
+         // will do no harm other than the slight overhead of one failed read
+         // per polling cycle.  And if the fault is temporary, this will pick
+         // up where we left off as soon as the fault clears.
+         StartRead();
+         return newReport;
+      }
+   }
+}
+
+void PinInput::OpenPinDev::StartRead()
+{
+   // set up the OVERLAPPED struct
+   memset(&ov, 0, sizeof(ov));
+   ov.hEvent = hIOEvent;
+
+   // start the read
+   if (ReadFile(hDevice, buf.data(), reportSize, &bytesRead, &ov))
+      readStatus = ERROR_SUCCESS;
+   else
+      readStatus = GetLastError();
 }

--- a/pininput.h
+++ b/pininput.h
@@ -175,7 +175,7 @@ private:
 
    int m_tail; // These are integer indices into keyq and should be in domain of 0..MAX_KEYQUEUE_SIZE-1
 
-   int m_plunger_axis, m_lr_axis, m_ud_axis;
+   int m_plunger_axis, m_plunger_speed_axis, m_lr_axis, m_ud_axis;
    int m_joylflipkey, m_joyrflipkey, m_joystagedlflipkey, m_joystagedrflipkey, m_joylmagnasave, m_joyrmagnasave, m_joyplungerkey, m_joystartgamekey, m_joyexitgamekey, m_joyaddcreditkey;
    int m_joyaddcreditkey2, m_joyframecount, m_joyvolumeup, m_joyvolumedown, m_joylefttilt, m_joycentertilt, m_joyrighttilt, m_joypmbuyin;
    int m_joypmcoin3, m_joypmcoin4, m_joypmcoindoor, m_joypmcancel, m_joypmdown, m_joypmup, m_joypmenter, m_joydebugballs, m_joydebugger, m_joylockbar, m_joymechtilt;

--- a/resource.h
+++ b/resource.h
@@ -863,6 +863,7 @@
 #define IDC_GLOBALJOLT                  528
 #define IDC_CBGLOBALROTATION            529
 #define IDC_CBGLOBALJOLT                530
+#define IDC_CBGLOBALACCVEL              530
 #define IDC_JOYPMBUYIN                  531
 #define IDC_JOYPMCOIN3                  532
 #define IDC_JOYPMCOIN4                  533
@@ -876,6 +877,7 @@
 #define IDC_GLOBALTILT                  541
 #define IDC_3D_STEREO                   542
 #define IDC_DisableESC_CB               542
+#define IDC_PLUNGERSPEEDSCALE           543
 #define IDC_3D_STEREO_OFS               543
 #define IDC_3D_STEREO_Y                 544
 #define IDC_ADAPTIVE_VSYNC              545
@@ -1222,6 +1224,7 @@
 #define IDC_BG_SOURCE                   885
 #define IDC_BACKGLASS_GROUP             886
 #define IDC_BACKGLASS_GROUP2            887
+#define IDC_PLUNGERSPEEDAXIS            887
 #define IDC_REFLECTION_PROBE            888
 #define IDC_REFRACTION_PROBE            889
 #define IDC_RENDER_PROBE_NAME_LABEL     890

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2116,8 +2116,33 @@ void Player::NudgeY(const int y, const int joyidx)
    m_curAccel[joyidx].y = v;
 }
 
-#define GetNudgeX() (((F32)m_curAccel[0].x) * (F32)(2.0 / JOYRANGE)) // Get the -2 .. 2 values from joystick input tilt sensor / ushock //!! why 2?
-#define GetNudgeY() (((F32)m_curAccel[0].y) * (F32)(2.0 / JOYRANGE))
+// Get the accelerometer input, normalized to a -1..+1 range. 
+// 
+// (Note that there was a mistaken comment here in earlier versions
+// that this normalizes the range to -2..+2.  I suspect someone saw
+// the 2.0 factor and misconstrued it as the desired normalization
+// range.  It's not; the 2.0 is there because JOYRANGE is defined
+// as the width of the whole axis in joystick units, from negative
+// to positive extreme, which makes JOYRANGE equal to 2x the
+// absolute value of each extreme.  That is, JOYRANGE == 2*max_value
+// and JOYRANGE == 2*abs(min_value), so JOYRANGE/2 == max_value, and
+// finally 2/JOYRANGE*max_value == 1.  To be really precise, the 
+// definition of JOYRANGE assumes that the range is for a 2's 
+// complement field of some bit width, so min_value == -max_value-1,
+// per the usual 2's complement rules.  So max_value is actually 
+// JOYRANGE/2 - 1, hence the final normalized range is actually
+// [-1, +1) - i.e., the normalized result can never actually reach 
+// +1 exactly, but must always be fractionally less, because of the 
+// limited range on the positive side of a 2's-complement field. 
+// It's also worth noting that the 2's-complement assumption is NOT
+// a device dependency; it's an assumption about how VP sets things 
+// up with the OS HID API, so it's under VP's control and not 
+// subject to breakage if the device uses some other axis 
+// representation.  It would only break if VP's own HID API setup
+// code chooses some other representation when initializing the 
+// axis usages.)
+#define GetNudgeX() (((F32)m_curAccel[0].x) * (F32)(2.0 / JOYRANGE))
+#define GetNudgeY() (((F32)m_curAccel[0].y) * (F32)(2.0 / JOYRANGE)) 
 
 #ifdef UNUSED_TILT
 int Player::NudgeGetTilt()

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -408,7 +408,9 @@ private:
 public:
    void NudgeX(const int x, const int joyidx);
    void NudgeY(const int y, const int joyidx);
-   void MechPlungerIn(const int z);
+   void MechPlungerIn(const int z, const int joyidx);
+   void MechPlungerSpeedIn(const int z, const int joyidx);
+   int GetMechPlungerSpeed() const;
    void SetGravity(float slopeDeg, float strength);
 
    Vertex3Ds m_gravity;
@@ -425,6 +427,16 @@ public:
    Vertex3Ds m_tableVelDelta;
    float m_nudgeSpring;
    float m_nudgeDamping;
+
+   // External accelerometer velocity input.  This is for newer 
+   // pinball I/O controllers that integrate the acceleration samples
+   // in the device to compute the instantaneous cabinet velocity.
+   // This works just like the "new nudging" scheme above, except
+   // that the velocity reading comes from the external, physical 
+   // pin cab, as measured on an accelerometer.
+   Vertex3Ds m_accelVel;
+   Vertex3Ds m_accelVelOld;
+   bool m_accelInputIsVelocity;
 
    // legacy/VP9 style keyboard nudging
    bool m_legacyNudge;
@@ -456,7 +468,10 @@ public:
 
    U32 m_movedPlunger; // has plunger moved, must have moved at least three times
    U32 m_LastPlungerHit; // The last time the plunger was in contact (at least the vicinity) of the ball.
-   float m_curMechPlungerPos;
+   float m_curMechPlungerPos;  // position from joystick axis input, if a position axis is assigned
+   int m_curMechPlungerSpeed;  // plunger speed from joystick axis input, if a speed axis is assigned
+   float m_plungerSpeedScale;  // scaling factor for plunger speed input, to convert from joystick to internal units
+   bool m_fExtPlungerSpeed;    // flag: plunger speed was received via joystick input
 
    // Physics stats
    U32 m_phys_iterations;
@@ -506,7 +521,8 @@ private:
 
    int2 m_curAccel[PININ_JOYMXCNT];
 
-   int m_curPlunger;
+   int m_curPlunger[PININ_JOYMXCNT];
+   int m_curPlungerSpeed[PININ_JOYMXCNT];
 #pragma endregion
 
 

--- a/src/physics/hitplunger.h
+++ b/src/physics/hitplunger.h
@@ -20,6 +20,7 @@ public:
    void SetObjects(const float len);
 
    float MechPlunger() const; // Returns mechanical plunger position 0 at rest, +1 pulled (fully extended)
+   float MechPlungerSpeed() const;  // Mechanical plunger speed from I/O controller, in plunger lengths per time step
 
    void PullBack(float speed);
    void Fire(float startPos);

--- a/txt/Changelog.txt
+++ b/txt/Changelog.txt
@@ -1,3 +1,12 @@
+TO BE DETERMINED
+----------------
+- add support for new I/O controller capabilities, for compatible controller devices
+  see: http://mjrnet.org/pinscape/OpenPinballDevice/NewPinCabInput.htm, http://mjrnet.org/pinscape/OpenPinballDevice/OpenPinballDeviceHID.htm
+ 1) velocity-based nudge input
+ 2) plunger speed input
+ 3) Open Pinball Device HID interface
+
+
 VP 10.8.0 Changelog
 ------------------------
 

--- a/vpinball_eng.rc
+++ b/vpinball_eng.rc
@@ -630,7 +630,7 @@ BEGIN
     COMBOBOX        IDC_JOYPMUP,379,69,50,100,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
     CTEXT           "Enter (0)",IDC_STATIC,438,54,50,14,0,WS_EX_DLGMODALFRAME
     COMBOBOX        IDC_JOYPMENTER,438,69,50,100,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
-    GROUPBOX        "Axis Assignments",IDC_STATIC,258,113,233,77
+    GROUPBOX        "Axis Assignments",IDC_STATIC,258,113,233,94
     LTEXT           "X Axis (L/R)",IDC_STATIC,265,125,39,8
     COMBOBOX        IDC_LRAXISCOMBO,307,124,40,100,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Reverse",IDC_LRAXISFLIP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,348,125,40,10
@@ -653,8 +653,12 @@ BEGIN
     RTEXT           "Dead Zone",IDC_STATIC,421,161,36,8
     EDITTEXT        IDC_DEADZONEAMT,462,160,18,13,ES_RIGHT | ES_AUTOHSCROLL
     LTEXT           "%",IDC_STATIC,482,161,8,8
+    LTEXT           "Pl. Speed",IDC_STATIC,265,175,34,8
+    COMBOBOX        IDC_PLUNGERSPEEDAXIS,307,174,40,100,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
+    RTEXT           "Scale",IDC_STATIC,347,176,19,8
+    EDITTEXT        IDC_PLUNGERSPEEDSCALE,369,174,20,13,ES_RIGHT | ES_AUTOHSCROLL
     CONTROL         "Enable 1s Plunger Retract",IDC_PLUNGERRETRACT,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,394,176,94,10
-    GROUPBOX        "Nudge, Plumb, Plunger (Changes will not affect open tables)",IDC_STATIC,254,103,241,146
+    GROUPBOX        "Nudge, Plumb, Plunger (Changes will not affect open tables)",IDC_STATIC,254,103,241,155
     CONTROL         "Legacy/VP9-style non-realistic Keyboard Nudge",IDC_ENABLE_LEGACY_NUDGE,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,257,193,173,10
     EDITTEXT        IDC_LEGACY_NUDGE_STRENGTH,432,192,18,13,ES_RIGHT | ES_AUTOHSCROLL
@@ -664,19 +668,21 @@ BEGIN
     CONTROL         "Enable Analog Nudge",IDC_GLOBALACCEL,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,257,217,102,10
     CONTROL         "Normal Board Mounting Orientation",IDC_GLOBALNMOUNT,
                     "Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,364,217,128,10
-    CONTROL         "Tilt Sensitivity",IDC_CBGLOBALTILT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,257,234,55,10
-    EDITTEXT        IDC_GLOBALTILT,314,233,20,13,ES_RIGHT | ES_AUTOHSCROLL
-    CONTROL         "Accelerometer Rotation",IDC_CBGLOBALROTATION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,364,234,90,10
-    EDITTEXT        IDC_GLOBALROTATION,460,233,20,13,ES_RIGHT | ES_AUTOHSCROLL
+    CONTROL         "Analog Nudge Input is Velocity",IDC_CBGLOBALACCVEL,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,257,229,113,10
+    CONTROL         "Tilt Sensitivity",IDC_CBGLOBALTILT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,257,241,55,10
+    EDITTEXT        IDC_GLOBALTILT,314,240,20,13,ES_RIGHT | ES_AUTOHSCROLL
+    CONTROL         "Accelerometer Rotation",IDC_CBGLOBALROTATION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,364,241,90,10
+    EDITTEXT        IDC_GLOBALROTATION,460,240,20,13,ES_RIGHT | ES_AUTOHSCROLL
     GROUPBOX        "",IDC_STATIC,262,118,128,21
     GROUPBOX        "",IDC_STATIC,262,136,128,21
-    GROUPBOX        "",IDC_STATIC,262,154,128,21
+    GROUPBOX        "",IDC_STATIC,262,154,128,36
     LTEXT           "* To assign Custom Keys to Gamepad Buttons, click on the button and select desired key, then choose desired gamepad button from dropdown box.",IDC_STATIC,13,307,168,25
-    LTEXT           "To interactively set, calibrate and test the Nudge parameters, please load the\n'Nudge Test and Calibration.vpx' table and run it",IDC_STATIC,255,279,357,25
+    LTEXT           "To interactively set, calibrate and test the Nudge parameters, please load the\n'Nudge Test and Calibration.vpx' table and run it",IDC_STATIC,255,289,266,25
     CONTROL         "Enable Mouse handling during Play",IDC_ENABLE_MOUSE_PLAYER,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,252,150,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,262,150,10
     CONTROL         "Enable flying around (Arrow Keys + Left Alt Key) during Camera/Light/Material Edit Mode",IDC_ENABLE_CAMERA_FLY_AROUND,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,264,300,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,254,274,300,10
     GROUPBOX        "DOF Controller Options",IDC_STATIC,500,7,120,191
     CTEXT           "Contactors",IDC_STATIC,505,17,50,14,0,WS_EX_DLGMODALFRAME
     COMBOBOX        IDC_DOF_CONTACTORS,505,32,50,100,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP


### PR DESCRIPTION
This update implements some enhancements to the pin cab I/O controller device input model that came out of work I'm doing on a Pico-based controller (a sequel the Pinscape KL25Z system).  The idea is to address some of the long-standing technical problems in the HID input model we're using today, which is a legacy of the earliest commercial I/O controllers.  All of the devices in the years since have just carried that old input model forward over the years, but it has some inherent problems that can be fixed through some relatively simple changes.  This update implements the changes that I think are needed to solve those problems.

The theory behind this is described here: [Improving the Virtual Pin Cab Input Model](http://mjrnet.org/pinscape/OpenPinballDevice/NewPinCabInput.htm).

I've implemented the device side of this experimentally in my new Pico project, which I haven't published yet, and in the KL25Z Pinscape project, which I have.  Anyone who has a KL25Z pin cab can try out the changes by installing the new KL25Z 2024-08-18 release.  See [Pinscape Release Builds](http://mjrnet.org/pinscape/swversions.php).

My testing with the KL25Z implementation has been quite encouraging.  The new model does seem to be a noticeable improvement.  It substantially improves the consistency of the plunger launch behavior for me, and the nudge response seems considerably more natural to my eye.  I don't think there are any downsides to the extensions, since they're **extensions**; they're basically new features alongside the existing ones that won't interfere with or affect existing setups.

This update **also** includes a closely related but somewhat orthogonal new feature, which is support for my proposed [Open Pinball Device HID](http://mjrnet.org/pinscape/OpenPinballDevice/OpenPinballDeviceHID.htm).  The idea behind this is to eventually replace the traditional joystick HID interface with a HID that's explicitly designated in its usage codes as a Pinball Device.  I recently discovered that the official USB HID Usage Tables actually set aside a code for a "Pinball Device" Application Collection (that's the USB term of art for a software model representing a physical box on your desktop, the same category used for keyboards, mice, and joysticks).  I'm pretty sure I'm the only person on Earth who knows it's there, because I don't think many people browse through those tables on their lunch hour, and I don't get the impression that the USB committee member who added the entry gave it more than about five minutes of thought at the time, so I fully expect they've forgotten about it by now.  At any rate, seeing it made me realize that we're doing it wrong by co-opting the HID Joystick CA for all of our devices.  The wrongness is *mostly* an academic matter of how USB was intended to be used at a conceptual level, but not entirely; I know from hearing from Pinscape users that the joystick model actually does create practical problems for some people, due to compatibility issues with non-pinball video games that believe that a HID device calling itself a joystick *really is* a joystick.  These sorts of issues can be solved by using HID as intended, by designating our devices under the functionally correct Pinball Device usage code.  This also has a few other potential advantages, particularly in terms of automatic configuration.  The rationale and technical details are all covered in depth in the linked proposal, so I won't go into further detail here.  The implementation is quite self-contained and has almost no impact on any of the existing input processing code, and it doesn't replace the joystick or any other existing input method, just adds a new one alongside them.