### PR TITLE
pup: include font style in name

### DIFF
--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -149,12 +149,16 @@ bool PUPManager::AddFont(TTF_Font* pFont, const string& szFilename)
       return false;
 
    string szFamilyName = string(TTF_GetFontFamilyName(pFont));
-   string szNormalizedFamilyName = string_to_lower(string_replace_all(szFamilyName, "  ", " "));
+   string szStyleName = string(TTF_GetFontStyleName(pFont));
+   string szFullName = szFamilyName;
+   if (szStyleName != "Regular")
+      szFullName += " " + szStyleName;
+   string szNormalizedFullName = string_to_lower(string_replace_all(szFullName, "  ", " "));
 
-   m_fontMap[szNormalizedFamilyName] = pFont;
+   m_fontMap[szNormalizedFullName] = pFont;
    m_fontFilenameMap[string_to_lower(szFilename.substr(0, szFilename.length() - 4))] = pFont;
 
-   PLOGI.printf("Font added: familyName=%s, filename=%s", szFamilyName.c_str(), szFilename.c_str());
+   PLOGI.printf("Font added: familyName=%s, styleName=%s, filename=%s", szFamilyName.c_str(), szStyleName.c_str(), szFilename.c_str());
 
    return true;
 }


### PR DESCRIPTION
The pup pack fonts dir has this font: `NeueAlteGrotesk-Bold.ttf`
The pup pack itself seems to reference `Neue Alte Grotesk Bold`

```
2025-01-19 16:44:21.919 ERROR [381750] [PUPLabel::PUPLabel@23] Font not found: label=PrevP2Combo, font=Neue Alte Grotesk Bold
```

The code tries to find the fonts by looking in the `m_fontMap` and the `m_fontFilenameMap`. File name matching obviously does not work here.

Normalized font name is `neue alte grotesk bold`

`m_fontMap` used to contain contains this:
![Image](https://github.com/user-attachments/assets/db688e6d-c058-4018-9d8f-af3f00e42d10)

Looks like on windows the style name is also added in case it's not regular.

This PR fixes that.