### PR TITLE
Physics: cleanup and optimisation of Quad/KDTree

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1320,7 +1320,6 @@ HitBall *Player::CreateBall(const float x, const float y, const float z, const f
    m_pBall->m_hitBall.m_d.m_vel.x = vx;
    m_pBall->m_hitBall.m_d.m_vel.y = vy;
    m_pBall->m_hitBall.m_d.m_vel.z = vz;
-   m_pBall->m_hitBall.CalcHitBBox(); // need to update here, as only done lazily
    m_pBall->m_d.m_useTableRenderSettings = true;
    m_ptable->m_vedit.push_back(m_pBall);
    m_vhitables.push_back(m_pBall);
@@ -2112,8 +2111,6 @@ void Player::PrepareFrame(const std::function<void()>& sync)
    
    VPXPluginAPIImpl::GetInstance().BroadcastVPXMsg(m_onPrepareFrameMsgId, nullptr);
    
-   m_physics->OnPrepareFrame();
-
    #ifdef EXT_CAPTURE
    // Trigger captures
    if (m_renderer->m_stereo3D == STEREO_VR)
@@ -2175,6 +2172,7 @@ void Player::PrepareFrame(const std::function<void()>& sync)
          if (m_liveUIOverride)
             VPinballLib::VPinball::SendEvent(VPinballLib::Event::LiveUIUpdate, nullptr);
       #endif
+      m_physics->ResetPerFrameStats();
    }
 
    // Shake screen when nudging

--- a/src/parts/ball.cpp
+++ b/src/parts/ball.cpp
@@ -26,7 +26,6 @@ Ball::Ball() : m_id(GetNextBallID())
    m_hitBall.m_d.m_mass = 1.f;
    m_hitBall.m_pBall = this;
    m_hitBall.m_editable = this;
-   m_hitBall.CalcHitBBox(); // need to update here, as only done lazily
 }
 
 Ball::~Ball()
@@ -209,14 +208,12 @@ void Ball::EndPlay() { IEditable::EndPlay(); }
 
 void Ball::PhysicSetup(PhysicsEngine* physics, const bool isUI)
 {
-   if (!isUI)
-      physics->AddBall(&m_hitBall);
+   physics->AddCollider(&m_hitBall, this, isUI);
 }
 
 void Ball::PhysicRelease(PhysicsEngine* physics, const bool isUI)
 {
-   if (!isUI)
-      physics->RemoveBall(&m_hitBall);
+   physics->RemoveCollider(&m_hitBall, this, isUI);
 }
 
 #pragma endregion

--- a/src/parts/surface.cpp
+++ b/src/parts/surface.cpp
@@ -362,7 +362,7 @@ void Surface::PhysicSetup(PhysicsEngine* physics, const bool isUI)
       rgv3Dt[i].y = pv1->y;
       rgv3Dt[i].z = top;
 
-      if (m_d.m_isBottomSolid)
+      if (m_d.m_isBottomSolid || isUI)
       {
          rgv3Db[count - 1 - i].x = pv1->x;
          rgv3Db[count - 1 - i].y = pv1->y;

--- a/src/physics/kdtree.h
+++ b/src/physics/kdtree.h
@@ -6,9 +6,9 @@
 #include "physics/collide.h"
 
 #ifdef ENABLE_SSE_OPTIMIZATIONS
-#define KDTREE_SSE_LEAFTEST
+   #define KDTREE_SSE_LEAFTEST
 #else
-#pragma message ("Warning: No SSE kdtree tests")
+   #pragma message ("Warning: No SSE kdtree tests")
 #endif
 
 class HitKD;
@@ -16,24 +16,18 @@ class HitKD;
 class HitKDNode final
 {
 private:
-   void Reset() { m_children = nullptr; m_hitoct = nullptr; m_start = 0; m_items = 0; }
+   void Reset() { m_children = nullptr; m_start = 0; m_items = 0; }
 
-   void HitTestBall(const HitBall* const pball, CollisionEvent& coll) const;
-   void HitTestXRay(const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const;
+   void HitTestBall(const HitKD* hitoct, const HitBall* const pball, CollisionEvent& coll) const;
+   void HitTestXRay(const HitKD* hitoct, const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const;
 
-   void CreateNextLevel(const unsigned int level, unsigned int level_empty);
-
-#ifdef KDTREE_SSE_LEAFTEST
-   void HitTestBallSse(const HitBall* const pball, CollisionEvent& coll) const;
-#endif
+   void CreateNextLevel(HitKD* hitoct, const unsigned int level, unsigned int level_empty);
 
    FRect3D m_rectbounds;
-   unsigned int m_start;
-   unsigned int m_items; // contains the 2 bits for axis (bits 30/31)
+   unsigned int m_start; // index of first item in HitKD.m_vho
+   unsigned int m_items; // number of items (bit 0..29) and axis (bits 30..31)
 
    HitKDNode * m_children; // if nullptr, is a leaf; otherwise keeps the 2 children
-
-   HitKD * m_hitoct; //!! meh, stupid
 
    friend class HitKD;
 };
@@ -44,68 +38,49 @@ public:
    HitKD();
    ~HitKD();
 
-   void Init(vector<HitObject*> &vho);
+   void Reset(const vector<HitObject*> &vho);
+   void Insert(HitObject* ho);
+   void Remove(HitObject* ho);
+   void Update(); // call when the bounding boxes of the HitObjects have changed to update the tree
+   void Finalize(); // call when finalizing a tree (no dynamic changes planned on it)
+   const vector<HitObject*>& GetHitObjects() const { return m_vho; }
 
-   void AddElementByIndex(unsigned i)
-   {
-      m_org_idx.push_back(i);
-   }
-
-   void FillFromVector(vector<HitObject*> &vho);
+   // FIXME dead code. Remove ?
+   void AddElementByIndex(unsigned i) { m_org_idx.push_back(i); }
    void FillFromIndices();
    void FillFromIndices(const FRect3D& initialBounds);
-
-   // call when the bounding boxes of the HitObjects have changed to update the tree
-   void Update();
-
-   // call when finalizing a tree (no dynamic changes planned on it)
-   void Finalize();
 
    unsigned int GetObjectCount() const { return m_num_items; }
    unsigned int GetNLevels() const { return m_nLevels; }
 
-   void HitTestBall(const HitBall* const pball, CollisionEvent& coll) const
-   {
-#ifdef KDTREE_SSE_LEAFTEST
-      m_rootNode.HitTestBallSse(pball, coll);
-#else
-      m_rootNode.HitTestBall(pball, coll);
-#endif
-   }
-
-   void HitTestXRay(const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const
-   {
-      m_rootNode.HitTestXRay(pball, pvhoHit, coll);
-   }
+   void HitTestBall(const HitBall* const pball, CollisionEvent& coll) const { m_rootNode.HitTestBall(this, pball, coll); }
+   void HitTestXRay(const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const { m_rootNode.HitTestXRay(this, pball, pvhoHit, coll); }
 
 private:
-
+   void Initialize();
    void InitSseArrays();
 
+   vector<HitObject*> m_vho; // all items
+   unsigned int m_num_items = 0; // alias of m_vho.size()
+   unsigned int m_max_items = 0;
+
    vector<unsigned int> m_org_idx;
+   HitObject* GetItemAt(const unsigned i) const { return m_vho[m_org_idx[i]]; }
 
    HitKDNode m_rootNode;
-
-   unsigned int m_num_items;
-   unsigned int m_max_items;
-
-   HitObject* GetItemAt(const unsigned i) const
-   {
-      return (*m_org_vho)[m_org_idx[i]];
-   }
-
+   
+   // Node pool
+   vector<HitKDNode> m_nodes;
+   unsigned m_num_nodes = 0;
    HitKDNode* AllocTwoNodes();
 
-   vector<HitObject*> *m_org_vho;
    vector<unsigned int> tmp;
-#ifdef KDTREE_SSE_LEAFTEST
-   float * __restrict l_r_t_b_zl_zh;
-#endif
 
-   vector< HitKDNode > m_nodes;
-   unsigned m_num_nodes;
-
-   friend class HitKDNode;
+   #ifdef KDTREE_SSE_LEAFTEST
+      float * __restrict l_r_t_b_zl_zh = nullptr;
+   #endif
 
    unsigned int m_nLevels = 0;
+
+   friend class HitKDNode;
 };

--- a/src/physics/quadtree.cpp
+++ b/src/physics/quadtree.cpp
@@ -4,67 +4,137 @@
 #include "quadtree.h"
 
 #ifdef ENABLE_SSE_OPTIMIZATIONS
-#define QUADTREE_SSE_LEAFTEST
+   #define QUADTREE_SSE_LEAFTEST
 #else
-#pragma message ("Warning: No SSE quadtree tests")
+   #pragma message ("Warning: No SSE quadtree tests")
 #endif
 
+#define MAX_LEVEL 128
+
+#ifdef USE_EMBREE
+   #include <mutex>
+   static std::mutex mtx;
+
+   #define CHECK_EMBREE(dev) \
+      { const RTCError rc = rtcGetDeviceError(dev); \
+      switch (rc) { \
+         case RTC_ERROR_NONE: break; \
+         default: { char error[256]; sprintf_s(error, sizeof(error), "%u %s %d",rc,__FILE__,__LINE__); ShowError(error); break; }; \
+      }}
+
+   void EmbreeBoundsFunc(const struct RTCBoundsFunctionArguments* const args)
+   {
+      const HitObject * const ho = (*((const vector<HitObject*> *)args->geometryUserPtr))[args->primID];
+      args->bounds_o->lower_x = ho->m_hitBBox.left;
+      args->bounds_o->lower_y = ho->m_hitBBox.top;
+      args->bounds_o->lower_z = ho->m_hitBBox.zlow;
+      args->bounds_o->upper_x = ho->m_hitBBox.right;
+      args->bounds_o->upper_y = ho->m_hitBBox.bottom;
+      args->bounds_o->upper_z = ho->m_hitBBox.zhigh;
+   }
+#endif
+
+
+
+HitQuadtree::HitQuadtree()
+{
+   m_bounds.Clear();
+#ifdef USE_EMBREE
+   m_embree_device = rtcNewDevice(nullptr);
+   m_scene = nullptr;
+#endif
+}
+   
 HitQuadtree::~HitQuadtree()
 {
-   Reset(vector<HitObject*>());
-}
-
-void HitQuadtree::Reset(const vector<HitObject*>& vho)
-{
 #ifndef USE_EMBREE
-   if (lefts_rights_tops_bottoms_zlows_zhighs != nullptr)
-      _aligned_free(lefts_rights_tops_bottoms_zlows_zhighs);
-   lefts_rights_tops_bottoms_zlows_zhighs = 0;
-
-   if (!m_leaf)
-      delete[] m_children;
-   m_leaf = true;
-   m_children = nullptr;
-   m_unique = nullptr;
-
+   #ifdef QUADTREE_SSE_LEAFTEST
+      if (l_r_t_b_zl_zh)
+         _aligned_free(l_r_t_b_zl_zh);
+   #endif
 #else
-   rtcReleaseScene(m_scene);
+   if (m_scene)
+      rtcReleaseScene(m_scene);
    rtcReleaseDevice(m_embree_device);
    m_embree_device = rtcNewDevice(nullptr);
    m_scene = nullptr;
 #endif
-
-   m_vho = vho;
 }
 
-#ifdef USE_EMBREE
-#include <mutex>
-static std::mutex mtx;
-
-#define CHECK_EMBREE(dev) \
-   { const RTCError rc = rtcGetDeviceError(dev); \
-   switch (rc) { \
-      case RTC_ERROR_NONE: break; \
-      default: { char error[256]; sprintf_s(error, sizeof(error), "%u %s %d",rc,__FILE__,__LINE__); ShowError(error); break; }; \
-   }}
-
-void EmbreeBoundsFunc(const struct RTCBoundsFunctionArguments* const args)
+void HitQuadtree::Reset(const vector<HitObject*>& vho)
 {
-   const HitObject * const ho = (*((const vector<HitObject*> *)args->geometryUserPtr))[args->primID];
-
-   args->bounds_o->lower_x = ho->m_hitBBox.left;
-   args->bounds_o->lower_y = ho->m_hitBBox.top;
-   args->bounds_o->lower_z = ho->m_hitBBox.zlow;
-   args->bounds_o->upper_x = ho->m_hitBBox.right;
-   args->bounds_o->upper_y = ho->m_hitBBox.bottom;
-   args->bounds_o->upper_z = ho->m_hitBBox.zhigh;
+   m_vho = vho;
+   Update();
 }
-#endif
+
+void HitQuadtree::Insert(HitObject* ho)
+{
+   m_vho.push_back(ho);
+   Initialize();
+}
+
+void HitQuadtree::Remove(HitObject* ho)
+{
+   vector<HitObject*>::const_iterator it = std::find(m_vho.begin(), m_vho.end(), ho);
+   if (it != m_vho.end())
+      m_vho.erase(it);
+   Initialize();
+}
+
+void HitQuadtree::Update()
+{
+   // need to update here, as only done lazily for balls
+   for (size_t i = 0; i < m_vho.size(); ++i)
+      m_vho[i]->CalcHitBBox();
+   Initialize();
+}
 
 void HitQuadtree::Initialize()
 {
+#ifndef USE_EMBREE
+   if (m_vho.size() > m_maxItems)
+   {
+      m_maxItems = m_vho.size();
+
+      m_tmp1.resize(m_maxItems);
+      m_tmp2.resize(m_maxItems);
+
+      #ifdef QUADTREE_SSE_LEAFTEST
+         if (l_r_t_b_zl_zh)
+            _aligned_free(l_r_t_b_zl_zh);
+         l_r_t_b_zl_zh = (float*)_aligned_malloc(sizeof(float) * ((m_maxItems + 3) & 0xFFFFFFFC) * 6, 16);
+      #endif
+
+      m_nodes.clear();
+      // Unfortunately, there is no a priori bound on the number of nodes in the tree. We just make
+      // an educated guess on the maximum and truncate the subdivision if we run out of nodes.
+      m_nodes.resize((m_vho.size() * 2 + 1) & ~3u); // Nodes are allocated 4 by 4, so round up accordingly
+   }
+
+   // did somebody call finalize inbetween?
+   if (m_tmp1.empty())
+      m_tmp1.resize(m_maxItems);
+   if (m_tmp2.empty())
+      m_tmp2.resize(m_maxItems);
+
+   FRect bounds(m_bounds);
+   if (bounds.left == FLT_MAX)
+   {
+      bounds.Clear();
+      for (size_t i = 0; i < m_vho.size(); ++i)
+         bounds.Extend(m_vho[i]->m_hitBBox);
+   }
+
    m_nLevels = 0;
-#ifdef USE_EMBREE
+   m_numNodes = 0;
+   m_rootNode.Reset();   
+   m_rootNode.m_start = 0;
+   m_rootNode.m_items = static_cast<unsigned int>(m_vho.size());
+   m_rootNode.CreateNextLevel(this, bounds, 0, 0);
+
+   InitSseArrays();
+   
+#else
    if (m_scene)
        rtcReleaseScene(m_scene);
 
@@ -73,10 +143,10 @@ void HitQuadtree::Initialize()
    rtcSetSceneFlags(m_scene, RTC_SCENE_FLAG_ROBUST);
 
    const RTCGeometry geom = rtcNewGeometry(m_embree_device, RTC_GEOMETRY_TYPE_USER);
-   rtcSetGeometryUserPrimitiveCount(geom, (*m_pvho).size());
+   rtcSetGeometryUserPrimitiveCount(geom, m_vho.size());
 
-   rtcSetGeometryUserData(geom, m_pvho);
-   rtcSetGeometryBoundsFunction(geom, &EmbreeBoundsFunc, m_pvho);
+   rtcSetGeometryUserData(geom, &m_vho);
+   rtcSetGeometryBoundsFunction(geom, &EmbreeBoundsFunc, &m_vho);
    rtcSetGeometryIntersectFunction(geom, nullptr); // no ray tracing
    rtcSetGeometryOccludedFunction(geom, nullptr); // no shadow ray tracing
    rtcSetGeometryIntersectFilterFunction(geom, nullptr); // no trace filter
@@ -92,76 +162,110 @@ void HitQuadtree::Initialize()
    //rtcGetSceneBounds(m_scene, &b);
 
    CHECK_EMBREE(m_embree_device);
-#else
-   FRect bounds; // FRect3D for an octree
-   bounds.Clear();
-
-   for (size_t i = 0; i < m_vho.size(); ++i)
-      bounds.Extend(m_vho[i]->m_hitBBox);
-
-   Initialize(bounds);
 #endif
 }
 
-// Ported at: VisualPinball.Engine/Physics/HitQuadTree.cs
-
-void HitQuadtree::Initialize(const FRect& bounds)
+void HitQuadtree::Finalize()
 {
-   m_nLevels = 0;
-#ifdef USE_EMBREE
-   m_pvho = &m_vho;
-   Initialize();
-#else
-   CreateNextLevel(bounds, 0, 0);
+#ifndef USE_EMBREE
+   m_tmp1.clear();
+   m_tmp2.clear();
 #endif
 }
 
-#ifdef USE_EMBREE
-void HitQuadtree::FillFromVector(vector<HitObject*>& vho)
-{
-   m_pvho = &vho;
-   for (size_t i = 0; i < vho.size(); ++i)
-      vho[i]->CalcHitBBox(); // need to update here, as only done lazily for some objects (i.e. balls!)
 
-   Initialize();
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Base implementation (not using Embree, with optional SSE path)
+
+#ifndef USE_EMBREE
+HitQuadtreeNode* HitQuadtree::AllocFourNodes()
+{
+   if ((m_numNodes + 3) >= (unsigned)m_nodes.size()) // space for 4 more nodes?
+      return nullptr;
+   else
+   {
+      m_nodes[m_numNodes    ].Reset();
+      m_nodes[m_numNodes + 1].Reset();
+      m_nodes[m_numNodes + 2].Reset();
+      m_nodes[m_numNodes + 3].Reset();
+      m_numNodes += 4;
+      return &m_nodes[m_numNodes - 4];
+   }
+}
+#endif
+
+// build SSE boundary arrays of the local hit-object/m_vho HitRect list, generated for -full- list completely in the end!
+void HitQuadtree::InitSseArrays()
+{
+#ifdef QUADTREE_SSE_LEAFTEST
+   const unsigned int padded = (m_vho.size() + 3) & 0xFFFFFFFC;
+   if (l_r_t_b_zl_zh == nullptr)
+      l_r_t_b_zl_zh = (float*)_aligned_malloc(padded * 6 * sizeof(float), 16);
+
+   for (unsigned int j = 0; j < m_vho.size(); ++j)
+   {
+      const FRect3D& r = m_vho[j]->m_hitBBox;
+      l_r_t_b_zl_zh[j             ] = r.left;
+      l_r_t_b_zl_zh[j + padded    ] = r.right;
+      l_r_t_b_zl_zh[j + padded * 2] = r.top;
+      l_r_t_b_zl_zh[j + padded * 3] = r.bottom;
+      l_r_t_b_zl_zh[j + padded * 4] = r.zlow;
+      l_r_t_b_zl_zh[j + padded * 5] = r.zhigh;
+   }
+
+   for (unsigned int j = m_vho.size(); j < padded; ++j)
+   {
+      l_r_t_b_zl_zh[j             ] =  FLT_MAX;
+      l_r_t_b_zl_zh[j + padded    ] = -FLT_MAX;
+      l_r_t_b_zl_zh[j + padded * 2] =  FLT_MAX;
+      l_r_t_b_zl_zh[j + padded * 3] = -FLT_MAX;
+      l_r_t_b_zl_zh[j + padded * 4] =  FLT_MAX;
+      l_r_t_b_zl_zh[j + padded * 5] = -FLT_MAX;
+   }
+#endif
 }
 
-void HitQuadtree::Update()
+HitQuadtreeNode::HitQuadtreeNode()
 {
-   FillFromVector(*m_pvho);
 }
 
-#else
-
-// Ported at: VisualPinball.Engine/Physics/HitQuadTree.cs
-
-void HitQuadtree::CreateNextLevel(const FRect& bounds, const unsigned int level, unsigned int level_empty)
+HitQuadtreeNode::~HitQuadtreeNode()
 {
-   if (m_vho.size() <= 4) //!! magic
+   Reset();
+}
+
+void HitQuadtreeNode::Reset()
+{
+   m_children = nullptr;
+   m_unique = nullptr;
+   m_start = 0;
+   m_items = 0;
+}
+
+void HitQuadtreeNode::CreateNextLevel(HitQuadtree* const quadTree, const FRect& bounds, const unsigned int level, unsigned int level_empty)
+{
+   if (level > quadTree->m_nLevels)
+      quadTree->m_nLevels = level;
+   
+   if ((m_items <= 4) //!! magic
+      || (level == MAX_LEVEL - 1) // bottom of tree
+      || ((m_children = quadTree->AllocFourNodes()) == nullptr)) // Ran out of nodes
       return;
 
-   m_nLevels++;
-
-   m_leaf = false;
-
-   m_vcenter.x = (bounds.left + bounds.right)*0.5f;
+   m_vcenter.x = (bounds.left + bounds.right) * 0.5f;
    m_vcenter.y = (bounds.top + bounds.bottom)*0.5f;
    //m_vcenter.z = (bounds.zlow + bounds.zhigh)*0.5f;
 
-   m_children = new HitQuadtree[4];
-
-   vector<HitObject*> vRemain; // hit objects which did not go to a quadrant
-
-   m_unique = (m_vho[0]->m_e != 0) ? m_vho[0]->m_obj : nullptr;
+   m_unique = (quadTree->m_vho[m_start]->m_e != 0) ? quadTree->m_vho[m_start]->m_obj : nullptr;
 
    // sort items into appropriate child nodes
-   for (size_t i = 0; i < m_vho.size(); i++)
+   int remaining = 0;
+   for (unsigned int i = m_start; i < m_start + m_items; ++i)
    {
-      HitObject * const pho = m_vho[i];
-
+      HitObject* const pho = quadTree->m_vho[i];
       if (((pho->m_e != 0) ? pho->m_obj : nullptr) != m_unique) // are all objects in current node unique/belong to the same primitive?
          m_unique = nullptr;
-
       int oct;
       if (pho->m_hitBBox.right < m_vcenter.x)
          oct = 0;
@@ -169,28 +273,42 @@ void HitQuadtree::CreateNextLevel(const FRect& bounds, const unsigned int level,
          oct = 1;
       else
          oct = 128;
-
       if (pho->m_hitBBox.bottom < m_vcenter.y)
          oct |= 0;
       else if (pho->m_hitBBox.top > m_vcenter.y)
          oct |= 2;
       else
          oct |= 128;
-
-      if ((oct & 128) == 0)
-         m_children[oct].m_vho.push_back(pho);
-      else
-         vRemain.push_back(pho);
+      switch (oct)
+      {
+      case 0: quadTree->m_tmp1[m_children[0].m_items] = pho; m_children[0].m_items++; break;
+      case 1: quadTree->m_tmp2[m_children[1].m_items] = pho; m_children[1].m_items++; break;
+      case 2: m_children[2].m_items++; quadTree->m_tmp1[m_items - m_children[2].m_items] = pho; break;
+      case 3: m_children[3].m_items++; quadTree->m_tmp2[m_items - m_children[3].m_items] = pho; break;
+      default: quadTree->m_vho[m_start + remaining] = pho; remaining++; break;
+      }
    }
+   m_children[0].m_start = m_start + remaining;
+   m_children[1].m_start = m_children[0].m_start + m_children[0].m_items;
+   m_children[2].m_start = m_children[1].m_start + m_children[1].m_items;
+   m_children[3].m_start = m_children[2].m_start + m_children[2].m_items;
+   if (m_children[0].m_items > 0)
+      memcpy(&quadTree->m_vho[m_children[0].m_start], &quadTree->m_tmp1[0], m_children[0].m_items * sizeof(HitObject*));
+   if (m_children[1].m_items > 0)
+      memcpy(&quadTree->m_vho[m_children[1].m_start], &quadTree->m_tmp2[0], m_children[1].m_items * sizeof(HitObject*));
+   if (m_children[2].m_items > 0)
+      memcpy(&quadTree->m_vho[m_children[2].m_start], &quadTree->m_tmp1[m_items - m_children[2].m_items], m_children[2].m_items * sizeof(HitObject*));
+   if (m_children[3].m_items > 0)
+      memcpy(&quadTree->m_vho[m_children[3].m_start], &quadTree->m_tmp2[m_items - m_children[3].m_items], m_children[3].m_items * sizeof(HitObject*));
+   m_items = remaining;
 
-   m_ObjType = (m_unique != nullptr) ? m_vho[0]->m_ObjType : eNull;
-
-   m_vho.swap(vRemain);
+   if (m_unique != nullptr)
+      m_ObjType = quadTree->m_vho[m_start]->m_ObjType;
 
    // check if at least two nodes feature objects, otherwise don't bother subdividing further
-   unsigned int count_empty = m_vho.empty() ? 1 : 0;
+   unsigned int count_empty = m_items == 0 ? 1 : 0;
    for (int i = 0; i < 4; ++i)
-      if (m_children[i].m_vho.empty())
+      if (m_children[i].m_items == 0)
          ++count_empty;
 
    if (count_empty >= 4)
@@ -201,6 +319,7 @@ void HitQuadtree::CreateNextLevel(const FRect& bounds, const unsigned int level,
    if (m_vcenter.x - bounds.left > 0.0001f && //!! magic
       level_empty <= 8 && // If 8 levels were all just subdividing the same objects without luck, exit & Free the nodes again (but at least empty space was cut off)
       level + 1 < 128 / 3)
+   {
       for (int i = 0; i < 4; ++i)
       {
          FRect childBounds;
@@ -213,113 +332,10 @@ void HitQuadtree::CreateNextLevel(const FRect& bounds, const unsigned int level,
          childBounds.bottom = (i & 2) ? bounds.bottom : m_vcenter.y;
          //childBounds.zhigh = bounds.zhigh;
 
-         m_children[i].CreateNextLevel(childBounds, level + 1, level_empty);
-      }
-
-   InitSseArrays();
-   for (int i = 0; i < 4; ++i)
-      m_children[i].InitSseArrays();
-}
-
-void HitQuadtree::InitSseArrays()
-{
-   // build SSE boundary arrays of the local hit-object list
-   // (don't init twice)
-   const size_t padded = ((m_vho.size() + 3) / 4) * 4;
-   if (lefts_rights_tops_bottoms_zlows_zhighs == nullptr && padded > 0)
-   {
-#ifdef DISABLE_ZTEST
-      constexpr size_t mul = 4;
-#else
-      constexpr size_t mul = 6;
-#endif
-      lefts_rights_tops_bottoms_zlows_zhighs = (float*)_aligned_malloc(padded * (mul * sizeof(float)), 16);
-
-      // fill array in chunks of 4xSIMD data: 4xleft,4xright,4xtop,4xbottom,4xzlow,4xzhigh, 4xleft ... ... ...
-
-      const unsigned int end = (unsigned int)m_vho.size() & 0xFFFFFFFCu;
-#ifdef DISABLE_ZTEST
-      constexpr unsigned int offs = 16;
-#else
-      constexpr unsigned int offs = 24;
-#endif
-      for (unsigned int j = 0,j2 = 0; j < end; j+=4,j2+=offs)
-      {
-         const FRect3D& r0 = m_vho[j  ]->m_hitBBox;
-         const FRect3D& r1 = m_vho[j+1]->m_hitBBox;
-         const FRect3D& r2 = m_vho[j+2]->m_hitBBox;
-         const FRect3D& r3 = m_vho[j+3]->m_hitBBox;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2   ] = r0.left; 
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 1] = r1.left;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 2] = r2.left;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 3] = r3.left; 
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 4] = r0.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 5] = r1.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 6] = r2.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 7] = r3.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 8] = r0.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 9] = r1.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+10] = r2.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+11] = r3.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+12] = r0.bottom;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+13] = r1.bottom;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+14] = r2.bottom;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+15] = r3.bottom;
-#ifndef DISABLE_ZTEST
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+16] = r0.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+17] = r1.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+18] = r2.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+19] = r3.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+20] = r0.zhigh;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+21] = r1.zhigh;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+22] = r2.zhigh;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+23] = r3.zhigh;
-#endif
-      }
-
-      // fill the remainder of the array with the remaining data and invalid BBoxes for padding
-
-      if (end != m_vho.size())
-      {
-         const FRect3D& r0 = m_vho[end]->m_hitBBox;
-         const FRect3D r1 = end + 1 < m_vho.size() ? m_vho[end + 1]->m_hitBBox : FRect3D(FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX);
-         const FRect3D r2 = end + 2 < m_vho.size() ? m_vho[end + 2]->m_hitBBox : FRect3D(FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX);
-         const FRect3D r3 = FRect3D(FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX);
-#ifdef DISABLE_ZTEST
-         const unsigned int j2 = end * 4;
-#else
-         const unsigned int j2 = end * 6;
-#endif
-         lefts_rights_tops_bottoms_zlows_zhighs[j2   ] = r0.left; 
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 1] = r1.left;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 2] = r2.left;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 3] = r3.left; 
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 4] = r0.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 5] = r1.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 6] = r2.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 7] = r3.right;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 8] = r0.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+ 9] = r1.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+10] = r2.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+11] = r3.top;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+12] = r0.bottom;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+13] = r1.bottom;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+14] = r2.bottom;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+15] = r3.bottom;
-#ifndef DISABLE_ZTEST
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+16] = r0.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+17] = r1.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+18] = r2.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+19] = r3.zlow;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+20] = r0.zhigh;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+21] = r1.zhigh;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+22] = r2.zhigh;
-         lefts_rights_tops_bottoms_zlows_zhighs[j2+23] = r3.zhigh;
-#endif
+         m_children[i].CreateNextLevel(quadTree, childBounds, level + 1, level_empty);
       }
    }
 }
-#endif
 
 // OUTDATED INFO?!
 // Hit logic needs to be expanded, during static and pseudo-static conditions, multiple hits (multi-face contacts)
@@ -338,77 +354,79 @@ void HitQuadtree::InitSseArrays()
 // slot is not in the random time generator algorithm, it is offset by STATICTIME so not to compete with the fast moving
 // collisions
 
-#ifndef USE_EMBREE
-void HitQuadtree::HitTestBall(const HitBall* const pball, CollisionEvent& coll) const
+#ifndef QUADTREE_SSE_LEAFTEST // Without SSE optimization
+void HitQuadtreeNode::HitTestBall(const HitQuadtree* const quadTree, const HitBall* const pball, CollisionEvent& coll) const
 {
-#ifdef QUADTREE_SSE_LEAFTEST
-
-   HitTestBallSse(pball, coll);
-
-#else // without SSE optimization
-
-// Ported at: VisualPinball.Engine/Physics/HitQuadTree.cs
-
    const float rcHitRadiusSqr = pball->HitRadiusSqr();
 
-   for (unsigned i=0; i<m_vho.size(); i++)
+   for (unsigned i=0; i<m_items; i++)
    {
-#ifdef DEBUGPHYSICS
-      g_pplayer->c_tested++;
-#endif
-      if ((pball != m_vho[i]) // ball can not hit itself
-         && fRectIntersect3D(pball->m_hitBBox, m_vho[i]->m_hitBBox)
-         && fRectIntersect3D(pball->m_d.m_pos, rcHitRadiusSqr, m_vho[i]->m_hitBBox))
+      #ifdef DEBUGPHYSICS
+         g_pplayer->c_tested++;
+      #endif
+      HitObject* pho = quadTree->m_vho[m_start + i];
+      if ((pball != pho) // ball can not hit itself
+         && fRectIntersect3D(pball->m_hitBBox, pho->m_hitBBox)
+         && fRectIntersect3D(pball->m_d.m_pos, rcHitRadiusSqr, pho->m_hitBBox))
       {
-         DoHitTest(pball, m_vho[i], coll);
+         DoHitTest(pball, pho, coll);
       }
-   }//end for loop
+   }
 
-   if (!m_leaf)
+   if (m_children != nullptr)
    {
+      #ifdef DEBUGPHYSICS
+         g_pplayer->c_tested++;
+      #endif
       const bool left = (pball->m_hitBBox.left <= m_vcenter.x);
       const bool right = (pball->m_hitBBox.right >= m_vcenter.x);
-
-#ifdef DEBUGPHYSICS
-      g_pplayer->c_tested++;
-#endif
       if (pball->m_hitBBox.top <= m_vcenter.y) // Top
       {
-         if (left)  m_children[0].HitTestBall(pball, coll);
-         if (right) m_children[1].HitTestBall(pball, coll);
+         if (left)  m_children[0].HitTestBall(quadTree, pball, coll);
+         if (right) m_children[1].HitTestBall(quadTree, pball, coll);
       }
       if (pball->m_hitBBox.bottom >= m_vcenter.y) // Bottom
       {
-         if (left)  m_children[2].HitTestBall(pball, coll);
-         if (right) m_children[3].HitTestBall(pball, coll);
+         if (left)  m_children[2].HitTestBall(quadTree, pball, coll);
+         if (right) m_children[3].HitTestBall(quadTree, pball, coll);
       }
    }
-#endif
 }
 
-#ifdef QUADTREE_SSE_LEAFTEST
-void HitQuadtree::HitTestBallSse(const HitBall* const pball, CollisionEvent& coll) const
+#else // with SSE optimization
+void HitQuadtreeNode::HitTestBall(const HitQuadtree* const quadTree, const HitBall* const pball, CollisionEvent& coll) const
 {
-   const HitQuadtree* stack[128]; //!! should be enough, but better implement test in construction to not exceed this
+   const HitQuadtreeNode* stack[MAX_LEVEL];
    unsigned int stackpos = 0;
    stack[0] = nullptr; // sentinel
 
-   const HitQuadtree* __restrict current = this;
+   const HitQuadtreeNode* __restrict current = this;
+
+   const unsigned int padded = (quadTree->m_vho.size() + 3) & 0xFFFFFFFC;
+
+   const __m128* __restrict const pL = (__m128*)quadTree->l_r_t_b_zl_zh;
+   const __m128* __restrict const pR = (__m128*)(quadTree->l_r_t_b_zl_zh + padded);
+   const __m128* __restrict const pT = (__m128*)(quadTree->l_r_t_b_zl_zh + padded * 2);
+   const __m128* __restrict const pB = (__m128*)(quadTree->l_r_t_b_zl_zh + padded * 3);
+   #ifndef DISABLE_ZTEST
+      const __m128* __restrict const pZl = (__m128*)(quadTree->l_r_t_b_zl_zh + padded * 4);
+      const __m128* __restrict const pZh = (__m128*)(quadTree->l_r_t_b_zl_zh + padded * 5);
+   #endif
 
    // init SSE registers with ball bbox
    const __m128 bleft = _mm_set1_ps(pball->m_hitBBox.left);
    const __m128 bright = _mm_set1_ps(pball->m_hitBBox.right);
    const __m128 btop = _mm_set1_ps(pball->m_hitBBox.top);
    const __m128 bbottom = _mm_set1_ps(pball->m_hitBBox.bottom);
-#ifndef DISABLE_ZTEST
-   const __m128 bzlow = _mm_set1_ps(pball->m_hitBBox.zlow);
-   const __m128 bzhigh = _mm_set1_ps(pball->m_hitBBox.zhigh);
-#endif
+   #ifndef DISABLE_ZTEST
+      const __m128 bzlow = _mm_set1_ps(pball->m_hitBBox.zlow);
+      const __m128 bzhigh = _mm_set1_ps(pball->m_hitBBox.zhigh);
+   #endif
    const __m128 posx = _mm_set1_ps(pball->m_d.m_pos.x);
    const __m128 posy = _mm_set1_ps(pball->m_d.m_pos.y);
-#ifndef DISABLE_ZTEST
-   const __m128 posz = _mm_set1_ps(pball->m_d.m_pos.z);
-#endif
+   #ifndef DISABLE_ZTEST
+      const __m128 posz = _mm_set1_ps(pball->m_d.m_pos.z);
+   #endif
    const __m128 rsqr = _mm_set1_ps(pball->HitRadiusSqr());
 
    const bool traversal_order = (rand_mt_01() < 0.5f); // swaps test order in leafs randomly
@@ -420,95 +438,102 @@ void HitQuadtree::HitTestBallSse(const HitBall* const pball, CollisionEvent& col
           || (current->m_ObjType == ePrimitive && ((Primitive*)current->m_unique)->m_d.m_collidable)
           || (current->m_ObjType == eHitTarget && ((HitTarget*)current->m_unique)->m_d.m_isDropped == false)) // early out if only one unique primitive/hittarget stored inside all of the subtree/current node that is also not collidable (at the moment)
       {
-         if (current->lefts_rights_tops_bottoms_zlows_zhighs != nullptr) // does node contain hitables?
+         if (current->m_items != 0) // does node contain hitables?
          {
-            const size_t size = (current->m_vho.size() + 3) / 4;
-
-            const __m128* const __restrict p = (__m128*)current->lefts_rights_tops_bottoms_zlows_zhighs;
+            const unsigned int size = (current->m_start + current->m_items + 3) / 4;
+            const unsigned int start = traversal_order ? current->m_start / 4 : (size - 1);
+            const unsigned int end = traversal_order ? size : (current->m_start / 4 - 1);
 
             // loop implements 4 collision checks at once
             // (rc1.right >= rc2.left && rc1.bottom >= rc2.top && rc1.left <= rc2.right && rc1.top <= rc2.bottom && rc1.zlow <= rc2.zhigh && rc1.zhigh >= rc2.zlow)
-            const size_t start = traversal_order ? 0 : (size - 1);
-#ifdef DISABLE_ZTEST
-            const size_t dt2 = dt * 4;
-            constexpr size_t mul = 4;
-#else
-            const size_t dt2 = dt * 6;
-            constexpr size_t mul = 6;
-#endif
-            const size_t end = traversal_order ? size : -1;
-            for (size_t i = start, i2 = start*mul; i != end; i += dt, i2 += dt2)
+            for (unsigned int i = start; i != end; i += dt)
             {
-#ifdef DEBUGPHYSICS
-               g_pplayer->m_physics->c_tested++; //!! +=4? or is this more fair?
-#endif
+               #ifdef DEBUGPHYSICS
+                  g_pplayer->m_physics->c_tested++; //!! +=4? or is this more fair?
+               #endif
+               const int idx = i; 
+
                // comparisons set bits if bounds miss. if all bits are set, there is no collision. otherwise continue comparisons
                // bits set, there is a bounding box collision
-               __m128 cmp = _mm_cmpge_ps(bright, p[i2]); // right vs left
+               __m128 cmp = _mm_cmpge_ps(bright, pL[idx]);
                int mask = _mm_movemask_ps(cmp);
                if (mask == 0) continue;
 
-               cmp = _mm_cmple_ps(bleft, p[i2+1]); // left vs right
+               cmp = _mm_cmple_ps(bleft, pR[idx]);
                mask &= _mm_movemask_ps(cmp);
                if (mask == 0) continue;
 
-               cmp = _mm_cmpge_ps(bbottom, p[i2+2]); // bottom vs top
+               cmp = _mm_cmpge_ps(bbottom, pT[idx]);
                mask &= _mm_movemask_ps(cmp);
                if (mask == 0) continue;
 
-               cmp = _mm_cmple_ps(btop, p[i2+3]); // top vs bottom
+               cmp = _mm_cmple_ps(btop, pB[idx]);
                mask &= _mm_movemask_ps(cmp);
                if (mask == 0) continue;
 
-#ifndef DISABLE_ZTEST
-               cmp = _mm_cmpge_ps(bzhigh, p[i2+4]); // zhigh vs zlow
-               mask &= _mm_movemask_ps(cmp);
-               if (mask == 0) continue;
+               #ifndef DISABLE_ZTEST
+                  cmp = _mm_cmpge_ps(bzhigh, pZl[idx]);
+                  mask &= _mm_movemask_ps(cmp);
+                  if (mask == 0) continue;
 
-               cmp = _mm_cmple_ps(bzlow, p[i2+5]); // zlow vs zhigh
-               mask &= _mm_movemask_ps(cmp);
-               if (mask == 0) continue;
-#endif
+                  cmp = _mm_cmple_ps(bzlow, pZh[idx]);
+                  mask &= _mm_movemask_ps(cmp);
+                  if (mask == 0) continue;
+               #endif
+
                // test actual sphere against box(es)
                const __m128 zero = _mm_setzero_ps();
-               __m128 ex = _mm_add_ps(_mm_max_ps(_mm_sub_ps(p[i2  ]/*left*/, posx), zero), _mm_max_ps(_mm_sub_ps(posx, p[i2+1]/*right */), zero));
-               __m128 ey = _mm_add_ps(_mm_max_ps(_mm_sub_ps(p[i2+2]/*top */, posy), zero), _mm_max_ps(_mm_sub_ps(posy, p[i2+3]/*bottom*/), zero));
-#ifndef DISABLE_ZTEST
-               __m128 ez = _mm_add_ps(_mm_max_ps(_mm_sub_ps(p[i2+4]/*zlow*/, posz), zero), _mm_max_ps(_mm_sub_ps(posz, p[i2+5]/*zhigh */), zero));
-#endif
+               __m128 ex = _mm_add_ps(_mm_max_ps(_mm_sub_ps(pL[idx], posx), zero), _mm_max_ps(_mm_sub_ps(posx, pR[idx] ), zero));
+               __m128 ey = _mm_add_ps(_mm_max_ps(_mm_sub_ps(pT[idx], posy), zero), _mm_max_ps(_mm_sub_ps(posy, pB[idx] ), zero));
+               #ifndef DISABLE_ZTEST
+                  __m128 ez = _mm_add_ps(_mm_max_ps(_mm_sub_ps(pZl[idx], posz), zero), _mm_max_ps(_mm_sub_ps(posz, pZh[idx]), zero));
+               #endif
                ex = _mm_mul_ps(ex, ex);
                ey = _mm_mul_ps(ey, ey);
-#ifndef DISABLE_ZTEST
-               ez = _mm_mul_ps(ez, ez);
-               const __m128 d = _mm_add_ps(_mm_add_ps(ex, ey), ez);
-#else
-               const __m128 d = _mm_add_ps(ex, ey);
-#endif
+               #ifndef DISABLE_ZTEST
+                  ez = _mm_mul_ps(ez, ez);
+                  const __m128 d = _mm_add_ps(_mm_add_ps(ex, ey), ez);
+               #else
+                  const __m128 d = _mm_add_ps(ex, ey);
+               #endif
                const __m128 cmp2 = _mm_cmple_ps(d, rsqr);
                const int mask2 = _mm_movemask_ps(cmp2);
                if (mask2 == 0) continue;
 
                // now there is at least one bbox collision
-               if ((mask2 & 1) != 0 && (pball != current->m_vho[i * 4])) // ball can not hit itself
-                  DoHitTest(pball, current->m_vho[i * 4], coll);
+               if ((mask2 & 1) != 0)
+               {
+                  HitObject* const pho = quadTree->m_vho[i * 4];
+                  if (pball != pho) // ball can not hit itself
+                     DoHitTest(pball, pho, coll);
+               }
                // array boundary checks for the rest not necessary as non-valid entries were initialized to keep these maskbits 0
-               if ((mask2 & 2) != 0 /*&& (i*4+1)<m_vho.size()*/ && (pball != current->m_vho[i * 4 + 1])) // ball can not hit itself
-                  DoHitTest(pball, current->m_vho[i * 4 + 1], coll);
-               if ((mask2 & 4) != 0 /*&& (i*4+2)<m_vho.size()*/ && (pball != current->m_vho[i * 4 + 2])) // ball can not hit itself
-                  DoHitTest(pball, current->m_vho[i * 4 + 2], coll);
-               if ((mask2 & 8) != 0 /*&& (i*4+3)<m_vho.size()*/ && (pball != current->m_vho[i * 4 + 3])) // ball can not hit itself
-                  DoHitTest(pball, current->m_vho[i * 4 + 3], coll);
+               if ((mask2 & 2) != 0 /*&& (i*4+1)<m_hitoct->m_num_items*/)
+               {
+                  HitObject* const pho = quadTree->m_vho[i * 4 + 1];
+                  if (pball != pho) // ball can not hit itself
+                     DoHitTest(pball, pho, coll);
+               }
+               if ((mask2 & 4) != 0 /*&& (i*4+2)<m_hitoct->m_num_items*/)
+               {
+                  HitObject* const pho = quadTree->m_vho[i * 4 + 2];
+                  if (pball != pho) // ball can not hit itself
+                     DoHitTest(pball, pho, coll);
+               }
+               if ((mask2 & 8) != 0 /*&& (i*4+3)<m_hitoct->m_num_items*/)
+               {
+                  HitObject* const pho = quadTree->m_vho[i * 4 + 3];
+                  if (pball != pho) // ball can not hit itself
+                     DoHitTest(pball, pho, coll);
+               }
             }
          }
 
-         //if (stackpos >= 127)
-         //	ShowError("Quadtree stack size to be exceeded");
-
-         if (!current->m_leaf)
+         if (current->m_children != nullptr)
          {
-#ifdef DEBUGPHYSICS
-            g_pplayer->m_physics->c_traversed++;
-#endif
+            #ifdef DEBUGPHYSICS
+               g_pplayer->m_physics->c_traversed++;
+            #endif
             const bool left = (pball->m_hitBBox.left <= current->m_vcenter.x);
             const bool right = (pball->m_hitBBox.right >= current->m_vcenter.x);
 
@@ -525,65 +550,83 @@ void HitQuadtree::HitTestBallSse(const HitBall* const pball, CollisionEvent& col
          }
       }
 
-      //current = stack[stackpos];
-      //if (stackpos > 0)
-      //    stackpos--;
-      current = stack[stackpos--]; // above test not needed due to sentinel in stack[0]=nullptr
-
-   } while (current);
+      current = stack[stackpos--];
+   } while (current); // stops when stackpos is 0 since we defined stack[0] to nullptr
 }
-#endif
-#endif
+#endif // SSE vs non SSE implementation
 
-void HitQuadtree::HitTestXRay(const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const
+void HitQuadtreeNode::HitTestXRay(const HitQuadtree* const quadTree, const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const
 {
-#ifdef USE_EMBREE
-   ShowError("HitTestXRay not implemented yet");
-#else
    const float rcHitRadiusSqr = pball->HitRadiusSqr();
 
-   for (size_t i = 0; i < m_vho.size(); i++)
+   for (size_t i = 0; i < m_items; i++)
    {
-#ifdef DEBUGPHYSICS
-      g_pplayer->m_physics->c_tested++;
-#endif
-      if ((pball != m_vho[i]) && fRectIntersect3D(pball->m_hitBBox, m_vho[i]->m_hitBBox) && fRectIntersect3D(pball->m_d.m_pos, rcHitRadiusSqr, m_vho[i]->m_hitBBox))
+      #ifdef DEBUGPHYSICS
+         g_pplayer->m_physics->c_tested++;
+      #endif
+      HitObject* pho = quadTree->m_vho[m_start + i];
+         if ((pball != pho) && fRectIntersect3D(pball->m_hitBBox, pho->m_hitBBox) && fRectIntersect3D(pball->m_d.m_pos, rcHitRadiusSqr, pho->m_hitBBox))
       {
-#ifdef DEBUGPHYSICS
-         g_pplayer->m_physics->c_deepTested++;
-#endif
-         const float newtime = m_vho[i]->HitTest(pball->m_d, coll.m_hittime, coll);
+         #ifdef DEBUGPHYSICS
+            g_pplayer->m_physics->c_deepTested++;
+         #endif
+         const float newtime = pho->HitTest(pball->m_d, coll.m_hittime, coll);
          if (newtime >= 0.f)
-         {
-            const HitTestResult r { m_vho[i], newtime };
-            pvhoHit.push_back(r);
-         }
+            pvhoHit.push_back({ pho, newtime });
       }
    }
 
-   if (!m_leaf)
+   if (m_children != nullptr)
    {
+      #ifdef DEBUGPHYSICS
+         g_pplayer->m_physics->c_tested++;
+      #endif
       const bool left = (pball->m_hitBBox.left <= m_vcenter.x);
       const bool right = (pball->m_hitBBox.right >= m_vcenter.x);
-
-#ifdef DEBUGPHYSICS
-      g_pplayer->m_physics->c_tested++;
-#endif
       if (pball->m_hitBBox.top <= m_vcenter.y) // Top
       {
-         if (left)  m_children[0].HitTestXRay(pball, pvhoHit, coll);
-         if (right) m_children[1].HitTestXRay(pball, pvhoHit, coll);
+         if (left) m_children[0].HitTestXRay(quadTree, pball, pvhoHit, coll);
+         if (right) m_children[1].HitTestXRay(quadTree, pball, pvhoHit, coll);
       }
       if (pball->m_hitBBox.bottom >= m_vcenter.y) // Bottom
       {
-         if (left)  m_children[2].HitTestXRay(pball, pvhoHit, coll);
-         if (right) m_children[3].HitTestXRay(pball, pvhoHit, coll);
+         if (left)  m_children[2].HitTestXRay(quadTree, pball, pvhoHit, coll);
+         if (right) m_children[3].HitTestXRay(quadTree, pball, pvhoHit, coll);
       }
    }
-#endif
 }
 
+void HitQuadtreeNode::DumpTree(const int indentLevel)
+{
+   #if !defined(NDEBUG) && defined(PRINT_DEBUG_COLLISION_TREE)
+      char indent[256];
+      for (int i = 0; i <= indentLevel; ++i)
+         indent[i] = (i == indentLevel) ? '\0' : ' ';
+      char msg[256];
+      sprintf_s(msg, sizeof(msg), "[%f %f], items=%u", m_vcenter.x, m_vcenter.y, m_vho.size());
+      strncat_s(indent, msg, sizeof(indent)-strnlen_s(indent, sizeof(indent))-1);
+      OutputDebugString(indent);
+      if (m_children != nullptr)
+      {
+         m_children[0].DumpTree(indentLevel + 1);
+         m_children[1].DumpTree(indentLevel + 1);
+         m_children[2].DumpTree(indentLevel + 1);
+         m_children[3].DumpTree(indentLevel + 1);
+      }
+   #endif
+}
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Embree implementation (prototype missing UI picking)
+
 #ifdef USE_EMBREE
+void HitQuadtree::HitTestXRay(const HitBall* const pball, vector<HitTestResult>& pvhoHit, CollisionEvent& coll) const
+{
+   ShowError("HitTestXRay not implemented yet");
+}
+
 void EmbreeBoundsFuncBalls(const struct RTCBoundsFunctionArguments* const args)
 {
    const HitBall* const ball = (*((const vector<HitBall*>*)args->geometryUserPtr))[args->primID];
@@ -601,7 +644,6 @@ struct VPCollisions
    const vector<HitObject*> *vho;
    const vector<HitBall*> *ball;
 };
-
 
 void EmbreeCollideBalls(void* const userPtr, RTCCollision* const collisions, const unsigned int num_collisions)
 {
@@ -663,7 +705,7 @@ void HitQuadtree::HitTestBall(vector<HitBall*> ball) const
    CHECK_EMBREE(m_embree_device);
 
    VPCollisions vpc;
-   vpc.vho = m_pvho;
+   vpc.vho = &m_vho;
    vpc.ball = &ball;
    rtcCollide(m_scene, scene, &EmbreeCollideBalls, &vpc);
 

--- a/third-party/include/tinyxml2/tinyxml2.cpp
+++ b/third-party/include/tinyxml2/tinyxml2.cpp
@@ -21,7 +21,7 @@ must not be misrepresented as being the original software.
 distribution.
 */
 #include "core/stdafx.h"
-#define _HAS_ITERATOR_DEBUGGING 0
+
 #include "tinyxml2.h"
 
 #include <new>		// yes, this one new style header, is in the Android SDK.


### PR DESCRIPTION
- make them owner of the hit object vectors (cleaner, less copies)
- optimize QuadTree creation similarly to KdTree (up to 5x faster)
- split QuadTree class from its node class
- don't mix physics & UI picking quadtree any more
- fix Surface invalid UI bounds
- fix Physics Engine stats
- overall cleanups