### PR TITLE
listres: Show error if sdl init fails

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -861,6 +861,12 @@ public:
          std::filesystem::create_directory(PATH_USER);
 
       if (m_listRes) {
+         if (!SDL_Init(SDL_INIT_VIDEO))
+         {
+            PLOGE << "SDL_Init(SDL_INIT_VIDEO) failed: " << SDL_GetError();
+            exit(1);
+         }
+         PLOGI << "Using video driver " << SDL_GetCurrentVideoDriver();
          PLOGI << "Available fullscreen resolutions:";
          vector<VPX::Window::DisplayConfig> displays;
          VPX::Window::GetDisplays(displays);


### PR DESCRIPTION
An example case is when compiling sdl on linux with some wayland dependencies missing and then using SDL_VIDEODRIVER=wayland the init will fail.
