### PR TITLE
fix: SDL3 DMD disable linear scaling

### DIFF
--- a/standalone/inc/common/DMDWindow.cpp
+++ b/standalone/inc/common/DMDWindow.cpp
@@ -106,8 +106,8 @@ void DMDWindow::Render()
          m_pTexture = SDL_CreateTexture(m_pRenderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, m_pRGB24DMD->GetWidth(), m_pRGB24DMD->GetHeight());
          if (!m_pTexture)
             return;
+         SDL_SetTextureScaleMode(m_pTexture, SDL_SCALEMODE_NEAREST);
       }
-      SDL_SetTextureScaleMode(m_pTexture, SDL_SCALEMODE_NEAREST);
       if (!SDL_UpdateTexture(m_pTexture, NULL, pRGB24Data, m_pitch))
          return;
       SDL_SetRenderDrawColor(m_pRenderer, 0, 0, 0, 255);

--- a/standalone/inc/common/DMDWindow.cpp
+++ b/standalone/inc/common/DMDWindow.cpp
@@ -107,6 +107,7 @@ void DMDWindow::Render()
          if (!m_pTexture)
             return;
       }
+      SDL_SetTextureScaleMode(m_pTexture, SDL_SCALEMODE_NEAREST);
       if (!SDL_UpdateTexture(m_pTexture, NULL, pRGB24Data, m_pitch))
          return;
       SDL_SetRenderDrawColor(m_pRenderer, 0, 0, 0, 255);


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/6478b61c-7624-4fe3-bb90-959dc8925bf5)

After
![image](https://github.com/user-attachments/assets/4929a183-9b07-4a45-9590-da6b47581a46)
