### PR TITLE
misc: fix sample keyword gles compile error

### DIFF
--- a/.github/workflows/vpinball-shaders.yml
+++ b/.github/workflows/vpinball-shaders.yml
@@ -1,0 +1,59 @@
+name: vpinball-bgfx-shaders
+on:
+  workflow_dispatch:
+
+env:
+  VERSION_START_SHA: ea558e7417f6f06fe567d34f0e33792a141b8e64
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      revision: ${{ steps.version.outputs.revision }}
+      version_short: ${{ steps.version.outputs.version_short }}
+      version_full: ${{ steps.version.outputs.version_full }}
+      sha7: ${{ steps.version.outputs.sha7 }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: version
+        run: |
+          REVISION=$(git rev-list ${{ env.VERSION_START_SHA }}..HEAD --count)
+          VERSION_MAJOR=$(grep -Eo "VP_VERSION_MAJOR\s+[0-9]+" src/core/vpversion.h | grep -Eo "[0-9]+")
+          VERSION_MINOR=$(grep -Eo "VP_VERSION_MINOR\s+[0-9]+" src/core/vpversion.h | grep -Eo "[0-9]+")
+          VERSION_REV=$(grep -Eo "VP_VERSION_REV\s+[0-9]+" src/core/vpversion.h | grep -Eo "[0-9]+")
+          VERSION_SHORT="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REV}"
+          VERSION_FULL="${VERSION_SHORT}.${REVISION}"
+          SHA7="${GITHUB_SHA::7}"
+          TAG="${VERSION_SHORT}-${REVISION}-${SHA7}"
+          echo "revision=${REVISION}" >> $GITHUB_OUTPUT
+          echo "version_short=${VERSION_SHORT}" >> $GITHUB_OUTPUT
+          echo "version_full=${VERSION_FULL}" >> $GITHUB_OUTPUT
+          echo "sha7=${SHA7}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+  shaders:
+    name: Shaders
+    runs-on: windows-latest
+    needs: [ version ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: generate shaders
+        run: |
+          cd src/shaders/bgfx
+          ./shaders.sh
+      - name: copy headers
+        run: |
+          mkdir tmp
+          cp src/shaders/bgfx*.h tmp
+      - uses: actions/upload-artifact@v4
+        with:
+          name: VPinballX-${{ needs.version.outputs.tag }}-bgfx-shaders
+          path: tmp

--- a/src/shaders/bgfx/fs_dmd2.sc
+++ b/src/shaders/bgfx/fs_dmd2.sc
@@ -42,13 +42,13 @@ float udRoundBox(vec2 p, float b, float r)
 }
 
 // Apply brightness (for colored DMDs) or convert BW data to RGB one (for monochrome DMDs)
-vec3 convertDmdToColor(vec4 sample)
+vec3 convertDmdToColor(vec4 samp)
 {
 	// FIXME PinMame does not push raw data but apply user range (default to 20..100)
-	if (sample.a == 0.0) // brightness data
-		return sample.r * (255. / 100.) * dotColor; // (max(0., sample.r * 255. - 20.) / 100.) * dotColor;
+	if (samp.a == 0.0) // brightness data
+		return samp.r * (255. / 100.) * dotColor; // (max(0., samp.r * 255. - 20.) / 100.) * dotColor;
 	else // RGB data
-		return sample.rgb * brightness; // max(0., sample.rgb - 20./255.) * (255. / 235.) * brightness;
+		return samp.rgb * brightness; // max(0., samp.rgb - 20./255.) * (255. / 235.) * brightness;
 }
 
 // Compute the dot color contribution from dot placed at 'ofs' to the fragment at dmdUv

--- a/src/shaders/bgfx/shaders.sh
+++ b/src/shaders/bgfx/shaders.sh
@@ -14,18 +14,19 @@ process_shader() {
         'mtl ' 
         'essl' 
         'glsl' 
-#        'dx11' 
+        'dx11' 
         'spv '
     )
+
     local targets=(
         '--platform osx     -p metal -O 3'
-        '--platform android -p 320_es    '
-        '--platform linux   -p 310_es    '
+        '--platform windows -p 310_es    '
         '--platform windows -p 440       '
-#        '--platform windows -p s_5_0 -O 3'
+        '--platform windows -p s_5_0 -O 3'
         '--platform windows -p spirv     '
     )
-    local shaderc="shaderc"
+
+    local shaderc="./shaderc"
 
     local output_path="../bgfx_${output_file}"
     local short_name="${header:0:${#header}-1}"


### PR DESCRIPTION
This PR fixes GLES compile issues as a guess `sample` must be a keyword. 

I also added a manual triggered workflow to make a build of the shader headers, since I can't easily compile on windows.

@vbousquet, @toxieainc , fwiw,  rk3588 builds need GLES 3.10 where android could use GLES 3.20. I'm not sure with the current code setup how to include support for either 3.10 or 3.20.   

