### PR TITLE
build: remove bass from externals and use one from libaltsound

### DIFF
--- a/make/CMakeLists_bgfx_lib.txt
+++ b/make/CMakeLists_bgfx_lib.txt
@@ -744,6 +744,7 @@ target_link_libraries(vpinball PUBLIC
 
 if(PLATFORM STREQUAL "ios" OR PLATFORM STREQUAL "ios-simulator")
    target_link_libraries(vpinball PUBLIC
+      bass
       freetype
       harfbuzz
       avcodec

--- a/platforms/android-arm64-v8a/external.sh
+++ b/platforms/android-arm64-v8a/external.sh
@@ -416,28 +416,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-android.zip -o bass.zip
-   unzip bass.zip
-   
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -482,6 +460,7 @@ cp libdmdutil/libdmdutil/third-party/runtime-libs/android/arm64-v8a/libsockpp.so
 
 cp libaltsound/libaltsound/build/libaltsound.so ../../../third-party/runtime-libs/android-arm64-v8a
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/android/arm64-v8a/libbass.so ../../../third-party/runtime-libs/android-arm64-v8a
 
 cp libdof/libdof/build/libdof.so ../../../third-party/runtime-libs/android-arm64-v8a
 cp -r libdof/libdof/include/DOF ../../../third-party/include/

--- a/platforms/ios-arm64/external.sh
+++ b/platforms/ios-arm64/external.sh
@@ -365,31 +365,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-ios.zip -o bass.zip
-   unzip bass.zip
-   lipo bass.xcframework/ios-arm64_armv7_armv7s/bass.framework/bass -extract arm64 -output libbass.dylib
-   install_name_tool -id @rpath/libbass.dylib libbass.dylib
-   codesign --force --sign - libbass.dylib
-   
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -436,6 +411,7 @@ cp libdmdutil/libdmdutil/third-party/build-libs/ios/arm64/libsockpp.a ../../../t
 
 cp libaltsound/libaltsound/build/libaltsound.a ../../../third-party/build-libs/ios-arm64
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/ios/arm64/libbass.dylib ../../../third-party/runtime-libs/ios-arm64
 
 cp libdof/libdof/build/libdof.a ../../../third-party/build-libs/ios-arm64
 cp -r libdof/libdof/include/DOF ../../../third-party/include/

--- a/platforms/ios-simulator-arm64/external.sh
+++ b/platforms/ios-simulator-arm64/external.sh
@@ -370,31 +370,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-ios.zip -o bass.zip
-   unzip bass.zip
-   lipo bass.xcframework/ios-arm64_i386_x86_64-simulator/bass.framework/bass -extract arm64 -output libbass.dylib
-   install_name_tool -id @rpath/libbass.dylib libbass.dylib
-   codesign --force --sign - libbass.dylib
-   
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -441,6 +416,7 @@ cp libdmdutil/libdmdutil/third-party/build-libs/ios-simulator/arm64/libsockpp.a 
 
 cp libaltsound/libaltsound/build/libaltsound.a ../../../third-party/build-libs/ios-simulator-arm64
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/ios-simulator/arm64/libbass.dylib ../../../third-party/runtime-libs/ios-simulator-arm64
 
 cp libdof/libdof/build/libdof.a ../../../third-party/build-libs/ios-simulator-arm64
 cp -r libdof/libdof/include/DOF ../../../third-party/include/

--- a/platforms/linux-aarch64/external.sh
+++ b/platforms/linux-aarch64/external.sh
@@ -340,27 +340,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-linux.zip -o bass.zip
-   unzip bass.zip
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -403,6 +382,7 @@ cp libdmdutil/libdmdutil/third-party/runtime-libs/linux/aarch64/libcargs.so ../.
 
 cp -a libaltsound/libaltsound/build/libaltsound.{so,so.*} ../../../third-party/runtime-libs/linux-aarch64
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/linux/aarch64/libbass.so ../../../third-party/runtime-libs/linux-aarch64
 
 cp -a libdof/libdof/build/libdof.{so,so.*} ../../../third-party/runtime-libs/linux-aarch64
 cp -r libdof/libdof/include/DOF ../../../third-party/include/

--- a/platforms/linux-x64/external.sh
+++ b/platforms/linux-x64/external.sh
@@ -341,27 +341,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-linux.zip -o bass.zip
-   unzip bass.zip
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -404,6 +383,7 @@ cp libdmdutil/libdmdutil/third-party/runtime-libs/linux/x64/libcargs.so ../../..
 
 cp -a libaltsound/libaltsound/build/libaltsound.{so,so.*} ../../../third-party/runtime-libs/linux-x64
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/linux/x64/libbass.so ../../../third-party/runtime-libs/linux-x64
 
 cp -a libdof/libdof/build/libdof.{so,so.*} ../../../third-party/runtime-libs/linux-x64
 cp -r libdof/libdof/include/DOF ../../../third-party/include/

--- a/platforms/macos-arm64/external.sh
+++ b/platforms/macos-arm64/external.sh
@@ -357,31 +357,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-osx.zip -o bass.zip
-   unzip bass.zip
-   lipo libbass.dylib -extract arm64 -output libbass-arm64.dylib
-   codesign --force --sign - libbass-arm64.dylib
-   rm libbass.dylib
-   mv libbass-arm64.dylib libbass.dylib
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -424,6 +399,7 @@ cp libdmdutil/libdmdutil/third-party/runtime-libs/macos/arm64/libcargs.dylib ../
 
 cp -a libaltsound/libaltsound/build/libaltsound.{dylib,*.dylib} ../../../third-party/runtime-libs/macos-arm64
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/macos/arm64/libbass.dylib ../../../third-party/runtime-libs/macos-arm64
 
 cp -a libdof/libdof/build/libdof.{dylib,*.dylib} ../../../third-party/runtime-libs/macos-arm64
 cp -r libdof/libdof/include/DOF ../../../third-party/include/

--- a/platforms/macos-x64/external.sh
+++ b/platforms/macos-x64/external.sh
@@ -357,31 +357,6 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
 fi
 
 #
-# bass
-#
-
-BASS_EXPECTED_SHA="bass24"
-BASS_FOUND_SHA="$([ -f bass/cache.txt ] && cat bass/cache.txt || echo "")"
-
-if [ "${BASS_EXPECTED_SHA}" != "${BASS_FOUND_SHA}" ]; then
-   echo "Fetching bass. Expected: ${BASS_EXPECTED_SHA}, Found: ${BASS_FOUND_SHA}"
-
-   rm -rf bass
-   mkdir bass
-   cd bass
-
-   curl -sL https://www.un4seen.com/files/bass24-osx.zip -o bass.zip
-   unzip bass.zip
-   lipo libbass.dylib -extract x86_64 -output libbass-x64.dylib
-   codesign --force --sign - libbass-x64.dylib
-   rm libbass.dylib
-   mv libbass-x64.dylib libbass.dylib
-   echo "$BASS_EXPECTED_SHA" > cache.txt
-
-   cd ..
-fi
-
-#
 # copy libraries
 #
 
@@ -424,6 +399,7 @@ cp libdmdutil/libdmdutil/third-party/runtime-libs/macos/x64/libcargs.dylib ../..
 
 cp -a libaltsound/libaltsound/build/libaltsound.{dylib,*.dylib} ../../../third-party/runtime-libs/macos-x64
 cp -r libaltsound/libaltsound/src/altsound.h ../../../third-party/include/
+cp libaltsound/libaltsound/third-party/runtime-libs/macos/x64/libbass.dylib ../../../third-party/runtime-libs/macos-x64
 
 cp -a libdof/libdof/build/libdof.{dylib,*.dylib} ../../../third-party/runtime-libs/macos-x64
 cp -r libdof/libdof/include/DOF ../../../third-party/include/


### PR DESCRIPTION
- Remove bass download from all `platforms/*/external.sh`
- For all platforms that include `libaltsound` copy `bass.[so,dylib]` into `runtime-libs`
- Since iOS has to statically link `libaltsound` still link `bass.dylib` from `runtime-libs` in the iOS `target_link_libraries`

see https://github.com/vpinball/vpinball/commit/a6a5ffcc02a1479f1d33761c2d77194f90d490a5#commitcomment-153584904