### PR TITLE
fix issue #2146

### DIFF
--- a/standalone/inc/vpinmame/VPinMAMEController.cpp
+++ b/standalone/inc/vpinmame/VPinMAMEController.cpp
@@ -187,7 +187,7 @@ VPinMAMEController::VPinMAMEController()
    m_szIniPath = find_directory_case_insensitive(m_szPath, "ini");
    if (m_szIniPath.empty()) {
       m_szIniPath = m_szPath + "ini" + PATH_SEPARATOR_CHAR;
-      std::filesystem::create_directory(m_szIniPath);
+      std::filesystem::create_directories(m_szIniPath);
    }
 
    PLOGI.printf("PinMAME ini path set to: %s", m_szIniPath.c_str());


### PR DESCRIPTION
As described in issue #2146, on first startup when supplying a pinmame .vpx file, I get this error:

```
2025-03-17 19:51:09.893 INFO  [127659] [VPinMAMEController::VPinMAMEController@185] PinMAME path set to: /home/baxelrod/.pinmame/
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot create directory: No such file or directory [/home/baxelrod/.pinmame/ini/]
Aborted (core dumped)
```

The issue is that `std::filesystem::create_directory()` doesn't create parent directories.  However, `std::filesystem::create_directories()` does.

I tested on my machine and it worked.