### PR TITLE
fix(standalone): vbscript GetRef for Functions

### DIFF
--- a/standalone/inc/wine/dlls/vbscript/global.c
+++ b/standalone/inc/wine/dlls/vbscript/global.c
@@ -141,17 +141,7 @@ static HRESULT WINAPI GetRef_Invoke(IDispatch *iface, DISPID id, REFIID riid, LC
        return E_FAIL;
 
     if (id == DISPID_VALUE && (flags & DISPATCH_METHOD)) {
-       if (dp->cArgs == 0 && (flags & DISPATCH_PROPERTYGET)) {
-          IDispatch *disp = &This->IDispatch_iface;
-          IDispatch_AddRef(disp);
-          V_VT(res) = VT_DISPATCH;
-          V_DISPATCH(res) = disp;
-
-          return S_OK;
-       }
-       else {
-          return exec_script(This->ctx, FALSE, This->func, NULL, dp, res);
-       }
+       return exec_script(This->ctx, FALSE, This->func, NULL, dp, res);
     }
 
     return DISP_E_UNKNOWNNAME;


### PR DESCRIPTION
This is a fix for an upcoming table using https://github.com/mpcarr/vpx-glf
Meanwhile this table was released: https://vpuniverse.com/files/file/24875-dark-chaos-apophis-2025/

```vbscript
Function Glf_3()
    Glf_3 = 15000
End Function

Dim m_value: m_value = "Glf_3"
```

```
Script.Print 'GetRef(m_value): Object'
Script.Print 'GetRef(m_value)(): Object'
Script.Print 'GetRef(m_value)()(): Object'
```

With this patch:

```
Script.Print 'GetRef(m_value): Object'
Script.Print 'GetRef(m_value)(): 15000'
```