### PR TITLE
Move table back/forth/left/right In VR

### DIFF
--- a/pininput.cpp
+++ b/pininput.cpp
@@ -1074,6 +1074,14 @@ void PinInput::FireKeyEvent(const int dispid, int keycode)
       g_pplayer->m_pin3d.m_pd3dPrimaryDevice->tableUp();
    else if (keycode == g_pplayer->m_rgKeys[eTableDown] && dispid == DISPID_GameEvents_KeyUp)
       g_pplayer->m_pin3d.m_pd3dPrimaryDevice->tableDown();
+   else if (keycode == g_pplayer->m_rgKeys[eTableForward] && dispid == DISPID_GameEvents_KeyUp)
+      g_pplayer->m_pin3d.m_pd3dPrimaryDevice->tableForward();
+   else if (keycode == g_pplayer->m_rgKeys[eTableBack] && dispid == DISPID_GameEvents_KeyUp)
+      g_pplayer->m_pin3d.m_pd3dPrimaryDevice->tableBack();
+   else if (keycode == g_pplayer->m_rgKeys[eTableRight] && dispid == DISPID_GameEvents_KeyUp)
+      g_pplayer->m_pin3d.m_pd3dPrimaryDevice->tableRight();
+   else if (keycode == g_pplayer->m_rgKeys[eTableLeft] && dispid == DISPID_GameEvents_KeyUp)
+      g_pplayer->m_pin3d.m_pd3dPrimaryDevice->tableLeft();
    else
 #endif
 

--- a/pininput.cpp
+++ b/pininput.cpp
@@ -104,7 +104,11 @@ PinInput::PinInput()
    m_joytablerecenter = 0;
    m_joytableup = 0;
    m_joytabledown = 0;
-
+   m_joytableforward = 0;
+   m_joytableback = 0;
+   m_joytableleft = 0;
+   m_joytableright = 0;
+ 
    m_firedautostart = 0;
 
    m_pressed_start = false;
@@ -198,6 +202,10 @@ void PinInput::LoadSettings(const Settings& settings)
    m_joytablerecenter = settings.LoadValueWithDefault(Settings::Player, "JoyTableRecenterKey"s, m_joytablerecenter);
    m_joytableup = settings.LoadValueWithDefault(Settings::Player, "JoyTableUpKey"s, m_joytableup);
    m_joytabledown = settings.LoadValueWithDefault(Settings::Player, "JoyTableDownKey"s, m_joytabledown);
+   m_joytableforward = settings.LoadValueWithDefault(Settings::Player, "JoyTableForwardKey"s, m_joytableforward);
+   m_joytableback = settings.LoadValueWithDefault(Settings::Player, "JoyTableBackKey"s, m_joytableback);
+   m_joytableleft = settings.LoadValueWithDefault(Settings::Player, "JoyTableLeftKey"s, m_joytableleft);
+   m_joytableright = settings.LoadValueWithDefault(Settings::Player, "JoyTableRightKey"s, m_joytableright);
    m_enableMouseInPlayer = settings.LoadValueWithDefault(Settings::Player, "EnableMouseInPlayer"s, m_enableMouseInPlayer);
    m_enableCameraModeFlyAround = settings.LoadValueWithDefault(Settings::Player, "EnableCameraModeFlyAround"s, m_enableCameraModeFlyAround);
    m_enable_nudge_filter = settings.LoadValueWithDefault(Settings::Player, "EnableNudgeFilter"s, m_enable_nudge_filter);
@@ -1265,6 +1273,10 @@ void PinInput::Joy(const unsigned int n, const int updown, const bool start)
    if (m_joytablerecenter == n) FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableRecenter]);
    if (m_joytableup == n)       FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableUp]);
    if (m_joytabledown == n)     FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableDown]);
+   if (m_joytableforward == n)  FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableForward]);
+   if (m_joytableback == n)     FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableBack]);
+   if (m_joytableleft == n)     FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableLeft]);
+   if (m_joytableright == n)    FireKeyEvent(updown, g_pplayer->m_rgKeys[eTableRight]);
    if (m_joystartgamekey == n)
    {
       if (start)

--- a/pininput.h
+++ b/pininput.h
@@ -221,6 +221,7 @@ private:
    int m_joypmcoin3, m_joypmcoin4, m_joypmcoindoor, m_joypmcancel, m_joypmdown, m_joypmup, m_joypmenter, m_joydebugballs, m_joydebugger, m_joylockbar, m_joymechtilt;
    int m_joycustom1, m_joycustom2, m_joycustom3, m_joycustom4;
    int m_joytablerecenter, m_joytableup, m_joytabledown, m_joypause, m_joytweak;
+   int m_joytableforward, m_joytableback, m_joytableleft, m_joytableright;
    int m_deadz;
    bool m_override_default_buttons, m_plunger_reverse, m_disable_esc, m_lr_axis_reverse, m_ud_axis_reverse;
    bool m_enableMouseInPlayer;

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -20,7 +20,7 @@ enum VRPreviewMode
    VRPREVIEW_RIGHT,
    VRPREVIEW_BOTH
 };
-
+//Panasony
 // NOTE that the following four definitions need to be in sync in their order!
 enum EnumAssignKeys
 {
@@ -49,6 +49,10 @@ enum EnumAssignKeys
    eTableRecenter,
    eTableUp,
    eTableDown,
+   eTableForward,
+   eTableBack,
+   eTableRight,
+   eTableLeft,
    eEscape,
    ePause,
    eTweak,
@@ -81,6 +85,10 @@ static const string regkey_string[eCKeys] = {
    "TableRecenterKey"s,
    "TableUpKey"s,
    "TableDownKey"s,
+   "TableForwardKey"s,
+   "TableBackKey"s,
+   "TableRightKey"s,
+   "TableLeftKey"s,
    "EscapeKey"s,
    "PauseKey"s,
    "TweakKey"s
@@ -111,6 +119,10 @@ static constexpr int regkey_defdik[eCKeys] = {
    DIK_NUMPAD5,
    DIK_NUMPAD8,
    DIK_NUMPAD2,
+   -1,
+   -1,
+   -1,
+   -1,
    DIK_ESCAPE,
    DIK_P,
    DIK_F12
@@ -141,6 +153,10 @@ static constexpr int regkey_idc[eCKeys] = {
    IDC_TABLEREC_TEXT,
    IDC_TABLEUP_TEXT,
    IDC_TABLEDOWN_TEXT,
+   -1,
+   -1,
+   -1,
+   -1,
    -1, // Escape
    IDC_PAUSE,
    IDC_TWEAK

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -20,7 +20,6 @@ enum VRPreviewMode
    VRPREVIEW_RIGHT,
    VRPREVIEW_BOTH
 };
-//Panasony
 // NOTE that the following four definitions need to be in sync in their order!
 enum EnumAssignKeys
 {

--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -2255,6 +2255,26 @@ void RenderDevice::tableDown()
       m_tablez = 0.0f;
    updateTableMatrix();
 }
+void RenderDevice::tableForward()
+{
+   m_tabley -= 1.0f;
+   updateTableMatrix();
+}
+void RenderDevice::tableBack()
+{
+   m_tabley += 1.0f;
+   updateTableMatrix();
+}
+void RenderDevice::tableRight()
+{
+   m_tablex -= 1.0f;
+   updateTableMatrix();
+}
+void RenderDevice::tableLeft()
+{
+   m_tablex += 1.0f;
+   updateTableMatrix();
+}
 
 void RenderDevice::recenterTable()
 {

--- a/src/renderer/RenderDevice.h
+++ b/src/renderer/RenderDevice.h
@@ -195,6 +195,10 @@ public:
    void UpdateVRPosition(ModelViewProj& mvp);
    void tableUp();
    void tableDown();
+   void tableForward();
+   void tableBack();
+   void tableRight();
+   void tableLeft();
    void recenterTable();
    void updateTableMatrix();
    static bool isVRinstalled();


### PR DESCRIPTION
The table can be moved back and forth and left and right to make it easier to align with the pin controller when using VR. No default key bindings are set to avoid conflicts with other key bindings. Users set key bindings by adding the following to VPinballX.ini: 
TableForwardKey = <num>
TableBackKey = <num>
TableLeftKey = <num>
TableRightKey = <num>