### PR TITLE
pup: msg function 15

### DIFF
--- a/standalone/inc/pup/PUPLabel.cpp
+++ b/standalone/inc/pup/PUPLabel.cpp
@@ -85,6 +85,10 @@ void PUPLabel::SetCaption(const string& szCaption)
                if (!szPath.empty()) {
                   m_szPath = szPath;
                   m_type = (szExt == "gif") ? PUP_LABEL_TYPE_GIF : PUP_LABEL_TYPE_IMAGE;
+               } else {
+                  PLOGW.printf("Image not found: screen=%d, label=%s, path=%s", m_pScreen->GetScreenNum(), m_szName.c_str(), szText.c_str());
+                  // we need to set a path otherwise the caption will be used as text
+                  m_szPath = szText;
                }
             }
          }

--- a/standalone/inc/pup/PUPPinDisplay.cpp
+++ b/standalone/inc/pup/PUPPinDisplay.cpp
@@ -422,12 +422,12 @@ STDMETHODIMP PUPPinDisplay::SendMSG(BSTR cMSG)
                   switch (fn) {
                      case 4:
                         // set StayOnTop { "mt":301, "SN": XX, "FN":4, "FS":1/0 }
-                        PLOGW.printf("Stay on top requested: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
+                        PLOGD.printf("Stay on top requested: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
                         pScreen->SetMode((json["FS"s].exists() && json["FS"s].as<int>() == 1) ? PUP_SCREEN_MODE_FORCE_ON : PUP_SCREEN_MODE_FORCE_BACK);
                         break;
                      case 6:
                         // Bring screen to the front
-                        PLOGW.printf("Bring screen to front requested: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
+                        PLOGD.printf("Bring screen to front requested: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
                         pScreen->SendToFront();
                         break;
                      case 10:
@@ -436,9 +436,17 @@ STDMETHODIMP PUPPinDisplay::SendMSG(BSTR cMSG)
                         break;
                      case 11:
                         // set all volume { "mt":301, "SN": XX, "FN":11, "VL":9}  VL=volume level
-                        PLOGW.printf("Set all volume requested: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
+                        PLOGD.printf("Set all volume requested: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
                         pScreen->SetVolume(std::stof(json["VL"].as_str()));
                         break;
+                     case 15:
+                        // set screen custompos { 'mt':301, 'SN':15,'FN':15,'CP':'parent_screen,x,y,w,h'} CP = CustomPos String, coordinates relative in %
+                        PLOGD.printf("Set screen custompos requested: screen={%s}, fn=%d, szMsg=%s",pScreen->ToString(false).c_str(), fn, szMsg.c_str());
+                        pScreen->SetCustomPos(json["CP"].as_str());
+                        break;
+                     case 22:
+                        // set screen transparency { "mt":301, "SN": 16, "FN":22, "AM":1, "AV":255 } AV: Alpha Value (0-255), AM: Alpha mode enabled 0/1?
+                        PLOGE.printf("Set screen transparency not implemented: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
                      default:
                         PLOGE.printf("Not implemented: screen={%s}, fn=%d, szMsg=%s", pScreen->ToString(false).c_str(), fn, szMsg.c_str());
                         break;

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -353,6 +353,13 @@ void PUPScreen::SetBackground(PUPPlaylist* pPlaylist, const std::string& szPlayF
    LoadRenderable(&m_background, pPlaylist->GetPlayFilePath(szPlayFile));
 }
 
+void PUPScreen::SetCustomPos(const string& szCustomPos)
+{
+   std::lock_guard<std::mutex> lock(m_renderMutex);
+   delete m_pCustomPos;
+   m_pCustomPos = PUPCustomPos::CreateFromCSV(szCustomPos);
+}
+
 void PUPScreen::SetOverlay(PUPPlaylist* pPlaylist, const std::string& szPlayFile)
 {
    std::lock_guard<std::mutex> lock(m_renderMutex);

--- a/standalone/inc/pup/PUPScreen.h
+++ b/standalone/inc/pup/PUPScreen.h
@@ -114,6 +114,7 @@ public:
    void Render();
    const SDL_Rect& GetRect() const { return m_rect; }
    void SetBackground(PUPPlaylist* pPlaylist, const std::string& szPlayFile);
+   void SetCustomPos(const string& string);
    void SetOverlay(PUPPlaylist* pPlaylist, const std::string& szPlayFile);
    void SetMedia(PUPPlaylist* pPlaylist, const std::string& szPlayFile, float volume, int priority, bool skipSamePriority);
    void StopMedia();


### PR DESCRIPTION
* pup: msg function 15
* log missing images and do not show path as caption

Further work for GOTG pup pack

Not sure if we should do something like marking all children dirty when update the `m_pCustomPos`?

Below screenshots are only for the label part. That whole screen was not visible without function 15.

This pup pack points to images that don't exist. And on windows this just does not render the images. I've seen similar issues on other pup packs.

before:
![image](https://github.com/user-attachments/assets/e2a529a1-2dfe-4a6f-9415-672e9ce8c7e2)

after:
![image](https://github.com/user-attachments/assets/7b866b4b-a444-4381-8f04-9ac4e1c3019e)
