### PR TITLE
android: mark app as game

### DIFF
--- a/standalone/android/app/src/main/AndroidManifest.xml
+++ b/standalone/android/app/src/main/AndroidManifest.xml
@@ -75,7 +75,9 @@
             android:allowBackup="true"
             android:theme="@style/Theme.VPinball"
             android:hardwareAccelerated="true"
-            android:largeHeap="true">
+            android:largeHeap="true"
+            android:isGame="true"
+            android:appCategory="game">
 
         <meta-data android:name="SDL_ENV.SDL_ACCELEROMETER_AS_JOYSTICK" android:value="0"/>
         <provider


### PR DESCRIPTION
https://developer.android.com/guide/topics/manifest/application-element

`isGame` is deprecated but seems to still be used a lot as a did a search on github.
https://github.com/search?q=android%3AappCategory%3D%22game%22&type=code&p=2