### PR TITLE
PinSim::FrontEndControls for 10.7.2; OpenPinDev report merge fix

### DIFF
--- a/codeview.cpp
+++ b/codeview.cpp
@@ -1160,7 +1160,7 @@ STDMETHODIMP CodeViewer::OnScriptError(IActiveScriptError *pscripterror)
 	SetLastErrorVisibility(true);
 
 	// Also pop up a dialog if this is a runtime error
-	if (isRuntimeError && !m_suppressErrorDialogs)
+	if (isRuntimeError && !m_suppressErrorDialogs && !(g_pplayer != nullptr && g_pplayer->m_closeType != 0))
 	{
 		g_pvp->EnableWindow(FALSE);
 		ScriptErrorDialog scriptErrorDialog(errorStr);
@@ -1373,7 +1373,7 @@ STDMETHODIMP CodeViewer::OnScriptErrorDebug(
 	SetLastErrorVisibility(true);
 
 	// Also pop up a dialog
-	if (!m_suppressErrorDialogs)
+    if (!m_suppressErrorDialogs && !(g_pplayer != nullptr && g_pplayer->m_closeType != 0))
 	{
 		g_pvp->EnableWindow(FALSE);
 		ScriptErrorDialog scriptErrorDialog(errorStr);

--- a/pin/hitplunger.cpp
+++ b/pin/hitplunger.cpp
@@ -740,7 +740,8 @@ float HitPlunger::HitTest(const BallS& ball, const float dtime, CollisionEvent& 
    // which at least tries to make the internal object's simulated
    // motion more realistic during times when it looks like we're in
    // a pull-and-release motion.
-   const float impulseSpeed = g_pplayer->m_fExtPlungerSpeed && m_plungerMover.m_plunger->m_d.m_mechPlunger ?
+   const float impulseSpeed = 
+       (m_plungerMover.m_fireTimer == 0 && g_pplayer->m_fExtPlungerSpeed && m_plungerMover.m_plunger->m_d.m_mechPlunger) ?
        m_plungerMover.MechPlungerSpeed() : 
        m_plungerMover.m_speed;
 

--- a/vpinball_h.h
+++ b/vpinball_h.h
@@ -190,7 +190,14 @@ public:
 
    HINSTANCE theInstance;
 
-   vector< CComObject<PinTable>* > m_vtable;
+   // registered window message ID for PinSim::FrontEndControls
+   // (http://mjrnet.org/pinscape/PinSimFrontEndControls/PinSimFrontEndControls.htm)
+   UINT m_pinSimFrontEndControlsMsg;
+
+   // handler for PinSim::FrontEndControls messages
+   LRESULT OnFrontEndControlsMsg(WPARAM wParam, LPARAM lParam);
+
+   vector<CComObject<PinTable>*> m_vtable;
    CComObject<PinTable> *m_ptableActive;
 
 //    HWND m_hwndToolbarMain;


### PR DESCRIPTION
This is a port of the FrontEndControls PR from 10.8.1 (#1921) to 10.7.2.  Also fixes a logic error in the OpenPinDev code.