### PR TITLE
Switch plugin onGameStart error to warning

### DIFF
--- a/src/plugins/VPXPluginAPIImpl.cpp
+++ b/src/plugins/VPXPluginAPIImpl.cpp
@@ -155,7 +155,7 @@ void VPXPluginAPIImpl::PinMameOnStart()
             }
          }else
          {
-            PLOGE << "Failed to get cGameName property from script, can't broadcast onGameStart event";
+            PLOGW << "Failed to get cGameName property from script, can't broadcast onGameStart event";
          }
       }
       pScriptDispatch->Release();


### PR DESCRIPTION
We have seen users reporting this error over and over again. Since these plugins are not really in use it can be a warning for now.