### PR TITLE
fix(pup): be more lenient in CustomPos parsing

### DIFF
--- a/standalone/inc/pup/PUPCustomPos.cpp
+++ b/standalone/inc/pup/PUPCustomPos.cpp
@@ -8,9 +8,16 @@
 
 PUPCustomPos* PUPCustomPos::CreateFromCSV(const string& line)
 {
-   vector<string> parts = parse_csv_line(line);
-   if (parts.size() != 5)
+   if (line.empty())
       return nullptr;
+   vector<string> parts = parse_csv_line(line);
+   if (parts.size() < 5){
+      PLOGE << "Expected 5 parts for CustomPos, got " << parts.size() << ": " << line;
+      return nullptr;
+   }
+   if (parts.size() > 5){
+      PLOGW << "Ignoring trailing parts for CustomPos. Expected 5 parts, got " << parts.size() << ": " << line;
+   }
 
    PUPCustomPos* pCustomPos = new PUPCustomPos();
 


### PR DESCRIPTION
This is a partial fix for the missing labels on the `Guardians of The Galaxy` pup pack

see also https://github.com/jsm174/vpx-standalone-scripts/pull/159

Related PuPPack documentation is available here:
https://nailbuster.com/wikipinup/doku.php?id=pup_capture#puppack_screen_terminology

Before:
![image](https://github.com/user-attachments/assets/c9be8434-9db0-4454-b087-7dc323eff207)

After:
![image](https://github.com/user-attachments/assets/1bf427ba-3050-452b-8f6d-a52952b45762)
