### PR TITLE
plugins: continue loading other plugins if one fails

### DIFF
--- a/src/plugins/MsgPluginManager.cpp
+++ b/src/plugins/MsgPluginManager.cpp
@@ -310,7 +310,7 @@ void MsgPluginManager::ScanPluginFolder(const std::string& pluginDir, const std:
             if (!std::filesystem::exists(libraryPath))
             {
                PLOGE << "Plugin " << id << " has an invalid library reference to a missing file for " << libraryKey << ": " << libraryFile;
-               return;
+               continue;
             }
             std::shared_ptr<MsgPlugin> plugin = std::make_shared<MsgPlugin>(id, 
                unquote(ini["configuration"s].get("name"s)),


### PR DESCRIPTION
I would expect it to stop vpinball or ignore the failing plugin.

Currently it stops loading other plugins but then happily continues loading the table.