### PR TITLE
standalone: fix random invalid globalEmissionScale value on android

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -422,8 +422,8 @@ private:
    bool m_extractScript;
    bool m_audit;
    bool m_tournament;
-   bool m_bgles;
-   float m_fgles;
+   bool m_bgles = false;
+   float m_fgles = 0.f;
 #ifdef __STANDALONE__
    string m_szPrefPath;
    bool m_listRes;

--- a/src/core/vpinball_h.h
+++ b/src/core/vpinball_h.h
@@ -267,8 +267,8 @@ public:
    bool m_primaryDisplay; // force use of pixel(0,0) monitor
    bool m_table_played_via_command_line;
    volatile bool m_table_played_via_SelectTableOnStart;
-   bool m_bgles; // override global emission scale by m_fgles below?
-   float m_fgles;
+   bool m_bgles = false; // override global emission scale by m_fgles below?
+   float m_fgles = 0.f;
    WCHAR *m_customParameters[MAX_CUSTOM_PARAM_INDEX];
 
    HBITMAP m_hbmInPlayMode;


### PR DESCRIPTION
Android and iOS does not fully flow through `main.cpp`

Sporatically, `g_pvp->m_bgles` would be true, setting the `m_globalEmissionScale` to some bizarre value.

```
   if (g_pvp->m_bgles)
   { // Overriden from command line

      m_globalEmissionScale = g_pvp->m_fgles;
   }
```

This defaults `m_bgles` to `false` and `m_fgles` to `0.f`.

![image](https://github.com/user-attachments/assets/42d1c16b-593b-438f-8b21-9c7aa46e6bf6)