### PR TITLE
flexdmd: limit size to 256 * 64 max

### DIFF
--- a/standalone/inc/flexdmd/FlexDMD.cpp
+++ b/standalone/inc/flexdmd/FlexDMD.cpp
@@ -187,6 +187,11 @@ STDMETHODIMP FlexDMD::get_Width(unsigned short *pRetVal)
 STDMETHODIMP FlexDMD::put_Width(unsigned short pRetVal)
 {
    m_width = pRetVal;
+   if (m_width > 256) {
+      // LibDMDUtil is limited 256 * 64
+      PLOGW.printf("FlexDMD width was set to %d but we only support up to 256 pixels", m_width);
+      m_width = 256;
+   }
 
    return S_OK;
 }
@@ -201,6 +206,11 @@ STDMETHODIMP FlexDMD::get_Height(unsigned short *pRetVal)
 STDMETHODIMP FlexDMD::put_Height(unsigned short pRetVal)
 {
    m_height = pRetVal;
+   if (m_height > 64) {
+      // LibDMDUtil is limited 256 * 64
+      PLOGW.printf("FlexDMD height was set to %d but we only support up to 64 pixels", m_width);
+      m_height = 64;
+   }
 
    return S_OK;
 }


### PR DESCRIPTION
https://vpuniverse.com/files/file/11755-hellraiser/ has the following code:

```vbscript
Const LCDScreen = True 
Dim UseFlexDMD
If Table1.ShowDT = True then
    UseFlexDMD = False
Else
    UseFlexDMD = True
End If
If LCDScreen = True Then
  FlexDMD.Width = 512
  FlexDMD.Height = 128
End If
```

However this segfaults in LibDMDUtil as the buffer is limited to `256 * 64`
https://github.com/vpinball/libdmdutil/blob/f54f084e995782948d30554391ea57a02010d3db/include/DMDUtil/DMD.h#L112