### PR TITLE
Sound: fix wrong volume, better LiveUI volume

### DIFF
--- a/src/audio/pinsound.h
+++ b/src/audio/pinsound.h
@@ -100,6 +100,7 @@ public:
 
    void UnInitialize();
    HRESULT ReInitialize(); // also uninits the sound
+   void UpdateVolume();
 
    // plays the sound
    void Play(const float volume, const float randompitch, const int pitch, 
@@ -137,18 +138,6 @@ public:
    //
    // Retrieves detected audio devices detected by SDL
    static void EnumerateAudioDevices(vector<AudioDevice>& devices);
-
-   ///////////////////////////////////
-   // Candidates for removal _S_REMOVE
-   ///////////////////////////////////
-
-   // not sure remove?
-   int bass_BG_idx;
-   int bass_STD_idx;
-
-   /////////////
-   // END REMOVE
-   /////////////
 
 private:
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2344,6 +2344,16 @@ void Player::FinishFrame()
 #endif
 }
 
+void Player::UpdateVolume()
+{
+   if (m_audio)
+      m_audio->UpdateVolume();
+   for (auto sound : m_ptable->m_vsound)
+      sound->UpdateVolume();
+   for (auto players : m_externalAudioPlayers)
+      players.second->UpdateVolume();
+}
+
 void Player::OnAudioUpdated(const unsigned int msgId, void* userData, void* msgData)
 {
    Player *me = static_cast<Player *>(userData);
@@ -2354,10 +2364,10 @@ void Player::OnAudioUpdated(const unsigned int msgId, void* userData, void* msgD
       if (msg.buffer != nullptr)
       {
          const int nChannels = (msg.type == CTLPI_AUDIO_SRC_BACKGLASS_MONO) ? 1 : 2;
-         PinSound* const m_pPinSound = new PinSound(me->m_ptable->m_settings); //!!??
-         m_pPinSound->StreamInit(static_cast<DWORD>(msg.sampleRate), nChannels, 1.f);
-         m_pPinSound->StreamUpdate(msg.buffer, msg.bufferSize);
-         me->m_externalAudioPlayers[msg.id.id] = m_pPinSound;
+         PinSound* const pPinSound = new PinSound(me->m_ptable->m_settings); //!!??
+         pPinSound->StreamInit(static_cast<DWORD>(msg.sampleRate), nChannels, 1.f);
+         pPinSound->StreamUpdate(msg.buffer, msg.bufferSize);
+         me->m_externalAudioPlayers[msg.id.id] = pPinSound;
       }
    }
    else

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -459,6 +459,7 @@ private:
 public:
    void PauseMusic();
    void UnpauseMusic();
+   void UpdateVolume();
 
    bool m_PlayMusic;
    bool m_PlaySound;

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -184,7 +184,7 @@ STDMETHODIMP ScriptGlobalTable::PlayMusic(BSTR str, float volume)
       EndMusic();
 
       g_pplayer->m_audio = new PinSound();
-      const float MusicVolume = max(min((float)g_pplayer->m_MusicVolume*m_pt->m_TableMusicVolume*volume, 100.0f), 0.0f) * (float)(1.0/100.0);
+      const float MusicVolume = clamp(static_cast<float>(g_pplayer->m_MusicVolume) * m_pt->m_TableMusicVolume * volume / 100.f, 0.f, 1.f);
 
       if (!g_pplayer->m_audio->MusicInit(MakeString(str), MusicVolume))
       {
@@ -209,7 +209,7 @@ STDMETHODIMP ScriptGlobalTable::put_MusicVolume(float volume)
 {
    if (g_pplayer && g_pplayer->m_PlayMusic && g_pplayer->m_audio)
    {
-      const float MusicVolume = max(min((float)g_pplayer->m_MusicVolume*m_pt->m_TableMusicVolume*volume, 100.0f), 0.0f) * (float)(1.0/100.0);
+      const float MusicVolume = clamp(m_pt->m_TableMusicVolume * volume, 0.f, 1.f);
       g_pplayer->m_audio->MusicVolume(MusicVolume);
    }
    return S_OK;

--- a/src/ui/LiveUI.h
+++ b/src/ui/LiveUI.h
@@ -60,7 +60,7 @@ private:
       // Point of View
       BS_ViewMode, BS_LookAt, BS_FOV, BS_Layback, BS_ViewHOfs, BS_ViewVOfs, BS_XYZScale, BS_XScale, BS_YScale, BS_ZScale, BS_XOffset, BS_YOffset, BS_ZOffset, BS_WndTopZOfs, BS_WndBottomZOfs,
       // Table tweaks & Custom table defined options (must be the last of this enum)
-      BS_MusicVolume, BS_SoundVolume, BS_DayNight, BS_Difficulty, BS_Tonemapper, BS_Exposure, BS_Custom
+      BS_Volume, BS_BackglassVolume, BS_PlayfieldVolume, BS_DayNight, BS_Difficulty, BS_Tonemapper, BS_Exposure, BS_Custom
    };
    U32 m_lastTweakKeyDown = 0;
    int m_activeTweakIndex = 0;

--- a/src/ui/vpinball_eng.rc
+++ b/src/ui/vpinball_eng.rc
@@ -935,15 +935,15 @@ BEGIN
     LTEXT           "back is side, backbox is front)",IDC_STATIC,23,120,101,8,NOT WS_GROUP
     CONTROL         "7.1 Surround Sound Feedback (enhanced)",IDC_RADIO_SND3DSSF,
                     "Button",BS_AUTORADIOBUTTON,12,133,150,10
-    CONTROL         "P&lay Sound Effects",IDC_PLAY_SOUND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,11,85,10
-    LTEXT           "&Sound Effects Volume",IDC_STATIC_SOUND,179,29,87,8
+    CONTROL         "Enable Playfield Sounds",IDC_PLAY_SOUND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,11,100,10
+    LTEXT           "&Playfield Volume",IDC_STATIC_SOUND,179,29,87,8
     CONTROL         "Slider1",IDC_SOUND_SLIDER,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,174,39,110,18
-    CONTROL         "&Play Music",IDC_PLAY_MUSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,73,50,10
-    LTEXT           "&Music Volume",IDC_STATIC_MUSIC,179,91,45,8
+    CONTROL         "Enable Backglass Sounds",IDC_PLAY_MUSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,73,100,10
+    LTEXT           "&Backglass Volume",IDC_STATIC_MUSIC,179,91,87,8
     CONTROL         "Slider1",IDC_MUSIC_SLIDER,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,174,102,110,18
-    LTEXT           "General output Sound Device",IDC_STATIC_SOUNDDEVICE,289,11,170,10
+    LTEXT           "Playfield Sound Device",IDC_STATIC_SOUNDDEVICE,289,11,170,10
     LISTBOX         IDC_SoundList,289,24,170,40,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Backglass specific Sound Device",IDC_STATIC_SOUNDDEVICE2,288,73,170,10
+    LTEXT           "Backglass Sound Device",IDC_STATIC_SOUNDDEVICE2,288,73,170,10
     LISTBOX         IDC_SoundListBG,288,86,171,40,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "Save Overrides",IDC_SAVE_OVERRIDES,273,141,60,14
     PUSHBUTTON      "Save Changes",IDC_SAVE_ALL,336,141,60,14


### PR DESCRIPTION
- Fix wrong backglass volume (musicvolume applied twice, scaled to 100 instead of 128)
- Allow to adjust volumes at runtime through LiveUI
- Rename Music/Sound => Backglass/Playfield
- Cleanups