### PR TITLE
audio: Fix double playing of audio sounds when loopcount is set to 1.…

### DIFF
--- a/src/audio/pinsound.cpp
+++ b/src/audio/pinsound.cpp
@@ -511,14 +511,14 @@ void PinSound::Play_SNDCFG_SND3DALLREAR(float nVolume, const float randompitch, 
          setPitch(pitch, randompitch);
          // register the effects.  must do this each time before PlayChannel and once the sound is done its unregistered automatically
          Mix_RegisterEffect(m_assignedChannel, PinSound::MoveFrontToRearEffect, nullptr, &m_mixEffectsData);
-         Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount);
+         Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount > 0 ? loopcount -1 : loopcount);
       }
    }
    else { // not playing
       setPitch(pitch, randompitch);
       // register the effects.  must do this each time before PlayChannel and once the sound is done its unregistered automatically
       Mix_RegisterEffect(m_assignedChannel, PinSound::MoveFrontToRearEffect, nullptr, &m_mixEffectsData);
-      Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount);
+      Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount > 0 ? loopcount -1 : loopcount);
    }
 }
 
@@ -559,14 +559,14 @@ void PinSound::Play_SNDCFG_SND3D2CH(float nVolume, const float randompitch, cons
          setPitch(pitch, randompitch);
          // register the effects.  must do this each time before PlayChannel and once the sound is done its unregistered automatically
          Mix_RegisterEffect(m_assignedChannel, PinSound::Pan2ChannelEffect, nullptr, &m_mixEffectsData);
-         Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount);
+         Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount > 0 ? loopcount -1 : loopcount);
       }
    }
    else { // not playing
       setPitch(pitch, randompitch);
       // register the effects.  must do this each time before PlayChannel and once the sound is done its unregistered automatically
       Mix_RegisterEffect(m_assignedChannel, PinSound::Pan2ChannelEffect, nullptr, &m_mixEffectsData);
-      Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount);
+      Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount > 0 ? loopcount -1 : loopcount);
    }
 }
 
@@ -609,14 +609,14 @@ void PinSound::Play_SNDCFG_SND3DSSF(float nVolume, const float randompitch, cons
          setPitch(pitch, randompitch);
          // register the effects.  must do this each time before PlayChannel.  When the sound is done playing its automatically unregistered.
          Mix_RegisterEffect(m_assignedChannel, PinSound::SSFEffect, nullptr, &m_mixEffectsData);
-         Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount);
+         Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount > 0 ? loopcount -1 : loopcount);
       }
    }
    else { // not playing
       setPitch(pitch, randompitch);
       // register the pitch effect.  must do this each time before PlayChannel.  When the sound is done playing its automatically unregistered.
       Mix_RegisterEffect(m_assignedChannel, PinSound::SSFEffect, nullptr, &m_mixEffectsData);
-      Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount);
+      Mix_PlayChannel(m_assignedChannel, m_pMixChunk, loopcount > 0 ? loopcount -1 : loopcount);
    }
 }
 


### PR DESCRIPTION
…  With SDL mixer the loopcount means how many times to loop after the original sample has played.  So setting it 1 really means it plays twice.

Related to issue [2339](https://github.com/vpinball/vpinball/issues/2339)