### PR TITLE
standalone: fix unpredictable multiple va_list/vsnprintf on linux

### DIFF
--- a/plugins/pinmame/PinMamePlugin.cpp
+++ b/plugins/pinmame/PinMamePlugin.cpp
@@ -203,9 +203,11 @@ LPI_IMPLEMENT // Implement shared login support
 
 void PINMAMECALLBACK OnLogMessage(PINMAME_LOG_LEVEL logLevel, const char* format, va_list args, void* const pUserData)
 {
-   int size = vsnprintf(nullptr, 0, format, args);
-   if (size > 0)
-   {
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
       char* const buffer = static_cast<char*>(malloc(size + 1));
       vsnprintf(buffer, size + 1, format, args);
       if (logLevel == PINMAME_LOG_LEVEL_INFO)

--- a/src/plugins/LoggingPlugin.h
+++ b/src/plugins/LoggingPlugin.h
@@ -52,7 +52,10 @@ typedef struct LoggingPluginAPI
       if (loggingApi != nullptr) { \
          va_list args; \
          va_start(args, format); \
-         int size = vsnprintf(NULL, 0, format, args); \
+         va_list args_copy; \
+         va_copy(args_copy, args); \
+         int size = vsnprintf(nullptr, 0, format, args_copy); \
+         va_end(args_copy); \
          if (size > 0) { \
             char* buffer = static_cast<char*>(malloc(size + 1)); \
             vsnprintf(buffer, size + 1, format, args); \

--- a/src/plugins/ScriptablePlugin.h
+++ b/src/plugins/ScriptablePlugin.h
@@ -158,10 +158,13 @@ typedef struct ScriptablePluginAPI
       if (scriptablePluginApi != nullptr) { \
          va_list args; \
          va_start(args, format); \
-         int size = vsnprintf(NULL, 0, format, args); \
+         va_list args_copy; \
+         va_copy(args_copy, args); \
+         int size = vsnprintf(nullptr, 0, format, args_copy); \
+         va_end(args_copy); \
          if (size > 0) { \
             char* buffer = static_cast<char*>(malloc(size + 1)); \
-            vsnprintf(buffer, size, format, args); \
+            vsnprintf(buffer, size + 1, format, args); \
             scriptablePluginApi->OnError(type, buffer); \
             free(buffer); \
          } \

--- a/src/utils/def.cpp
+++ b/src/utils/def.cpp
@@ -820,32 +820,53 @@ HRESULT external_create_object(const WCHAR* progid, IClassFactory* cf, IUnknown*
 
 void external_log_info(const char* format, ...)
 {
-    char buffer[1024];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
-    va_end(args);
-    PLOGI << buffer;
+   va_list args;
+   va_start(args, format);
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
+      char* const buffer = static_cast<char*>(malloc(size + 1));
+      vsnprintf(buffer, size + 1, format, args);
+      PLOGI << buffer;
+      free(buffer);
+   }
+   va_end(args);
 }
 
 void external_log_debug(const char* format, ...)
 {
-    char buffer[1024];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
-    va_end(args);
-    PLOGD << buffer;
+   va_list args;
+   va_start(args, format);
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
+      char* const buffer = static_cast<char*>(malloc(size + 1));
+      vsnprintf(buffer, size + 1, format, args);
+      PLOGD << buffer;
+      free(buffer);
+   }
+   va_end(args);
 }
 
 void external_log_error(const char* format, ...)
 {
-    char buffer[1024];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
-    va_end(args);
-    PLOGE << buffer;
+   va_list args;
+   va_start(args, format);
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
+      char* const buffer = static_cast<char*>(malloc(size + 1));
+      vsnprintf(buffer, size + 1, format, args);
+      PLOGE << buffer;
+      free(buffer);
+   }
+   va_end(args);
 }
 
 #endif

--- a/standalone/Standalone.cpp
+++ b/standalone/Standalone.cpp
@@ -14,10 +14,21 @@
 
 void OnDMDUtilLog(DMDUtil_LogLevel logLevel, const char* format, va_list args)
 {
-   char buffer[4096];
-   vsnprintf(buffer, sizeof(buffer), format, args);
-
-   PLOGI.printf("%s", buffer);
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
+      char* const buffer = static_cast<char*>(malloc(size + 1));
+      vsnprintf(buffer, size + 1, format, args);
+      if (logLevel == DMDUtil_LogLevel_INFO) {
+         PLOGI << buffer;
+      }
+      else if (logLevel == DMDUtil_LogLevel_ERROR) {
+         PLOGE << buffer;
+      }
+      free(buffer);
+   }
 }
 
 void OnSignalHandler(int signum)

--- a/standalone/inc/dof/DOFPlugin.cpp
+++ b/standalone/inc/dof/DOFPlugin.cpp
@@ -4,10 +4,21 @@
 
 void OnDOFLog(DOF_LogLevel logLevel, const char* format, va_list args)
 {
-   char buffer[4096];
-   vsnprintf(buffer, sizeof(buffer), format, args);
-
-   PLOGI.printf("%s", buffer);
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
+      char* const buffer = static_cast<char*>(malloc(size + 1));
+      vsnprintf(buffer, size + 1, format, args);
+      if (logLevel == DOF_LogLevel_INFO) {
+         PLOGI << buffer;
+      }
+      else if (logLevel == DOF_LogLevel_ERROR) {
+         PLOGE << buffer;
+      }
+      free(buffer);
+   }
 }
 
 DOFPlugin::DOFPlugin() : Plugin()

--- a/standalone/inc/vpinmame/VPinMAMEController.cpp
+++ b/standalone/inc/vpinmame/VPinMAMEController.cpp
@@ -127,14 +127,20 @@ int PINMAMECALLBACK VPinMAMEController::OnAudioUpdated(void* p_buffer, int sampl
 
 void PINMAMECALLBACK VPinMAMEController::OnLogMessage(PINMAME_LOG_LEVEL logLevel, const char* format, va_list args, void* const pUserData)
 {
-   char buffer[4096];
-   vsnprintf(buffer, sizeof(buffer), format, args);
-
-   if (logLevel == PINMAME_LOG_LEVEL_INFO) {
-      PLOGI.printf("%s", buffer);
-   }
-   else if (logLevel == PINMAME_LOG_LEVEL_ERROR) {
-      PLOGE.printf("%s", buffer);
+   va_list args_copy;
+   va_copy(args_copy, args);
+   int size = vsnprintf(nullptr, 0, format, args_copy);
+   va_end(args_copy);
+   if (size > 0) {
+      char* const buffer = static_cast<char*>(malloc(size + 1));
+      vsnprintf(buffer, size + 1, format, args);
+      if (logLevel == PINMAME_LOG_LEVEL_INFO) {
+         PLOGI << buffer;
+      }
+      else if (logLevel == PINMAME_LOG_LEVEL_ERROR) {
+         PLOGE << buffer;
+      }
+      free(buffer);
    }
 }
 


### PR DESCRIPTION
No one has been able to use the new plugins on Linux, so I finally had a chance to look into it. 

Evidentially you can not use `vsnprintf` multiple times with args unless you copy them. I updated all logging that did this to copy the arguments first:

```
   va_list args_copy;
   va_copy(args_copy, args);
   int size = vsnprintf(nullptr, 0, format, args_copy);
   va_end(args_copy);
```

Fixes:  https://github.com/vpinball/vpinball/issues/2179
