### PR TITLE
fix: bring back disabled vsync

### DIFF
--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -572,7 +572,7 @@ void RenderDevice::RenderThread(RenderDevice* rd, const bgfx::Init& initReq)
          }
 
          // If the user asked to sync on another frame rate than the refresh rate, then perform manual synchronization
-         if (!noSync && (!needsVSync || (g_pplayer->GetTargetRefreshRate() != rd->m_outputWnd[0]->GetRefreshRate())))
+         if (!noSync && (needsVSync || (g_pplayer->GetTargetRefreshRate() != rd->m_outputWnd[0]->GetRefreshRate())))
          {
             g_pplayer->m_renderProfiler->EnterProfileSection(FrameProfiler::PROFILE_RENDER_SLEEP);
             #ifdef MSVC_CONCURRENCY_VIEWER


### PR DESCRIPTION
This fixes unlocked fps in the case of:
```ini
SyncMode = 0
MaxFramerate = 0
```

Regression  happened in 317bf42
Not sure if this is the best/correct way to fix this. Higher up in the code there is already `needsVSync = useVSync && !noSync` so that `!noSync &&` in the `if` is probably not needed.

However after some more testing there is still some strangeness for MaxFramerate > monitor refresh rate

https://github.com/vpinball/vpinball/blob/ded4119928d1979e3a7bd24b4f50a1470fe8229e/src/renderer/RenderDevice.cpp#L585

I wonder what this magic number `2000` is here and why this `clamp` is used. It causes frame rates of 68,2 fps for any `MaxFramerate` higher than the display refresh rate (60hz in my case). I would expect it to end up with a 90fps in below case.

```ini
SyncMode = 0
MaxFramerate = 90
```

_Further I also see that the `MaxFramerate = 0` is no longer required to have unlocked fps. Leaving the value empty is also working now._

fixes #2267