### PR TITLE
logs: move pup logs to info for anything non-warning

### DIFF
--- a/standalone/inc/pup/PUPMediaManager.cpp
+++ b/standalone/inc/pup/PUPMediaManager.cpp
@@ -26,7 +26,7 @@ void PUPMediaManager::Play(PUPPlaylist* pPlaylist, const string& szPlayFile, flo
       return;
    }
 
-   PLOGW.printf("screen={%s}, playlist={%s}, playFile=%s, path=%s, volume=%.1f, priority=%d",
+   PLOGD.printf("screen={%s}, playlist={%s}, playFile=%s, path=%s, volume=%.1f, priority=%d",
       m_pScreen->ToString(false).c_str(), pPlaylist->ToString().c_str(), szPlayFile.c_str(), szPath.c_str(), volume, priority);
 
    m_pMainPlayer->player.Play(szPath);
@@ -46,17 +46,17 @@ void PUPMediaManager::SetBG(bool isBackground)
 {
    if (isBackground) {
       if (m_pBackgroundPlayer) {
-         PLOGW.printf("Stopping background player, screen={%s}", m_pScreen->ToString(false).c_str());
+         PLOGD.printf("Stopping background player, screen={%s}", m_pScreen->ToString(false).c_str());
          m_pBackgroundPlayer->player.Stop();
       }
-      PLOGW.printf("Transferring main player to background, screen={%s}", m_pScreen->ToString(false).c_str());
+      PLOGD.printf("Transferring main player to background, screen={%s}", m_pScreen->ToString(false).c_str());
       m_pBackgroundPlayer = m_pMainPlayer;
       m_pBackgroundPlayer->player.SetLoop(true);
       m_pMainPlayer = (m_pMainPlayer == &m_player1) ? &m_player2 : &m_player1;
    }
    else {
       if (m_pBackgroundPlayer) {
-         PLOGW.printf("Removing looping from background player, screen={%s}", m_pScreen->ToString(false).c_str());
+         PLOGD.printf("Removing looping from background player, screen={%s}", m_pScreen->ToString(false).c_str());
          m_pBackgroundPlayer->player.SetLoop(false);
       }
    }
@@ -75,11 +75,11 @@ void PUPMediaManager::Stop()
 void PUPMediaManager::Stop(int priority)
 {
    if (priority > m_pMainPlayer->priority) {
-      PLOGW.printf("Priority > main player priority: screen={%s}, priority=%d", m_pScreen->ToString(false).c_str(), priority);
+      PLOGD.printf("Priority > main player priority: screen={%s}, priority=%d", m_pScreen->ToString(false).c_str(), priority);
       m_pMainPlayer->player.Stop();
    }
    else {
-      PLOGW.printf("Priority <= main player priority: screen={%s}, priority=%d", m_pScreen->ToString(false).c_str(), priority);
+      PLOGD.printf("Priority <= main player priority: screen={%s}, priority=%d", m_pScreen->ToString(false).c_str(), priority);
    }
 }
 
@@ -87,7 +87,7 @@ void PUPMediaManager::Stop(PUPPlaylist* pPlaylist, const string& szPlayFile)
 {
    string szPath = pPlaylist->GetPlayFilePath(szPlayFile);
    if (!szPath.empty() && szPath == m_pMainPlayer->szPath) {
-      PLOGW.printf("Main player path match: screen={%s}, path=%s", m_pScreen->ToString(false).c_str(), szPath.c_str());
+      PLOGD.printf("Main player path match: screen={%s}, path=%s", m_pScreen->ToString(false).c_str(), szPath.c_str());
       m_pMainPlayer->player.Stop();
    }
    else {

--- a/standalone/inc/pup/PUPMediaPlayer.cpp
+++ b/standalone/inc/pup/PUPMediaPlayer.cpp
@@ -75,7 +75,7 @@ void PUPMediaPlayer::SetRenderer(SDL_Renderer* pRenderer)
 
 void PUPMediaPlayer::Play(const string& szFilename)
 {
-   PLOGW.printf("filename=%s", szFilename.c_str());
+   PLOGD.printf("filename=%s", szFilename.c_str());
 
    Stop();
 
@@ -173,7 +173,7 @@ void PUPMediaPlayer::Play(const string& szFilename)
       return;
    }
 
-   PLOGW.printf("Playing: filename=%s", m_szFilename.c_str());
+   PLOGD.printf("Playing: filename=%s", m_szFilename.c_str());
    m_pAudioPlayer->StreamVolume(0);
 
    m_running = true;
@@ -196,7 +196,7 @@ void PUPMediaPlayer::Pause(bool pause)
 void PUPMediaPlayer::Stop()
 {
    if (IsPlaying()) {
-      PLOGW.printf("Stop: %s", m_szFilename.c_str());
+      PLOGD.printf("Stop: %s", m_szFilename.c_str());
    }
 
    {
@@ -266,7 +266,7 @@ void PUPMediaPlayer::Run()
       if (!flushing) {
          if (av_read_frame(m_pFormatContext, pPacket) < 0) {
             if (count == 0)  {
-               PLOGW.printf("End of stream, finishing decode: %s", m_szFilename.c_str());
+               PLOGD.printf("End of stream, finishing decode: %s", m_szFilename.c_str());
             }
 
             if (m_pAudioContext)
@@ -372,7 +372,7 @@ void PUPMediaPlayer::SetLoop(bool loop)
 {
    std::lock_guard<std::mutex> lock(m_mutex);
    if (m_loop != loop) {
-      PLOGW.printf("setting loop: loop=%d", loop);
+      PLOGD.printf("setting loop: loop=%d", loop);
       m_loop = loop;
    }
 }
@@ -381,7 +381,7 @@ void PUPMediaPlayer::SetVolume(float volume)
 {
    std::lock_guard<std::mutex> lock(m_mutex);
    if (m_volume != volume) {
-       PLOGW.printf("setting volume: volume=%.1f%%", volume);
+       PLOGD.printf("setting volume: volume=%.1f%%", volume);
        m_volume = volume;
    }
 }

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -403,7 +403,7 @@ void PUPScreen::QueuePlay(const string& szPlaylist, const string& szPlayFile, fl
       return;
    }
 
-   PLOGW.printf("queueing play, screen={%s}, playlist={%s}, playFile=%s, volume=%.f, priority=%d",
+   PLOGD.printf("queueing play, screen={%s}, playlist={%s}, playFile=%s, volume=%.f, priority=%d",
       ToString(false).c_str(), pPlaylist->ToString().c_str(), szPlayFile.c_str(), volume, priority);
 
    PUPPinDisplayRequest* pRequest = new PUPPinDisplayRequest();
@@ -422,7 +422,7 @@ void PUPScreen::QueuePlay(const string& szPlaylist, const string& szPlayFile, fl
 
 void PUPScreen::QueueStop()
 {
-   PLOGW.printf("queueing stop, screen={%s}", ToString(false).c_str());
+   PLOGD.printf("queueing stop, screen={%s}", ToString(false).c_str());
 
    PUPPinDisplayRequest* pRequest = new PUPPinDisplayRequest();
    pRequest->type = PUP_PINDISPLAY_REQUEST_TYPE_STOP;
@@ -436,7 +436,7 @@ void PUPScreen::QueueStop()
 
 void PUPScreen::QueueLoop(int state)
 {
-   PLOGW.printf("queueing loop, screen={%s}, state=%d", ToString(false).c_str(), state);
+   PLOGD.printf("queueing loop, screen={%s}, state=%d", ToString(false).c_str(), state);
 
    PUPPinDisplayRequest* pRequest = new PUPPinDisplayRequest();
    pRequest->type = PUP_PINDISPLAY_REQUEST_TYPE_LOOP;
@@ -451,7 +451,7 @@ void PUPScreen::QueueLoop(int state)
 
 void PUPScreen::QueueBG(int mode)
 {
-   PLOGW.printf("queueing bg, screen={%s}, mode=%d", ToString(false).c_str(), mode);
+   PLOGD.printf("queueing bg, screen={%s}, mode=%d", ToString(false).c_str(), mode);
 
    PUPPinDisplayRequest* pRequest = new PUPPinDisplayRequest();
    pRequest->type = PUP_PINDISPLAY_REQUEST_TYPE_SET_BG;
@@ -488,7 +488,7 @@ void PUPScreen::QueueTrigger(char type, int number, int value)
 
 void PUPScreen::Start()
 {
-   PLOGW.printf("Starting: screen={%s}", ToString(false).c_str());
+   PLOGD.printf("Starting: screen={%s}", ToString(false).c_str());
 
    m_isRunning = true;
    m_thread = std::thread(&PUPScreen::ProcessQueue, this);
@@ -496,7 +496,7 @@ void PUPScreen::Start()
 
 void PUPScreen::Init(SDL_Renderer* pRenderer)
 {
-   PLOGW.printf("Initializing: screen={%s}", ToString(false).c_str());
+   PLOGD.printf("Initializing: screen={%s}", ToString(false).c_str());
 
    m_pRenderer = pRenderer;
 
@@ -538,7 +538,7 @@ void PUPScreen::ProcessQueue()
 
 void PUPScreen::ProcessPinDisplayRequest(PUPPinDisplayRequest* pRequest)
 {
-   PLOGW.printf("processing pin display request: screen={%s}, type=%s, playlist={%s}, playFile=%s, volume=%.1f, priority=%d, value=%d",
+   PLOGD.printf("processing pin display request: screen={%s}, type=%s, playlist={%s}, playFile=%s, volume=%.1f, priority=%d, value=%d",
       ToString(false).c_str(),
       PUP_PINDISPLAY_REQUEST_TYPE_TO_STRING(pRequest->type),
       pRequest->pPlaylist ? pRequest->pPlaylist->ToString().c_str() : "",
@@ -591,7 +591,7 @@ void PUPScreen::ProcessTriggerRequest(PUPTriggerRequest* pRequest)
    }
    pTrigger->SetTriggered();
 
-   PLOGW.printf("processing trigger: trigger={%s}", pTrigger->ToString().c_str());
+   PLOGD.printf("processing trigger: trigger={%s}", pTrigger->ToString().c_str());
 
    switch(pTrigger->GetPlayAction()) {
       case PUP_TRIGGER_PLAY_ACTION_NORMAL:


### PR DESCRIPTION
Currently anything pup pack related is logged on `warn` level which is annoying if you are looking for actual issues.