### PR TITLE
standalone: Pinscape has multiple usb product id's

### DIFF
--- a/src/assets/Default_gamecontrollerdb.txt
+++ b/src/assets/Default_gamecontrollerdb.txt
@@ -6,8 +6,10 @@
 # Mac OS
 03000000fafa0000f00000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
 03000000fafa0000f70000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03004c8009120000eaea000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
 
 # Linux
 03000000790000000600000010010000,DragonRise Inc.   Generic   USB  Joystick,a:b4,b:b1,y:b2,leftshoulder:b0,rightshoulder:b6,dpdown:b5,platform:Linux,
 03004c80fafa0000f000000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
 03004c80fafa0000f700000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c8009120000eaea000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,

--- a/src/assets/Default_gamecontrollerdb.txt
+++ b/src/assets/Default_gamecontrollerdb.txt
@@ -4,12 +4,44 @@
 0300f020790000000600000000000000,Generic USB Joystick,a:b4,b:b1,y:b2,leftshoulder:b0,rightshoulder:b6,dpdown:b5,lefttrigger:b7,righttrigger:b8,platform:Windows,
 
 # Mac OS
-03000000fafa0000f00000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
-03000000fafa0000f70000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+#  Pinscape exclusive PID
 03004c8009120000eaea000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+#  Pinscape emulating LedWiz
+03000000fafa0000f00000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f10000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f20000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f30000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f40000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f50000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f60000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f70000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f80000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f90000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000fa0000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000fb0000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000fc0000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000fd0000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000fe0000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000ff0000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
 
 # Linux
 03000000790000000600000010010000,DragonRise Inc.   Generic   USB  Joystick,a:b4,b:b1,y:b2,leftshoulder:b0,rightshoulder:b6,dpdown:b5,platform:Linux,
-03004c80fafa0000f000000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
-03004c80fafa0000f700000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+#  Pinscape exclusive PID
 03004c8009120000eaea000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+#  Pinscape emulating LedWiz
+03004c80fafa0000f000000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f100000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f200000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f300000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f400000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f500000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f600000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f700000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f800000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000f900000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000fa00000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000fb00000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000fc00000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000fd00000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000fe00000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
+03004c80fafa0000ff00000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,

--- a/src/assets/Default_gamecontrollerdb.txt
+++ b/src/assets/Default_gamecontrollerdb.txt
@@ -5,7 +5,9 @@
 
 # Mac OS
 03000000fafa0000f00000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
+03000000fafa0000f70000000a000000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Mac OS X,
 
 # Linux
 03000000790000000600000010010000,DragonRise Inc.   Generic   USB  Joystick,a:b4,b:b1,y:b2,leftshoulder:b0,rightshoulder:b6,dpdown:b5,platform:Linux,
+03004c80fafa0000f000000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,
 03004c80fafa0000f700000011010000,mjrnet Pinscape Controller,leftx:a0,lefty:a1~,righty:a2,platform:Linux,


### PR DESCRIPTION
I have 2 pinscapes, one was not recognized. They both report a different id.

`lsusb` will show this detail:

```
  idProduct          0x00f7 Pinscape Controller
  idProduct          0x00f0 Pinscape Controller
```

The product Id was updated 8 years ago but it seems that a version before that change is still popular.

https://github.com/mjrgh/Pinscape_Controller/commit/dcd8e614d09c68aac8eac2275a615f1dd8630fd1#diff-dba8f2421d03ea929e7f78c769eaa4046472804b124eff804aa9b0c0ecdb9603R136

<img width="611" alt="image" src="https://github.com/user-attachments/assets/086d0e16-acec-43df-b766-05c2e88ffd20">
