### PR TITLE
Move EditableReg::m_map static definition out of main

### DIFF
--- a/make/CMakeLists_bgfx-win-x64.txt
+++ b/make/CMakeLists_bgfx-win-x64.txt
@@ -79,6 +79,7 @@ add_executable(vpinball WIN32
    src/audio/wavread.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/make/CMakeLists_bgfx-win-x86.txt
+++ b/make/CMakeLists_bgfx-win-x86.txt
@@ -80,6 +80,7 @@ add_executable(vpinball WIN32
    src/audio/wavread.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/make/CMakeLists_dx9-win-x64.txt
+++ b/make/CMakeLists_dx9-win-x64.txt
@@ -121,6 +121,7 @@ add_executable(vpinball WIN32
    src/audio/wavread.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/make/CMakeLists_dx9-win-x86.txt
+++ b/make/CMakeLists_dx9-win-x86.txt
@@ -122,6 +122,7 @@ add_executable(vpinball WIN32
    src/audio/wavread.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/make/CMakeLists_gl-win-x64.txt
+++ b/make/CMakeLists_gl-win-x64.txt
@@ -87,6 +87,7 @@ add_executable(vpinball WIN32
    src/audio/wavread.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/make/CMakeLists_gl-win-x86.txt
+++ b/make/CMakeLists_gl-win-x86.txt
@@ -88,6 +88,7 @@ add_executable(vpinball WIN32
    src/audio/wavread.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/make/VisualPinball.net2022.vcxproj
+++ b/make/VisualPinball.net2022.vcxproj
@@ -1130,6 +1130,7 @@
     </ClCompile>
     <ClCompile Include="src/core/extern.cpp" />
     <ClCompile Include="src/core/ieditable.cpp" />
+    <ClCompile Include="src/core/editablereg.cpp" />
     <ClCompile Include="src/core/iselect.cpp" />
     <ClCompile Include="src/core/pininput.cpp" />
     <ClCompile Include="src/core/pininput_OpenPinDev.cpp" />

--- a/src/core/editablereg.cpp
+++ b/src/core/editablereg.cpp
@@ -1,0 +1,4 @@
+#include "main.h"
+#include "editablereg.h"
+
+robin_hood::unordered_map<ItemTypeEnum, EditableInfo> EditableRegistry::m_map;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -216,8 +216,6 @@ int g_argc;
 char **g_argv;
 #endif
 
-robin_hood::unordered_map<ItemTypeEnum, EditableInfo> EditableRegistry::m_map;
-
 static const string options[] = { // keep in sync with option_names & option_descs!
    "h"s,
    "Help"s,

--- a/standalone/cmake/CMakeLists_bgfx-android-arm64-v8a.txt
+++ b/standalone/cmake/CMakeLists_bgfx-android-arm64-v8a.txt
@@ -62,6 +62,7 @@ add_library(vpinball SHARED
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_bgfx-linux-aarch64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-linux-aarch64.txt
@@ -75,6 +75,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_bgfx-linux-x64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-linux-x64.txt
@@ -63,6 +63,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_bgfx-macos-arm64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-macos-arm64.txt
@@ -66,6 +66,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_bgfx-macos-x64.txt
+++ b/standalone/cmake/CMakeLists_bgfx-macos-x64.txt
@@ -65,6 +65,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_bgfx_lib.txt
+++ b/standalone/cmake/CMakeLists_bgfx_lib.txt
@@ -84,6 +84,7 @@ add_library(vpinball SHARED
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_gl-android-arm64-v8a.txt
+++ b/standalone/cmake/CMakeLists_gl-android-arm64-v8a.txt
@@ -68,6 +68,7 @@ add_library(vpinball SHARED
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_gl-linux-aarch64.txt
+++ b/standalone/cmake/CMakeLists_gl-linux-aarch64.txt
@@ -81,6 +81,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_gl-linux-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-linux-x64.txt
@@ -68,6 +68,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_gl-macos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-arm64.txt
@@ -71,6 +71,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_gl-macos-x64.txt
+++ b/standalone/cmake/CMakeLists_gl-macos-x64.txt
@@ -71,6 +71,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h

--- a/standalone/cmake/CMakeLists_gl-tvos-arm64.txt
+++ b/standalone/cmake/CMakeLists_gl-tvos-arm64.txt
@@ -76,6 +76,7 @@ add_executable(vpinball
    src/audio/pinsound.h
 
    src/core/dispid.h
+   src/core/editablereg.cpp
    src/core/editablereg.h
    src/core/extern.cpp
    src/core/extern.h


### PR DESCRIPTION
I was trying to compile VPinball as a shared library for a side project. I used the standalone `CMakeLists_gl-linux-x64.txt` and remove the application entry point file `main.cpp` from compilation.

I had some linker issue for `EditableRegistry::m_map` static member.

This PR moves the implementation of this static member out of the `main.cpp`.
Now, this file is better centered around options parsing and application configuration and launch.