### PR TITLE
Ensure number of processors is strictly positive

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -448,9 +448,9 @@ public:
       //!! max(2u, std::thread::hardware_concurrency()) ??
       SYSTEM_INFO sysinfo;
       GetSystemInfo(&sysinfo);
-      m_vpinball.m_logicalNumberOfProcessors = sysinfo.dwNumberOfProcessors; //!! this ignores processor groups, so if at some point we need extreme multi threading, implement this in addition!
+      m_vpinball.SetLogicalNumberOfProcessors(sysinfo.dwNumberOfProcessors); //!! this ignores processor groups, so if at some point we need extreme multi threading, implement this in addition!
 #else
-      m_vpinball.m_logicalNumberOfProcessors = SDL_GetNumLogicalCPUCores();
+      m_vpinball.SetLogicalNumberOfProcessors(SDL_GetNumLogicalCPUCores());
 #endif
 
       IsOnWine(); // init static variable in there
@@ -593,7 +593,10 @@ public:
          //
 
          if (compare_option(szArglist[i], OPTION_LESSCPUTHREADS))
-             m_vpinball.m_logicalNumberOfProcessors = max(min(m_vpinball.m_logicalNumberOfProcessors, 2), m_vpinball.m_logicalNumberOfProcessors/4); // only use 1/4th the threads, but at least 2 (if there are 2)
+         {
+            int procCount = m_vpinball.GetLogicalNumberOfProcessors();
+            m_vpinball.SetLogicalNumberOfProcessors(max(min(procCount, 2), procCount/4)); // only use 1/4th the threads, but at least 2 (if there are 2)
+         }
 
          //
 
@@ -936,7 +939,7 @@ public:
 
 #ifdef __STANDALONE__
       PLOGI << "Settings file was loaded from " << m_szIniFileName;
-      PLOGI << "m_logicalNumberOfProcessors=" << m_vpinball.m_logicalNumberOfProcessors;
+      PLOGI << "m_logicalNumberOfProcessors=" << m_vpinball.GetLogicalNumberOfProcessors();
       PLOGI << "m_szMyPath=" << m_vpinball.m_szMyPath;
       PLOGI << "m_szMyPrefPath=" << m_vpinball.m_szMyPrefPath;
 

--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -1776,6 +1776,21 @@ void VPinball::ShowSubDialog(CDialog &dlg, const bool show)
 #endif
 }
 
+void VPinball::SetLogicalNumberOfProcessors(int procNumber)
+{
+   m_logicalNumberOfProcessors = procNumber;
+}
+
+int VPinball::GetLogicalNumberOfProcessors() const
+{
+   if (m_logicalNumberOfProcessors < 1) {
+      PLOGE << "Invalid number of processor " << m_logicalNumberOfProcessors << ". Fallback to single processor.";
+      return 1;
+   }
+
+   return m_logicalNumberOfProcessors;
+}
+
 int VPinball::OnCreate(CREATESTRUCT& cs)
 {
 #ifndef __STANDALONE__

--- a/src/core/vpinball_h.h
+++ b/src/core/vpinball_h.h
@@ -59,6 +59,9 @@ public:
 
    void ShowSubDialog(CDialog& dlg, const bool show);
 
+   void SetLogicalNumberOfProcessors(int procNumber);
+   int GetLogicalNumberOfProcessors() const;
+
 private:
    void ShowSearchSelect();
    void SetDefaultPhysics();
@@ -264,7 +267,6 @@ public:
    volatile bool m_table_played_via_SelectTableOnStart;
    bool m_bgles; // override global emission scale by m_fgles below?
    float m_fgles;
-   int m_logicalNumberOfProcessors;
    WCHAR *m_customParameters[MAX_CUSTOM_PARAM_INDEX];
 
    HBITMAP m_hbmInPlayMode;
@@ -302,6 +304,7 @@ private:
    //CMenu m_mainMenu;
    vector<string> m_recentTableList;
 
+   int m_logicalNumberOfProcessors;
    HANDLE  m_workerthread;
    unsigned int m_workerthreadid;
    bool    m_closing;

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -4084,7 +4084,7 @@ HRESULT PinTable::LoadGameFromFilename(const string& szFileName)
             assert(m_vimage.empty());
             m_vimage.resize(ctextures); // due to multithreaded loading do pre-allocation
             {
-               ThreadPool pool(g_pvp->m_logicalNumberOfProcessors); //!! Note that this dramatically increases the amount of temporary memory needed, especially if Max Texture Dimension is set (as then all the additional conversion/rescale mem is also needed 'in parallel')
+               ThreadPool pool(g_pvp->GetLogicalNumberOfProcessors()); //!! Note that this dramatically increases the amount of temporary memory needed, especially if Max Texture Dimension is set (as then all the additional conversion/rescale mem is also needed 'in parallel')
 
                int count = 0;
                for (int i = 0; i < ctextures; i++)

--- a/src/parts/primitive.cpp
+++ b/src/parts/primitive.cpp
@@ -1802,7 +1802,7 @@ bool Primitive::LoadToken(const int id, BiffReader * const pbr)
       mz_uint8 * c = (mz_uint8 *)malloc(m_compressedVertices);
       pbr->GetStruct(c, m_compressedVertices);
 	  if (g_pPrimitiveDecompressThreadPool == nullptr)
-		  g_pPrimitiveDecompressThreadPool = new ThreadPool(g_pvp->m_logicalNumberOfProcessors);
+		  g_pPrimitiveDecompressThreadPool = new ThreadPool(g_pvp->GetLogicalNumberOfProcessors());
 
 	  g_pPrimitiveDecompressThreadPool->enqueue([uclen, c, this] {
 		  mz_ulong uclen2 = uclen;
@@ -1842,7 +1842,7 @@ bool Primitive::LoadToken(const int id, BiffReader * const pbr)
          mz_uint8 * c = (mz_uint8 *)malloc(m_compressedIndices);
          pbr->GetStruct(c, m_compressedIndices);
 		 if (g_pPrimitiveDecompressThreadPool == nullptr)
-			 g_pPrimitiveDecompressThreadPool = new ThreadPool(g_pvp->m_logicalNumberOfProcessors);
+			 g_pPrimitiveDecompressThreadPool = new ThreadPool(g_pvp->GetLogicalNumberOfProcessors());
 
 		 g_pPrimitiveDecompressThreadPool->enqueue([uclen, c, this] {
 			 mz_ulong uclen2 = uclen;
@@ -1860,7 +1860,7 @@ bool Primitive::LoadToken(const int id, BiffReader * const pbr)
          mz_uint8 * c = (mz_uint8 *)malloc(m_compressedIndices);
          pbr->GetStruct(c, m_compressedIndices);
          if (g_pPrimitiveDecompressThreadPool == nullptr)
-            g_pPrimitiveDecompressThreadPool = new ThreadPool(g_pvp->m_logicalNumberOfProcessors);
+            g_pPrimitiveDecompressThreadPool = new ThreadPool(g_pvp->GetLogicalNumberOfProcessors());
 
          g_pPrimitiveDecompressThreadPool->enqueue([uclen, c, this] {
             vector<WORD> tmp(m_numIndices);

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -593,7 +593,7 @@ BaseTexture* Renderer::EnvmapPrecalc(const Texture* envTex, const unsigned int r
    //!! (note though that even 4096 samples can be too low if very bright spots (i.e. sun) in the image! see Delta_2k.hdr -> thus pre-filter enabled above!)
    // but with this implementation one can also have custom maps/LUTs for glossy, etc. later-on
    {
-      ThreadPool pool(g_pvp->m_logicalNumberOfProcessors);
+      ThreadPool pool(g_pvp->GetLogicalNumberOfProcessors());
 
       for (unsigned int y = 0; y < rad_env_yres; ++y) {
          pool.enqueue([y, rad_envmap, rad_format, rad_env_xres, rad_env_yres, envmap, env_format, env_xres, env_yres] {

--- a/standalone/VPinballLib.cpp
+++ b/standalone/VPinballLib.cpp
@@ -48,14 +48,14 @@ void VPinball::Init(std::function<void*(Event, void*)> callback)
    SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 
    g_pvp = new ::VPinball();
-   g_pvp->m_logicalNumberOfProcessors = SDL_GetNumLogicalCPUCores();
+   g_pvp->SetLogicalNumberOfProcessors(SDL_GetNumLogicalCPUCores());
    g_pvp->m_settings.LoadFromFile(g_pvp->m_szMyPrefPath + "VPinballX.ini", true);
 
    Logger::GetInstance()->Init();
    Logger::GetInstance()->SetupLogger(true);
 
    PLOGI << "VPX - " << VP_VERSION_STRING_FULL_LITERAL;
-   PLOGI << "m_logicalNumberOfProcessors=" << g_pvp->m_logicalNumberOfProcessors;
+   PLOGI << "m_logicalNumberOfProcessors=" << g_pvp->GetLogicalNumberOfProcessors();
    PLOGI << "m_szMyPath=" << g_pvp->m_szMyPath;
    PLOGI << "m_szMyPrefPath=" << g_pvp->m_szMyPrefPath;
 
@@ -104,7 +104,7 @@ void VPinball::ResetLog()
    Logger::GetInstance()->Truncate();
 
    PLOGI << "VPX - " << VP_VERSION_STRING_FULL_LITERAL;
-   PLOGI << "m_logicalNumberOfProcessors=" << g_pvp->m_logicalNumberOfProcessors;
+   PLOGI << "m_logicalNumberOfProcessors=" << g_pvp->GetLogicalNumberOfProcessors();
    PLOGI << "m_szMyPath=" << g_pvp->m_szMyPath;
    PLOGI << "m_szMyPrefPath=" << g_pvp->m_szMyPrefPath;
 }
@@ -806,7 +806,7 @@ void VPinball::Cleanup()
    delete g_pvp;
    g_pvp = new ::VPinball();
    g_pvp->m_settings.LoadFromFile(g_pvp->m_szMyPrefPath + "VPinballX.ini", true);
-   g_pvp->m_logicalNumberOfProcessors = SDL_GetNumLogicalCPUCores();
+   g_pvp->SetLogicalNumberOfProcessors(SDL_GetNumLogicalCPUCores());
    
    {
       std::lock_guard<std::mutex> lock(m_liveUIMutex);


### PR DESCRIPTION
If someone forgot to set the value of `VPinball::m_logicalNumberOfProcessors` (as I did), the default value will be -1.

This can cause a huge number of threads to be spawn due to ThreadPool [stop condition](https://github.com/vpinball/vpinball/blob/master/third-party/include/ThreadPool.h#L113) not taking in account possible negative numbers and spawning nearly infinite threads.

This PR ensures that any use of `VPinball::m_logicalNumberOfProcessors` returns a valid positive number of processors.
A log line will tell the user that something is wrong and the application will run with a very limited number of threads until VPinball class configuration is fixed.

Another solution would have been to raise an exception and crash the application if a not strictly positive.
I prefer the solution of having an error message and the application continue running in non-optimal state.
I can switch to raising an exception if you like it better.

**Before:**

![before](https://github.com/user-attachments/assets/c50fa263-b39c-42b9-a993-289a98de78ba)

**After:**

![after](https://github.com/user-attachments/assets/685aa5ce-08c2-4086-a366-5f59bede399e)
