### PR TITLE
Pin sim controls (10.8.1)

### DIFF
--- a/src/core/pininput_OpenPinDev.cpp
+++ b/src/core/pininput_OpenPinDev.cpp
@@ -342,11 +342,12 @@ void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
    OpenPinballDeviceReport cr { 0 };
 
    // read input from each device
+   bool isNewReport = false;
    for (auto &p : m_OpenPinDevContext->m_openPinDevs)
    {
       // check for a new report
-      if (!p->ReadReport())
-         continue;
+      if (p->ReadReport())
+         isNewReport = true;
 
       // Merge the data into the combined struct.  For the accelerometer
       // and plunger analog quantities, just arbitrarily pick the last
@@ -407,6 +408,10 @@ void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
       cr.genericButtons |= r.genericButtons;
       cr.pinballButtons |= r.pinballButtons;
    }
+
+   // if there were no reports, there's no need to update the player
+   if (!isNewReport)
+      return;
 
    // Axis scaling factor.  All Open Pinball Device analog axes are
    // INT16's (-32768..+32767).  The VP functional axes are designed

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -819,6 +819,9 @@ Player::~Player()
       PLOGE << "Player::OnClose discarded since player is already closing (destructor called from 2 different places...)";
       return;
    }
+
+   // note if application exit was requested, and set the new closing state to CLOSED
+   bool appExitRequested = (m_closing == CS_CLOSE_APP);
    m_closing = CS_CLOSED;
    PLOGI << "Closing player...";
 
@@ -1016,7 +1019,7 @@ Player::~Player()
       m_progressDialog.Destroy();
 
    // Reactivate edited table or close application if requested
-   if (m_closing == CS_CLOSE_APP)
+   if (appExitRequested)
    {
       g_pvp->PostMessage(WM_CLOSE, 0, 0);
    }

--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -2044,21 +2044,7 @@ LRESULT VPinball::OnFrontEndControlsMsg(WPARAM wParam, LPARAM lParam)
       // GAME_TO_FOREGROUND
       // If a player is running, bring its main window to the foreground
       if (g_pplayer != nullptr && g_pplayer->m_playfieldWnd != nullptr)
-      {
-         // bring the window to the foreground
-         HWND hwndPlayer = g_pplayer->m_playfieldWnd->GetCore();
-         ::BringWindowToTop(hwndPlayer);
-         ::SetForegroundWindow(hwndPlayer);
-
-         // Windows automatically minimizes full-screen-exclusive windows when they're
-         // moved to the background, but it doesn't automatically restore them when
-         // they're brought back in front, so we have to do this explicitly.
-         if (::IsIconic(hwndPlayer))
-         {
-            DWORD_PTR result;
-            ::SendMessageTimeout(hwndPlayer, WM_SYSCOMMAND, SC_RESTORE, 0, SMTO_ABORTIFHUNG, 100, &result);
-         }
-      }
+         g_pplayer->m_playfieldWnd->RaiseAndFocus(true);
 
       // handled
       return 1;
@@ -2067,7 +2053,7 @@ LRESULT VPinball::OnFrontEndControlsMsg(WPARAM wParam, LPARAM lParam)
       // QUERY_GAME_HWND
       // If a player is running, return its main window handle
       return (g_pplayer != nullptr && g_pplayer->m_playfieldWnd != nullptr) ?
-         reinterpret_cast<DWORD_PTR>(g_pplayer->m_playfieldWnd->GetCore()) : 0;
+         reinterpret_cast<DWORD_PTR>(g_pplayer->m_playfieldWnd->GetNativeHWND()) : 0;
    }
 #endif // __STANDALONE__
 

--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -133,6 +133,9 @@ VPinball::VPinball()
            ShowError("Unable to load SciLexerVP.DLL or SciLexer.DLL");
        #endif
    }
+
+   // register the PinSim::FrontEndControls name window message
+   m_pinSimFrontEndControlsMsg = RegisterWindowMessageA("PinSim::FrontEndControls");
 #endif
 }
 
@@ -1959,11 +1962,97 @@ LRESULT VPinball::WndProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
    }
    case UWM_UPDATECOMMAND:
       return FinalWindowProc(uMsg, wParam, lParam);
+
+   default:
+      // check for the PinSim::FrontEndControls registered message
+      if (uMsg == m_pinSimFrontEndControlsMsg)
+         return OnFrontEndControlsMsg(wParam, lParam);
+
+      // not handled
+      break;
    }
    return WndProcDefault(uMsg, wParam, lParam);
 #else
    return 0L;
 #endif
+}
+
+// See http://mjrnet.org/pinscape/PinSimFrontEndControls/PinSimFrontEndControls.htm
+LRESULT VPinball::OnFrontEndControlsMsg(WPARAM wParam, LPARAM lParam)
+{
+#ifndef __STANDALONE__
+   // the WPARAM contains a sub-command code telling us the specific action
+   // the caller is requesting
+   switch (wParam)
+   {
+   case 1:
+      // IS_HANDLER_WINDOW
+      // Return the current supported interface version (1)
+      return 1;
+
+   case 2:
+      // CLOSE_APP
+      // Close the player and exit the program
+      QuitPlayer(Player::CloseState::CS_CLOSE_APP);
+
+      // If we're showing a modal dialog, close it.  Closing one dialog
+      // can trigger opening another, so iterate this until no modal
+      // dialogs are found (but limit the iterations, in case we're in
+      // some kind of pathological situation where the dialogs are
+      // displayed in an infinite loop).
+      for (int tries = 0 ; tries < 20 ; ++tries)
+      {
+          // enumerate the windows on this thread
+          struct WindowLister
+          {
+              WindowLister()
+              {
+                  EnumThreadWindows(GetCurrentThreadId(), [](HWND hwnd, LPARAM param) -> BOOL 
+                  {
+                     // check for an enabled, visible model dialog window (window class "#32770")
+                     char cls[128];
+                     if (::IsWindowVisible(hwnd) && ::IsWindowEnabled(hwnd)
+                         && ::RealGetWindowClassA(hwnd, cls, std::size(cls)) != 0
+                         && strcmp(cls, "#32770") == 0)
+                     {
+                        // close it by sending IDCANCEL
+                        DWORD_PTR result;
+                        ::SendMessageTimeout(hwnd, WM_COMMAND, IDCANCEL, 0, SMTO_ABORTIFHUNG, 100, &result);
+
+                        // note that we found at least one window to close
+                        reinterpret_cast<WindowLister*>(param)->closed = true;
+                     }
+
+                     // continue the iteration
+                     return TRUE;
+                  }, reinterpret_cast<LPARAM>(this));
+              }
+              bool closed = false;
+          };
+          WindowLister wl;
+
+          // if we didn't find anything to close, nothing changed during this
+          // iteration, so we don't need to keep looping
+          if (!wl.closed)
+              break;
+      }
+
+      // handled
+      return 1;
+
+   case 3:
+      // GAME_TO_FOREGROUND
+      // If a player is running, bring it to the foreground.
+      if (g_pplayer != nullptr && g_pplayer->m_playfieldWnd != nullptr)
+          ::SetForegroundWindow(g_pplayer->m_playfieldWnd->GetCore());
+
+      // handled
+      return 1;
+   }
+#endif // __STANDALONE__
+
+   // not handled
+   return 0;
 }
 
 LRESULT VPinball::OnMDIActivated(UINT msg, WPARAM wparam, LPARAM lparam)

--- a/src/core/vpinball_h.h
+++ b/src/core/vpinball_h.h
@@ -201,6 +201,13 @@ public:
 
    HINSTANCE theInstance;
 
+   // registered window message ID for PinSim::FrontEndControls
+   // (http://mjrnet.org/pinscape/PinSimFrontEndControls/PinSimFrontEndControls.htm)
+   UINT m_pinSimFrontEndControlsMsg;
+
+   // handler for PinSim::FrontEndControls messages
+   LRESULT OnFrontEndControlsMsg(WPARAM wParam, LPARAM lParam);
+
    vector< CComObject<PinTable>* > m_vtable;
    CComObject<PinTable> *m_ptableActive;
 

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -37,8 +37,13 @@ public:
 
    #ifdef ENABLE_SDL_VIDEO // SDL Windowing
       SDL_Window * GetCore() const { return m_nwnd; }
+
+      #ifdef _WIN32
+         HWND GetNativeHWND() const;
+      #endif
    #else // Win32 Windowing
       HWND GetCore() const { return m_nwnd; }
+      HWND GetNativeHWND() const { return m_nwnd; }
    #endif
 
    struct VideoMode

--- a/src/ui/codeview.cpp
+++ b/src/ui/codeview.cpp
@@ -1517,8 +1517,12 @@ STDMETHODIMP CodeViewer::OnScriptErrorDebug(
       pt->m_pcv->SetLastErrorVisibility(true);
    }
 
-	// Also pop up a dialog
-	if (!m_suppressErrorDialogs)
+	// Also pop up a dialog.  Suppress the dialog if the user has so
+    // directed, or if the player Close State is CLOSE APP, since in
+    // that case the decision to exit the whole program has already
+    // been made, precluding further UI input.
+	if (!m_suppressErrorDialogs
+		&& !(g_pplayer != nullptr && g_pplayer->GetCloseState() == Player::CloseState::CS_CLOSE_APP))
 	{
 #ifndef __STANDALONE__
 		g_pvp->EnableWindow(FALSE);

--- a/src/ui/codeview.cpp
+++ b/src/ui/codeview.cpp
@@ -1285,7 +1285,7 @@ STDMETHODIMP CodeViewer::OnScriptError(IActiveScriptError *pscripterror)
    }
 
 	// Also pop up a dialog if this is a runtime error
-	if (isRuntimeError && !m_suppressErrorDialogs)
+	if (isRuntimeError && !m_suppressErrorDialogs && !(g_pplayer != nullptr && g_pplayer->GetCloseState() == Player::CloseState::CS_CLOSE_APP))
 	{
 #ifndef __STANDALONE__
 		g_pvp->EnableWindow(FALSE);


### PR DESCRIPTION
This is another "inter-op" proposal, this time for improving coordination between simulators like VP and front ends like PinballX, Popper, and PinballY.  The rationale and details for the proposal are here: http://mjrnet.org/pinscape/PinSimFrontEndControls/PinSimFrontEndControls.htm.

The VP implementation is simple and isolated, so I don't think there's much risk in adding this, but I'm marking this as a draft so that everyone can take a look at the scheme at the design level and decide if the design looks sound.  My main goal was to keep it simple to implement and use while solving a couple of key inter-op problems that all of the front ends have always suffered from and that I think are just intractable without SOME kind of explicit coordination between parties.

By the way, in the course of implementing this, I came across a little bug in VPinball::~VPinball() related to the way CS_CLOSE_APP is handled - the changes to vpinball.cpp are just a fix for that bug, not anything related to my additions (other than that the bug was preventing the additions from working, which is how I found it).  That can be fixed separately if the broader proposal here isn't to everyone's liking.

If this does seem reasonable, I'll submit additional PRs porting it to master, 10.7.2, and 9.9.5.