### PR TITLE
New OpenPinDev report (removes special flipper button handling)

### DIFF
--- a/src/core/pininput_OpenPinDev.cpp
+++ b/src/core/pininput_OpenPinDev.cpp
@@ -60,7 +60,7 @@ struct OpenPinballDeviceReport
       if (sizeRemaining >= nBytesInT)
       {
          // we can complete the full read
-         for (size_t i = 0; i < nBytesInT; ++i, ele |= static_cast<T>(*p++) << (i * 8))
+         for (size_t i = 0; i < nBytesInT; ele |= static_cast<T>(*p++) << (i * 8), ++i)
             ;
 
          // deduct the size consumed and return success

--- a/src/core/pininput_OpenPinDev.cpp
+++ b/src/core/pininput_OpenPinDev.cpp
@@ -463,7 +463,7 @@ void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
       }
 
       // remember the new button state
-      cr.genericButtons = m_openPinDev_generic_buttons;
+      m_openPinDev_generic_buttons = cr.genericButtons;
    }
    if (cr.pinballButtons != m_openPinDev_pinball_buttons)
    {
@@ -509,6 +509,7 @@ void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
       {
          // check for a state change
          uint32_t const mask = m->mask;
+
          DISPID const isDown = (cr.pinballButtons & mask) != 0 ? DISPID_GameEvents_KeyDown : DISPID_GameEvents_KeyUp;
          DISPID const wasDown = (m_openPinDev_pinball_buttons & mask) != 0 ? DISPID_GameEvents_KeyDown : DISPID_GameEvents_KeyUp;
          if (isDown != wasDown)
@@ -516,6 +517,6 @@ void PinInput::ReadOpenPinballDevices(const U32 cur_time_msec)
       }
 
       // remember the new button state
-      cr.pinballButtons = m_openPinDev_pinball_buttons;
+      m_openPinDev_pinball_buttons = cr.pinballButtons;
    }
 }


### PR DESCRIPTION
Since there aren't any Open Pin Device implementations in the wild yet, I figure I can still make incompatible changes without breaking anyone's setup, so I'm taking the opportunity to delete the special flipper-button fields.  Those fields were in the original design speculatively, pending further investigation of ways to represent button event timing on a finer time scale than the native USB HID reporting interval.  Well, I've finally done the further investigation, and my verdict is that the whole idea was unnecessary and should be removed.

The extra fields were motivated by the observation that the original WPC software (running on its original hardware, before emulators ever got involved) polls its flipper button switches at 1ms intervals, whereas HID polling cycles might be more like 8-10ms.  So the idea was to stuff some extra information into the HID reports that represented a breakdown of what happened *between* HID reports, at a 1ms time scale.

My plan was to flesh out the details of exactly how to represent the extra time detail and process it in VP, so I started off by setting up a test system with my custom HID device to do the button polling, and a bunch of timing instrumentation to measure the time sequence of events between the device and Windows.  The first thing I looked at was the HID polling cycle, and what I found there is that the Windows HID drivers will actually respect the polling cycle that the device asks for.  I was under the impression from what I've read about the subject that the HID driver chooses the polling cycle, and there's not much the device can do about it.  But empirically, Windows does respect the cycle time that the driver requests via its interface descriptors.  The descriptors can specify a polling cycle at the granularity of the USB frame time, which is 1ms with the Full Speed mode that most of the current microcontrollers implement. 

In other words, we can achieve the same button polling rate as the original WPC platform running on its original hardware, using plain old USB HID, without any extra complications in the device reporting structure.  Given that, I think it's a big improvement to rip out the special handling and treat the flippers as ordinary buttons.

By the way, this is also good news for those concerned about basic latency.  The original motivation for the extra detail report feature was unrelated to latency - it was about distinguishing "short taps" from "long taps" at the same fine time scale that the original WPC hardware could - but the HID polling cycle also acts as a bottleneck for basic input latency, so the ability of devices to set a 1ms cycle makes it possible to pretty faithfully replicate WPC on a PC.  This definitely makes the various code initiatives in VP and VPM to aim for a uniform 1ms HID sampling cycle worthwhile.

(I've only done this particular practical HID polling rate testing on Windows 11, so it's possible that other platforms don't respect the interface descriptor rate as faithfully.  But I suspect they all do, since this is a basic element of USB that's been there from the beginning.  I think my previous assumptions that they wouldn't respect it were based on either misleading information in USB-related sources I've read in the past, or just my own misinterpretation of what they were trying to say.)
