### PR TITLE
pup: include font style in name (revised)

### DIFF
--- a/standalone/inc/pup/PUPManager.h
+++ b/standalone/inc/pup/PUPManager.h
@@ -84,6 +84,7 @@ private:
    string m_szRootPath;
    string m_szPath;
    std::map<int, PUPScreen*> m_screenMap;
+   vector<TTF_Font*> m_fonts;
    std::map<string, TTF_Font*> m_fontMap;
    std::map<string, TTF_Font*> m_fontFilenameMap;
    vector<PUPWindow*> m_windows;


### PR DESCRIPTION
Did some more testing and for `Total Nuclear Annihilation` stylized fonts are referenced without their style.

I think it's still not ideal, when there are two styles of the same font and a font is requested without style suffix it might pick the wrong style (the last one loaded). 