### PR TITLE
WCG: fix some wrong luminance calculation, replace None tonemapper by…

### DIFF
--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -313,6 +313,7 @@ void RenderDevice::RenderThread(RenderDevice* rd, const bgfx::Init& initReq)
    if (bgfx::getCaps()->supported & BGFX_CAPS_HDR10)
    {
       init.resolution.format = bgfx::TextureFormat::RGB10A2;
+      //init.resolution.format = bgfx::TextureFormat::RGBA16F; // Also supported by BGFX, but less efficient and would need and adjusted tonemapper to output in DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709 colorspace (linear sRGB)
       init.resolution.reset |= BGFX_RESET_HDR10;
       bgfx::reset(init.resolution.width, init.resolution.height, init.resolution.reset, init.resolution.format);
    }
@@ -321,6 +322,7 @@ void RenderDevice::RenderThread(RenderDevice* rd, const bgfx::Init& initReq)
    colorFormat back_buffer_format;
    switch (init.resolution.format)
    {
+   case bgfx::TextureFormat::RGBA16F: back_buffer_format = colorFormat::RGBA16F; break;
    case bgfx::TextureFormat::RGB10A2: back_buffer_format = colorFormat::RGBA10; break;
    case bgfx::TextureFormat::R5G6B5: back_buffer_format = colorFormat::RGB5; break;
    case bgfx::TextureFormat::RGBA8: back_buffer_format = colorFormat::RGBA8; break;

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -1896,11 +1896,14 @@ void Renderer::PrepareVideoBuffers()
       }
 
       if (isHdr2020)
+      {
+         const float maxDisplayLuminance = m_renderDevice->m_outputWnd[0]->GetHDRHeadRoom() * (m_renderDevice->m_outputWnd[0]->GetSDRWhitePoint() * 80.f); // Maximum luminance of display in nits
          m_renderDevice->m_FBShader->SetVector(SHADER_exposure_wcg,
             m_exposure,
-            1.f / m_renderDevice->m_outputWnd[0]->GetHDRHeadRoom(),
-            m_renderDevice->m_outputWnd[0]->GetHDRHeadRoom() * (m_renderDevice->m_outputWnd[0]->GetSDRWhitePoint() / 80.f),
+            (m_renderDevice->m_outputWnd[0]->GetSDRWhitePoint() * 80.f) / maxDisplayLuminance, // Apply SDR whitepoint (1.0 -> white point in nits), then scale down by maximum luminance (in nits) of display to get a relative value before before tonemapping
+            maxDisplayLuminance / 10000.f, // Apply back maximum luminance in nits of display after tonemapping, scaled down to PQ limits (1.0 is 10000 nits)
             1.f);
+      }
       else
          m_renderDevice->m_FBShader->SetVector(SHADER_exposure_wcg, m_exposure, 1.f, 1.f, 0.f);
 

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -27,8 +27,8 @@ public:
    int GetAdapterId() const { return m_adapter; }
    int GetBitDepth() const { return m_bitdepth; }
    float GetHiDPIScale() const { return m_hidpiScale; } // HiDPI scale on Apple devices
-   float GetSDRWhitePoint() const { return m_sdrWhitePoint; }
-   float GetHDRHeadRoom() const { return m_hdrHeadRoom; }
+   float GetSDRWhitePoint() const { return m_sdrWhitePoint; } // Selected SDR White Point of display in multiple of 80nits (so 3 gives 240nits for SDR white)
+   float GetHDRHeadRoom() const { return m_hdrHeadRoom; } // Maximum luminance of display expressed in multiple of SDRWhitePoint (so 6 means 6 times the SDR whitepoint)
 
    void SetPos(const int x, const int y);
    void Show(const bool show = true);

--- a/src/ui/LiveUI.cpp
+++ b/src/ui/LiveUI.cpp
@@ -977,6 +977,7 @@ void LiveUI::Render()
    }
 
    #if defined(ENABLE_BGFX)
+   // FIXME scale down linear RGB colors by HDR headroom to get the right SDR white point on WCG displays
    ImGui_Implbgfx_RenderDrawLists(draw_data);
 
    #elif defined(ENABLE_OPENGL)


### PR DESCRIPTION
… a basic Reinhart (c/1+c)