### PR TITLE
standalone: add support for RegExp and IFileCollection

### DIFF
--- a/standalone/idl/parser/src/main/java/org/vpinball/IDLParserToC.java
+++ b/standalone/idl/parser/src/main/java/org/vpinball/IDLParserToC.java
@@ -538,6 +538,7 @@ public class IDLParserToC {
                 	new IDLInterface("IDriveCollection", "drivecoll"),
                 	new IDLInterface("IFolderCollection", "foldercoll"),
                 	new IDLInterface("IFolder", "folder"),
+                	new IDLInterface("IFileCollection", "filecoll"),
                 	new IDLInterface("IDrive", "drive"),
                 	new IDLInterface("ITextStream", "textstream"),
                 	new IDLInterface("IFile", "file"),

--- a/standalone/idl/parser/src/main/java/org/vpinball/IDLParserToC.java
+++ b/standalone/idl/parser/src/main/java/org/vpinball/IDLParserToC.java
@@ -514,6 +514,18 @@ public class IDLParserToC {
         IDLParserToC parser = new IDLParserToC();
 
         parser.parse(
+                "../../inc/wine/dlls/vbscript/vbsregexp55.idl",
+                "regexp_proxy.c",
+                Arrays.asList(
+                	new IDLInterface("IRegExp", "RegExp"),
+                	new IDLInterface("IRegExp2", "RegExp2"),
+                	new IDLInterface("IMatch", "Match"),
+                	new IDLInterface("IMatch2", "Match2"),
+                	new IDLInterface("IMatchCollection", "MatchCollection"),
+                	new IDLInterface("IMatchCollection2", "MatchCollection2"),
+                	new IDLInterface("ISubMatches", "SubMatches")));
+
+        parser.parse(
                 "../../inc/wine/dlls/scrrun/scrrun.idl", 
                 "dictionary_proxy.c",
                 Arrays.asList(

--- a/standalone/inc/wine/dlls/scrrun/filesystem.c
+++ b/standalone/inc/wine/dlls/scrrun/filesystem.c
@@ -2126,6 +2126,11 @@ static HRESULT WINAPI filecoll_GetTypeInfo(IFileCollection *iface, UINT iTInfo,
     return get_typeinfo(IFileCollection_tid, ppTInfo);
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI filecoll_GetIDsOfNames(IFileCollection *iface, REFIID riid,
+    LPOLESTR *rgszNames, UINT cNames,
+    LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI filecoll_GetIDsOfNames(IFileCollection *iface, REFIID riid,
                                         LPOLESTR *rgszNames, UINT cNames,
                                         LCID lcid, DISPID *rgDispId)
@@ -2144,7 +2149,14 @@ static HRESULT WINAPI filecoll_GetIDsOfNames(IFileCollection *iface, REFIID riid
 
     return hr;
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI filecoll_Invoke(IFileCollection *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags,
+    DISPPARAMS *pDispParams, VARIANT *pVarResult,
+    EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI filecoll_Invoke(IFileCollection *iface, DISPID dispIdMember,
                                       REFIID riid, LCID lcid, WORD wFlags,
                                       DISPPARAMS *pDispParams, VARIANT *pVarResult,
@@ -2166,6 +2178,7 @@ static HRESULT WINAPI filecoll_Invoke(IFileCollection *iface, DISPID dispIdMembe
 
     return hr;
 }
+#endif
 
 static HRESULT WINAPI filecoll_get_Item(IFileCollection *iface, VARIANT Key, IFile **file)
 {

--- a/standalone/inc/wine/dlls/vbscript/regexp_proxy.c
+++ b/standalone/inc/wine/dlls/vbscript/regexp_proxy.c
@@ -1,0 +1,772 @@
+void external_log_info(const char* format, ...);
+
+static HRESULT WINAPI RegExp_GetIDsOfNames(IRegExp *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"Execute", DISPID_REGEXP_EXECUTE },
+			{ L"Global", DISPID_REGEXP_GLOBAL },
+			{ L"IgnoreCase", DISPID_REGEXP_IGNORECASE },
+			{ L"Pattern", DISPID_REGEXP_PATTERN },
+			{ L"Replace", DISPID_REGEXP_REPLACE },
+			{ L"Test", DISPID_REGEXP_TEST }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI RegExp_Invoke(IRegExp *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_REGEXP_PATTERN: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 45: [id(DISPID_REGEXP_PATTERN), propget]HRESULT Pattern([out, retval] BSTR *pPattern);
+				V_VT(&res) = VT_BSTR;
+				hres = RegExp_get_Pattern(iface, &V_BSTR(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 48: [id(DISPID_REGEXP_PATTERN), propput]HRESULT Pattern([in] BSTR pPattern);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				hres = RegExp_put_Pattern(iface, V_BSTR(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_IGNORECASE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 51: [id(DISPID_REGEXP_IGNORECASE), propget]HRESULT IgnoreCase([out, retval] VARIANT_BOOL *pIgnoreCase);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp_get_IgnoreCase(iface, &V_BOOL(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 54: [id(DISPID_REGEXP_IGNORECASE), propput]HRESULT IgnoreCase([in] VARIANT_BOOL pIgnoreCase);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BOOL);
+				hres = RegExp_put_IgnoreCase(iface, V_BOOL(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_GLOBAL: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 57: [id(DISPID_REGEXP_GLOBAL), propget]HRESULT Global([out, retval] VARIANT_BOOL *pGlobal);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp_get_Global(iface, &V_BOOL(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 60: [id(DISPID_REGEXP_GLOBAL), propput]HRESULT Global([in] VARIANT_BOOL pGlobal);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BOOL);
+				hres = RegExp_put_Global(iface, V_BOOL(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_EXECUTE: {
+			if (wFlags & DISPATCH_METHOD) {
+				// line 63: [id(DISPID_REGEXP_EXECUTE)]HRESULT Execute([in] BSTR sourceString,[out, retval] IDispatch **ppMatches);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				V_VT(&res) = VT_DISPATCH;
+				hres = RegExp_Execute(iface, V_BSTR(&var0), (IDispatch**)&V_DISPATCH(&res));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_TEST: {
+			if (wFlags & DISPATCH_METHOD) {
+				// line 68: [id(DISPID_REGEXP_TEST)]HRESULT Test([in] BSTR sourceString,[out, retval] VARIANT_BOOL *pMatch);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp_Test(iface, V_BSTR(&var0), &V_BOOL(&res));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_REPLACE: {
+			if (wFlags & DISPATCH_METHOD) {
+				// line 73: [id(DISPID_REGEXP_REPLACE)]HRESULT Replace([in] BSTR sourceString,[in] BSTR replaceString,[out, retval] BSTR *pDestString);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				VARIANT var1;
+				V_VT(&var1) = VT_EMPTY;
+				VariantChangeType(&var1, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				V_VT(&res) = VT_BSTR;
+				hres = RegExp_Replace(iface, V_BSTR(&var0), V_BSTR(&var1), &V_BSTR(&res));
+				VariantClear(&var0);
+				VariantClear(&var1);
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("RegExp_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}
+
+static HRESULT WINAPI RegExp2_GetIDsOfNames(IRegExp2 *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"Execute", DISPID_REGEXP_EXECUTE },
+			{ L"Global", DISPID_REGEXP_GLOBAL },
+			{ L"IgnoreCase", DISPID_REGEXP_IGNORECASE },
+			{ L"Multiline", DISPID_REGEXP_MULTILINE },
+			{ L"Pattern", DISPID_REGEXP_PATTERN },
+			{ L"Replace", DISPID_REGEXP_REPLACE },
+			{ L"Test", DISPID_REGEXP_TEST }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI RegExp2_Invoke(IRegExp2 *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_REGEXP_PATTERN: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 90: [id(DISPID_REGEXP_PATTERN), propget]HRESULT Pattern([out, retval] BSTR *pPattern);
+				V_VT(&res) = VT_BSTR;
+				hres = RegExp2_get_Pattern(iface, &V_BSTR(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 93: [id(DISPID_REGEXP_PATTERN), propput]HRESULT Pattern([in] BSTR pPattern);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				hres = RegExp2_put_Pattern(iface, V_BSTR(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_IGNORECASE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 96: [id(DISPID_REGEXP_IGNORECASE), propget]HRESULT IgnoreCase([out, retval] VARIANT_BOOL *pIgnoreCase);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp2_get_IgnoreCase(iface, &V_BOOL(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 99: [id(DISPID_REGEXP_IGNORECASE), propput]HRESULT IgnoreCase([in] VARIANT_BOOL pIgnoreCase);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BOOL);
+				hres = RegExp2_put_IgnoreCase(iface, V_BOOL(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_GLOBAL: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 102: [id(DISPID_REGEXP_GLOBAL), propget]HRESULT Global([out, retval] VARIANT_BOOL *pGlobal);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp2_get_Global(iface, &V_BOOL(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 105: [id(DISPID_REGEXP_GLOBAL), propput]HRESULT Global([in] VARIANT_BOOL pGlobal);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BOOL);
+				hres = RegExp2_put_Global(iface, V_BOOL(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_MULTILINE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 108: [id(DISPID_REGEXP_MULTILINE), propget]HRESULT Multiline([out, retval] VARIANT_BOOL *pMultiline);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp2_get_Multiline(iface, &V_BOOL(&res));
+			}
+			else if (wFlags & DISPATCH_PROPERTYPUT) {
+				// line 111: [id(DISPID_REGEXP_MULTILINE), propput]HRESULT Multiline([in] VARIANT_BOOL pMultiline);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BOOL);
+				hres = RegExp2_put_Multiline(iface, V_BOOL(&var0));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_EXECUTE: {
+			if (wFlags & DISPATCH_METHOD) {
+				// line 114: [id(DISPID_REGEXP_EXECUTE)]HRESULT Execute([in] BSTR sourceString,[out, retval] IDispatch **ppMatches);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				V_VT(&res) = VT_DISPATCH;
+				hres = RegExp2_Execute(iface, V_BSTR(&var0), (IDispatch**)&V_DISPATCH(&res));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_TEST: {
+			if (wFlags & DISPATCH_METHOD) {
+				// line 119: [id(DISPID_REGEXP_TEST)]HRESULT Test([in] BSTR sourceString,[out, retval] VARIANT_BOOL *pMatch);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				V_VT(&res) = VT_BOOL;
+				hres = RegExp2_Test(iface, V_BSTR(&var0), &V_BOOL(&res));
+				VariantClear(&var0);
+			}
+			break;
+		}
+		case DISPID_REGEXP_REPLACE: {
+			if (wFlags & DISPATCH_METHOD) {
+				// line 124: [id(DISPID_REGEXP_REPLACE)]HRESULT Replace([in] BSTR sourceString,[in] VARIANT replaceVar,[out, retval] BSTR *pDestString);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_BSTR);
+				VARIANT var1;
+				V_VT(&var1) = VT_EMPTY;
+				VariantChangeType(&var1, &pDispParams->rgvarg[--index], 0, VT_VARIANT);
+				V_VT(&res) = VT_BSTR;
+				hres = RegExp2_Replace(iface, V_BSTR(&var0), var1, &V_BSTR(&res));
+				VariantClear(&var0);
+				VariantClear(&var1);
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("RegExp2_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}
+
+static HRESULT WINAPI Match_GetIDsOfNames(IMatch *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"FirstIndex", DISPID_MATCH_FIRSTINDEX },
+			{ L"Length", DISPID_MATCH_LENGTH }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI Match_Invoke(IMatch *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 141: [id(DISPID_VALUE), propget]HRESULT Value([out, retval] BSTR *pValue);
+				V_VT(&res) = VT_BSTR;
+				hres = Match_get_Value(iface, &V_BSTR(&res));
+			}
+			else if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_MATCH_FIRSTINDEX: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 144: [id(DISPID_MATCH_FIRSTINDEX), propget]HRESULT FirstIndex([out, retval] LONG *pFirstIndex);
+				V_VT(&res) = VT_I4;
+				hres = Match_get_FirstIndex(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		case DISPID_MATCH_LENGTH: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 147: [id(DISPID_MATCH_LENGTH), propget]HRESULT Length([out, retval] LONG *pLength);
+				V_VT(&res) = VT_I4;
+				hres = Match_get_Length(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("Match_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}
+
+static HRESULT WINAPI Match2_GetIDsOfNames(IMatch2 *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"FirstIndex", DISPID_MATCH_FIRSTINDEX },
+			{ L"Length", DISPID_MATCH_LENGTH },
+			{ L"SubMatches", DISPID_MATCH_SUBMATCHES }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI Match2_Invoke(IMatch2 *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 161: [id(DISPID_VALUE), propget]HRESULT Value([out, retval] BSTR *pValue);
+				V_VT(&res) = VT_BSTR;
+				hres = Match2_get_Value(iface, &V_BSTR(&res));
+			}
+			else if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_MATCH_FIRSTINDEX: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 164: [id(DISPID_MATCH_FIRSTINDEX), propget]HRESULT FirstIndex([out, retval] LONG *pFirstIndex);
+				V_VT(&res) = VT_I4;
+				hres = Match2_get_FirstIndex(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		case DISPID_MATCH_LENGTH: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 167: [id(DISPID_MATCH_LENGTH), propget]HRESULT Length([out, retval] LONG *pLength);
+				V_VT(&res) = VT_I4;
+				hres = Match2_get_Length(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		case DISPID_MATCH_SUBMATCHES: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 170: [id(DISPID_MATCH_SUBMATCHES), propget]HRESULT SubMatches([out, retval] IDispatch **ppSubMatches);
+				V_VT(&res) = VT_DISPATCH;
+				hres = Match2_get_SubMatches(iface, (IDispatch**)&V_DISPATCH(&res));
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("Match2_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}
+
+static HRESULT WINAPI MatchCollection_GetIDsOfNames(IMatchCollection *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"Count", DISPID_MATCHCOLLECTION_COUNT }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI MatchCollection_Invoke(IMatchCollection *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 184: [id(DISPID_VALUE), propget]HRESULT Item([in] LONG index,[out, retval] IDispatch **ppMatch);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_I4);
+				V_VT(&res) = VT_DISPATCH;
+				hres = MatchCollection_get_Item(iface, V_I4(&var0), (IDispatch**)&V_DISPATCH(&res));
+				VariantClear(&var0);
+			}
+			else if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_MATCHCOLLECTION_COUNT: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 189: [id(DISPID_MATCHCOLLECTION_COUNT), propget]HRESULT Count([out, retval] LONG *pCount);
+				V_VT(&res) = VT_I4;
+				hres = MatchCollection_get_Count(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		case DISPID_NEWENUM: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 192: [id(DISPID_NEWENUM), propget]HRESULT _NewEnum([out, retval] IUnknown **ppEnum);
+				V_VT(&res) = VT_UNKNOWN;
+				hres = MatchCollection_get__NewEnum(iface, &V_UNKNOWN(&res));
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("MatchCollection_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}
+
+static HRESULT WINAPI MatchCollection2_GetIDsOfNames(IMatchCollection2 *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"Count", DISPID_MATCHCOLLECTION_COUNT }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI MatchCollection2_Invoke(IMatchCollection2 *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 206: [id(DISPID_VALUE), propget]HRESULT Item([in] LONG index,[out, retval] IDispatch **ppMatch);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_I4);
+				V_VT(&res) = VT_DISPATCH;
+				hres = MatchCollection2_get_Item(iface, V_I4(&var0), (IDispatch**)&V_DISPATCH(&res));
+				VariantClear(&var0);
+			}
+			else if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_MATCHCOLLECTION_COUNT: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 211: [id(DISPID_MATCHCOLLECTION_COUNT), propget]HRESULT Count([out, retval] LONG *pCount);
+				V_VT(&res) = VT_I4;
+				hres = MatchCollection2_get_Count(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		case DISPID_NEWENUM: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 214: [id(DISPID_NEWENUM), propget]HRESULT _NewEnum([out, retval] IUnknown **ppEnum);
+				V_VT(&res) = VT_UNKNOWN;
+				hres = MatchCollection2_get__NewEnum(iface, &V_UNKNOWN(&res));
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("MatchCollection2_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}
+
+static HRESULT WINAPI SubMatches_GetIDsOfNames(ISubMatches *iface, REFIID riid, LPOLESTR *rgszNames,
+                UINT cNames, LCID lcid, DISPID *rgDispId)
+{
+	static struct {
+		const WCHAR *name;
+		DISPID dispId;
+	} names_ids_list[] = {
+			{ NULL },
+			{ L"Count", DISPID_SUBMATCHES_COUNT }
+	};
+
+	size_t min = 1, max = ARRAY_SIZE(names_ids_list) - 1, i;
+	int r;
+	while(min <= max) {
+		i = (min + max) / 2;
+		r = wcsicmp(names_ids_list[i].name, *rgszNames);
+		if(!r) {
+			*rgDispId = names_ids_list[i].dispId;
+			return S_OK;
+		}
+		if(r < 0)
+		   min = i+1;
+		else
+		   max = i-1;
+	}
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+static HRESULT WINAPI SubMatches_Invoke(ISubMatches *iface, DISPID dispIdMember,
+                                      REFIID riid, LCID lcid, WORD wFlags,
+                                      DISPPARAMS *pDispParams, VARIANT *pVarResult,
+                                      EXCEPINFO *pExcepInfo, UINT *puArgErr)
+{
+	int index = pDispParams->cArgs;
+	VARIANT res;
+	HRESULT hres = DISP_E_UNKNOWNNAME;
+
+	V_VT(&res) = VT_EMPTY;
+
+	switch(dispIdMember) {
+		case DISPID_VALUE: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 228: [id(DISPID_VALUE), propget]HRESULT Item([in] LONG index,[out, retval] VARIANT *pSubMatch);
+				VARIANT var0;
+				V_VT(&var0) = VT_EMPTY;
+				VariantChangeType(&var0, &pDispParams->rgvarg[--index], 0, VT_I4);
+				hres = SubMatches_get_Item(iface, V_I4(&var0), &res);
+				VariantClear(&var0);
+			}
+			else if (wFlags == (DISPATCH_METHOD | DISPATCH_PROPERTYGET)) {
+				V_VT(&res) = VT_DISPATCH;
+				V_DISPATCH(&res) = (IDispatch*)iface;
+				hres = S_OK;
+			}
+			break;
+		}
+		case DISPID_SUBMATCHES_COUNT: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 233: [id(DISPID_SUBMATCHES_COUNT), propget]HRESULT Count([out, retval] LONG *pCount);
+				V_VT(&res) = VT_I4;
+				hres = SubMatches_get_Count(iface, (LONG*)&V_I4(&res));
+			}
+			break;
+		}
+		case DISPID_NEWENUM: {
+			if (wFlags & DISPATCH_PROPERTYGET) {
+				// line 236: [id(DISPID_NEWENUM), propget]HRESULT _NewEnum([out, retval] IUnknown **ppEnum);
+				V_VT(&res) = VT_UNKNOWN;
+				hres = SubMatches_get__NewEnum(iface, &V_UNKNOWN(&res));
+			}
+			break;
+		}
+		default:
+		break;
+	}
+	if (hres == S_OK) {
+		if (pVarResult)
+			*pVarResult = res;
+		else
+			VariantClear(&res);
+	}
+	else if (hres != S_FALSE) {
+		external_log_info("SubMatches_Invoke: dispId=%d (0x%08x), wFlags=%d, hres=%d\n", dispIdMember, dispIdMember, wFlags, hres);
+	}
+	return hres;
+}

--- a/standalone/inc/wine/dlls/vbscript/vbregexp.c
+++ b/standalone/inc/wine/dlls/vbscript/vbregexp.c
@@ -209,6 +209,10 @@ static HRESULT WINAPI SubMatches_GetTypeInfo(ISubMatches *iface,
     return E_NOTIMPL;
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI SubMatches_GetIDsOfNames(ISubMatches *iface,
+    REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI SubMatches_GetIDsOfNames(ISubMatches *iface,
         REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
@@ -219,7 +223,13 @@ static HRESULT WINAPI SubMatches_GetIDsOfNames(ISubMatches *iface,
 
     return ITypeInfo_GetIDsOfNames(typeinfos[SubMatches_tid], rgszNames, cNames, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI SubMatches_Invoke(ISubMatches *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+                    VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI SubMatches_Invoke(ISubMatches *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
                         VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -232,6 +242,7 @@ static HRESULT WINAPI SubMatches_Invoke(ISubMatches *iface, DISPID dispIdMember,
     return ITypeInfo_Invoke(typeinfos[SubMatches_tid], iface, dispIdMember, wFlags,
             pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI SubMatches_get_Item(ISubMatches *iface,
         LONG index, VARIANT *pSubMatch)
@@ -415,6 +426,10 @@ static HRESULT WINAPI Match2_GetTypeInfo(IMatch2 *iface,
     return E_NOTIMPL;
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI Match2_GetIDsOfNames(IMatch2 *iface,
+    REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI Match2_GetIDsOfNames(IMatch2 *iface,
         REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
@@ -425,7 +440,13 @@ static HRESULT WINAPI Match2_GetIDsOfNames(IMatch2 *iface,
 
     return ITypeInfo_GetIDsOfNames(typeinfos[Match2_tid], rgszNames, cNames, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI Match2_Invoke(IMatch2 *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+            VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI Match2_Invoke(IMatch2 *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
                 VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -438,6 +459,7 @@ static HRESULT WINAPI Match2_Invoke(IMatch2 *iface, DISPID dispIdMember,
     return ITypeInfo_Invoke(typeinfos[Match2_tid], iface, dispIdMember, wFlags,
             pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI Match2_get_Value(IMatch2 *iface, BSTR *pValue)
 {
@@ -549,13 +571,23 @@ static HRESULT WINAPI Match_GetTypeInfo(IMatch *iface, UINT iTInfo, LCID lcid, I
     return IMatch2_GetTypeInfo(&This->IMatch2_iface, iTInfo, lcid, ppTInfo);
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI Match_GetIDsOfNames(IMatch *iface, REFIID riid,
+    LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI Match_GetIDsOfNames(IMatch *iface, REFIID riid,
         LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
     Match2 *This = impl_from_IMatch(iface);
     return IMatch2_GetIDsOfNames(&This->IMatch2_iface, riid, rgszNames, cNames, lcid, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI Match_Invoke(IMatch *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+    VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI Match_Invoke(IMatch *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
         VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -564,6 +596,7 @@ static HRESULT WINAPI Match_Invoke(IMatch *iface, DISPID dispIdMember,
     return IMatch2_Invoke(&This->IMatch2_iface, dispIdMember, riid, lcid,
             wFlags, pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI Match_get_Value(IMatch *iface, BSTR *pValue)
 {
@@ -853,6 +886,10 @@ static HRESULT WINAPI MatchCollection2_GetTypeInfo(IMatchCollection2 *iface,
     return E_NOTIMPL;
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI MatchCollection2_GetIDsOfNames(IMatchCollection2 *iface,
+    REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI MatchCollection2_GetIDsOfNames(IMatchCollection2 *iface,
         REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
@@ -863,7 +900,13 @@ static HRESULT WINAPI MatchCollection2_GetIDsOfNames(IMatchCollection2 *iface,
 
     return ITypeInfo_GetIDsOfNames(typeinfos[MatchCollection2_tid], rgszNames, cNames, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI MatchCollection2_Invoke(IMatchCollection2 *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+    VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI MatchCollection2_Invoke(IMatchCollection2 *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
         VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -876,6 +919,7 @@ static HRESULT WINAPI MatchCollection2_Invoke(IMatchCollection2 *iface, DISPID d
     return ITypeInfo_Invoke(typeinfos[MatchCollection2_tid], iface, dispIdMember, wFlags,
             pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI MatchCollection2_get_Item(IMatchCollection2 *iface,
         LONG index, IDispatch **ppMatch)
@@ -969,6 +1013,10 @@ static HRESULT WINAPI MatchCollection_GetTypeInfo(IMatchCollection *iface,
     return IMatchCollection2_GetTypeInfo(&This->IMatchCollection2_iface, iTInfo, lcid, ppTInfo);
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI MatchCollection_GetIDsOfNames(IMatchCollection *iface, REFIID riid,
+    LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI MatchCollection_GetIDsOfNames(IMatchCollection *iface, REFIID riid,
         LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
@@ -976,7 +1024,13 @@ static HRESULT WINAPI MatchCollection_GetIDsOfNames(IMatchCollection *iface, REF
     return IMatchCollection2_GetIDsOfNames(&This->IMatchCollection2_iface,
             riid, rgszNames, cNames, lcid, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI MatchCollection_Invoke(IMatchCollection *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult,
+    EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI MatchCollection_Invoke(IMatchCollection *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult,
         EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -985,6 +1039,7 @@ static HRESULT WINAPI MatchCollection_Invoke(IMatchCollection *iface, DISPID dis
     return IMatchCollection2_Invoke(&This->IMatchCollection2_iface, dispIdMember,
             riid, lcid, wFlags, pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI MatchCollection_get_Item(IMatchCollection *iface, LONG index, IDispatch **ppMatch)
 {
@@ -1047,9 +1102,11 @@ static HRESULT create_match_collection2(IMatchCollection2 **match_collection)
     MatchCollection2 *ret;
     HRESULT hres;
 
+#ifndef __STANDALONE__
     hres = init_regexp_typeinfo(MatchCollection2_tid);
     if(FAILED(hres))
         return hres;
+#endif
 
     ret = calloc(1, sizeof(*ret));
     if(!ret)
@@ -1148,6 +1205,10 @@ static HRESULT WINAPI RegExp2_GetTypeInfo(IRegExp2 *iface,
     return S_OK;
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI RegExp2_GetIDsOfNames(IRegExp2 *iface, REFIID riid,
+    LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI RegExp2_GetIDsOfNames(IRegExp2 *iface, REFIID riid,
         LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
@@ -1158,7 +1219,13 @@ static HRESULT WINAPI RegExp2_GetIDsOfNames(IRegExp2 *iface, REFIID riid,
 
     return ITypeInfo_GetIDsOfNames(typeinfos[RegExp2_tid], rgszNames, cNames, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI RegExp2_Invoke(IRegExp2 *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+    VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI RegExp2_Invoke(IRegExp2 *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
         VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -1171,6 +1238,7 @@ static HRESULT WINAPI RegExp2_Invoke(IRegExp2 *iface, DISPID dispIdMember,
     return ITypeInfo_Invoke(typeinfos[RegExp2_tid], iface, dispIdMember, wFlags,
             pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI RegExp2_get_Pattern(IRegExp2 *iface, BSTR *pPattern)
 {
@@ -1713,13 +1781,23 @@ static HRESULT WINAPI RegExp_GetTypeInfo(IRegExp *iface,
     return IRegExp2_GetTypeInfo(&This->IRegExp2_iface, iTInfo, lcid, ppTInfo);
 }
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI RegExp_GetIDsOfNames(IRegExp *iface, REFIID riid,
+    LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
+#else
 static HRESULT WINAPI RegExp_GetIDsOfNames(IRegExp *iface, REFIID riid,
         LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
     RegExp2 *This = impl_from_IRegExp(iface);
     return IRegExp2_GetIDsOfNames(&This->IRegExp2_iface, riid, rgszNames, cNames, lcid, rgDispId);
 }
+#endif
 
+#ifdef __STANDALONE__
+static HRESULT WINAPI RegExp_Invoke(IRegExp *iface, DISPID dispIdMember,
+    REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
+            VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
+#else
 static HRESULT WINAPI RegExp_Invoke(IRegExp *iface, DISPID dispIdMember,
         REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams,
                 VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
@@ -1728,6 +1806,7 @@ static HRESULT WINAPI RegExp_Invoke(IRegExp *iface, DISPID dispIdMember,
     return IRegExp2_Invoke(&This->IRegExp2_iface, dispIdMember, riid, lcid,
             wFlags, pDispParams, pVarResult, pExcepInfo, puArgErr);
 }
+#endif
 
 static HRESULT WINAPI RegExp_get_Pattern(IRegExp *iface, BSTR *pPattern)
 {
@@ -1813,9 +1892,11 @@ HRESULT create_regexp(IDispatch **ret)
     RegExp2 *regexp;
     HRESULT hres;
 
+#ifndef __STANDALONE__
     hres = init_regexp_typeinfo(RegExp2_tid);
     if(FAILED(hres))
         return hres;
+#endif
 
     regexp = calloc(1, sizeof(*regexp));
     if(!regexp)
@@ -1857,3 +1938,7 @@ void release_regexp_typelib(void)
     if(typelib)
         ITypeLib_Release(typelib);
 }
+
+#ifdef __STANDALONE__
+#include "regexp_proxy.c"
+#endif

--- a/standalone/inc/wine/dlls/vbscript/vbsregexp55.idl
+++ b/standalone/inc/wine/dlls/vbscript/vbsregexp55.idl
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2013 Piotr Caban for CodeWeavers
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#pragma makedep regtypelib
+
+import "oaidl.idl";
+
+#include "vbscript_defs.h"
+
+[
+    helpstring("Microsoft VBScript Regular Expressions 5.5"),
+    id(3),
+    uuid(3f4daca7-160d-11d2-a8e9-00104b365c9f),
+    version(5.5)
+]
+library VBScript_RegExp_55
+{
+    importlib("stdole2.tlb");
+
+    [
+        dual,
+        hidden,
+        nonextensible,
+        odl,
+        oleautomation,
+        uuid(3f4daca0-160d-11d2-a8e9-00104b365c9f),
+    ]
+    interface IRegExp : IDispatch
+    {
+        [id(DISPID_REGEXP_PATTERN), propget]
+        HRESULT Pattern([out, retval] BSTR *pPattern);
+
+        [id(DISPID_REGEXP_PATTERN), propput]
+        HRESULT Pattern([in] BSTR pPattern);
+
+        [id(DISPID_REGEXP_IGNORECASE), propget]
+        HRESULT IgnoreCase([out, retval] VARIANT_BOOL *pIgnoreCase);
+
+        [id(DISPID_REGEXP_IGNORECASE), propput]
+        HRESULT IgnoreCase([in] VARIANT_BOOL pIgnoreCase);
+
+        [id(DISPID_REGEXP_GLOBAL), propget]
+        HRESULT Global([out, retval] VARIANT_BOOL *pGlobal);
+
+        [id(DISPID_REGEXP_GLOBAL), propput]
+        HRESULT Global([in] VARIANT_BOOL pGlobal);
+
+        [id(DISPID_REGEXP_EXECUTE)]
+        HRESULT Execute(
+                [in] BSTR sourceString,
+                [out, retval] IDispatch **ppMatches);
+
+        [id(DISPID_REGEXP_TEST)]
+        HRESULT Test(
+                [in] BSTR sourceString,
+                [out, retval] VARIANT_BOOL *pMatch);
+
+        [id(DISPID_REGEXP_REPLACE)]
+        HRESULT Replace(
+                [in] BSTR sourceString,
+                [in] BSTR replaceString,
+                [out, retval] BSTR *pDestString);
+    }
+
+    [
+        dual,
+        hidden,
+        nonextensible,
+        odl,
+        oleautomation,
+        uuid(3f4dacb0-160d-11d2-a8e9-00104b365c9f)
+    ]
+    interface IRegExp2 : IDispatch
+    {
+        [id(DISPID_REGEXP_PATTERN), propget]
+        HRESULT Pattern([out, retval] BSTR *pPattern);
+
+        [id(DISPID_REGEXP_PATTERN), propput]
+        HRESULT Pattern([in] BSTR pPattern);
+
+        [id(DISPID_REGEXP_IGNORECASE), propget]
+        HRESULT IgnoreCase([out, retval] VARIANT_BOOL *pIgnoreCase);
+
+        [id(DISPID_REGEXP_IGNORECASE), propput]
+        HRESULT IgnoreCase([in] VARIANT_BOOL pIgnoreCase);
+
+        [id(DISPID_REGEXP_GLOBAL), propget]
+        HRESULT Global([out, retval] VARIANT_BOOL *pGlobal);
+
+        [id(DISPID_REGEXP_GLOBAL), propput]
+        HRESULT Global([in] VARIANT_BOOL pGlobal);
+
+        [id(DISPID_REGEXP_MULTILINE), propget]
+        HRESULT Multiline([out, retval] VARIANT_BOOL *pMultiline);
+
+        [id(DISPID_REGEXP_MULTILINE), propput]
+        HRESULT Multiline([in] VARIANT_BOOL pMultiline);
+
+        [id(DISPID_REGEXP_EXECUTE)]
+        HRESULT Execute(
+                [in] BSTR sourceString,
+                [out, retval] IDispatch **ppMatches);
+
+        [id(DISPID_REGEXP_TEST)]
+        HRESULT Test(
+                [in] BSTR sourceString,
+                [out, retval] VARIANT_BOOL *pMatch);
+
+        [id(DISPID_REGEXP_REPLACE)]
+        HRESULT Replace(
+                [in] BSTR sourceString,
+                [in] VARIANT replaceVar,
+                [out, retval] BSTR *pDestString);
+    }
+
+    [
+        dual,
+        hidden,
+        nonextensible,
+        odl,
+        oleautomation,
+        uuid(3f4daca1-160d-11d2-a8e9-00104b365c9f)
+    ]
+    interface IMatch : IDispatch
+    {
+        [id(DISPID_VALUE), propget]
+        HRESULT Value([out, retval] BSTR *pValue);
+
+        [id(DISPID_MATCH_FIRSTINDEX), propget]
+        HRESULT FirstIndex([out, retval] LONG *pFirstIndex);
+
+        [id(DISPID_MATCH_LENGTH), propget]
+        HRESULT Length([out, retval] LONG *pLength);
+    }
+
+    [
+        odl,
+        uuid(3f4dacb1-160d-11d2-a8e9-00104b365c9f),
+        hidden,
+        dual,
+        nonextensible,
+        oleautomation
+    ]
+    interface IMatch2 : IDispatch
+    {
+        [id(DISPID_VALUE), propget]
+        HRESULT Value([out, retval] BSTR *pValue);
+
+        [id(DISPID_MATCH_FIRSTINDEX), propget]
+        HRESULT FirstIndex([out, retval] LONG *pFirstIndex);
+
+        [id(DISPID_MATCH_LENGTH), propget]
+        HRESULT Length([out, retval] LONG *pLength);
+
+        [id(DISPID_MATCH_SUBMATCHES), propget]
+        HRESULT SubMatches([out, retval] IDispatch **ppSubMatches);
+    }
+
+    [
+        dual,
+        hidden,
+        nonextensible,
+        odl,
+        oleautomation,
+        uuid(3f4daca2-160d-11d2-a8e9-00104b365c9f)
+    ]
+    interface IMatchCollection : IDispatch
+    {
+        [id(DISPID_VALUE), propget]
+        HRESULT Item(
+                [in] LONG index,
+                [out, retval] IDispatch **ppMatch);
+
+        [id(DISPID_MATCHCOLLECTION_COUNT), propget]
+        HRESULT Count([out, retval] LONG *pCount);
+
+        [id(DISPID_NEWENUM), propget]
+        HRESULT _NewEnum([out, retval] IUnknown **ppEnum);
+    }
+
+    [
+        dual,
+        hidden,
+        nonextensible,
+        odl,
+        oleautomation,
+        uuid(3f4dacb2-160d-11d2-a8e9-00104b365c9f)
+    ]
+    interface IMatchCollection2 : IDispatch
+    {
+        [id(DISPID_VALUE), propget]
+        HRESULT Item(
+                [in] LONG index,
+                [out, retval] IDispatch **ppMatch);
+
+        [id(DISPID_MATCHCOLLECTION_COUNT), propget]
+        HRESULT Count([out, retval] LONG *pCount);
+
+        [id(DISPID_NEWENUM), propget]
+        HRESULT _NewEnum([out, retval] IUnknown **ppEnum);
+    }
+
+    [
+        dual,
+        hidden,
+        nonextensible,
+        odl,
+        oleautomation,
+        uuid(3f4dacb3-160d-11d2-a8e9-00104b365c9f)
+    ]
+    interface ISubMatches : IDispatch
+    {
+        [id(DISPID_VALUE), propget]
+        HRESULT Item(
+                [in] LONG index,
+                [out, retval] VARIANT *pSubMatch);
+
+        [id(DISPID_SUBMATCHES_COUNT), propget]
+        HRESULT Count([out, retval] LONG *pCount);
+
+        [id(DISPID_NEWENUM), propget]
+        HRESULT _NewEnum([out, retval] IUnknown **ppEnum);
+    }
+
+    [
+        uuid(3f4daca4-160d-11d2-a8e9-00104b365c9f)
+    ]
+    coclass RegExp
+    {
+        [default] interface IRegExp2;
+    }
+
+    [
+        noncreatable,
+        uuid(3f4daca5-160d-11d2-a8e9-00104b365c9f)
+    ]
+    coclass Match
+    {
+        [default] interface IMatch2;
+    }
+
+    [
+        noncreatable,
+        uuid(3f4daca6-160d-11d2-a8e9-00104b365c9f)
+    ]
+    coclass MatchCollection
+    {
+        [default] interface IMatchCollection2;
+    }
+
+    [
+        noncreatable,
+        uuid(3f4dacc0-160d-11d2-a8e9-00104b365c9f)
+    ]
+    coclass SubMatches {
+        [default] interface ISubMatches;
+    }
+}


### PR DESCRIPTION
The new Dark Chaos table uses the new [VPX Game Logic Framework](https://mpcarr.github.io/vpx-glf/).

After examining some of the code, there are large blocks of code that use `RegExp`. I never enabled the `RegExp` interface in VBScript even though we were compiling it.

This PR now enables that. This will get us a little closer to Dark Chaos running.

Finally, some tables need to query folders to get a list of music assets. For example MFDOOM does this.

```
  Dim matchedFiles()
  Dim rootPath:rootPath = MusicDirectory &"\MFDOOM"
  Dim objFile,bMatch,curFile

  Set re = New RegExp
  re.Global     = True
  re.IgnoreCase = False
  re.Pattern    = ".*\.mp3"
  
  Set fso = CreateObject("Scripting.FileSystemObject")
  set folder = fso.GetFolder(rootPath)
  Set files = folder.Files

  For Each objFile in files
    bMatch = re.Test(objFile.Name)
    curFile = objFile.Name
  ```
  
I enabled `IFileCollection` and tried to emulate `FindFirstFileW`, `FindNextFileW`, and `FindClose` the best I could. (with a little help from ChatGPT)

MFDOOM runs now, out of the box and does not require a patch.

I'm sure though we will eventually hit a case insensitive directory issue, but this is tougher to fix since the wine stubs are outside of VPX.