### PR TITLE
fix: initialize m_hitEvent for Primitive

### DIFF
--- a/src/parts/primitive.cpp
+++ b/src/parts/primitive.cpp
@@ -220,6 +220,7 @@ Primitive::Primitive()
    m_propVisual = nullptr;
    m_d.m_overwritePhysics = true;
    m_d.m_useAsPlayfield = false;
+   m_d.m_hitEvent = false;
 }
 
 Primitive::~Primitive()


### PR DESCRIPTION
While working on my [vpx read/write library](https://github.com/francisdb/vpin) I found strange boolean values for HTEV

This could also use a backport to 10.8.0