### PR TITLE
APP_TOUCH fix

### DIFF
--- a/src/core/pininput.h
+++ b/src/core/pininput.h
@@ -34,21 +34,28 @@
 #define USHOCKTYPE_VIRTUAPIN  4
 #define USHOCKTYPE_GENERIC    5
 
+// Input type ID - keyboard
 #define APP_KEYBOARD   0
-#define APP_JOYSTICKMN 1
-#define APP_MOUSE      2
-#define APP_TOUCH      3
 
+// Input type ID - mouse
+#define APP_MOUSE      1
+
+// Input type ID - touchscreen
+#define APP_TOUCH      2
+
+// Input type ID - joystick 1 through 8
 // handle multiple joysticks, APP_JOYSTICKMN..APP_JOYSTICKMX
+#define APP_JOYSTICKMN 3
 #define PININ_JOYMXCNT 8
+#define APP_JOYSTICK(n) (APP_JOYSTICKMN + (n))
+#define APP_JOYSTICKMX  (APP_JOYSTICK(PININ_JOYMXCNT - 1))
 
+
+// Joystick axis normalized input range
 #define JOYRANGEMN (-65536)
 #define JOYRANGEMX (+65536)
-
 #define JOYRANGE ((JOYRANGEMX) - (JOYRANGEMN) + 1)
 
-#define APP_JOYSTICKMX (APP_JOYSTICKMN + PININ_JOYMXCNT -1)
-#define APP_JOYSTICK(n) (APP_JOYSTICKMN + (n))
 
 #ifdef _WIN32
 #define USE_DINPUT_FOR_KEYBOARD // can lead to less input lag maybe on some systems if disabled, but can miss input if key is only pressed very very quickly and/or FPS are low


### PR DESCRIPTION
I just started working on merging my recent input handling changes into 10.8.1, and noticed some bizarre behavior in my initial build.  It turned out to be a collision in the numbering of the APP_xxx input sources.  APP_JOYSTICK is supposed to occupy a range of values from 1 to 8 (for up to 8 joystick devices), but APP_MOUSE and APP_TOUCH were added at some point with IDs 2 and 3, respectively.  So if you happen to have two or three joysticks attached, the input from those will get misinterpreted as mouse or touchscreen input.  The resulting behavior is basically random input events, mostly because APP_TOUCH will read the NUMBER on the joystick axis and think that it's a KEY PRESS identifier.  I thought my devices had gone haywire, but no, it was just a little input bug.  I guess it's a good thing I happened to have a bunch of Picos attached to my system so this got caught.

Anyway, the fix is ridiculously simple, we just have to renumber the input sources so that they don't collide with one another.

*** 

As long as I'm looking at these macros, I'll throw in another comment, in case anyone's reading this far.  Does it REALLY make sense for the joystick normalized input axis range to be -65536 to +65536?  That strikes me as a very strange range indeed, when viewed in computer bit/byte terms; it's basically the range of a 17-bit 2's complement number, BUT NOT QUITE, since it goes up to +65536 instead of +65535.  So you need 18 bits to represent it, to make room for that one extra value on the positive side, but it leaves almost half of that notional 18-bit container range unused.  I expect that the underlying devices are all sending values in some ACTUAL 2's complement range that's from 8 to 16 bits wide, so I'd think that a range of -32768 to +32767 would provide the highest fidelity scaling for the ranges actually reported by devices.   I guess I have two questions.  First, is there some good reason for this peculiar range, like "it's what DirectInput uses" or "it has special favorable properties with (some subtle integer rescaling formula we're using)"?  And second, if not, does anyone think it would do any harm or be at all destabilizing to change it something that seems saner to my HID-blinkered, 8-bit-byte mindset, like -32768..+32767?  I don't think it's particular a problem as it is, it just seems very strange.
