### PR TITLE
standalone: log missing sounds

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -7206,12 +7206,23 @@ HRESULT PinTable::StopSound(BSTR Sound)
    WideCharToMultiByteNull(CP_ACP, 0, Sound, -1, szName, MAXSTRING, nullptr, nullptr);
    const string name(szName);
 
-   for (size_t i = 0; i < m_vsound.size(); i++)
+   size_t i;
+   for (i = 0; i < m_vsound.size(); i++)
       if (StrCompareNoCase(m_vsound[i]->m_szName, name))
-      {
-         m_vsound[i]->Stop();
          break;
+
+   if (i == m_vsound.size()) // did not find it
+   {
+      if (!name.empty() && !m_soundsMissing.contains(name))
+      {
+         PLOGW << "Request to stop \"" << name << "\", but sound not found.";
+         m_soundsMissing.insert(name);
       }
+      return S_OK;
+   }
+
+   PinSound * const pps = m_vsound[i];
+   pps->Stop();
 
    return S_OK;
 }
@@ -7239,16 +7250,15 @@ STDMETHODIMP PinTable::PlaySound(BSTR bstr, int loopcount, float volume, float p
 
    if (i == m_vsound.size()) // did not find it
    {
-      if (!name.empty() && m_pcv && g_pplayer && g_pplayer->m_hwndDebugOutput)
+      if (!name.empty() && !m_soundsMissing.contains(name))
       {
-         const string logmsg = "Request to play \"" + name + "\", but sound not found.";
-         m_pcv->AddToDebugOutput(logmsg.c_str());
+         PLOGW << "Request to play \"" << name << "\", but sound not found.";
+         m_soundsMissing.insert(name);
       }
       return S_OK;
    }
 
    PinSound * const pps = m_vsound[i];
-
    pps->Play(volume, randompitch, pitch, pan, front_rear_fade, loopcount, VBTOb(usesame), VBTOb(restart));
 
    return S_OK;

--- a/src/parts/pintable.h
+++ b/src/parts/pintable.h
@@ -722,6 +722,7 @@ public:
    const vector<Material *> &GetMaterialList() const { return m_materials; }
 
    vector<PinSound *> m_vsound;
+   ankerl::unordered_dense::set<std::string> m_soundsMissing;
 
    vector<PinFont *> m_vfont;
 


### PR DESCRIPTION
I was debugging why Hellraiser is not playing background music and found out that missing sounds are only logged on windows.

What I want:
* Missing sounds are logged as `WARN` (marked yellow in log)
* This can be optional by setting some config value as some badly written tables try to play ball roll sounds that don't exist. For example this Hellraiser table defines 20 balls in the ball roll sound code but there are only 10 `fx_ballrolling#` sounds.

Went for the simplest solution but I'm expecting some feedback on this one.

On windows there is a debug screen.
There is an option to redirect log output to that screen.
The sound code is a a bit special in that it directly sends to that debug screen without going through the logs. 
On standalone there is no debug screen `m_hwndDebugOutput`. Therefore no missing sounds are logged.

There is also `DebuggerModule::Print` but this does not have any log levels.
This feature is controlled by a setting `Editor::EnableLog` and `Editor::LogScriptOutput` with different defaults depending on standalone.

Questions:

* How do we make this logging optional and where should this code that checks the setting before logging be placed? I guess there should not be multiple places where the same setting is checked?
* We might also want to log warnings if sounds are being stopped that don't exist?




