### PR TITLE
fix build error on Ubuntu 20.04 with C++20

### DIFF
--- a/src/audio/pinsound.cpp
+++ b/src/audio/pinsound.cpp
@@ -664,8 +664,14 @@ PinSound *AudioMusicPlayer::LoadFile(const string& strFileName)
 	   pps->m_cdata = (int)ftell(f);
 	   fseek(f, 0, SEEK_SET);
 	   pps->m_pdata = new char[pps->m_cdata];
-	   fread_s(pps->m_pdata, pps->m_cdata, 1, pps->m_cdata, f);
+	   size_t n_read = fread_s(pps->m_pdata, pps->m_cdata, 1, pps->m_cdata, f);
 	   fclose(f);
+
+	   if (n_read == 0)
+	   {
+           ShowError("Error reading file.");
+		   return nullptr;
+	   }
 
 	   const SoundConfigTypes SoundMode3D = (pps->GetOutputTarget() == SNDOUT_BACKGLASS) ? SNDCFG_SND3D2CH : (SoundConfigTypes)g_pvp->m_settings.LoadValueWithDefault(Settings::Player, "Sound3D"s, (int)SNDCFG_SND3D2CH);
 

--- a/src/core/def.h
+++ b/src/core/def.h
@@ -24,10 +24,10 @@
 #endif
 #endif
 
-#if __cplusplus >= 202302L  // C++23 and later
-#define CONSTEXPR constexpr
-#else
+#if defined(__GNUC__) && (__GNUC__ < 12)
 #define CONSTEXPR
+#else
+#define CONSTEXPR constexpr
 #endif
 
 template <typename T>

--- a/src/core/def.h
+++ b/src/core/def.h
@@ -24,6 +24,12 @@
 #endif
 #endif
 
+#if __cplusplus >= 202302L  // C++23 and later
+#define CONSTEXPR constexpr
+#else
+#define CONSTEXPR
+#endif
+
 template <typename T>
 constexpr __forceinline T min(const T x, const T y)
 {
@@ -660,7 +666,7 @@ constexpr inline void szUpper(char* pC)
     }
 }
 
-constexpr inline void StrToLower(string& str)
+CONSTEXPR inline void StrToLower(string& str)
 {
    std::ranges::transform(str.begin(), str.end(), str.begin(), cLower);
 }

--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -3286,29 +3286,35 @@ void VPinball::GenerateImageFromTournamentFile(const string &tablefile, const st
    FILE *f;
    if (fopen_s(&f, txtfile.c_str(), "r") == 0 && f)
    {
-      [[maybe_unused]] int unused;
-      unused = fscanf_s(f, "%03X", &x);
-      unused = fscanf_s(f, "%03X", &y);
-      unused = fscanf_s(f, "%01X", &cpu);
-      unused = fscanf_s(f, "%01X", &bits);
-      unused = fscanf_s(f, "%01X", &os);
-      unused = fscanf_s(f, "%01X", &renderer);
-      unused = fscanf_s(f, "%01X", &major);
-      unused = fscanf_s(f, "%01X", &minor);
-      unused = fscanf_s(f, "%01X", &rev);
-      unused = fscanf_s(f, "%04X", &git_rev);
-      unused = fscanf_s(f, "%08X", &tablefileChecksum_in);
-      unused = fscanf_s(f, "%08X", &vpxChecksum_in);
-      unused = fscanf_s(f, "%08X", &scriptsChecksum_in);
+      bool error = false;
+      error |= fscanf_s(f, "%03X", &x) != 1;
+      error |= fscanf_s(f, "%03X", &y) != 1;
+      error |= fscanf_s(f, "%01X", &cpu) != 1;
+      error |= fscanf_s(f, "%01X", &bits) != 1;
+      error |= fscanf_s(f, "%01X", &os) != 1;
+      error |= fscanf_s(f, "%01X", &renderer) != 1;
+      error |= fscanf_s(f, "%01X", &major) != 1;
+      error |= fscanf_s(f, "%01X", &minor) != 1;
+      error |= fscanf_s(f, "%01X", &rev) != 1;
+      error |= fscanf_s(f, "%04X", &git_rev) != 1;
+      error |= fscanf_s(f, "%08X", &tablefileChecksum_in) != 1;
+      error |= fscanf_s(f, "%08X", &vpxChecksum_in) != 1;
+      error |= fscanf_s(f, "%08X", &scriptsChecksum_in) != 1;
       dmd_size = x * y + 16;
       dmd_data = new BYTE[dmd_size];
       for (unsigned int i = 0; i < dmd_size; ++i)
       {
          unsigned int v;
-         unused = fscanf_s(f, "%02X", &v);
+         error |= fscanf_s(f, "%02X", &v) != 1;
          dmd_data[i] = v;
       }
       fclose(f);
+
+      if (error)
+      {
+         ShowError("Error parsing Tournament file");
+         return;
+      }
    }
    else
    {

--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -3286,25 +3286,26 @@ void VPinball::GenerateImageFromTournamentFile(const string &tablefile, const st
    FILE *f;
    if (fopen_s(&f, txtfile.c_str(), "r") == 0 && f)
    {
-      fscanf_s(f, "%03X", &x);
-      fscanf_s(f, "%03X", &y);
-      fscanf_s(f, "%01X", &cpu);
-      fscanf_s(f, "%01X", &bits);
-      fscanf_s(f, "%01X", &os);
-      fscanf_s(f, "%01X", &renderer);
-      fscanf_s(f, "%01X", &major);
-      fscanf_s(f, "%01X", &minor);
-      fscanf_s(f, "%01X", &rev);
-      fscanf_s(f, "%04X", &git_rev);
-      fscanf_s(f, "%08X", &tablefileChecksum_in);
-      fscanf_s(f, "%08X", &vpxChecksum_in);
-      fscanf_s(f, "%08X", &scriptsChecksum_in);
+      [[maybe_unused]] int unused;
+      unused = fscanf_s(f, "%03X", &x);
+      unused = fscanf_s(f, "%03X", &y);
+      unused = fscanf_s(f, "%01X", &cpu);
+      unused = fscanf_s(f, "%01X", &bits);
+      unused = fscanf_s(f, "%01X", &os);
+      unused = fscanf_s(f, "%01X", &renderer);
+      unused = fscanf_s(f, "%01X", &major);
+      unused = fscanf_s(f, "%01X", &minor);
+      unused = fscanf_s(f, "%01X", &rev);
+      unused = fscanf_s(f, "%04X", &git_rev);
+      unused = fscanf_s(f, "%08X", &tablefileChecksum_in);
+      unused = fscanf_s(f, "%08X", &vpxChecksum_in);
+      unused = fscanf_s(f, "%08X", &scriptsChecksum_in);
       dmd_size = x * y + 16;
       dmd_data = new BYTE[dmd_size];
       for (unsigned int i = 0; i < dmd_size; ++i)
       {
          unsigned int v;
-         fscanf_s(f, "%02X", &v);
+         unused = fscanf_s(f, "%02X", &v);
          dmd_data[i] = v;
       }
       fclose(f);

--- a/src/ui/codeview.cpp
+++ b/src/ui/codeview.cpp
@@ -3295,7 +3295,12 @@ void CodeViewer::ParseVPCore()
 	while (!feof(fCore))
 	{
 		char text[MAX_LINE_LENGTH] = {};
-		fgets(text, MAX_LINE_LENGTH, fCore);
+		if (fgets(text, MAX_LINE_LENGTH, fCore) == NULL)
+		{
+			//error or EOF
+			break;
+		}
+
 		if (text[0] != '\0')
 		{
 			string wholeline(text);

--- a/src/utils/objloader.cpp
+++ b/src/utils/objloader.cpp
@@ -92,7 +92,11 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       if (strcmp(lineHeader, "v") == 0)
       {
          Vertex3Ds tmp;
-         [[maybe_unused]] int unused = fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z);
+         if (fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z) != 3)
+         {
+            ShowError("Error parsing `v`");
+            goto Error;
+         }
          if (convertToLeftHanded)
             tmp.z = -tmp.z;
          m_tmpVerts.push_back(tmp);
@@ -100,7 +104,11 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       else if (strcmp(lineHeader, "vt") == 0)
       {
          Vertex2D tmp;
-         [[maybe_unused]] int unused = fscanf_s(f, "%f %f", &tmp.x, &tmp.y);
+         if (fscanf_s(f, "%f %f", &tmp.x, &tmp.y) != 2)
+         {
+            ShowError("Error parsing `vt`");
+            goto Error;
+         }
          if (flipTv || convertToLeftHanded)
             tmp.y = 1.f - tmp.y;
          m_tmpTexel.push_back(tmp);
@@ -108,7 +116,11 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       else if (strcmp(lineHeader, "vn") == 0)
       {
          Vertex3Ds tmp;
-         [[maybe_unused]] int unused = fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z);
+         if (fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z) != 3)
+         {
+            ShowError("Error parsing `vn`");
+            goto Error;
+         }
          if (convertToLeftHanded)
             tmp.z = -tmp.z;
          m_tmpNorms.push_back(tmp);

--- a/src/utils/objloader.cpp
+++ b/src/utils/objloader.cpp
@@ -92,7 +92,7 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       if (strcmp(lineHeader, "v") == 0)
       {
          Vertex3Ds tmp;
-         fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z);
+         [[maybe_unused]] int unused = fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z);
          if (convertToLeftHanded)
             tmp.z = -tmp.z;
          m_tmpVerts.push_back(tmp);
@@ -100,7 +100,7 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       else if (strcmp(lineHeader, "vt") == 0)
       {
          Vertex2D tmp;
-         fscanf_s(f, "%f %f", &tmp.x, &tmp.y);
+         [[maybe_unused]] int unused = fscanf_s(f, "%f %f", &tmp.x, &tmp.y);
          if (flipTv || convertToLeftHanded)
             tmp.y = 1.f - tmp.y;
          m_tmpTexel.push_back(tmp);
@@ -108,7 +108,7 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       else if (strcmp(lineHeader, "vn") == 0)
       {
          Vertex3Ds tmp;
-         fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z);
+         [[maybe_unused]] int unused = fscanf_s(f, "%f %f %f\n", &tmp.x, &tmp.y, &tmp.z);
          if (convertToLeftHanded)
             tmp.z = -tmp.z;
          m_tmpNorms.push_back(tmp);
@@ -178,7 +178,7 @@ bool ObjLoader::Load(const string& filename, const bool flipTv, const bool conve
       else
       {
          // unknown line header, skip rest of line
-         fgets(lineHeader, 256, f);
+         [[maybe_unused]] char* unused = fgets(lineHeader, 256, f);
       }
    }
 


### PR DESCRIPTION
## Changes Made

 1. Fixes a bug when building on Ubuntu 20.04 with C++20.  I guess `constexpr` was only added to `std::string::begin()` in C++23.  This adds a preprocessor macro to only add `constexpr` when using C++23 or greater.

 2. Appease many `-Wunused-result` warnings.

## Testing Done

Built and ran `standalone` on Ubuntu 20.04