### PR TITLE
standalone: overhaul web server

### DIFF
--- a/src/assets/Default_VPinballX.ini
+++ b/src/assets/Default_VPinballX.ini
@@ -13,7 +13,6 @@
 ; #######################################################
 ; # Standalone
 [Standalone]
-LaunchTable = 
 VPRegPath = 
 # Path to the PinMAME folder. (Default is ~/.pinmame)
 PinMAMEPath = 

--- a/src/assets/vpx.html
+++ b/src/assets/vpx.html
@@ -1,373 +1,1356 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>VPX</title>
-    <style>
-      html,
-      body {
-        height: 100%;
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Visual Pinball File Manager</title>
+  <style>
+    :root {
+      --primary-color: #fd3423;
+      --primary-hover: #e02010;
+      --danger-color: #ef4444;
+      --danger-hover: #dc2626;
+      --success-color: #10b981;
+      --success-hover: #059669;
+      --secondary-color: #6b7280;
+      --secondary-hover: #4b5563;
+      --background-color: #f9fafb;
+      --card-background: #ffffff;
+      --border-color: #e5e7eb;
+      --text-primary: #111827;
+      --text-secondary: #4b5563;
+      --text-tertiary: #9ca3af;
+      --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+      --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+      --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+      --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+      --radius: 0.375rem;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
+        "Helvetica Neue", sans-serif;
+      background-color: var(--background-color);
+      color: var(--text-primary);
+      line-height: 1.5;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    .app-container {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1rem;
+    }
+
+    .app-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      padding: 1rem 0;
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .logo-container {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .logo-title {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .logo-container img {
+      width: 32px;
+      height: 32px;
+    }
+
+    .logo-container h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .version-info {
+      font-size: 0.8rem;
+      color: var(--text-tertiary);
+      margin-top: 0.25rem;
+      margin-left: 2.5rem;
+      font-style: italic;
+    }
+
+    .status-container {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.75rem;
+    }
+
+    .current-table-container {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      max-width: 400px;
+      text-align: right;
+    }
+
+    .current-table-label {
+      font-size: 0.75rem;
+      color: var(--text-tertiary);
+      font-weight: 500;
+    }
+
+    .current-table {
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+      word-break: break-all;
+      line-height: 1.3;
+    }
+
+    .header-actions {
+      display: flex;
+      gap: 0.75rem;
+      margin-top: 0.5rem;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      border-radius: var(--radius);
+      font-weight: 500;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      border: none;
+      outline: none;
+    }
+
+    .btn-icon {
+      display: inline-flex;
+      width: 16px;
+      height: 16px;
+      margin-right: 0.25rem;
+    }
+
+    .btn-icon svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    .btn-primary {
+      background-color: var(--primary-color);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background-color: var(--primary-hover);
+    }
+
+    .btn-secondary {
+      background-color: white;
+      color: var(--text-primary);
+      border: 1px solid var(--border-color);
+    }
+
+    .btn-secondary:hover {
+      background-color: var(--background-color);
+    }
+
+    .btn-danger {
+      background-color: var(--danger-color);
+      color: white;
+    }
+
+    .btn-danger:hover {
+      background-color: var(--danger-hover);
+    }
+
+    .btn-success {
+      background-color: var(--success-color);
+      color: white;
+    }
+
+    .btn-success:hover {
+      background-color: var(--success-hover);
+    }
+
+    .main-container {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      padding: 1rem 0;
+    }
+
+    .path-container {
+      margin-bottom: 1rem;
+    }
+
+    .path-display {
+      font-size: 1rem;
+      font-weight: 500;
+      color: var(--text-secondary);
+    }
+
+    .actions-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+
+    .left-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .right-actions {
+      display: flex;
+      align-items: center;
+    }
+
+    .status-message {
+      margin-left: 0.75rem;
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+    }
+
+    .search-container {
+      position: relative;
+    }
+
+    .search-container input {
+      padding: 0.5rem 0.75rem;
+      padding-left: 2rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--border-color);
+      font-size: 0.875rem;
+      width: 200px;
+      transition: all 0.2s ease;
+    }
+
+    .search-container input:focus {
+      outline: none;
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 2px rgba(253, 52, 35, 0.2);
+      width: 250px;
+    }
+
+    .search-icon {
+      position: absolute;
+      left: 0.5rem;
+      top: 50%;
+      transform: translateY(-50%);
+      color: var(--text-tertiary);
+      width: 16px;
+      height: 16px;
+    }
+
+    .file-list-container {
+      flex: 1;
+      overflow: auto;
+      background-color: var(--card-background);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+    }
+
+    .file-list-header {
+      display: grid;
+      grid-template-columns: 1fr 180px 120px 120px;
+      padding: 0.75rem 1rem;
+      background-color: var(--background-color);
+      border-bottom: 1px solid var(--border-color);
+      font-weight: 600;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    .file-list-header a {
+      color: var(--text-primary);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+
+    .file-list-header a:hover {
+      color: var(--primary-color);
+    }
+
+    .sort-indicator {
+      margin-left: 0.25rem;
+      font-size: 0.75rem;
+    }
+
+    .file-list {
+      list-style-type: none;
+    }
+
+    .file-item {
+      display: grid;
+      grid-template-columns: 1fr 180px 120px 120px;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--border-color);
+      align-items: center;
+      transition: background-color 0.2s ease;
+    }
+
+    .file-item:hover {
+      background-color: rgba(253, 52, 35, 0.05);
+    }
+
+    .file-name {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .file-icon {
+      width: 16px;
+      height: 16px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .file-name a {
+      color: var(--text-primary);
+      text-decoration: none;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .file-name a:hover {
+      color: var(--primary-color);
+    }
+
+    .file-date {
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+    }
+
+    .file-size {
+      text-align: right;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+    }
+
+    .file-actions {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: flex-end;
+    }
+
+    .action-icon {
+      width: 24px;
+      height: 24px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: #000000;
+    }
+
+    .action-icon:hover {
+      opacity: 0.7;
+    }
+
+    .action-icon svg {
+      width: 16px;
+      height: 16px;
+      stroke: currentColor;
+      stroke-width: 2;
+      fill: none;
+    }
+
+    .editor-container {
+      display: none;
+      flex-direction: column;
+      height: 100%;
+      padding: 1rem 0;
+    }
+
+    .editor-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+
+    .editor-actions {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .editor-content {
+      flex: 1;
+      padding: 1rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--border-color);
+      resize: none;
+      font-family: monospace;
+      font-size: 0.875rem;
+      line-height: 1.6;
+      background-color: var(--card-background);
+      color: var(--text-primary);
+    }
+
+    .editor-content:focus {
+      outline: none;
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 2px rgba(253, 52, 35, 0.2);
+    }
+
+    .editor-content[readonly] {
+      background-color: var(--background-color);
+      cursor: default;
+    }
+
+    .drop-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(253, 52, 35, 0.8);
+      display: none;
+      justify-content: center;
+      align-items: center;
+      z-index: 100;
+    }
+
+    .drop-message {
+      background-color: white;
+      padding: 2rem;
+      border-radius: var(--radius);
+      text-align: center;
+      box-shadow: var(--shadow-lg);
+    }
+
+    .drop-icon {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 1rem;
+    }
+
+    .drop-icon svg {
+      width: 100%;
+      height: 100%;
+      fill: var(--primary-color);
+    }
+
+    @media (max-width: 768px) {
+      .app-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
       }
-      body {
-        font-family: Arial, sans-serif;
+
+      .status-container {
+        align-items: flex-start;
+        width: 100%;
       }
-      .container {
-        height: 80%;
+
+      .current-table-container {
+        align-items: flex-start;
+        text-align: left;
+        max-width: 100%;
       }
-      ul {
-        list-style-type: none;
-        padding: 0;
-        width: 50%;
+
+      .header-actions {
+        width: 100%;
+        justify-content: flex-start;
       }
-      li {
-        margin-bottom: 5px;
-        display: grid;
-        grid-template-columns: auto 100px 200px;
-        grid-gap: 10px;
-        align-items: center;
+
+      .actions-bar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
       }
-      li.row:hover {
-        background-color: #f5f5f5;
+
+      .right-actions {
+        width: 100%;
       }
-      li a {
-        text-decoration: none;
-        color: #007bff;
+
+      .search-container input {
+        width: 100%;
       }
-      li.header a {
-        color: #000000;
-        font-weight: bold;
+
+      .file-list-header,
+      .file-item {
+        grid-template-columns: 1fr auto;
       }
-      .actions span {
-        height: 1em;
-        width: 1em;
-        background-repeat: no-repeat;
-        background-position: center;
-        display: inline-block;
-        margin: 0 5px;
-      }
-      .action-icon {
-        cursor: pointer;
-      }
-      .edit-icon {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M362.7 19.3L314.3 67.7 444.3 197.7l48.4-48.4c25-25 25-65.5 0-90.5L453.3 19.3c-25-25-65.5-25-90.5 0zm-71 71L58.6 323.5c-10.4 10.4-18 23.3-22.2 37.4L1 481.2C-1.5 489.7 .8 498.8 7 505s15.3 8.5 23.7 6.1l120.3-35.4c14.1-4.2 27-11.8 37.4-22.2L421.7 220.3 291.7 90.3z"/></svg>');
-      }
-      .delete-icon {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M135.2 17.7C140.6 6.8 151.7 0 163.8 0H284.2c12.1 0 23.2 6.8 28.6 17.7L320 32h96c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 96 0 81.7 0 64S14.3 32 32 32h96l7.2-14.3zM32 128H416V448c0 35.3-28.7 64-64 64H96c-35.3 0-64-28.7-64-64V128zm96 64c-8.8 0-16 7.2-16 16V432c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16V432c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16V432c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16z"/></svg>');
-      }
-      .extract-icon {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M64 464c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16h48c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16h48v80c0 17.7 14.3 32 32 32h80V448c0 8.8-7.2 16-16 16H64zM64 0C28.7 0 0 28.7 0 64V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V154.5c0-17-6.7-33.3-18.7-45.3L274.7 18.7C262.7 6.7 246.5 0 229.5 0H64zm48 112c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H128c-8.8 0-16 7.2-16 16zm0 64c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H128c-8.8 0-16 7.2-16 16zm-6.3 71.8L82.1 335.9c-1.4 5.4-2.1 10.9-2.1 16.4c0 35.2 28.8 63.7 64 63.7s64-28.5 64-63.7c0-5.5-.7-11.1-2.1-16.4l-23.5-88.2c-3.7-14-16.4-23.8-30.9-23.8H136.6c-14.5 0-27.2 9.7-30.9 23.8zM128 336h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H128c-8.8 0-16-7.2-16-16s7.2-16 16-16z"/></svg>');
-      }
-      .activate-icon {
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M32 0C49.7 0 64 14.3 64 32V48l69-17.2c38.1-9.5 78.3-5.1 113.5 12.5c46.3 23.2 100.8 23.2 147.1 0l9.6-4.8C423.8 28.1 448 43.1 448 66.1V345.8c0 13.3-8.3 25.3-20.8 30l-34.7 13c-46.2 17.3-97.6 14.6-141.7-7.4c-37.9-19-81.3-23.7-122.5-13.4L64 384v96c0 17.7-14.3 32-32 32s-32-14.3-32-32V400 334 64 32C0 14.3 14.3 0 32 0zM64 187.1l64-13.9v65.5L64 252.6V318l48.8-12.2c5.1-1.3 10.1-2.4 15.2-3.3V238.7l38.9-8.4c8.3-1.8 16.7-2.5 25.1-2.1l0-64c13.6 .4 27.2 2.6 40.4 6.4l23.6 6.9v66.7l-41.7-12.3c-7.3-2.1-14.8-3.4-22.3-3.8v71.4c21.8 1.9 43.3 6.7 64 14.4V244.2l22.7 6.7c13.5 4 27.3 6.4 41.3 7.4V194c-7.8-.8-15.6-2.3-23.2-4.5l-40.8-12v-62c-13-3.8-25.8-8.8-38.2-15c-8.2-4.1-16.9-7-25.8-8.8v72.4c-13-.4-26 .8-38.7 3.6L128 173.2V98L64 114v73.1zM320 335.7c16.8 1.5 33.9-.7 50-6.8l14-5.2V251.9l-7.9 1.8c-18.4 4.3-37.3 5.7-56.1 4.5v77.4zm64-149.4V115.4c-20.9 6.1-42.4 9.1-64 9.1V194c13.9 1.4 28 .5 41.7-2.6l22.3-5.2z"/></svg>');
-      }
-      #editor {
+      
+      .file-list-header div:nth-child(2),
+      .file-list-header div:nth-child(3),
+      .file-item div:nth-child(2),
+      .file-item div:nth-child(3) {
         display: none;
       }
-      #editor-content {
-        height: 90%;
-        width: 90%;
+    }
+  </style>
+</head>
+<body ondragover="event.preventDefault()">
+  <div class="app-container">
+    <header class="app-header">
+      <div class="logo-container">
+        <div class="logo-title">
+          <img src="vpinball.png" alt="Visual Pinball Logo">
+          <h1>Visual Pinball File Manager</h1>
+        </div>
+        <div id="version-info" class="version-info"></div>
+      </div>
+      <div class="status-container">
+        <div class="current-table-container">
+          <div class="current-table-label">Current Table:</div>
+          <div id="current-table" class="current-table"></div>
+        </div>
+        <div id="header-actions" class="header-actions">
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="main-container">
+      <div class="path-container">
+        <h2 id="main-path" class="path-display"></h2>
+      </div>
+      
+      <div class="actions-bar">
+        <div class="left-actions">
+          <button class="btn btn-secondary" onclick="newFolder()">
+            <span class="btn-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                <line x1="12" y1="11" x2="12" y2="17"></line>
+                <line x1="9" y1="14" x2="15" y2="14"></line>
+              </svg>
+            </span>
+            New Folder
+          </button>
+          <button class="btn btn-secondary" onclick="uploadFile()">
+            <span class="btn-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="17 8 12 3 7 8"></polyline>
+                <line x1="12" y1="3" x2="12" y2="15"></line>
+              </svg>
+            </span>
+            Upload
+          </button>
+          <span id="main-status" class="status-message"></span>
+        </div>
+        <div class="right-actions">
+          <div class="search-container">
+            <span class="search-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8"></circle>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+              </svg>
+            </span>
+            <input type="text" id="search-input" placeholder="Search files..." onkeyup="filterFiles()">
+          </div>
+        </div>
+      </div>
+
+      <div class="file-list-container">
+        <div class="file-list-header">
+          <div class="file-name">
+            <a href="#" onclick="toggleSort('name')">Name</a>
+            <span id="name-sort-indicator" class="sort-indicator">
+              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="6 9 12 15 18 9"></polyline>
+              </svg>
+            </span>
+          </div>
+          <div class="file-date">
+            <a href="#" onclick="toggleSort('date')">Modified</a>
+            <span id="date-sort-indicator" class="sort-indicator"></span>
+          </div>
+          <div class="file-size">
+            <a href="#" onclick="toggleSort('size')">Size</a>
+            <span id="size-sort-indicator" class="sort-indicator"></span>
+          </div>
+          <div class="file-actions">
+            <a href="#">Actions</a>
+          </div>
+        </div>
+        <ul id="file-list" class="file-list"></ul>
+      </div>
+    </main>
+
+    <div id="editor" class="editor-container">
+      <div class="editor-header">
+        <h2 id="editor-path" class="path-display"></h2>
+        <div class="editor-actions">
+          <button id="edit-button" class="btn btn-secondary" style="display: none;">
+            <span class="btn-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+              </svg>
+            </span>
+            Edit
+          </button>
+          <button id="save-button" class="btn btn-primary" style="display: none;">
+            <span class="btn-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                <polyline points="17 21 17 13 7 13 7 21"></polyline>
+                <polyline points="7 3 7 8 15 8"></polyline>
+              </svg>
+            </span>
+            Save
+          </button>
+          <button id="download-button" class="btn btn-secondary" style="display: none;">
+            <span class="btn-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="7 10 12 15 17 10"></polyline>
+                <line x1="12" y1="15" x2="12" y2="3"></line>
+              </svg>
+            </span>
+            Download
+          </button>
+          <button id="close-button" class="btn btn-secondary" onclick="closeEditor()">
+            <span class="btn-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </span>
+            Close
+          </button>
+          <span id="editor-status" class="status-message"></span>
+        </div>
+      </div>
+      <textarea id="editor-content" class="editor-content" spellcheck="false"></textarea>
+    </div>
+
+    <div id="drop-overlay" class="drop-overlay">
+      <div class="drop-message">
+        <div class="drop-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="17 8 12 3 7 8"></polyline>
+            <line x1="12" y1="3" x2="12" y2="15"></line>
+          </svg>
+        </div>
+        <h3>Drop files here to upload</h3>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const SVG_ICONS = {
+      folder: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>',
+      file: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>',
+      code: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>',
+      settings: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>',
+      web: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>',
+      zip: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>',
+      font: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 7 4 4 20 4 20 7"></polyline><line x1="9" y1="20" x2="15" y2="20"></line><line x1="12" y1="4" x2="12" y2="20"></line></svg>',
+      game: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"  viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="11" x2="10" y2="11"></line><line x1="8" y1="9" x2="8" y2="13"></line><rect x="14" y="9" width="4" height="4"></rect><circle cx="19" cy="12" r="1"></circle><rect x="3" y="6" width="18" height="12" rx="2" ry="2"></rect></svg>',
+      edit: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>',
+      delete: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>',
+      extract: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"></path><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path><path d="M12 10v6"></path><path d="M9.5 12.5l2.5 -2.5l2.5 2.5"></path><path d="M9.5 16.5l2.5 2.5l2.5 -2.5"></path></svg>',
+      sortAsc: '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>',
+      sortDesc: '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>'
+    };
+
+    var _directory;
+    var _data;
+    var _lastSort = "name";
+    var _sortOrders = {
+      name: "asc",
+      size: "asc",
+      date: "desc"
+    };
+    var _statusData = null;
+    var _statusInterval = null;
+    var _connectionFailed = false;
+    var _currentFilePath = null;
+    var _isReadOnly = true;
+
+    function fetchStatus() {
+      fetch('/status')
+        .then(response => response.json())
+        .then(data => {
+          _connectionFailed = false;
+          _statusData = data;
+          updateStatusDisplay();
+        })
+        .catch(error => {
+          console.error('Error fetching status:', error);
+          _connectionFailed = true;
+          clearStatusDisplay();
+        });
+    }
+
+    function clearStatusDisplay() {
+      document.getElementById('version-info').textContent = '';
+      document.getElementById('current-table').textContent = 'Connection failed';
+      document.getElementById('header-actions').innerHTML = '';
+    }
+
+    function updateStatusDisplay() {
+      if (!_statusData) return;
+
+      document.getElementById('version-info').textContent = _statusData.version;
+      
+      if (_statusData.running && _statusData.currentTable) {
+        document.getElementById('current-table').textContent = _statusData.currentTable;
+      } else {
+        document.getElementById('current-table').textContent = 'No table running';
       }
-    </style>
-  </head>
-  <body ondragover="event.preventDefault()">
-    <div id="main" class="container">
-      <h1>VPX</h1>
-      <p>
-        <button onclick="sendCommand('fps')">Toggle FPS</button>
-        <button onclick="sendCommand('shutdown')">Shutdown</button>
-      </p>
-      <h4 id="main-path"></h4>
-      <p>
-        <button onclick="newFolder()">New Folder</button>
-        <button onclick="uploadFile()">Upload</button> <span id="main-status"></span>
-      </p>
-      <ul id="file-list-header">
-        <li class="header">
-          <a href="#" onclick="toggleSort('name')">Name</a>
-          <span></span>
-          <span><a href="#" onclick="toggleSort('size')">Size</a></span>
-        </li>
-      </ul>
-      <ul id="file-list"></ul>
-    </div>
-    <div id="editor" class="container">
-      <h1>VPX</h1>
-      <h4 id="editor-path"></h4>
-      <p>
-        <button id="save-button">Save</button>
-        <button onclick="closeEditor()">Close</button> <span id="editor-status"></span>
-      </p>
-      <textarea id="editor-content"></textarea>
-    </div>
-    <script>
-      var _directory;
-      var _data;
-      var _lastSort = "name";
-      var _sortOrders = {
-        name: "asc",
-        size: "asc",
+
+      const headerActions = document.getElementById('header-actions');
+      headerActions.innerHTML = '';
+
+      if (_statusData.running) {
+        const fpsButton = document.createElement('button');
+        fpsButton.className = 'btn btn-primary';
+        fpsButton.onclick = () => sendCommand('fps');
+        fpsButton.innerHTML = `
+          <span class="btn-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path>
+            </svg>
+          </span>
+          Toggle FPS
+        `;
+        headerActions.appendChild(fpsButton);
+
+        const exitButton = document.createElement('button');
+        exitButton.className = 'btn btn-danger';
+        exitButton.onclick = () => sendCommand('shutdown');
+        exitButton.innerHTML = `
+          <span class="btn-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18.36 6.64a9 9 0 1 1-12.73 0"></path>
+              <line x1="12" y1="2" x2="12" y2="12"></line>
+            </svg>
+          </span>
+          Exit Table
+        `;
+        headerActions.appendChild(exitButton);
+      }
+    }
+
+    function fetchFiles(directory) {
+      fetch(`files?q=${encodeURIComponent(directory)}`)
+        .then((response) => response.json())
+        .then((data) => {
+          _directory = directory;
+          _data = data;
+
+          document.getElementById("main-path").innerHTML = `Index of /${directory ? directory : ""}`;
+
+          sortFiles(_lastSort);
+          updateSortIndicators();
+        })
+        .catch((error) => console.error("Error:", error));
+    }
+
+    function updateFilesList() {
+      document.getElementById("file-list").innerHTML = "";
+
+      if (_directory !== "") {
+        var parentDirectory = _directory.substring(0, _directory.lastIndexOf("/"));
+        parentDirectory = parentDirectory.replace("'", "\\'");
+        const listItem = document.createElement("li");
+        listItem.className = "file-item";
+        listItem.onclick = (e) => {
+          if (e.target.tagName !== 'BUTTON' && !e.target.closest('.action-icon')) {
+            fetchFiles(parentDirectory);
+          }
+        };
+        listItem.style.cursor = "pointer";
+
+        const nameDiv = document.createElement("div");
+        nameDiv.className = "file-name";
+
+        const folderIcon = document.createElement("span");
+        folderIcon.className = "file-icon";
+        folderIcon.innerHTML = SVG_ICONS.folder;
+        nameDiv.appendChild(folderIcon);
+
+        const link = document.createElement("a");
+        link.href = "#";
+        link.onclick = (e) => {
+          e.stopPropagation();
+          fetchFiles(parentDirectory);
+          return false;
+        };
+        link.textContent = "..";
+        nameDiv.appendChild(link);
+
+        listItem.appendChild(nameDiv);
+        listItem.appendChild(document.createElement("div"));
+        listItem.appendChild(document.createElement("div"));
+        listItem.appendChild(document.createElement("div"));
+
+        document.getElementById("file-list").appendChild(listItem);
+      }
+
+      _data.forEach((file) => {
+        const listItem = document.createElement("li");
+        listItem.className = "file-item";
+        
+        listItem.style.cursor = "pointer";
+        if (file.isDir) {
+          var subdirectory = _directory ? `${_directory}/${file.name}` : file.name;
+          subdirectory = subdirectory.replace("'", "\\'");
+          listItem.onclick = (e) => {
+            if (e.target.tagName !== 'BUTTON' && !e.target.closest('.action-icon')) {
+              fetchFiles(subdirectory);
+            }
+          };
+        } else {
+          const filePath = _directory ? `${_directory}/${file.name}` : file.name;
+          const isTextFile = ["vbs", "ini", "txt", "log", "html", "json", "xml", "fnt", "glfx", "fxh"].includes(file.ext);
+          
+          listItem.onclick = (e) => {
+            if (e.target.tagName !== 'BUTTON' && !e.target.closest('.action-icon')) {
+              if (isTextFile) {
+                viewFile(file.name);
+              } else {
+                window.location.href = `download?q=${encodeURIComponent(filePath)}`;
+              }
+            }
+          };
+        }
+
+        const nameDiv = document.createElement("div");
+        nameDiv.className = "file-name";
+
+        const icon = document.createElement("span");
+        icon.className = "file-icon";
+        icon.innerHTML = getFileIcon(file.ext, file.isDir);
+        nameDiv.appendChild(icon);
+
+        const link = document.createElement("a");
+        link.href = "#";
+
+        if (file.isDir) {
+          var subdirectory = _directory ? `${_directory}/${file.name}` : file.name;
+          subdirectory = subdirectory.replace("'", "\\'");
+          link.onclick = (e) => {
+            e.stopPropagation();
+            fetchFiles(subdirectory);
+            return false;
+          };
+          link.textContent = `${file.name}`;
+        } else {
+          const filePath = _directory ? `${_directory}/${file.name}` : file.name;
+          const isTextFile = ["vbs", "ini", "txt", "log", "html", "json", "xml", "fnt", "glfx", "fxh"].includes(file.ext);
+          
+          if (isTextFile) {
+            link.onclick = (e) => {
+              e.stopPropagation();
+              viewFile(file.name);
+              return false;
+            };
+          } else {
+            link.href = `download?q=${encodeURIComponent(filePath)}`;
+          }
+          
+          link.textContent = file.name;
+        }
+
+        nameDiv.appendChild(link);
+        listItem.appendChild(nameDiv);
+
+        const dateDiv = document.createElement("div");
+        dateDiv.className = "file-date";
+        dateDiv.textContent = formatDate(file.date);
+        listItem.appendChild(dateDiv);
+
+        const sizeDiv = document.createElement("div");
+        sizeDiv.className = "file-size";
+        sizeDiv.textContent = formatFileSize(file.size);
+        listItem.appendChild(sizeDiv);
+
+        const actionsDiv = document.createElement("div");
+        actionsDiv.className = "file-actions";
+
+        var fileName = file.name.replace("'", "\\'");
+
+        if (["vbs", "ini", "txt", "log", "html", "json", "xml", "fnt", "glfx", "fxh"].includes(file.ext)) {
+          const editIcon = document.createElement("span");
+          editIcon.className = "action-icon edit-icon";
+          editIcon.innerHTML = SVG_ICONS.edit;
+          editIcon.onclick = (e) => {
+            e.stopPropagation();
+            editFile(fileName);
+          };
+          editIcon.title = "Edit";
+          actionsDiv.appendChild(editIcon);
+        }
+
+        if (file.ext == "zip") {
+          const extractIcon = document.createElement("span");
+          extractIcon.className = "action-icon extract-icon";
+          extractIcon.innerHTML = SVG_ICONS.extract;
+          extractIcon.onclick = (e) => {
+            e.stopPropagation();
+            extractFile(fileName);
+          };
+          extractIcon.title = "Extract";
+          actionsDiv.appendChild(extractIcon);
+        }
+
+        const deleteIcon = document.createElement("span");
+        deleteIcon.className = "action-icon delete-icon";
+        deleteIcon.innerHTML = SVG_ICONS.delete;
+        deleteIcon.onclick = (e) => {
+          e.stopPropagation();
+          deleteFile(fileName);
+        };
+        deleteIcon.title = "Delete";
+        actionsDiv.appendChild(deleteIcon);
+
+        listItem.appendChild(actionsDiv);
+
+        document.getElementById("file-list").appendChild(listItem);
+      });
+    }
+
+    function formatDate(dateString) {
+      if (!dateString) return "";
+      
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return "";
+      
+      return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+
+    function getFileIcon(ext, isDir) {
+      if (isDir) return SVG_ICONS.folder;
+      
+      const iconMap = {
+        txt: SVG_ICONS.file,
+        log: SVG_ICONS.file,
+        ini: SVG_ICONS.settings,
+        json: SVG_ICONS.code,
+        xml: SVG_ICONS.code,
+        html: SVG_ICONS.web,
+        vbs: SVG_ICONS.code,
+        zip: SVG_ICONS.zip,
+        fnt: SVG_ICONS.font,
+        glfx: SVG_ICONS.game,
+        fxh: SVG_ICONS.game,
       };
 
-      function fetchFiles(directory) {
-        fetch(`files?q=${encodeURIComponent(directory)}`)
-          .then((response) => response.json())
-          .then((data) => {
-            _directory = directory;
-            _data = data;
+      return iconMap[ext] || SVG_ICONS.file;
+    }
 
-            document.getElementById("main-path").innerHTML = `Index of /${directory ? directory : ""}`;
+    function updateSortIndicators() {
+      document.getElementById("name-sort-indicator").innerHTML = "";
+      document.getElementById("size-sort-indicator").innerHTML = "";
+      document.getElementById("date-sort-indicator").innerHTML = "";
 
-            sortFiles(_lastSort);
-          })
-          .catch((error) => console.error("Error:", error));
+      if (_lastSort === "name") {
+        document.getElementById("name-sort-indicator").innerHTML = _sortOrders[_lastSort] === "asc" ? SVG_ICONS.sortAsc : SVG_ICONS.sortDesc;
+      } else if (_lastSort === "size") {
+        document.getElementById("size-sort-indicator").innerHTML = _sortOrders[_lastSort] === "asc" ? SVG_ICONS.sortAsc : SVG_ICONS.sortDesc;
+      } else if (_lastSort === "date") {
+        document.getElementById("date-sort-indicator").innerHTML = _sortOrders[_lastSort] === "asc" ? SVG_ICONS.sortAsc : SVG_ICONS.sortDesc;
       }
+    }
 
-      function updateFilesList() {
-        document.getElementById("file-list").innerHTML = "";
-
-        if (_directory !== "") {
-          var parentDirectory = _directory.substring(0, _directory.lastIndexOf("/"));
-          parentDirectory = parentDirectory.replace("'", "\\'");
-          document.getElementById(
-            "file-list"
-          ).innerHTML += `<li class="row"><a href="#" onclick="fetchFiles('${parentDirectory}')">..</a></li>`;
-        }
-
-        _data.forEach((file) => {
-          var listItem = `<li class="row">`;
-
-          if (file.isDir) {
-            var subdirectory = _directory ? `${_directory}/${file.name}` : file.name;
-            subdirectory = subdirectory.replace("'", "\\'");
-            listItem += `<a href="#" onclick="fetchFiles('${subdirectory}')">${file.name}/</a>`;
-          } else {
-            const filePath = _directory ? `${_directory}/${file.name}` : file.name;
-            listItem += `<a href="download?q=${encodeURIComponent(filePath)}">${file.name}</a>`;
-          }
-
-          var actionsSpan = `<span class="actions">`;
-          var fileName = file.name.replace("'", "\\'");
-
-          if (["vbs", "ini", "txt", "log", "html", "json", "xml", "fnt", "glfx", "fxh"].includes(file.ext)) {
-            actionsSpan += `<span class="action-icon edit-icon" onclick="editFile('${fileName}')"></span>`;
-          } else {
-            actionsSpan += `<span></span>`;
-          }
-
-          actionsSpan += `<span class="action-icon delete-icon" onclick="deleteFile('${fileName}')"></span>`;
-
-          if (file.ext == "zip") {
-            actionsSpan += `<span class="action-icon extract-icon" onclick="extractFile('${fileName}')"></span>`;
-          } else if (file.ext == "vpx") {
-            actionsSpan += `<span class="action-icon activate-icon" onclick="activateFile('${fileName}')"></span>`;
-          } else {
-            actionsSpan += `<span></span>`;
-          }
-
-          actionsSpan += "</span>";
-          listItem += actionsSpan;
-
-          listItem += `<span>${formatFileSize(file.size)}</span>`;
-
-          listItem += `</li>`;
-
-          document.getElementById("file-list").innerHTML += listItem;
-        });
-      }
-
-      function toggleSort(column) {
-        if (_sortOrders[column] === "asc") {
-          _sortOrders[column] = "desc";
-        } else {
-          _sortOrders[column] = "asc";
-        }
-
-        sortFiles(column);
-      }
-
-      function sortFiles(column) {
-        _data.sort((a, b) => {
-          if (column === "name") {
-            if (_sortOrders[column] === "asc") {
-              return a.name.localeCompare(b.name);
-            } else {
-              return b.name.localeCompare(a.name);
-            }
-          } else if (column === "size") {
-            if (_sortOrders[column] === "asc") {
-              return a.size - b.size;
-            } else {
-              return b.size - a.size;
-            }
-          }
-        });
-
+    function toggleSort(column) {
+      if (_lastSort === column) {
+        _sortOrders[column] = _sortOrders[column] === "asc" ? "desc" : "asc";
+      } else {
         _lastSort = column;
-
-        updateFilesList();
       }
 
-      function formatFileSize(size) {
-        if (size === 0) return "0 Bytes";
-        const units = ["Bytes", "KB", "MB", "GB", "TB"];
-        const i = Math.floor(Math.log(size) / Math.log(1024));
-        return `${(size / Math.pow(1024, i)).toFixed(2)} ${units[i]}`;
-      }
+      sortFiles(column);
+      updateSortIndicators();
+    }
 
-      function newFolder() {
-        var folderName = prompt("Enter the folder name:");
-        if (folderName !== null && folderName.trim() !== "") {
-          folderName = folderName.trim();
-          const filePath = _directory ? `${_directory}/${folderName}` : folderName;
-          fetch(`folder?q=${encodeURIComponent(filePath)}`, { method: "POST" })
-            .then((response) => {
-              if (response.ok) {
-                _directory = filePath;
-                fetchFiles(_directory);
-              }
-            })
-            .catch((error) => console.error("Error:", error));
+    function sortFiles(column) {
+      _data.sort((a, b) => {
+        if (a.isDir && !b.isDir) return -1;
+        if (!a.isDir && b.isDir) return 1;
+
+        if (column === "name") {
+          if (_sortOrders[column] === "asc") {
+            return a.name.localeCompare(b.name);
+          } else {
+            return b.name.localeCompare(a.name);
+          }
+        } else if (column === "size") {
+          if (_sortOrders[column] === "asc") {
+            return a.size - b.size;
+          } else {
+            return b.size - a.size;
+          }
+        } else if (column === "date") {
+          const dateA = a.date ? new Date(a.date).getTime() : 0;
+          const dateB = b.date ? new Date(b.date).getTime() : 0;
+          
+          if (_sortOrders[column] === "asc") {
+            return dateA - dateB;
+          } else {
+            return dateB - dateA;
+          }
         }
+      });
+
+      _lastSort = column;
+
+      updateFilesList();
+    }
+
+    function filterFiles() {
+      const searchTerm = document.getElementById("search-input").value.toLowerCase();
+      const fileItems = document.querySelectorAll(".file-item");
+
+      fileItems.forEach((item) => {
+        const fileName = item.querySelector(".file-name a").textContent.toLowerCase();
+        if (fileName === "..") {
+          item.style.display = "grid";
+        } else if (fileName.includes(searchTerm)) {
+          item.style.display = "grid";
+        } else {
+          item.style.display = "none";
+        }
+      });
+    }
+
+    function formatFileSize(size) {
+      if (size === 0) return "0 Bytes";
+      const units = ["Bytes", "KB", "MB", "GB", "TB"];
+      const i = Math.floor(Math.log(size) / Math.log(1024));
+      
+      if (i === 0) {
+        return `${size} ${units[i]}`;
       }
 
-      function uploadFile() {
-        const fileInput = document.createElement("input");
-        fileInput.type = "file";
+      return `${(size / Math.pow(1024, i)).toFixed(2)} ${units[i]}`;
+    }
 
-        fileInput.addEventListener("change", () => {
+    function newFolder() {
+      var folderName = prompt("Enter the folder name:");
+      if (folderName !== null && folderName.trim() !== "") {
+        folderName = folderName.trim();
+        const filePath = _directory ? `${_directory}/${folderName}` : folderName;
+        fetch(`folder?q=${encodeURIComponent(filePath)}`, { method: "POST" })
+          .then((response) => {
+            if (response.ok) {
+              showStatusMessage("main-status", "Folder created successfully!", "success");
+              fetchFiles(_directory);
+            } else {
+              showStatusMessage("main-status", "Failed to create folder", "error");
+            }
+          })
+          .catch((error) => {
+            console.error("Error:", error);
+            showStatusMessage("main-status", "Error creating folder", "error");
+          });
+      }
+    }
+
+    function uploadFile() {
+      const fileInput = document.createElement("input");
+      fileInput.type = "file";
+
+      fileInput.addEventListener("change", () => {
+        if (fileInput.files.length > 0) {
           var file = fileInput.files[0];
           var reader = new FileReader();
           reader.readAsArrayBuffer(file);
-          reader.onload = function () {
+          reader.onload = () => {
             const filePath = _directory ? `${_directory}/${file.name}` : file.name;
             const data = new Uint8Array(reader.result);
             sendChunk(filePath, data, 0, 1024 * 512, "main-status", () => {
               fetchFiles(_directory);
             });
           };
+        }
+      });
+
+      fileInput.click();
+    }
+
+    function viewFile(fileName) {
+      const filePath = _directory ? `${_directory}/${fileName}` : fileName;
+      _currentFilePath = filePath;
+      _isReadOnly = true;
+      
+      fetch(`download?q=${encodeURIComponent(filePath)}`)
+        .then((response) => {
+          if (response.ok) {
+            return response.text();
+          } else {
+            throw new Error("Failed to load file");
+          }
+        })
+        .then((text) => {
+          document.getElementById("editor-path").innerHTML = `Viewing file /${filePath}`;
+          
+          const editorContent = document.getElementById("editor-content");
+          editorContent.value = text;
+          editorContent.setAttribute("readonly", "readonly");
+          
+          document.getElementById("save-button").style.display = "none";
+          document.getElementById("edit-button").style.display = "inline-flex";
+          document.getElementById("download-button").style.display = "inline-flex";
+          
+          document.getElementById("edit-button").onclick = () => {
+            switchToEditMode();
+          };
+          
+          document.getElementById("download-button").onclick = () => {
+            window.location.href = `download?q=${encodeURIComponent(filePath)}`;
+          };
+
+          document.getElementById("main").style.display = "none";
+          document.getElementById("editor").style.display = "flex";
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          showStatusMessage("main-status", "Error loading file", "error");
         });
+    }
 
-        fileInput.click();
-      }
+    function switchToEditMode() {
+      _isReadOnly = false;
+      
+      const editorContent = document.getElementById("editor-content");
+      editorContent.removeAttribute("readonly");
+      
+      document.getElementById("editor-path").innerHTML = `Editing file /${_currentFilePath}`;
+      
+      document.getElementById("save-button").style.display = "inline-flex";
+      document.getElementById("edit-button").style.display = "none";
+      
+      document.getElementById("save-button").onclick = () => {
+        const data = new Uint8Array(new TextEncoder().encode(document.getElementById("editor-content").value));
+        sendChunk(_currentFilePath, data, 0, 1024 * 512, "editor-status", () => {
+          showStatusMessage("editor-status", "File saved successfully!", "success");
+        });
+      };
+      
+      editorContent.focus();
+    }
 
-      function editFile(fileName) {
+    function editFile(fileName) {
+      const filePath = _directory ? `${_directory}/${fileName}` : fileName;
+      _currentFilePath = filePath;
+      _isReadOnly = false;
+      
+      fetch(`download?q=${encodeURIComponent(filePath)}`)
+        .then((response) => {
+          if (response.ok) {
+            return response.text();
+          } else {
+            throw new Error("Failed to load file");
+          }
+        })
+        .then((text) => {
+          document.getElementById("editor-path").innerHTML = `Editing file /${filePath}`;
+          
+          const editorContent = document.getElementById("editor-content");
+          editorContent.value = text;
+          editorContent.removeAttribute("readonly");
+          
+          document.getElementById("save-button").style.display = "inline-flex";
+          document.getElementById("edit-button").style.display = "none";
+          document.getElementById("download-button").style.display = "inline-flex";
+          
+          document.getElementById("save-button").onclick = () => {
+            const data = new Uint8Array(new TextEncoder().encode(document.getElementById("editor-content").value));
+            sendChunk(filePath, data, 0, 1024 * 512, "editor-status", () => {
+              showStatusMessage("editor-status", "File saved successfully!", "success");
+            });
+          };
+          
+          document.getElementById("download-button").onclick = () => {
+            window.location.href = `download?q=${encodeURIComponent(filePath)}`;
+          };
+
+          document.getElementById("main").style.display = "none";
+          document.getElementById("editor").style.display = "flex";
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          showStatusMessage("main-status", "Error loading file", "error");
+        });
+    }
+
+    function closeEditor() {
+      document.getElementById("main").style.display = "flex";
+      document.getElementById("editor").style.display = "none";
+      _currentFilePath = null;
+      fetchFiles(_directory);
+    }
+
+    function deleteFile(fileName) {
+      if (confirm(`Are you sure you want to delete ${fileName}?`)) {
         const filePath = _directory ? `${_directory}/${fileName}` : fileName;
-        fetch(`download?q=${encodeURIComponent(filePath)}`)
+        fetch(`delete?q=${encodeURIComponent(filePath)}`, { method: "DELETE" })
           .then((response) => {
             if (response.ok) {
-              return response.text();
+              showStatusMessage("main-status", "File deleted successfully!", "success");
+              fetchFiles(_directory);
+            } else {
+              showStatusMessage("main-status", "Failed to delete file", "error");
             }
           })
-          .then((text) => {
-            document.getElementById("editor-path").innerHTML = `Editing file /${filePath}`;
-
-            document.getElementById("save-button").onclick = function () {
-              const data = new Uint8Array(new TextEncoder().encode(document.getElementById("editor-content").value));
-              sendChunk(filePath, data, 0, 1024 * 512, "editor-status", () => {
-                fetchFiles(_directory);
-              });
-            };
-
-            document.getElementById("editor-content").value = text;
-
-            document.getElementById("main").style.display = "none";
-            document.getElementById("editor").style.display = "block";
-          })
-          .catch((error) => console.error("Error:", error));
+          .catch((error) => {
+            console.error("Error:", error);
+            showStatusMessage("main-status", "Error deleting file", "error");
+          });
       }
+    }
 
-      function closeEditor() {
-        document.getElementById("main").style.display = "block";
-        document.getElementById("editor").style.display = "none";
-      }
+    function extractFile(fileName) {
+      const filePath = _directory ? `${_directory}/${fileName}` : fileName;
+      showStatusMessage("main-status", "Extracting file...", "info");
+      fetch(`extract?q=${encodeURIComponent(filePath)}`, { method: "POST" })
+        .then((response) => {
+          if (response.ok) {
+            showStatusMessage("main-status", "File extracted successfully!", "success");
+            fetchFiles(_directory);
+          } else {
+            showStatusMessage("main-status", "Failed to extract file", "error");
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          showStatusMessage("main-status", "Error extracting file", "error");
+        });
+    }
 
-      function deleteFile(fileName) {
-        if (confirm(`Are you sure you want to delete ${fileName}?`)) {
-          const filePath = _directory ? `${_directory}/${fileName}` : fileName;
-          fetch(`delete?q=${encodeURIComponent(filePath)}`, { method: "DELETE" })
+    function sendCommand(cmd) {
+      if (cmd == "shutdown") {
+        if (confirm(`Are you sure you want to exit the current table?`)) {
+          fetch(`command?cmd=${cmd}`, { method: "POST" })
             .then((response) => {
               if (response.ok) {
-                fetchFiles(_directory);
+                showStatusMessage("main-status", "Exit table command sent", "info");
+                setTimeout(fetchStatus, 1000); 
               }
             })
             .catch((error) => console.error("Error:", error));
         }
-      }
-
-      function extractFile(fileName) {
-        const filePath = _directory ? `${_directory}/${fileName}` : fileName;
-        fetch(`extract?q=${encodeURIComponent(filePath)}`, { method: "POST" })
+      } else {
+        fetch(`command?cmd=${cmd}`, { method: "POST" })
           .then((response) => {
             if (response.ok) {
-              fetchFiles(_directory);
+              showStatusMessage("main-status", `${cmd.toUpperCase()} command sent`, "info");
             }
           })
           .catch((error) => console.error("Error:", error));
       }
+    }
 
-      function activateFile(fileName) {
-        if (confirm(`Are you sure you want to activate ${fileName}?`)) {
-          const filePath = _directory ? `${_directory}/${fileName}` : fileName;
-          fetch(`activate?q=${encodeURIComponent(filePath)}`, { method: "POST" }).catch((error) =>
-            console.error("Error:", error)
-          );
-        }
+    function showStatusMessage(elementId, message, type) {
+      const statusElement = document.getElementById(elementId);
+      statusElement.textContent = message;
+
+      statusElement.className = "status-message";
+      if (type === "error") {
+        statusElement.style.color = "var(--danger-color)";
+      } else if (type === "success") {
+        statusElement.style.color = "var(--success-color)";
+      } else {
+        statusElement.style.color = "var(--text-secondary)";
       }
 
-      function sendCommand(cmd) {
-        if (cmd == "shutdown") {
-          if (confirm(`Are you sure you want to shutdown VPX?`)) {
-            fetch(`command?cmd=${cmd}`, { method: "POST" }).catch((error) => console.error("Error:", error));
+      setTimeout(() => {
+        statusElement.textContent = "";
+      }, 3000);
+    }
+
+    function sendChunk(filePath, data, offset, chunkSize, statusId, callback) {
+      const progressPercentage = (offset / data.length) * 100;
+      document.getElementById(statusId).innerHTML = `Uploading... ${progressPercentage.toFixed(0)}%`;
+      document.getElementById(statusId).style.color = "var(--primary-color)";
+
+      let directory = "";
+      let filename = filePath;
+      
+      const lastSlashIndex = filePath.lastIndexOf('/');
+      if (lastSlashIndex !== -1) {
+        directory = filePath.substring(0, lastSlashIndex);
+        filename = filePath.substring(lastSlashIndex + 1);
+      }
+
+      var chunk = data.subarray(offset, offset + chunkSize) || "";
+      fetch(`/upload?offset=${offset}&q=${encodeURIComponent(directory)}&file=${encodeURIComponent(filename)}`, { method: "POST", body: chunk })
+        .then((res) => {
+          if (res.ok && chunk.length > 0) {
+            sendChunk(filePath, data, offset + chunk.length, chunkSize, statusId, callback);
           }
-        } else {
-          fetch(`command?cmd=${cmd}`, { method: "POST" }).catch((error) => console.error("Error:", error));
-        }
-      }
-
-      function sendChunk(filePath, data, offset, chunkSize, statusId, callback) {
-        var ok;
-        const progressPercentage = (offset / data.length) * 100;
-        document.getElementById(statusId).innerHTML = `Sending (${progressPercentage.toFixed(2)}%)`;
-        var chunk = data.subarray(offset, offset + chunkSize) || "";
-        fetch(`/upload?offset=${offset}&q=${encodeURIComponent(filePath)}`, { method: "POST", body: chunk })
-          .then(function (res) {
-            if (res.ok && chunk.length > 0) {
-              sendChunk(filePath, data, offset + chunk.length, chunkSize, statusId, callback);
+          return res.ok ? res.text() : Promise.reject(res.text());
+        })
+        .then((text) => {
+          if (text === "0") {
+            showStatusMessage(statusId, "Upload complete!", "success");
+            if (callback) {
+              callback();
             }
-            ok = res.ok;
-            return res.text();
-          })
-          .then(function (text) {
-            if (!ok) {
-              document.getElementById(statusId).innerHTML = `Error ${text}`;
-            } else {
-              if (text === "0") {
-                document.getElementById(statusId).innerHTML = `Success!`;
-                setTimeout(() => {
-                  document.getElementById(statusId).innerHTML = "";
-                }, 2000);
-                if (callback) {
-                  callback();
-                }
-              }
-            }
-          })
-          .catch((error) => console.error("Error:", error));
-      }
-
-      function startup() {
-        document.getElementById("file-list").addEventListener("dragenter", (e) => {
-          e.stopPropagation();
-          e.preventDefault();
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          showStatusMessage(statusId, "Upload failed", "error");
         });
+    }
 
-        document.getElementById("file-list").addEventListener("drop", (e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          const files = e.dataTransfer.files;
+    function setupDragAndDrop() {
+      const dropOverlay = document.getElementById("drop-overlay");
+
+      document.addEventListener("dragenter", (e) => {
+        e.preventDefault();
+        dropOverlay.style.display = "flex";
+      });
+
+      dropOverlay.addEventListener("dragover", (e) => {
+        e.preventDefault();
+      });
+
+      dropOverlay.addEventListener("dragleave", (e) => {
+        e.preventDefault();
+        if (e.target === dropOverlay) {
+          dropOverlay.style.display = "none";
+        }
+      });
+
+      dropOverlay.addEventListener("drop", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        dropOverlay.style.display = "none";
+
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
           for (let i = 0; i < files.length; i++) {
             const file = files[i];
             const reader = new FileReader();
-            reader.onload = function () {
+            reader.onload = () => {
               const filePath = _directory ? `${_directory}/${file.name}` : file.name;
               const data = new Uint8Array(reader.result);
               sendChunk(filePath, data, 0, 1024 * 512, "main-status", () => {
@@ -376,12 +1359,24 @@
             };
             reader.readAsArrayBuffer(file);
           }
-        });
+        }
+      });
+    }
 
-        fetchFiles("");
-      }
+    function startup() {
+      setupDragAndDrop();
+      fetchStatus();
+      fetchFiles("");
+      
+      _statusInterval = setInterval(() => {
+        fetchStatus();
+        if (_connectionFailed) {
+          clearStatusDisplay();
+        }
+      }, 5000);
+    }
 
-      startup();
-    </script>
-  </body>
+    document.addEventListener("DOMContentLoaded", startup);
+  </script>
+</body>
 </html>

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1011,13 +1011,6 @@ public:
       if (m_listRes || m_listSnd)
          exit(0);
 
-#if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
-      const string launchTable = g_pvp->m_settings.LoadValueWithDefault(Settings::Standalone, "LaunchTable"s, "assets/exampleTable.vpx"s);
-      m_szTableFileName = m_vpinball.m_szMyPrefPath + launchTable;
-      m_file = true;
-      m_play = true;
-#endif
-
 #endif
 
       // Start VP with file dialog open and then also playing that one?

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2022,10 +2022,6 @@ void Player::FinishFrame()
       m_closing = CS_STOP_PLAY;
 #else
       m_closing = CS_CLOSE_APP;
-#if (defined(__APPLE__) && (defined(TARGET_OS_TV) && TARGET_OS_TV))
-      PLOGE.printf("Runtime error detected. Resetting LaunchTable to default.");
-      g_pvp->m_settings.SaveValue(Settings::Standalone, "LaunchTable"s, "assets/exampleTable.vpx"s);
-#endif
 #endif
    }
 

--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -1239,10 +1239,6 @@ void VPinball::DoPlay(const int playMode)
    if (initError)
    {
       g_pvp->m_table_played_via_SelectTableOnStart = false;
-      #if defined(__APPLE__) && defined(TARGET_OS_TV) && TARGET_OS_TV
-         PLOGE.printf("Load failure detected. Resetting LaunchTable to default.");
-         g_pvp->m_settings.SaveValue(Settings::Standalone, "LaunchTable"s, "assets/exampleTable.vpx");
-      #endif
    }
 
    #ifdef __LIBVPINBALL__
@@ -1286,6 +1282,7 @@ void VPinball::LoadFileName(const string& szFileName, const bool updateEditor, V
       OnInitialUpdate();
 
    m_currentTablePath = PathFromFilename(szFileName);
+
    CloseAllDialogs();
 
    PinTableMDI * const mdiTable = new PinTableMDI(this);
@@ -1304,13 +1301,6 @@ void VPinball::LoadFileName(const string& szFileName, const bool updateEditor, V
       ShowError("This file does not exist, or is corrupt and failed to load.");
 
       delete mdiTable;
-
-#ifdef __STANDALONE__
-#if (defined(__APPLE__) && (defined(TARGET_OS_TV) && TARGET_OS_TV))
-      PLOGE.printf("Load failure detected. Resetting LaunchTable to default.");
-      g_pvp->m_settings.SaveValue(Settings::Standalone, "LaunchTable"s, "assets/exampleTable.vpx");
-#endif
-#endif
    }
    else
    {

--- a/src/ui/LiveUI.cpp
+++ b/src/ui/LiveUI.cpp
@@ -4337,68 +4337,12 @@ void LiveUI::UpdateMainSplashModal()
          ImGui::GetIO().MousePos.y = 0;
       }
 #endif
-#ifndef __LIBVPINBALL__
-      bool webServerRunning = g_pvp->m_webServer.IsRunning();
-      if (ImGui::Button(webServerRunning ? "Disable Web Server" : "Enable Web Server", size))
-      {
-         g_pvp->m_settings.SaveValue(Settings::Standalone, "WebServer"s, !webServerRunning);
-
-         if (webServerRunning)
-            g_pvp->m_webServer.Stop();
-         else
-            g_pvp->m_webServer.Start();
-
-#if ((defined(__APPLE__) && (defined(TARGET_OS_IOS) && TARGET_OS_IOS)) || defined(__ANDROID__))
-         ImGui::GetIO().MousePos.x = 0;
-         ImGui::GetIO().MousePos.y = 0;
-#endif
-      }
-#endif
-
       if (ImGui::Button("Quit", size) || (enableKeyboardShortcuts && ImGui::IsKeyPressed(dikToImGuiKeys[m_player->m_rgKeys[eExitGame]])))
       {
          ImGui::CloseCurrentPopup();
          HideUI();
          m_table->QuitPlayer(Player::CS_CLOSE_APP);
       }
-
-#if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS && !defined(__LIBVPINBALL__)) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
-      ImGui::Dummy(ImVec2(0.f, m_dpi * 4.f));
-      ImGui::Separator();
-      ImGui::Dummy(ImVec2(0.f, m_dpi * 4.f));
-      ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ((ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize("Launch Table:").x) * 0.5f));
-      ImGui::Text("Launch Table:");
-
-      ImGui::PushItemWidth(size.x);
-
-      const string launchTable = g_pvp->m_settings.LoadValueWithDefault(Settings::Standalone, "LaunchTable"s, "assets/exampleTable.vpx"s);
-      if (ImGui::BeginCombo("##Launch Table", launchTable.c_str()))
-      {
-         vector<string> files = find_files_by_extension(g_pvp->m_szMyPrefPath, "vpx"s);
-
-         for (const auto& file : files) {
-            if (ImGui::Selectable(file.c_str()))
-               g_pvp->m_settings.SaveValue(Settings::Standalone, "LaunchTable"s, file);
-         }
-
-         ImGui::EndCombo();
-      }
-
-      ImGui::PopItemWidth();
-#endif
-
-#ifndef __LIBVPINBALL__
-      string url = g_pvp->m_webServer.GetUrl();
-      if (!url.empty())
-      {
-         ImGui::Dummy(ImVec2(0.f, m_dpi * 4.f));
-         ImGui::Separator();
-         ImGui::Dummy(ImVec2(0.f, m_dpi * 4.f));
-         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ((ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(url.c_str()).x) * 0.5f));
-         ImGui::Text("%s", url.c_str());
-      }
-#endif
-
 #endif
       const ImVec2 pos = ImGui::GetWindowPos();
       ImVec2 max = ImGui::GetWindowSize();

--- a/standalone/inc/webserver/WebServer.h
+++ b/standalone/inc/webserver/WebServer.h
@@ -8,7 +8,7 @@ public:
     WebServer();
     ~WebServer();
 
-    static void EventHandler(struct mg_connection *c, int ev, void *ev_data, void *fn_data);
+    static void EventHandler(struct mg_connection *c, int ev, void *ev_data);
 
     void Start();
     void Stop();
@@ -17,13 +17,13 @@ public:
 
 private:
     bool Unzip(const char* pSource);
+    void Status(struct mg_connection *c, struct mg_http_message* hm);
     void Files(struct mg_connection *c, struct mg_http_message* hm);
     void Download(struct mg_connection *c, struct mg_http_message* hm);
     void Upload(struct mg_connection *c, struct mg_http_message* hm);
     void Delete(struct mg_connection *c, struct mg_http_message* hm);
     void Folder(struct mg_connection *c, struct mg_http_message* hm);
     void Extract(struct mg_connection *c, struct mg_http_message* hm);
-    void Activate(struct mg_connection *c, struct mg_http_message* hm);
     void Command(struct mg_connection *c, struct mg_http_message* hm);
     string GetIPAddress();
 

--- a/standalone/inc/webserver/mongoose.c
+++ b/standalone/inc/webserver/mongoose.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2004-2013 Sergey Lyubka
-// Copyright (c) 2013-2022 Cesanta Software Limited
+// Copyright (c) 2013-2025 Cesanta Software Limited
 // All rights reserved
 //
 // This software is dual-licensed: you can redistribute it and/or modify
@@ -24,8 +24,7 @@
 #endif
 
 
-
-static int mg_b64idx(int c) {
+static int mg_base64_encode_single(int c) {
   if (c < 26) {
     return c + 'A';
   } else if (c < 52) {
@@ -37,7 +36,7 @@ static int mg_b64idx(int c) {
   }
 }
 
-static int mg_b64rev(int c) {
+static int mg_base64_decode_single(int c) {
   if (c >= 'A' && c <= 'Z') {
     return c - 'A';
   } else if (c >= 'a' && c <= 'z') {
@@ -55,24 +54,24 @@ static int mg_b64rev(int c) {
   }
 }
 
-int mg_base64_update(unsigned char ch, char *to, int n) {
-  int rem = (n & 3) % 3;
+size_t mg_base64_update(unsigned char ch, char *to, size_t n) {
+  unsigned long rem = (n & 3) % 3;
   if (rem == 0) {
-    to[n] = (char) mg_b64idx(ch >> 2);
+    to[n] = (char) mg_base64_encode_single(ch >> 2);
     to[++n] = (char) ((ch & 3) << 4);
   } else if (rem == 1) {
-    to[n] = (char) mg_b64idx(to[n] | (ch >> 4));
+    to[n] = (char) mg_base64_encode_single(to[n] | (ch >> 4));
     to[++n] = (char) ((ch & 15) << 2);
   } else {
-    to[n] = (char) mg_b64idx(to[n] | (ch >> 6));
-    to[++n] = (char) mg_b64idx(ch & 63);
+    to[n] = (char) mg_base64_encode_single(to[n] | (ch >> 6));
+    to[++n] = (char) mg_base64_encode_single(ch & 63);
     n++;
   }
   return n;
 }
 
-int mg_base64_final(char *to, int n) {
-  int saved = n;
+size_t mg_base64_final(char *to, size_t n) {
+  size_t saved = n;
   // printf("---[%.*s]\n", n, to);
   if (n & 3) n = mg_base64_update(0, to, n);
   if ((saved & 3) == 2) n--;
@@ -82,20 +81,27 @@ int mg_base64_final(char *to, int n) {
   return n;
 }
 
-int mg_base64_encode(const unsigned char *p, int n, char *to) {
-  int i, len = 0;
+size_t mg_base64_encode(const unsigned char *p, size_t n, char *to, size_t dl) {
+  size_t i, len = 0;
+  if (dl > 0) to[0] = '\0';
+  if (dl < ((n / 3) + (n % 3 ? 1 : 0)) * 4 + 1) return 0;
   for (i = 0; i < n; i++) len = mg_base64_update(p[i], to, len);
   len = mg_base64_final(to, len);
   return len;
 }
 
-int mg_base64_decode(const char *src, int n, char *dst) {
+size_t mg_base64_decode(const char *src, size_t n, char *dst, size_t dl) {
   const char *end = src == NULL ? NULL : src + n;  // Cannot add to NULL
-  int len = 0;
+  size_t len = 0;
+  if (dl < n / 4 * 3 + 1) goto fail;
   while (src != NULL && src + 3 < end) {
-    int a = mg_b64rev(src[0]), b = mg_b64rev(src[1]), c = mg_b64rev(src[2]),
-        d = mg_b64rev(src[3]);
-    if (a == 64 || a < 0 || b == 64 || b < 0 || c < 0 || d < 0) return 0;
+    int a = mg_base64_decode_single(src[0]),
+        b = mg_base64_decode_single(src[1]),
+        c = mg_base64_decode_single(src[2]),
+        d = mg_base64_decode_single(src[3]);
+    if (a == 64 || a < 0 || b == 64 || b < 0 || c < 0 || d < 0) {
+      goto fail;
+    }
     dst[len++] = (char) ((a << 2) | (b >> 4));
     if (src[2] != '=') {
       dst[len++] = (char) ((b << 4) | (c >> 2));
@@ -105,6 +111,9 @@ int mg_base64_decode(const char *src, int n, char *dst) {
   }
   dst[len] = '\0';
   return len;
+fail:
+  if (dl > 0) dst[0] = '\0';
+  return 0;
 }
 
 #ifdef MG_ENABLE_LINES
@@ -128,17 +137,17 @@ struct dns_data {
 static void mg_sendnsreq(struct mg_connection *, struct mg_str *, int,
                          struct mg_dns *, bool);
 
-static void mg_dns_free(struct mg_connection *c, struct dns_data *d) {
-  LIST_DELETE(struct dns_data,
-              (struct dns_data **) &c->mgr->active_dns_requests, d);
+static void mg_dns_free(struct dns_data **head, struct dns_data *d) {
+  LIST_DELETE(struct dns_data, head, d);
   free(d);
 }
 
 void mg_resolve_cancel(struct mg_connection *c) {
-  struct dns_data *tmp, *d = (struct dns_data *) c->mgr->active_dns_requests;
-  for (; d != NULL; d = tmp) {
+  struct dns_data *tmp, *d;
+  struct dns_data **head = (struct dns_data **) &c->mgr->active_dns_requests;
+  for (d = *head; d != NULL; d = tmp) {
     tmp = d->next;
-    if (d->c == c) mg_dns_free(c, d);
+    if (d->c == c) mg_dns_free(head, d);
   }
 }
 
@@ -211,12 +220,16 @@ size_t mg_dns_parse_rr(const uint8_t *buf, size_t len, size_t ofs,
 bool mg_dns_parse(const uint8_t *buf, size_t len, struct mg_dns_message *dm) {
   const struct mg_dns_header *h = (struct mg_dns_header *) buf;
   struct mg_dns_rr rr;
-  size_t i, n, ofs = sizeof(*h);
+  size_t i, n, num_answers, ofs = sizeof(*h);
   memset(dm, 0, sizeof(*dm));
 
   if (len < sizeof(*h)) return 0;                // Too small, headers dont fit
   if (mg_ntohs(h->num_questions) > 1) return 0;  // Sanity
-  if (mg_ntohs(h->num_answers) > 10) return 0;   // Sanity
+  num_answers = mg_ntohs(h->num_answers);
+  if (num_answers > 10) {
+    MG_DEBUG(("Got %u answers, ignoring beyond 10th one", num_answers));
+    num_answers = 10;  // Sanity cap
+  }
   dm->txnid = mg_ntohs(h->txnid);
 
   for (i = 0; i < mg_ntohs(h->num_questions); i++) {
@@ -224,7 +237,7 @@ bool mg_dns_parse(const uint8_t *buf, size_t len, struct mg_dns_message *dm) {
     // MG_INFO(("Q %lu %lu %hu/%hu", ofs, n, rr.atype, rr.aclass));
     ofs += n;
   }
-  for (i = 0; i < mg_ntohs(h->num_answers); i++) {
+  for (i = 0; i < num_answers; i++) {
     if ((n = mg_dns_parse_rr(buf, len, ofs, false, &rr)) == 0) return false;
     // MG_INFO(("A -- %lu %lu %hu/%hu %s", ofs, n, rr.atype, rr.aclass,
     // dm->name));
@@ -238,7 +251,7 @@ bool mg_dns_parse(const uint8_t *buf, size_t len, struct mg_dns_message *dm) {
       break;  // Return success
     } else if (rr.alen == 16 && rr.atype == 28 && rr.aclass == 1) {
       dm->addr.is_ip6 = true;
-      memcpy(&dm->addr.ip6, &buf[ofs - 16], 16);
+      memcpy(&dm->addr.ip, &buf[ofs - 16], 16);
       dm->resolved = true;
       break;  // Return success
     }
@@ -246,13 +259,12 @@ bool mg_dns_parse(const uint8_t *buf, size_t len, struct mg_dns_message *dm) {
   return true;
 }
 
-static void dns_cb(struct mg_connection *c, int ev, void *ev_data,
-                   void *fn_data) {
+static void dns_cb(struct mg_connection *c, int ev, void *ev_data) {
   struct dns_data *d, *tmp;
+  struct dns_data **head = (struct dns_data **) &c->mgr->active_dns_requests;
   if (ev == MG_EV_POLL) {
     uint64_t now = *(uint64_t *) ev_data;
-    for (d = (struct dns_data *) c->mgr->active_dns_requests; d != NULL;
-         d = tmp) {
+    for (d = *head; d != NULL; d = tmp) {
       tmp = d->next;
       // MG_DEBUG ("%lu %lu dns poll", d->expire, now));
       if (now > d->expire) mg_error(d->c, "DNS timeout");
@@ -265,8 +277,7 @@ static void dns_cb(struct mg_connection *c, int ev, void *ev_data,
       mg_hexdump(c->recv.buf, c->recv.len);
     } else {
       // MG_VERBOSE(("%s %d", dm.name, dm.resolved));
-      for (d = (struct dns_data *) c->mgr->active_dns_requests; d != NULL;
-           d = tmp) {
+      for (d = *head; d != NULL; d = tmp) {
         tmp = d->next;
         // MG_INFO(("d %p %hu %hu", d, d->txnid, dm.txnid));
         if (dm.txnid != d->txnid) continue;
@@ -289,21 +300,19 @@ static void dns_cb(struct mg_connection *c, int ev, void *ev_data,
         } else {
           MG_ERROR(("%lu already resolved", d->c->id));
         }
-        mg_dns_free(c, d);
+        mg_dns_free(head, d);
         resolved = 1;
       }
     }
     if (!resolved) MG_ERROR(("stray DNS reply"));
     c->recv.len = 0;
   } else if (ev == MG_EV_CLOSE) {
-    for (d = (struct dns_data *) c->mgr->active_dns_requests; d != NULL;
-         d = tmp) {
+    for (d = *head; d != NULL; d = tmp) {
       tmp = d->next;
       mg_error(d->c, "DNS error");
-      mg_dns_free(c, d);
+      mg_dns_free(head, d);
     }
   }
-  (void) fn_data;
 }
 
 static bool mg_dns_send(struct mg_connection *c, const struct mg_str *name,
@@ -318,9 +327,9 @@ static bool mg_dns_send(struct mg_connection *c, const struct mg_str *name,
   pkt.header.flags = mg_htons(0x100);
   pkt.header.num_questions = mg_htons(1);
   for (i = n = 0; i < sizeof(pkt.data) - 5; i++) {
-    if (name->ptr[i] == '.' || i >= name->len) {
+    if (name->buf[i] == '.' || i >= name->len) {
       pkt.data[n] = (uint8_t) (i - n);
-      memcpy(&pkt.data[n + 1], name->ptr + n, i - n);
+      memcpy(&pkt.data[n + 1], name->buf + n, i - n);
       n = i + 1;
     }
     if (i >= name->len) break;
@@ -358,7 +367,7 @@ static void mg_sendnsreq(struct mg_connection *c, struct mg_str *name, int ms,
     d->c = c;
     c->is_resolving = 1;
     MG_VERBOSE(("%lu resolving %.*s @ %s, txnid %hu", c->id, (int) name->len,
-                name->ptr, dnsc->url, d->txnid));
+                name->buf, dnsc->url, d->txnid));
     if (!mg_dns_send(dnsc->c, name, d->txnid, ipv6)) {
       mg_error(dnsc->c, "DNS send");
     }
@@ -386,12 +395,22 @@ void mg_resolve(struct mg_connection *c, const char *url) {
 
 
 
+
 void mg_call(struct mg_connection *c, int ev, void *ev_data) {
-  // Run user-defined handler first, in order to give it an ability
-  // to intercept processing (e.g. clean input buffer) before the
-  // protocol handler kicks in
-  if (c->fn != NULL) c->fn(c, ev, ev_data, c->fn_data);
-  if (c->pfn != NULL) c->pfn(c, ev, ev_data, c->pfn_data);
+#if MG_ENABLE_PROFILE
+  const char *names[] = {
+      "EV_ERROR",    "EV_OPEN",      "EV_POLL",      "EV_RESOLVE",
+      "EV_CONNECT",  "EV_ACCEPT",    "EV_TLS_HS",    "EV_READ",
+      "EV_WRITE",    "EV_CLOSE",     "EV_HTTP_MSG",  "EV_HTTP_CHUNK",
+      "EV_WS_OPEN",  "EV_WS_MSG",    "EV_WS_CTL",    "EV_MQTT_CMD",
+      "EV_MQTT_MSG", "EV_MQTT_OPEN", "EV_SNTP_TIME", "EV_USER"};
+  if (ev != MG_EV_POLL && ev < (int) (sizeof(names) / sizeof(names[0]))) {
+    MG_PROF_ADD(c, names[ev]);
+  }
+#endif
+  // Fire protocol handler first, user handler second. See #2559
+  if (c->pfn != NULL) c->pfn(c, ev, ev_data);
+  if (c->fn != NULL) c->fn(c, ev, ev_data);
 }
 
 void mg_error(struct mg_connection *c, const char *fmt, ...) {
@@ -400,10 +419,83 @@ void mg_error(struct mg_connection *c, const char *fmt, ...) {
   va_start(ap, fmt);
   mg_vsnprintf(buf, sizeof(buf), fmt, &ap);
   va_end(ap);
-  MG_ERROR(("%lu %p %s", c->id, c->fd, buf));
+  MG_ERROR(("%lu %ld %s", c->id, c->fd, buf));
   c->is_closing = 1;             // Set is_closing before sending MG_EV_CALL
-  mg_call(c, MG_EV_ERROR, buf);  // Let user handler to override it
+  mg_call(c, MG_EV_ERROR, buf);  // Let user handler override it
 }
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/flash.c"
+#endif
+
+
+
+
+
+#if MG_OTA != MG_OTA_NONE && MG_OTA != MG_OTA_CUSTOM
+
+static char *s_addr;      // Current address to write to
+static size_t s_size;     // Firmware size to flash. In-progress indicator
+static uint32_t s_crc32;  // Firmware checksum
+
+bool mg_ota_flash_begin(size_t new_firmware_size, struct mg_flash *flash) {
+  bool ok = false;
+  if (s_size) {
+    MG_ERROR(("OTA already in progress. Call mg_ota_end()"));
+  } else {
+    size_t half = flash->size / 2;
+    s_crc32 = 0;
+    s_addr = (char *) flash->start + half;
+    MG_DEBUG(("FW %lu bytes, max %lu", new_firmware_size, half));
+    if (new_firmware_size < half) {
+      ok = true;
+      s_size = new_firmware_size;
+      MG_INFO(("Starting OTA, firmware size %lu", s_size));
+    } else {
+      MG_ERROR(("Firmware %lu is too big to fit %lu", new_firmware_size, half));
+    }
+  }
+  return ok;
+}
+
+bool mg_ota_flash_write(const void *buf, size_t len, struct mg_flash *flash) {
+  bool ok = false;
+  if (s_size == 0) {
+    MG_ERROR(("OTA is not started, call mg_ota_begin()"));
+  } else {
+    size_t len_aligned_down = MG_ROUND_DOWN(len, flash->align);
+    if (len_aligned_down) ok = flash->write_fn(s_addr, buf, len_aligned_down);
+    if (len_aligned_down < len) {
+      size_t left = len - len_aligned_down;
+      char tmp[flash->align];
+      memset(tmp, 0xff, sizeof(tmp));
+      memcpy(tmp, (char *) buf + len_aligned_down, left);
+      ok = flash->write_fn(s_addr + len_aligned_down, tmp, sizeof(tmp));
+    }
+    s_crc32 = mg_crc32(s_crc32, (char *) buf, len);  // Update CRC
+    MG_DEBUG(("%#x %p %lu -> %d", s_addr - len, buf, len, ok));
+    s_addr += len;
+  }
+  return ok;
+}
+
+bool mg_ota_flash_end(struct mg_flash *flash) {
+  char *base = (char *) flash->start + flash->size / 2;
+  bool ok = false;
+  if (s_size) {
+    size_t size = (size_t) (s_addr - base);
+    uint32_t crc32 = mg_crc32(0, base, s_size);
+    if (size == s_size && crc32 == s_crc32) ok = true;
+    MG_DEBUG(("CRC: %x/%x, size: %lu/%lu, status: %s", s_crc32, crc32, s_size,
+              size, ok ? "ok" : "fail"));
+    s_size = 0;
+    if (ok) ok = flash->swap_fn();
+  }
+  MG_INFO(("Finishing OTA: %s", ok ? "ok" : "fail"));
+  return ok;
+}
+
+#endif
 
 #ifdef MG_ENABLE_LINES
 #line 1 "src/fmt.c"
@@ -458,28 +550,36 @@ static size_t mg_dtoa(char *dst, size_t dstlen, double d, int width, bool tz) {
 
   // Round
   saved = d;
-  mul = 1.0;
-  while (d >= 10.0 && d / mul >= 10.0) mul *= 10.0;
+  if (tz) {
+    mul = 1.0;
+    while (d >= 10.0 && d / mul >= 10.0) mul *= 10.0;
+  } else {
+    mul = 0.1;
+  }
+
   while (d <= 1.0 && d / mul <= 1.0) mul /= 10.0;
   for (i = 0, t = mul * 5; i < width; i++) t /= 10.0;
+
   d += t;
+
   // Calculate exponent, and 'mul' for scientific representation
   mul = 1.0;
   while (d >= 10.0 && d / mul >= 10.0) mul *= 10.0, e++;
   while (d < 1.0 && d / mul < 1.0) mul /= 10.0, e--;
   // printf(" --> %g %d %g %g\n", saved, e, t, mul);
 
-  if (e >= width && width > 1) {
+  if (tz && e >= width && width > 1) {
     n = (int) mg_dtoa(buf, sizeof(buf), saved / mul, width, tz);
     // printf(" --> %.*g %d [%.*s]\n", 10, d / t, e, n, buf);
     n += addexp(buf + s + n, e, '+');
     return mg_snprintf(dst, dstlen, "%.*s", n, buf);
-  } else if (e <= -width && width > 1) {
+  } else if (tz && e <= -width && width > 1) {
     n = (int) mg_dtoa(buf, sizeof(buf), saved / mul, width, tz);
     // printf(" --> %.*g %d [%.*s]\n", 10, d / mul, e, n, buf);
     n += addexp(buf + s + n, -e, '-');
     return mg_snprintf(dst, dstlen, "%.*s", n, buf);
   } else {
+    int targ_width = width;
     for (i = 0, t = mul; t >= 1.0 && s + n < (int) sizeof(buf); i++) {
       int ch = (int) (d / t);
       if (n > 0 || ch > 0) buf[s + n++] = (char) (ch + '0');
@@ -491,15 +591,17 @@ static size_t mg_dtoa(char *dst, size_t dstlen, double d, int width, bool tz) {
     while (t >= 1.0 && n + s < (int) sizeof(buf)) buf[n++] = '0', t /= 10.0;
     if (s + n < (int) sizeof(buf)) buf[n + s++] = '.';
     // printf(" 1--> [%g] -> [%.*s]\n", saved, s + n, buf);
-    for (i = 0, t = 0.1; s + n < (int) sizeof(buf) && n < width; i++) {
+    if (!tz && n > 0) targ_width = width + n;
+    for (i = 0, t = 0.1; s + n < (int) sizeof(buf) && n < targ_width; i++) {
       int ch = (int) (d / t);
       buf[s + n++] = (char) (ch + '0');
       d -= ch * t;
       t /= 10.0;
     }
   }
+
   while (tz && n > 0 && buf[s + n - 1] == '0') n--;  // Trim trailing zeroes
-  if (n > 0 && buf[s + n - 1] == '.') n--;           // Trim trailing dot
+  if (tz && n > 0 && buf[s + n - 1] == '.') n--;           // Trim trailing dot
   n += s;
   if (n >= (int) sizeof(buf)) n = (int) sizeof(buf) - 1;
   buf[n] = '\0';
@@ -638,6 +740,7 @@ size_t mg_vxprintf(void (*out)(char, void *), void *param, const char *fmt,
 
 
 
+
 struct mg_fd *mg_fs_open(struct mg_fs *fs, const char *path, int flags) {
   struct mg_fd *fd = (struct mg_fd *) calloc(1, sizeof(*fd));
   if (fd != NULL) {
@@ -658,25 +761,21 @@ void mg_fs_close(struct mg_fd *fd) {
   }
 }
 
-char *mg_file_read(struct mg_fs *fs, const char *path, size_t *sizep) {
-  struct mg_fd *fd;
-  char *data = NULL;
-  size_t size = 0;
-  fs->st(path, &size, NULL);
-  if ((fd = mg_fs_open(fs, path, MG_FS_READ)) != NULL) {
-    data = (char *) calloc(1, size + 1);
-    if (data != NULL) {
-      if (fs->rd(fd->fd, data, size) != size) {
-        free(data);
-        data = NULL;
-      } else {
-        data[size] = '\0';
-        if (sizep != NULL) *sizep = size;
-      }
+struct mg_str mg_file_read(struct mg_fs *fs, const char *path) {
+  struct mg_str result = {NULL, 0};
+  void *fp;
+  fs->st(path, &result.len, NULL);
+  if ((fp = fs->op(path, MG_FS_READ)) != NULL) {
+    result.buf = (char *) calloc(1, result.len + 1);
+    if (result.buf != NULL &&
+        fs->rd(fp, (void *) result.buf, result.len) != result.len) {
+      free((void *) result.buf);
+      result.buf = NULL;
     }
-    mg_fs_close(fd);
+    fs->cl(fp);
   }
-  return data;
+  if (result.buf == NULL) result.len = 0;
+  return result;
 }
 
 bool mg_file_write(struct mg_fs *fs, const char *path, const void *buf,
@@ -708,6 +807,26 @@ bool mg_file_printf(struct mg_fs *fs, const char *path, const char *fmt, ...) {
   result = mg_file_write(fs, path, data, strlen(data));
   free(data);
   return result;
+}
+
+// This helper function allows to scan a filesystem in a sequential way,
+// without using callback function:
+//      char buf[100] = "";
+//      while (mg_fs_ls(&mg_fs_posix, "./", buf, sizeof(buf))) {
+//        ...
+static void mg_fs_ls_fn(const char *filename, void *param) {
+  struct mg_str *s = (struct mg_str *) param;
+  if (s->buf[0] == '\0') {
+    mg_snprintf((char *) s->buf, s->len, "%s", filename);
+  } else if (strcmp(s->buf, filename) == 0) {
+    ((char *) s->buf)[0] = '\0';  // Fetch next file
+  }
+}
+
+bool mg_fs_ls(struct mg_fs *fs, const char *path, char *buf, size_t len) {
+  struct mg_str s = {buf, len};
+  fs->ls(path, mg_fs_ls_fn, &s);
+  return buf[0] != '\0';
 }
 
 #ifdef MG_ENABLE_LINES
@@ -855,13 +974,12 @@ struct packed_file {
   size_t pos;
 };
 
-const char *mg_unpack(const char *path, size_t *size, time_t *mtime);
-const char *mg_unlist(size_t no);
-
 #if MG_ENABLE_PACKED_FS
 #else
 const char *mg_unpack(const char *path, size_t *size, time_t *mtime) {
-  (void) path, (void) size, (void) mtime;
+  if (size != NULL) *size = 0;
+  if (mtime != NULL) *mtime = 0;
+  (void) path;
   return NULL;
 }
 const char *mg_unlist(size_t no) {
@@ -869,6 +987,12 @@ const char *mg_unlist(size_t no) {
   return NULL;
 }
 #endif
+
+struct mg_str mg_unpacked(const char *path) {
+  size_t len = 0;
+  const char *buf = mg_unpack(path, &len, NULL);
+  return mg_str_n(buf, len);
+}
 
 static int is_dir_prefix(const char *prefix, size_t n, const char *path) {
   // MG_INFO(("[%.*s] [%s] %c", (int) n, prefix, path, path[n]));
@@ -969,7 +1093,7 @@ struct mg_fs mg_fs_packed = {
 #endif
 
 
-#if MG_ENABLE_FILE
+#if MG_ENABLE_POSIX_FS
 
 #ifndef MG_STAT_STRUCT
 #define MG_STAT_STRUCT stat
@@ -995,7 +1119,7 @@ static int p_stat(const char *path, size_t *size, time_t *mtime) {
     FILE *fp = _wfopen(tmp, L"rb");
     if (fp != NULL) {
       fseek(fp, 0, SEEK_END);
-      if (ftell(fp) > 0) st.st_size = ftell(fp); // Use _ftelli64 on win10+
+      if (ftell(fp) > 0) st.st_size = ftell(fp);  // Use _ftelli64 on win10+
       fclose(fp);
     }
   }
@@ -1020,6 +1144,7 @@ typedef struct win32_dir {
   struct dirent result;
 } DIR;
 
+#if 0
 int gettimeofday(struct timeval *tv, void *tz) {
   FILETIME ft;
   unsigned __int64 tmpres = 0;
@@ -1037,6 +1162,7 @@ int gettimeofday(struct timeval *tv, void *tz) {
   (void) tz;
   return 0;
 }
+#endif
 
 static int to_wchar(const char *path, wchar_t *wbuf, size_t wbuf_len) {
   int ret;
@@ -1135,13 +1261,14 @@ static void p_list(const char *dir, void (*fn)(const char *, void *),
 }
 
 static void *p_open(const char *path, int flags) {
-  const char *mode = flags == MG_FS_READ ? "rb" : "a+b";
 #if MG_ARCH == MG_ARCH_WIN32
+  const char *mode = flags == MG_FS_READ ? "rb" : "a+b";
   wchar_t b1[MG_PATH_MAX], b2[10];
   MultiByteToWideChar(CP_UTF8, 0, path, -1, b1, sizeof(b1) / sizeof(b1[0]));
   MultiByteToWideChar(CP_UTF8, 0, mode, -1, b2, sizeof(b2) / sizeof(b2[0]));
   return (void *) _wfopen(b1, b2);
 #else
+  const char *mode = flags == MG_FS_READ ? "rbe" : "a+be";  // e for CLOEXEC
   return (void *) fopen(path, mode);
 #endif
 }
@@ -1243,6 +1370,37 @@ struct mg_fs mg_fs_posix = {p_stat,  p_list, p_open,   p_close,  p_read,
 
 
 
+static int mg_ncasecmp(const char *s1, const char *s2, size_t len) {
+  int diff = 0;
+  if (len > 0) do {
+      int c = *s1++, d = *s2++;
+      if (c >= 'A' && c <= 'Z') c += 'a' - 'A';
+      if (d >= 'A' && d <= 'Z') d += 'a' - 'A';
+      diff = c - d;
+    } while (diff == 0 && s1[-1] != '\0' && --len > 0);
+  return diff;
+}
+
+bool mg_to_size_t(struct mg_str str, size_t *val);
+bool mg_to_size_t(struct mg_str str, size_t *val) {
+  size_t i = 0, max = (size_t) -1, max2 = max / 10, result = 0, ndigits = 0;
+  while (i < str.len && (str.buf[i] == ' ' || str.buf[i] == '\t')) i++;
+  if (i < str.len && str.buf[i] == '-') return false;
+  while (i < str.len && str.buf[i] >= '0' && str.buf[i] <= '9') {
+    size_t digit = (size_t) (str.buf[i] - '0');
+    if (result > max2) return false;  // Overflow
+    result *= 10;
+    if (result > max - digit) return false;  // Overflow
+    result += digit;
+    i++, ndigits++;
+  }
+  while (i < str.len && (str.buf[i] == ' ' || str.buf[i] == '\t')) i++;
+  if (ndigits == 0) return false;  // #2322: Content-Length = 1 * DIGIT
+  if (i != str.len) return false;  // Ditto
+  *val = (size_t) result;
+  return true;
+}
+
 // Chunk deletion marker is the MSB in the "processed" counter
 #define MG_DMARK ((size_t) 1 << (sizeof(size_t) * 8 - 1))
 
@@ -1261,7 +1419,7 @@ struct mg_fs mg_fs_posix = {p_stat,  p_list, p_open,   p_close,  p_read,
 size_t mg_http_next_multipart(struct mg_str body, size_t ofs,
                               struct mg_http_part *part) {
   struct mg_str cd = mg_str_n("Content-Disposition", 19);
-  const char *s = body.ptr;
+  const char *s = body.buf;
   size_t b = ofs, h1, h2, b1, b2, max = body.len;
 
   // Init part params
@@ -1280,7 +1438,7 @@ size_t mg_http_next_multipart(struct mg_str body, size_t ofs,
     if (h2 + 2 >= max) return 0;
     // MG_INFO(("Header: [%.*s]", (int) (h2 - h1), &s[h1]));
     if (part != NULL && h1 + cd.len + 2 < h2 && s[h1 + cd.len] == ':' &&
-        mg_ncasecmp(&s[h1], cd.ptr, cd.len) == 0) {
+        mg_ncasecmp(&s[h1], cd.buf, cd.len) == 0) {
       struct mg_str v = mg_str_n(&s[h1 + cd.len + 2], h2 - (h1 + cd.len + 2));
       part->name = mg_http_get_header_var(v, mg_str_n("name", 4));
       part->filename = mg_http_get_header_var(v, mg_str_n("filename", 8));
@@ -1304,16 +1462,16 @@ void mg_http_bauth(struct mg_connection *c, const char *user,
   size_t need = c->send.len + 36 + (u.len + p.len) * 2;
   if (c->send.size < need) mg_iobuf_resize(&c->send, need);
   if (c->send.size >= need) {
-    int i, n = 0;
+    size_t i, n = 0;
     char *buf = (char *) &c->send.buf[c->send.len];
     memcpy(buf, "Authorization: Basic ", 21);  // DON'T use mg_send!
-    for (i = 0; i < (int) u.len; i++) {
-      n = mg_base64_update(((unsigned char *) u.ptr)[i], buf + 21, n);
+    for (i = 0; i < u.len; i++) {
+      n = mg_base64_update(((unsigned char *) u.buf)[i], buf + 21, n);
     }
     if (p.len > 0) {
       n = mg_base64_update(':', buf + 21, n);
-      for (i = 0; i < (int) p.len; i++) {
-        n = mg_base64_update(((unsigned char *) p.ptr)[i], buf + 21, n);
+      for (i = 0; i < p.len; i++) {
+        n = mg_base64_update(((unsigned char *) p.buf)[i], buf + 21, n);
       }
     }
     n = mg_base64_final(buf + 21, n);
@@ -1325,9 +1483,10 @@ void mg_http_bauth(struct mg_connection *c, const char *user,
 }
 
 struct mg_str mg_http_var(struct mg_str buf, struct mg_str name) {
-  struct mg_str k, v, result = mg_str_n(NULL, 0);
-  while (mg_split(&buf, &k, &v, '&')) {
-    if (name.len == k.len && mg_ncasecmp(name.ptr, k.ptr, k.len) == 0) {
+  struct mg_str entry, k, v, result = mg_str_n(NULL, 0);
+  while (mg_span(buf, &entry, &buf, '&')) {
+    if (mg_span(entry, &k, &v, '=') && name.len == k.len &&
+        mg_ncasecmp(name.buf, k.buf, k.len) == 0) {
       result = v;
       break;
     }
@@ -1338,17 +1497,19 @@ struct mg_str mg_http_var(struct mg_str buf, struct mg_str name) {
 int mg_http_get_var(const struct mg_str *buf, const char *name, char *dst,
                     size_t dst_len) {
   int len;
+  if (dst != NULL && dst_len > 0) {
+    dst[0] = '\0';  // If destination buffer is valid, always nul-terminate it
+  }
   if (dst == NULL || dst_len == 0) {
     len = -2;  // Bad destination
-  } else if (buf->ptr == NULL || name == NULL || buf->len == 0) {
+  } else if (buf->buf == NULL || name == NULL || buf->len == 0) {
     len = -1;  // Bad source
-    dst[0] = '\0';
   } else {
     struct mg_str v = mg_http_var(*buf, mg_str(name));
-    if (v.ptr == NULL) {
+    if (v.buf == NULL) {
       len = -4;  // Name does not exist
     } else {
-      len = mg_url_decode(v.ptr, v.len, dst, dst_len, 1);
+      len = mg_url_decode(v.buf, v.len, dst, dst_len, 1);
       if (len < 0) len = -3;  // Failed to decode
     }
   }
@@ -1367,7 +1528,7 @@ int mg_url_decode(const char *src, size_t src_len, char *dst, size_t dst_len,
     if (src[i] == '%') {
       // Use `i + 2 < src_len`, not `i < src_len - 2`, note small src_len
       if (i + 2 < src_len && isx(src[i + 1]) && isx(src[i + 2])) {
-        mg_unhex(src + i + 1, 2, (uint8_t *) &dst[j]);
+        mg_str_to_num(mg_str_n(src + i + 1, 2), 16, &dst[j], sizeof(uint8_t));
         i += 2;
       } else {
         return -1;
@@ -1382,7 +1543,9 @@ int mg_url_decode(const char *src, size_t src_len, char *dst, size_t dst_len,
   return i >= src_len && j < dst_len ? (int) j : -1;
 }
 
-static bool isok(uint8_t c) { return c == '\n' || c == '\r' || c >= ' '; }
+static bool isok(uint8_t c) {
+  return c == '\n' || c == '\r' || c == '\t' || c >= ' ';
+}
 
 int mg_http_get_request_len(const unsigned char *buf, size_t buf_len) {
   size_t i;
@@ -1394,78 +1557,118 @@ int mg_http_get_request_len(const unsigned char *buf, size_t buf_len) {
   }
   return 0;
 }
-
-static const char *skip(const char *s, const char *e, const char *d,
-                        struct mg_str *v) {
-  v->ptr = s;
-  while (s < e && *s != '\n' && strchr(d, *s) == NULL) s++;
-  v->len = (size_t) (s - v->ptr);
-  while (s < e && strchr(d, *s) != NULL) s++;
-  return s;
-}
-
 struct mg_str *mg_http_get_header(struct mg_http_message *h, const char *name) {
   size_t i, n = strlen(name), max = sizeof(h->headers) / sizeof(h->headers[0]);
   for (i = 0; i < max && h->headers[i].name.len > 0; i++) {
     struct mg_str *k = &h->headers[i].name, *v = &h->headers[i].value;
-    if (n == k->len && mg_ncasecmp(k->ptr, name, n) == 0) return v;
+    if (n == k->len && mg_ncasecmp(k->buf, name, n) == 0) return v;
   }
   return NULL;
 }
 
-static void mg_http_parse_headers(const char *s, const char *end,
-                                  struct mg_http_header *h, int max_headers) {
-  int i;
-  for (i = 0; i < max_headers; i++) {
-    struct mg_str k, v, tmp;
-    const char *he = skip(s, end, "\n", &tmp);
-    s = skip(s, he, ": \r\n", &k);
-    s = skip(s, he, "\r\n", &v);
-    if (k.len == tmp.len) continue;
-    while (v.len > 0 && v.ptr[v.len - 1] == ' ') v.len--;  // Trim spaces
-    if (k.len == 0) break;
-    // MG_INFO(("--HH [%.*s] [%.*s] [%.*s]", (int) tmp.len - 1, tmp.ptr,
-    //(int) k.len, k.ptr, (int) v.len, v.ptr));
-    h[i].name = k;
-    h[i].value = v;
+// Is it a valid utf-8 continuation byte
+static bool vcb(uint8_t c) {
+  return (c & 0xc0) == 0x80;
+}
+
+// Get character length (valid utf-8). Used to parse method, URI, headers
+static size_t clen(const char *s, const char *end) {
+  const unsigned char *u = (unsigned char *) s, c = *u;
+  long n = (long) (end - s);
+  if (c > ' ' && c < '~') return 1;  // Usual ascii printed char
+  if ((c & 0xe0) == 0xc0 && n > 1 && vcb(u[1])) return 2;  // 2-byte UTF8
+  if ((c & 0xf0) == 0xe0 && n > 2 && vcb(u[1]) && vcb(u[2])) return 3;
+  if ((c & 0xf8) == 0xf0 && n > 3 && vcb(u[1]) && vcb(u[2]) && vcb(u[3]))
+    return 4;
+  return 0;
+}
+
+// Skip until the newline. Return advanced `s`, or NULL on error
+static const char *skiptorn(const char *s, const char *end, struct mg_str *v) {
+  v->buf = (char *) s;
+  while (s < end && s[0] != '\n' && s[0] != '\r') s++, v->len++;  // To newline
+  if (s >= end || (s[0] == '\r' && s[1] != '\n')) return NULL;    // Stray \r
+  if (s < end && s[0] == '\r') s++;                               // Skip \r
+  if (s >= end || *s++ != '\n') return NULL;                      // Skip \n
+  return s;
+}
+
+static bool mg_http_parse_headers(const char *s, const char *end,
+                                  struct mg_http_header *h, size_t max_hdrs) {
+  size_t i, n;
+  for (i = 0; i < max_hdrs; i++) {
+    struct mg_str k = {NULL, 0}, v = {NULL, 0};
+    if (s >= end) return false;
+    if (s[0] == '\n' || (s[0] == '\r' && s[1] == '\n')) break;
+    k.buf = (char *) s;
+    while (s < end && s[0] != ':' && (n = clen(s, end)) > 0) s += n, k.len += n;
+    if (k.len == 0) return false;                     // Empty name
+    if (s >= end || clen(s, end) == 0) return false;  // Invalid UTF-8
+    if (*s++ != ':') return false;  // Invalid, not followed by :
+    // if (clen(s, end) == 0) return false;        // Invalid UTF-8
+    while (s < end && (s[0] == ' ' || s[0] == '\t')) s++;  // Skip spaces
+    if ((s = skiptorn(s, end, &v)) == NULL) return false;
+    while (v.len > 0 && (v.buf[v.len - 1] == ' ' || v.buf[v.len - 1] == '\t')) {
+      v.len--;  // Trim spaces
+    }
+    // MG_INFO(("--HH [%.*s] [%.*s]", (int) k.len, k.buf, (int) v.len, v.buf));
+    h[i].name = k, h[i].value = v;  // Success. Assign values
   }
+  return true;
 }
 
 int mg_http_parse(const char *s, size_t len, struct mg_http_message *hm) {
   int is_response, req_len = mg_http_get_request_len((unsigned char *) s, len);
   const char *end = s == NULL ? NULL : s + req_len, *qs;  // Cannot add to NULL
-  struct mg_str *cl;
+  const struct mg_str *cl;
+  size_t n;
+  bool version_prefix_valid;
 
   memset(hm, 0, sizeof(*hm));
   if (req_len <= 0) return req_len;
 
-  hm->message.ptr = hm->head.ptr = s;
-  hm->body.ptr = end;
+  hm->message.buf = hm->head.buf = (char *) s;
+  hm->body.buf = (char *) end;
   hm->head.len = (size_t) req_len;
-  hm->chunk.ptr = end;
-  hm->message.len = hm->body.len = (size_t) ~0;  // Set body length to infinite
+  hm->message.len = hm->body.len = (size_t) -1;  // Set body length to infinite
 
   // Parse request line
-  s = skip(s, end, " ", &hm->method);
-  s = skip(s, end, " ", &hm->uri);
-  s = skip(s, end, "\r\n", &hm->proto);
-
-  // Sanity check. Allow protocol/reason to be empty
-  if (hm->method.len == 0 || hm->uri.len == 0) return -1;
-
-  // If URI contains '?' character, setup query string
-  if ((qs = (const char *) memchr(hm->uri.ptr, '?', hm->uri.len)) != NULL) {
-    hm->query.ptr = qs + 1;
-    hm->query.len = (size_t) (&hm->uri.ptr[hm->uri.len] - (qs + 1));
-    hm->uri.len = (size_t) (qs - hm->uri.ptr);
+  hm->method.buf = (char *) s;
+  while (s < end && (n = clen(s, end)) > 0) s += n, hm->method.len += n;
+  while (s < end && s[0] == ' ') s++;  // Skip spaces
+  hm->uri.buf = (char *) s;
+  while (s < end && (n = clen(s, end)) > 0) s += n, hm->uri.len += n;
+  while (s < end && s[0] == ' ') s++;  // Skip spaces
+  is_response = hm->method.len > 5 &&
+                (mg_ncasecmp(hm->method.buf, "HTTP/", 5) == 0);
+  if ((s = skiptorn(s, end, &hm->proto)) == NULL) return false;
+  // If we're given a version, check that it is HTTP/x.x
+  version_prefix_valid = hm->proto.len > 5 &&
+                         (mg_ncasecmp(hm->proto.buf, "HTTP/", 5) == 0);
+  if (!is_response && hm->proto.len > 0 &&
+    (!version_prefix_valid || hm->proto.len != 8 ||
+    (hm->proto.buf[5] < '0' || hm->proto.buf[5] > '9') ||
+    (hm->proto.buf[6] != '.') ||
+    (hm->proto.buf[7] < '0' || hm->proto.buf[7] > '9'))) {
+    return -1;
   }
 
-  mg_http_parse_headers(s, end, hm->headers,
-                        sizeof(hm->headers) / sizeof(hm->headers[0]));
+  // If URI contains '?' character, setup query string
+  if ((qs = (const char *) memchr(hm->uri.buf, '?', hm->uri.len)) != NULL) {
+    hm->query.buf = (char *) qs + 1;
+    hm->query.len = (size_t) (&hm->uri.buf[hm->uri.len] - (qs + 1));
+    hm->uri.len = (size_t) (qs - hm->uri.buf);
+  }
+
+  // Sanity check. Allow protocol/reason to be empty
+  // Do this check after hm->method.len and hm->uri.len are finalised
+  if (hm->method.len == 0 || hm->uri.len == 0) return -1;
+
+  if (!mg_http_parse_headers(s, end, hm->headers,
+                             sizeof(hm->headers) / sizeof(hm->headers[0])))
+    return -1;  // error when parsing
   if ((cl = mg_http_get_header(hm, "Content-Length")) != NULL) {
-    int64_t content_len = mg_to64(*cl);
-    if(content_len < 0) return -1;
-    hm->body.len = (size_t) content_len;
+    if (mg_to_size_t(*cl, &hm->body.len) == false) return -1;
     hm->message.len = (size_t) req_len + hm->body.len;
   }
 
@@ -1481,20 +1684,20 @@ int mg_http_parse(const char *s, size_t len, struct mg_http_message *hm) {
   //
   // So, if it is HTTP request, and Content-Length is not set,
   // and method is not (PUT or POST) then reset body length to zero.
-  is_response = mg_ncasecmp(hm->method.ptr, "HTTP/", 5) == 0;
   if (hm->body.len == (size_t) ~0 && !is_response &&
-      mg_vcasecmp(&hm->method, "PUT") != 0 &&
-      mg_vcasecmp(&hm->method, "POST") != 0) {
+      mg_strcasecmp(hm->method, mg_str("PUT")) != 0 &&
+      mg_strcasecmp(hm->method, mg_str("POST")) != 0) {
     hm->body.len = 0;
     hm->message.len = (size_t) req_len;
   }
 
   // The 204 (No content) responses also have 0 body length
   if (hm->body.len == (size_t) ~0 && is_response &&
-      mg_vcasecmp(&hm->uri, "204") == 0) {
+      mg_strcasecmp(hm->uri, mg_str("204")) == 0) {
     hm->body.len = 0;
     hm->message.len = (size_t) req_len;
   }
+  if (hm->message.len < (size_t) req_len) return -1;  // Overflow protection
 
   return req_len;
 }
@@ -1530,21 +1733,69 @@ void mg_http_write_chunk(struct mg_connection *c, const char *buf, size_t len) {
 static const char *mg_http_status_code_str(int status_code) {
   switch (status_code) {
     case 100: return "Continue";
+    case 101: return "Switching Protocols";
+    case 102: return "Processing";
+    case 200: return "OK";
     case 201: return "Created";
     case 202: return "Accepted";
+    case 203: return "Non-authoritative Information";
     case 204: return "No Content";
+    case 205: return "Reset Content";
     case 206: return "Partial Content";
+    case 207: return "Multi-Status";
+    case 208: return "Already Reported";
+    case 226: return "IM Used";
+    case 300: return "Multiple Choices";
     case 301: return "Moved Permanently";
     case 302: return "Found";
+    case 303: return "See Other";
     case 304: return "Not Modified";
+    case 305: return "Use Proxy";
+    case 307: return "Temporary Redirect";
+    case 308: return "Permanent Redirect";
     case 400: return "Bad Request";
     case 401: return "Unauthorized";
+    case 402: return "Payment Required";
     case 403: return "Forbidden";
     case 404: return "Not Found";
+    case 405: return "Method Not Allowed";
+    case 406: return "Not Acceptable";
+    case 407: return "Proxy Authentication Required";
+    case 408: return "Request Timeout";
+    case 409: return "Conflict";
+    case 410: return "Gone";
+    case 411: return "Length Required";
+    case 412: return "Precondition Failed";
+    case 413: return "Payload Too Large";
+    case 414: return "Request-URI Too Long";
+    case 415: return "Unsupported Media Type";
+    case 416: return "Requested Range Not Satisfiable";
+    case 417: return "Expectation Failed";
     case 418: return "I'm a teapot";
+    case 421: return "Misdirected Request";
+    case 422: return "Unprocessable Entity";
+    case 423: return "Locked";
+    case 424: return "Failed Dependency";
+    case 426: return "Upgrade Required";
+    case 428: return "Precondition Required";
+    case 429: return "Too Many Requests";
+    case 431: return "Request Header Fields Too Large";
+    case 444: return "Connection Closed Without Response";
+    case 451: return "Unavailable For Legal Reasons";
+    case 499: return "Client Closed Request";
     case 500: return "Internal Server Error";
     case 501: return "Not Implemented";
-    default: return "OK";
+    case 502: return "Bad Gateway";
+    case 503: return "Service Unavailable";
+    case 504: return "Gateway Timeout";
+    case 505: return "HTTP Version Not Supported";
+    case 506: return "Variant Also Negotiates";
+    case 507: return "Insufficient Storage";
+    case 508: return "Loop Detected";
+    case 510: return "Not Extended";
+    case 511: return "Network Authentication Required";
+    case 599: return "Network Connect Timeout Error";
+    default: return "";
   }
 }
 // clang-format on
@@ -1567,7 +1818,7 @@ void mg_http_reply(struct mg_connection *c, int code, const char *headers,
   c->is_resp = 0;
 }
 
-static void http_cb(struct mg_connection *, int, void *, void *);
+static void http_cb(struct mg_connection *, int, void *);
 static void restore_http_cb(struct mg_connection *c) {
   mg_fs_close((struct mg_fd *) c->pfn_data);
   c->pfn_data = NULL;
@@ -1581,10 +1832,9 @@ char *mg_http_etag(char *buf, size_t len, size_t size, time_t mtime) {
   return buf;
 }
 
-static void static_cb(struct mg_connection *c, int ev, void *ev_data,
-                      void *fn_data) {
+static void static_cb(struct mg_connection *c, int ev, void *ev_data) {
   if (ev == MG_EV_WRITE || ev == MG_EV_POLL) {
-    struct mg_fd *fd = (struct mg_fd *) fn_data;
+    struct mg_fd *fd = (struct mg_fd *) c->pfn_data;
     // Read to send IO buffer directly, avoid extra on-stack buffer
     size_t n, max = MG_IO_SIZE, space;
     size_t *cl = (size_t *) &c->data[(sizeof(c->data) - sizeof(size_t)) /
@@ -1605,6 +1855,7 @@ static void static_cb(struct mg_connection *c, int ev, void *ev_data,
 // Known mime types. Keep it outside guess_content_type() function, since
 // some environments don't like it defined there.
 // clang-format off
+#define MG_C_STR(a) { (char *) (a), sizeof(a) - 1 }
 static struct mg_str s_known_types[] = {
     MG_C_STR("html"), MG_C_STR("text/html; charset=utf-8"),
     MG_C_STR("htm"), MG_C_STR("text/html; charset=utf-8"),
@@ -1641,43 +1892,41 @@ static struct mg_str s_known_types[] = {
 // clang-format on
 
 static struct mg_str guess_content_type(struct mg_str path, const char *extra) {
-  struct mg_str k, v, s = mg_str(extra);
+  struct mg_str entry, k, v, s = mg_str(extra), asterisk = mg_str_n("*", 1);
   size_t i = 0;
 
   // Shrink path to its extension only
-  while (i < path.len && path.ptr[path.len - i - 1] != '.') i++;
-  path.ptr += path.len - i;
+  while (i < path.len && path.buf[path.len - i - 1] != '.') i++;
+  path.buf += path.len - i;
   path.len = i;
 
   // Process user-provided mime type overrides, if any
-  while (mg_commalist(&s, &k, &v)) {
-    if (mg_strcmp(path, k) == 0) return v;
+  while (mg_span(s, &entry, &s, ',')) {
+    if (mg_span(entry, &k, &v, '=') &&
+        (mg_strcmp(asterisk, k) == 0 || mg_strcmp(path, k) == 0))
+      return v;
   }
 
   // Process built-in mime types
-  for (i = 0; s_known_types[i].ptr != NULL; i += 2) {
+  for (i = 0; s_known_types[i].buf != NULL; i += 2) {
     if (mg_strcmp(path, s_known_types[i]) == 0) return s_known_types[i + 1];
   }
 
   return mg_str("text/plain; charset=utf-8");
 }
 
-static int getrange(struct mg_str *s, int64_t *a, int64_t *b) {
+static int getrange(struct mg_str *s, size_t *a, size_t *b) {
   size_t i, numparsed = 0;
-  // MG_INFO(("%.*s", (int) s->len, s->ptr));
   for (i = 0; i + 6 < s->len; i++) {
-    if (memcmp(&s->ptr[i], "bytes=", 6) == 0) {
-      struct mg_str p = mg_str_n(s->ptr + i + 6, s->len - i - 6);
-      if (p.len > 0 && p.ptr[0] >= '0' && p.ptr[0] <= '9') numparsed++;
-      *a = mg_to64(p);
-      // MG_INFO(("PPP [%.*s] %d", (int) p.len, p.ptr, numparsed));
-      while (p.len && p.ptr[0] >= '0' && p.ptr[0] <= '9') p.ptr++, p.len--;
-      if (p.len && p.ptr[0] == '-') p.ptr++, p.len--;
-      *b = mg_to64(p);
-      if (p.len > 0 && p.ptr[0] >= '0' && p.ptr[0] <= '9') numparsed++;
-      // MG_INFO(("PPP [%.*s] %d", (int) p.len, p.ptr, numparsed));
-      break;
+    struct mg_str k, v = mg_str_n(s->buf + i + 6, s->len - i - 6);
+    if (memcmp(&s->buf[i], "bytes=", 6) != 0) continue;
+    if (mg_span(v, &k, &v, '-')) {
+      if (mg_to_size_t(k, a)) numparsed++;
+      if (v.len > 0 && mg_to_size_t(v, b)) numparsed++;
+    } else {
+      if (mg_to_size_t(v, a)) numparsed++;
     }
+    break;
   }
   return (int) numparsed;
 }
@@ -1697,10 +1946,14 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
   if (path != NULL) {
     // If a browser sends us "Accept-Encoding: gzip", try to open .gz first
     struct mg_str *ae = mg_http_get_header(hm, "Accept-Encoding");
-    if (ae != NULL && mg_strstr(*ae, mg_str("gzip")) != NULL) {
-      mg_snprintf(tmp, sizeof(tmp), "%s.gz", path);
-      fd = mg_fs_open(fs, tmp, MG_FS_READ);
-      if (fd != NULL) gzip = true, path = tmp;
+    if (ae != NULL) {
+      char *ae_ = mg_mprintf("%.*s", ae->len, ae->buf);
+      if (ae_ != NULL && strstr(ae_, "gzip") != NULL) {
+        mg_snprintf(tmp, sizeof(tmp), "%s.gz", path);
+        fd = mg_fs_open(fs, tmp, MG_FS_READ);
+        if (fd != NULL) gzip = true, path = tmp;
+      }
+      free(ae_);
     }
     // No luck opening .gz? Open what we've told to open
     if (fd == NULL) fd = mg_fs_open(fs, path, MG_FS_READ);
@@ -1709,8 +1962,8 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
   // Failed to open, and page404 is configured? Open it, then
   if (fd == NULL && opts->page404 != NULL) {
     fd = mg_fs_open(fs, opts->page404, MG_FS_READ);
-    mime = guess_content_type(mg_str(path), opts->mime_types);
     path = opts->page404;
+    mime = guess_content_type(mg_str(path), opts->mime_types);
   }
 
   if (fd == NULL || fs->st(path, &size, &mtime) == 0) {
@@ -1719,18 +1972,18 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
     // NOTE: mg_http_etag() call should go first!
   } else if (mg_http_etag(etag, sizeof(etag), size, mtime) != NULL &&
              (inm = mg_http_get_header(hm, "If-None-Match")) != NULL &&
-             mg_vcasecmp(inm, etag) == 0) {
+             mg_strcasecmp(*inm, mg_str(etag)) == 0) {
     mg_fs_close(fd);
     mg_http_reply(c, 304, opts->extra_headers, "");
   } else {
     int n, status = 200;
     char range[100];
-    int64_t r1 = 0, r2 = 0, cl = (int64_t) size;
+    size_t r1 = 0, r2 = 0, cl = size;
 
     // Handle Range header
     struct mg_str *rh = mg_http_get_header(hm, "Range");
     range[0] = '\0';
-    if (rh != NULL && (n = getrange(rh, &r1, &r2)) > 0 && r1 >= 0 && r2 >= 0) {
+    if (rh != NULL && (n = getrange(rh, &r1, &r2)) > 0) {
       // If range is specified like "400-", set second limit to content len
       if (n == 1) r2 = cl - 1;
       if (r1 > r2 || r2 >= cl) {
@@ -1742,9 +1995,9 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
         status = 206;
         cl = r2 - r1 + 1;
         mg_snprintf(range, sizeof(range),
-                    "Content-Range: bytes %lld-%lld/%lld\r\n", r1, r1 + cl - 1,
-                    (int64_t) size);
-        fs->sk(fd->fd, (size_t) r1);
+                    "Content-Range: bytes %llu-%llu/%llu\r\n", (uint64_t) r1,
+                    (uint64_t) (r1 + cl - 1), (uint64_t) size);
+        fs->sk(fd->fd, r1);
       }
     }
     mg_printf(c,
@@ -1753,11 +2006,10 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
               "Etag: %s\r\n"
               "Content-Length: %llu\r\n"
               "%s%s%s\r\n",
-              status, mg_http_status_code_str(status), (int) mime.len, mime.ptr,
-              etag, cl, gzip ? "Content-Encoding: gzip\r\n" : "", range,
-              opts->extra_headers ? opts->extra_headers : "");
-    if (mg_vcasecmp(&hm->method, "HEAD") == 0) {
-      c->is_draining = 1;
+              status, mg_http_status_code_str(status), (int) mime.len, mime.buf,
+              etag, (uint64_t) cl, gzip ? "Content-Encoding: gzip\r\n" : "",
+              range, opts->extra_headers ? opts->extra_headers : "");
+    if (mg_strcasecmp(hm->method, mg_str("HEAD")) == 0) {
       c->is_resp = 0;
       mg_fs_close(fd);
     } else {
@@ -1766,7 +2018,7 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
                                         sizeof(size_t) * sizeof(size_t)];
       c->pfn = static_cb;
       c->pfn_data = fd;
-      *clp = (size_t) cl;
+      *clp = cl;
     }
   }
 }
@@ -1778,6 +2030,7 @@ struct printdirentrydata {
   const char *dir;
 };
 
+#if MG_ENABLE_DIRLIST
 static void printdirentry(const char *name, void *userdata) {
   struct printdirentrydata *d = (struct printdirentrydata *) userdata;
   struct mg_fs *fs = d->opts->fs == NULL ? &mg_fs_posix : d->opts->fs;
@@ -1847,7 +2100,7 @@ static void listdir(struct mg_connection *c, struct mg_http_message *hm,
   struct printdirentrydata d = {c, hm, opts, dir};
   char tmp[10], buf[MG_PATH_MAX];
   size_t off, n;
-  int len = mg_url_decode(hm->uri.ptr, hm->uri.len, buf, sizeof(buf), 0);
+  int len = mg_url_decode(hm->uri.buf, hm->uri.len, buf, sizeof(buf), 0);
   struct mg_str uri = len > 0 ? mg_str_n(buf, (size_t) len) : hm->uri;
 
   mg_printf(c,
@@ -1868,8 +2121,8 @@ static void listdir(struct mg_connection *c, struct mg_http_message *hm,
             "<tr><td colspan=\"3\"><hr></td></tr>"
             "</thead>"
             "<tbody id=\"tb\">\n",
-            (int) uri.len, uri.ptr, sort_js_code, sort_js_code2, (int) uri.len,
-            uri.ptr);
+            (int) uri.len, uri.buf, sort_js_code, sort_js_code2, (int) uri.len,
+            uri.buf);
   mg_printf(c, "%s",
             "  <tr><td><a href=\"..\">..</a></td>"
             "<td name=-1></td><td name=-1>[DIR]</td></tr>\n");
@@ -1884,6 +2137,7 @@ static void listdir(struct mg_connection *c, struct mg_http_message *hm,
   memcpy(c->send.buf + off - 12, tmp, n);  // Set content length
   c->is_resp = 0;                          // Mark response end
 }
+#endif
 
 // Resolve requested file into `path` and return its fs->st() result
 static int uri_to_path2(struct mg_connection *c, struct mg_http_message *hm,
@@ -1891,29 +2145,39 @@ static int uri_to_path2(struct mg_connection *c, struct mg_http_message *hm,
                         char *path, size_t path_size) {
   int flags, tmp;
   // Append URI to the root_dir, and sanitize it
-  size_t n = mg_snprintf(path, path_size, "%.*s", (int) dir.len, dir.ptr);
-  if (n > path_size) n = path_size;
+  size_t n = mg_snprintf(path, path_size, "%.*s", (int) dir.len, dir.buf);
+  if (n + 2 >= path_size) {
+    mg_http_reply(c, 400, "", "Exceeded path size");
+    return -1;
+  }
   path[path_size - 1] = '\0';
-  if (n + 2 < path_size) path[n++] = '/', path[n] = '\0';
-  mg_url_decode(hm->uri.ptr + url.len, hm->uri.len - url.len, path + n,
-                path_size - n, 0);
+  // Terminate root dir with slash
+  if (n > 0 && path[n - 1] != '/') path[n++] = '/', path[n] = '\0';
+  if (url.len < hm->uri.len) {
+    mg_url_decode(hm->uri.buf + url.len, hm->uri.len - url.len, path + n,
+                  path_size - n, 0);
+  }
   path[path_size - 1] = '\0';  // Double-check
-  mg_remove_double_dots(path);
+  if (!mg_path_is_sane(mg_str_n(path, path_size))) {
+    mg_http_reply(c, 400, "", "Invalid path");
+    return -1;
+  }
   n = strlen(path);
   while (n > 1 && path[n - 1] == '/') path[--n] = 0;  // Trim trailing slashes
-  flags = mg_vcmp(&hm->uri, "/") == 0 ? MG_FS_DIR : fs->st(path, NULL, NULL);
-  MG_VERBOSE(("%lu %.*s -> %s %d", c->id, (int) hm->uri.len, hm->uri.ptr, path,
+  flags = mg_strcmp(hm->uri, mg_str("/")) == 0 ? MG_FS_DIR
+                                               : fs->st(path, NULL, NULL);
+  MG_VERBOSE(("%lu %.*s -> %s %d", c->id, (int) hm->uri.len, hm->uri.buf, path,
               flags));
   if (flags == 0) {
     // Do nothing - let's caller decide
   } else if ((flags & MG_FS_DIR) && hm->uri.len > 0 &&
-             hm->uri.ptr[hm->uri.len - 1] != '/') {
+             hm->uri.buf[hm->uri.len - 1] != '/') {
     mg_printf(c,
               "HTTP/1.1 301 Moved\r\n"
               "Location: %.*s/\r\n"
               "Content-Length: 0\r\n"
               "\r\n",
-              (int) hm->uri.len, hm->uri.ptr);
+              (int) hm->uri.len, hm->uri.buf);
     c->is_resp = 0;
     flags = -1;
   } else if (flags & MG_FS_DIR) {
@@ -1940,11 +2204,12 @@ static int uri_to_path(struct mg_connection *c, struct mg_http_message *hm,
                        const struct mg_http_serve_opts *opts, char *path,
                        size_t path_size) {
   struct mg_fs *fs = opts->fs == NULL ? &mg_fs_posix : opts->fs;
-  struct mg_str k, v, s = mg_str(opts->root_dir), u = {0, 0}, p = {0, 0};
-  while (mg_commalist(&s, &k, &v)) {
-    if (v.len == 0) v = k, k = mg_str("/");
+  struct mg_str k, v, part, s = mg_str(opts->root_dir), u = {NULL, 0}, p = u;
+  while (mg_span(s, &part, &s, ',')) {
+    if (!mg_span(part, &k, &v, '=')) k = part, v = mg_str_n(NULL, 0);
+    if (v.len == 0) v = k, k = mg_str("/"), u = k, p = v;
     if (hm->uri.len < k.len) continue;
-    if (mg_strcmp(k, mg_str_n(hm->uri.ptr, k.len)) != 0) continue;
+    if (mg_strcmp(k, mg_str_n(hm->uri.buf, k.len)) != 0) continue;
     u = k, p = v;
   }
   return uri_to_path2(c, hm, fs, u, p, path, path_size);
@@ -1958,9 +2223,12 @@ void mg_http_serve_dir(struct mg_connection *c, struct mg_http_message *hm,
   if (flags < 0) {
     // Do nothing: the response has already been sent by uri_to_path()
   } else if (flags & MG_FS_DIR) {
+#if MG_ENABLE_DIRLIST
     listdir(c, hm, opts, path);
-  } else if (flags && sp != NULL &&
-             mg_globmatch(sp, strlen(sp), path, strlen(path))) {
+#else
+    mg_http_reply(c, 403, "", "Forbidden\n");
+#endif
+  } else if (flags && sp != NULL && mg_match(mg_str(path), mg_str(sp), NULL)) {
     mg_http_serve_ssi(c, opts->root_dir, path);
   } else {
     mg_http_serve_file(c, hm, path, opts);
@@ -1980,9 +2248,8 @@ size_t mg_url_encode(const char *s, size_t sl, char *buf, size_t len) {
     if (mg_is_url_safe(c)) {
       buf[n++] = s[i];
     } else {
-      buf[n++] = '%';
-      mg_hex(&s[i], 1, &buf[n]);
-      n += 2;
+      mg_snprintf(&buf[n], 4, "%%%M", mg_print_hex, 1, &s[i]);
+      n += 3;
     }
   }
   if (len > 0 && n < len - 1) buf[n] = '\0';  // Null-terminate the destination
@@ -1994,80 +2261,84 @@ void mg_http_creds(struct mg_http_message *hm, char *user, size_t userlen,
                    char *pass, size_t passlen) {
   struct mg_str *v = mg_http_get_header(hm, "Authorization");
   user[0] = pass[0] = '\0';
-  if (v != NULL && v->len > 6 && memcmp(v->ptr, "Basic ", 6) == 0) {
+  if (v != NULL && v->len > 6 && memcmp(v->buf, "Basic ", 6) == 0) {
     char buf[256];
-    int n = mg_base64_decode(v->ptr + 6, (int) v->len - 6, buf);
-    const char *p = (const char *) memchr(buf, ':', n > 0 ? (size_t) n : 0);
+    size_t n = mg_base64_decode(v->buf + 6, v->len - 6, buf, sizeof(buf));
+    const char *p = (const char *) memchr(buf, ':', n > 0 ? n : 0);
     if (p != NULL) {
-      mg_snprintf(user, userlen, "%.*s", (int) (p - buf), buf);
-      mg_snprintf(pass, passlen, "%.*s", n - (int) (p - buf) - 1, p + 1);
+      mg_snprintf(user, userlen, "%.*s", p - buf, buf);
+      mg_snprintf(pass, passlen, "%.*s", n - (size_t) (p - buf) - 1, p + 1);
     }
-  } else if (v != NULL && v->len > 7 && memcmp(v->ptr, "Bearer ", 7) == 0) {
-    mg_snprintf(pass, passlen, "%.*s", (int) v->len - 7, v->ptr + 7);
+  } else if (v != NULL && v->len > 7 && memcmp(v->buf, "Bearer ", 7) == 0) {
+    mg_snprintf(pass, passlen, "%.*s", (int) v->len - 7, v->buf + 7);
   } else if ((v = mg_http_get_header(hm, "Cookie")) != NULL) {
     struct mg_str t = mg_http_get_header_var(*v, mg_str_n("access_token", 12));
-    if (t.len > 0) mg_snprintf(pass, passlen, "%.*s", (int) t.len, t.ptr);
+    if (t.len > 0) mg_snprintf(pass, passlen, "%.*s", (int) t.len, t.buf);
   } else {
     mg_http_get_var(&hm->query, "access_token", pass, passlen);
   }
 }
 
 static struct mg_str stripquotes(struct mg_str s) {
-  return s.len > 1 && s.ptr[0] == '"' && s.ptr[s.len - 1] == '"'
-             ? mg_str_n(s.ptr + 1, s.len - 2)
+  return s.len > 1 && s.buf[0] == '"' && s.buf[s.len - 1] == '"'
+             ? mg_str_n(s.buf + 1, s.len - 2)
              : s;
 }
 
 struct mg_str mg_http_get_header_var(struct mg_str s, struct mg_str v) {
   size_t i;
   for (i = 0; v.len > 0 && i + v.len + 2 < s.len; i++) {
-    if (s.ptr[i + v.len] == '=' && memcmp(&s.ptr[i], v.ptr, v.len) == 0) {
-      const char *p = &s.ptr[i + v.len + 1], *b = p, *x = &s.ptr[s.len];
+    if (s.buf[i + v.len] == '=' && memcmp(&s.buf[i], v.buf, v.len) == 0) {
+      const char *p = &s.buf[i + v.len + 1], *b = p, *x = &s.buf[s.len];
       int q = p < x && *p == '"' ? 1 : 0;
       while (p < x &&
              (q ? p == b || *p != '"' : *p != ';' && *p != ' ' && *p != ','))
         p++;
-      // MG_INFO(("[%.*s] [%.*s] [%.*s]", (int) s.len, s.ptr, (int) v.len,
-      // v.ptr, (int) (p - b), b));
+      // MG_INFO(("[%.*s] [%.*s] [%.*s]", (int) s.len, s.buf, (int) v.len,
+      // v.buf, (int) (p - b), b));
       return stripquotes(mg_str_n(b, (size_t) (p - b + q)));
     }
   }
   return mg_str_n(NULL, 0);
 }
 
-bool mg_http_match_uri(const struct mg_http_message *hm, const char *glob) {
-  return mg_match(hm->uri, mg_str(glob), NULL);
-}
-
 long mg_http_upload(struct mg_connection *c, struct mg_http_message *hm,
-                    struct mg_fs *fs, const char *path, size_t max_size) {
-  char buf[20] = "0";
+                    struct mg_fs *fs, const char *dir, size_t max_size) {
+  char buf[20] = "0", file[MG_PATH_MAX], path[MG_PATH_MAX];
   long res = 0, offset;
   mg_http_get_var(&hm->query, "offset", buf, sizeof(buf));
+  mg_http_get_var(&hm->query, "file", file, sizeof(file));
   offset = strtol(buf, NULL, 0);
+  mg_snprintf(path, sizeof(path), "%s%c%s", dir, MG_DIRSEP, file);
   if (hm->body.len == 0) {
     mg_http_reply(c, 200, "", "%ld", res);  // Nothing to write
+  } else if (file[0] == '\0') {
+    mg_http_reply(c, 400, "", "file required");
+    res = -1;
+  } else if (mg_path_is_sane(mg_str(file)) == false) {
+    mg_http_reply(c, 400, "", "%s: invalid file", file);
+    res = -2;
+  } else if (offset < 0) {
+    mg_http_reply(c, 400, "", "offset required");
+    res = -3;
+  } else if ((size_t) offset + hm->body.len > max_size) {
+    mg_http_reply(c, 400, "", "%s: over max size of %lu", path,
+                  (unsigned long) max_size);
+    res = -4;
   } else {
     struct mg_fd *fd;
     size_t current_size = 0;
-    MG_DEBUG(("%s -> %d bytes @ %ld", path, (int) hm->body.len, offset));
+    MG_DEBUG(("%s -> %lu bytes @ %ld", path, hm->body.len, offset));
     if (offset == 0) fs->rm(path);  // If offset if 0, truncate file
     fs->st(path, &current_size, NULL);
-    if (offset < 0) {
-      mg_http_reply(c, 400, "", "offset required");
-      res = -1;
-    } else if (offset > 0 && current_size != (size_t) offset) {
+    if (offset > 0 && current_size != (size_t) offset) {
       mg_http_reply(c, 400, "", "%s: offset mismatch", path);
-      res = -2;
-    } else if ((size_t) offset + hm->body.len > max_size) {
-      mg_http_reply(c, 400, "", "%s: over max size of %lu", path,
-                    (unsigned long) max_size);
-      res = -3;
+      res = -5;
     } else if ((fd = mg_fs_open(fs, path, MG_FS_WRITE)) == NULL) {
       mg_http_reply(c, 400, "", "open(%s): %d", path, errno);
-      res = -4;
+      res = -6;
     } else {
-      res = offset + (long) fs->wr(fd->fd, hm->body.ptr, hm->body.len);
+      res = offset + (long) fs->wr(fd->fd, hm->body.buf, hm->body.len);
       mg_fs_close(fd);
       mg_http_reply(c, 200, "", "%ld", res);
     }
@@ -2076,147 +2347,145 @@ long mg_http_upload(struct mg_connection *c, struct mg_http_message *hm,
 }
 
 int mg_http_status(const struct mg_http_message *hm) {
-  return atoi(hm->uri.ptr);
+  return atoi(hm->uri.buf);
 }
 
-// If a server sends data to the client using chunked encoding, Mongoose strips
-// off the chunking prefix (hex length and \r\n) and suffix (\r\n), appends the
-// stripped data to the body, and fires the MG_EV_HTTP_CHUNK event.  When zero
-// chunk is received, we fire MG_EV_HTTP_MSG, and the body already has all
-// chunking prefixes/suffixes stripped.
-//
-// If a server sends data without chunked encoding, we also fire a series of
-// MG_EV_HTTP_CHUNK events for every received piece of data, and then we fire
-// MG_EV_HTTP_MSG event in the end.
-//
-// We track total processed length in the c->pfn_data, which is a void *
-// pointer: we store a size_t value there.
-static bool getchunk(struct mg_str s, size_t *prefixlen, size_t *datalen) {
-  size_t i = 0, n;
-  while (i < s.len && s.ptr[i] != '\r' && s.ptr[i] != '\n') i++;
-  n = mg_unhexn(s.ptr, i);
-  // MG_INFO(("%d %d", (int) (i + n + 4), (int) s.len));
-  if (s.len < i + n + 4) return false;  // Chunk not yet fully buffered
-  if (s.ptr[i] != '\r' || s.ptr[i + 1] != '\n') return false;
-  if (s.ptr[i + n + 2] != '\r' || s.ptr[i + n + 3] != '\n') return false;
-  *prefixlen = i + 2;
-  *datalen = n;
-  return true;
+static bool is_hex_digit(int c) {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+         (c >= 'A' && c <= 'F');
 }
 
-static bool mg_is_chunked(struct mg_http_message *hm) {
-  const char *needle = "chunked";
-  struct mg_str *te = mg_http_get_header(hm, "Transfer-Encoding");
-  return te != NULL && mg_vcasecmp(te, needle) == 0;
+static int skip_chunk(const char *buf, int len, int *pl, int *dl) {
+  int i = 0, n = 0;
+  if (len < 3) return 0;
+  while (i < len && is_hex_digit(buf[i])) i++;
+  if (i == 0) return -1;                     // Error, no length specified
+  if (i > (int) sizeof(int) * 2) return -1;  // Chunk length is too big
+  if (len < i + 1 || buf[i] != '\r' || buf[i + 1] != '\n') return -1;  // Error
+  if (mg_str_to_num(mg_str_n(buf, (size_t) i), 16, &n, sizeof(int)) == false)
+    return -1;                    // Decode chunk length, overflow
+  if (n < 0) return -1;           // Error. TODO(): some checks now redundant
+  if (n > len - i - 4) return 0;  // Chunk not yet fully buffered
+  if (buf[i + n + 2] != '\r' || buf[i + n + 3] != '\n') return -1;  // Error
+  *pl = i + 2, *dl = n;
+  return i + 2 + n + 2;
 }
 
-void mg_http_delete_chunk(struct mg_connection *c, struct mg_http_message *hm) {
-  size_t ofs = (size_t) (hm->chunk.ptr - (char *) c->recv.buf);
-  mg_iobuf_del(&c->recv, ofs, hm->chunk.len);
-  c->pfn_data = (void *) ((size_t) c->pfn_data | MG_DMARK);
-}
-
-static void deliver_chunked_chunks(struct mg_connection *c, size_t hlen,
-                                   struct mg_http_message *hm, bool *next) {
-  //  |  ... headers ... | HEXNUM\r\n ..data.. \r\n | ......
-  //  +------------------+--------------------------+----
-  //  |      hlen        |           chunk1         | ......
-  char *buf = (char *) &c->recv.buf[hlen], *p = buf;
-  size_t len = c->recv.len - hlen;
-  size_t processed = ((size_t) c->pfn_data) & ~MG_DMARK;
-  size_t mark, pl, dl, del = 0, ofs = 0;
-  bool last = false;
-  if (processed <= len) len -= processed, buf += processed;
-  while (!last && getchunk(mg_str_n(buf + ofs, len - ofs), &pl, &dl)) {
-    size_t saved = c->recv.len;
-    memmove(p + processed, buf + ofs + pl, dl);
-    // MG_INFO(("P2 [%.*s]", (int) (processed + dl), p));
-    hm->chunk = mg_str_n(p + processed, dl);
-    mg_call(c, MG_EV_HTTP_CHUNK, hm);
-    ofs += pl + dl + 2, del += pl + 2;  // 2 is for \r\n suffix
-    processed += dl;
-    if (c->recv.len != saved) processed -= dl, buf -= dl;
-    // mg_hexdump(c->recv.buf, hlen + processed);
-    last = (dl == 0);
-  }
-  mg_iobuf_del(&c->recv, hlen + processed, del);
-  mark = ((size_t) c->pfn_data) & MG_DMARK;
-  c->pfn_data = (void *) (processed | mark);
-  if (last) {
-    hm->body.len = processed;
-    hm->message.len = hlen + processed;
-    c->pfn_data = NULL;
-    if (mark) mg_iobuf_del(&c->recv, 0, hlen), *next = true;
-    // MG_INFO(("LAST, mark: %lx", mark));
-    // mg_hexdump(c->recv.buf, c->recv.len);
-  }
-}
-
-static void deliver_normal_chunks(struct mg_connection *c, size_t hlen,
-                                  struct mg_http_message *hm, bool *next) {
-  size_t left, processed = ((size_t) c->pfn_data) & ~MG_DMARK;
-  size_t deleted = ((size_t) c->pfn_data) & MG_DMARK;
-  hm->chunk = mg_str_n((char *) &c->recv.buf[hlen], c->recv.len - hlen);
-  if (processed <= hm->chunk.len && !deleted) {
-    hm->chunk.len -= processed;
-    hm->chunk.ptr += processed;
-  }
-  left = hm->body.len < processed ? 0 : hm->body.len - processed;
-  if (hm->chunk.len > left) hm->chunk.len = left;
-  if (hm->chunk.len > 0) mg_call(c, MG_EV_HTTP_CHUNK, hm);
-  processed += hm->chunk.len;
-  deleted = ((size_t) c->pfn_data) & MG_DMARK;  // Re-evaluate after user call
-  if (processed >= hm->body.len) {              // Last, 0-len chunk
-    hm->chunk.len = 0;                          // Reset length
-    mg_call(c, MG_EV_HTTP_CHUNK, hm);           // Call user handler
-    c->pfn_data = NULL;                         // Reset processed counter
-    if (processed && deleted) mg_iobuf_del(&c->recv, 0, hlen), *next = true;
-  } else {
-    c->pfn_data = (void *) (processed | deleted);  // if it is set
-  }
-}
-
-static void http_cb(struct mg_connection *c, int ev, void *evd, void *fnd) {
-  if (ev == MG_EV_READ || ev == MG_EV_CLOSE) {
+static void http_cb(struct mg_connection *c, int ev, void *ev_data) {
+  if (ev == MG_EV_READ || ev == MG_EV_CLOSE ||
+      (ev == MG_EV_POLL && c->is_accepted && !c->is_draining &&
+       c->recv.len > 0)) {  // see #2796
     struct mg_http_message hm;
-    // mg_hexdump(c->recv.buf, c->recv.len);
-    while (c->recv.buf != NULL && c->recv.len > 0) {
-      bool next = false;
-      int hlen = mg_http_parse((char *) c->recv.buf, c->recv.len, &hm);
-      if (hlen < 0) {
-        mg_error(c, "HTTP parse:\n%.*s", (int) c->recv.len, c->recv.buf);
-        break;
+    size_t ofs = 0;  // Parsing offset
+    while (c->is_resp == 0 && ofs < c->recv.len) {
+      const char *buf = (char *) c->recv.buf + ofs;
+      int n = mg_http_parse(buf, c->recv.len - ofs, &hm);
+      struct mg_str *te;  // Transfer - encoding header
+      bool is_chunked = false;
+      size_t old_len = c->recv.len;
+      if (n < 0) {
+        // We don't use mg_error() here, to avoid closing pipelined requests
+        // prematurely, see #2592
+        MG_ERROR(("HTTP parse, %lu bytes", c->recv.len));
+        c->is_draining = 1;
+        mg_hexdump(buf, c->recv.len - ofs > 16 ? 16 : c->recv.len - ofs);
+        c->recv.len = 0;
+        return;
       }
-      if (c->is_resp) break;           // Response is still generated
-      if (hlen == 0) break;            // Request is not buffered yet
-      if (ev == MG_EV_CLOSE) {         // If client did not set Content-Length
-        hm.message.len = c->recv.len;  // and closes now, deliver a MSG
-        hm.body.len = hm.message.len - (size_t) (hm.body.ptr - hm.message.ptr);
+      if (n == 0) break;                 // Request is not buffered yet
+      mg_call(c, MG_EV_HTTP_HDRS, &hm);  // Got all HTTP headers
+      if (c->recv.len != old_len) {
+        // User manipulated received data. Wash our hands
+        MG_DEBUG(("%lu detaching HTTP handler", c->id));
+        c->pfn = NULL;
+        return;
       }
-      if (mg_is_chunked(&hm)) {
-        deliver_chunked_chunks(c, (size_t) hlen, &hm, &next);
-      } else {
-        deliver_normal_chunks(c, (size_t) hlen, &hm, &next);
+      if (ev == MG_EV_CLOSE) {           // If client did not set Content-Length
+        hm.message.len = c->recv.len - ofs;  // and closes now, deliver MSG
+        hm.body.len = hm.message.len - (size_t) (hm.body.buf - hm.message.buf);
       }
-      if (next) continue;  // Chunks & request were deleted
-      //  Chunk events are delivered. If we have full body, deliver MSG
-      if (c->recv.len < hm.message.len) break;
+      if ((te = mg_http_get_header(&hm, "Transfer-Encoding")) != NULL) {
+        if (mg_strcasecmp(*te, mg_str("chunked")) == 0) {
+          is_chunked = true;
+        } else {
+          mg_error(c, "Invalid Transfer-Encoding");  // See #2460
+          return;
+        }
+      } else if (mg_http_get_header(&hm, "Content-length") == NULL) {
+        // #2593: HTTP packets must contain either Transfer-Encoding or
+        // Content-length
+        bool is_response = mg_ncasecmp(hm.method.buf, "HTTP/", 5) == 0;
+        bool require_content_len = false;
+        if (!is_response && (mg_strcasecmp(hm.method, mg_str("POST")) == 0 ||
+                             mg_strcasecmp(hm.method, mg_str("PUT")) == 0)) {
+          // POST and PUT should include an entity body. Therefore, they should
+          // contain a Content-length header. Other requests can also contain a
+          // body, but their content has no defined semantics (RFC 7231)
+          require_content_len = true;
+          ofs += (size_t) n;  // this request has been processed
+        } else if (is_response) {
+          // HTTP spec 7.2 Entity body: All other responses must include a body
+          // or Content-Length header field defined with a value of 0.
+          int status = mg_http_status(&hm);
+          require_content_len = status >= 200 && status != 204 && status != 304;
+        }
+        if (require_content_len) {
+          if (!c->is_client) mg_http_reply(c, 411, "", "");
+          MG_ERROR(("Content length missing from %s", is_response ? "response" : "request"));
+        }
+      }
+
+      if (is_chunked) {
+        // For chunked data, strip off prefixes and suffixes from chunks
+        // and relocate them right after the headers, then report a message
+        char *s = (char *) c->recv.buf + ofs + n;
+        int o = 0, pl, dl, cl, len = (int) (c->recv.len - ofs - (size_t) n);
+
+        // Find zero-length chunk (the end of the body)
+        while ((cl = skip_chunk(s + o, len - o, &pl, &dl)) > 0 && dl) o += cl;
+        if (cl == 0) break;  // No zero-len chunk, buffer more data
+        if (cl < 0) {
+          mg_error(c, "Invalid chunk");
+          break;
+        }
+
+        // Zero chunk found. Second pass: strip + relocate
+        o = 0, hm.body.len = 0, hm.message.len = (size_t) n;
+        while ((cl = skip_chunk(s + o, len - o, &pl, &dl)) > 0) {
+          memmove(s + hm.body.len, s + o + pl, (size_t) dl);
+          o += cl, hm.body.len += (size_t) dl, hm.message.len += (size_t) dl;
+          if (dl == 0) break;
+        }
+        ofs += (size_t) (n + o);
+      } else {  // Normal, non-chunked data
+        size_t len = c->recv.len - ofs - (size_t) n;
+        if (hm.body.len > len) break;  // Buffer more data
+        ofs += (size_t) n + hm.body.len;
+      }
+
       if (c->is_accepted) c->is_resp = 1;  // Start generating response
       mg_call(c, MG_EV_HTTP_MSG, &hm);     // User handler can clear is_resp
-      mg_iobuf_del(&c->recv, 0, hm.message.len);
+      if (c->is_accepted && !c->is_resp) {
+        struct mg_str *cc = mg_http_get_header(&hm, "Connection");
+        if (cc != NULL && mg_strcasecmp(*cc, mg_str("close")) == 0) {
+          c->is_draining = 1;  // honor "Connection: close"
+          break;
+        }
+      }
     }
+    if (ofs > 0) mg_iobuf_del(&c->recv, 0, ofs);  // Delete processed data
   }
-  (void) evd, (void) fnd;
+  (void) ev_data;
 }
 
-static void mg_hfn(struct mg_connection *c, int ev, void *ev_data, void *fnd) {
+static void mg_hfn(struct mg_connection *c, int ev, void *ev_data) {
   if (ev == MG_EV_HTTP_MSG) {
     struct mg_http_message *hm = (struct mg_http_message *) ev_data;
-    if (mg_http_match_uri(hm, "/quit")) {
+    if (mg_match(hm->uri, mg_str("/quit"), NULL)) {
       mg_http_reply(c, 200, "", "ok\n");
       c->is_draining = 1;
       c->data[0] = 'X';
-    } else if (mg_http_match_uri(hm, "/debug")) {
+    } else if (mg_match(hm->uri, mg_str("/debug"), NULL)) {
       int level = (int) mg_json_get_long(hm->body, "$.level", MG_LL_DEBUG);
       mg_log_set(level);
       mg_http_reply(c, 200, "", "Debug level set to %d\n", level);
@@ -2224,7 +2493,7 @@ static void mg_hfn(struct mg_connection *c, int ev, void *ev_data, void *fnd) {
       mg_http_reply(c, 200, "", "hi\n");
     }
   } else if (ev == MG_EV_CLOSE) {
-    if (c->data[0] == 'X') *(bool *) fnd = true;
+    if (c->data[0] == 'X') *(bool *) c->fn_data = true;
   }
 }
 
@@ -2258,13 +2527,6 @@ struct mg_connection *mg_http_listen(struct mg_mgr *mgr, const char *url,
 
 
 
-// Not using memset for zeroing memory, cause it can be dropped by compiler
-// See https://github.com/cesanta/mongoose/pull/1265
-static void zeromem(volatile unsigned char *buf, size_t len) {
-  if (buf != NULL) {
-    while (len--) *buf++ = 0;
-  }
-}
 
 static size_t roundup(size_t size, size_t align) {
   return align == 0 ? size : (size + align - 1) / align * align;
@@ -2274,7 +2536,7 @@ int mg_iobuf_resize(struct mg_iobuf *io, size_t new_size) {
   int ok = 1;
   new_size = roundup(new_size, io->align);
   if (new_size == 0) {
-    zeromem(io->buf, io->size);
+    mg_bzero(io->buf, io->size);
     free(io->buf);
     io->buf = NULL;
     io->len = io->size = 0;
@@ -2285,7 +2547,7 @@ int mg_iobuf_resize(struct mg_iobuf *io, size_t new_size) {
     if (p != NULL) {
       size_t len = new_size < io->len ? new_size : io->len;
       if (len > 0 && io->buf != NULL) memmove(p, io->buf, len);
-      zeromem(io->buf, io->size);
+      mg_bzero(io->buf, io->size);
       free(io->buf);
       io->buf = (unsigned char *) p;
       io->size = new_size;
@@ -2320,7 +2582,7 @@ size_t mg_iobuf_del(struct mg_iobuf *io, size_t ofs, size_t len) {
   if (ofs > io->len) ofs = io->len;
   if (ofs + len > io->len) len = io->len - ofs;
   if (io->buf) memmove(io->buf + ofs, io->buf + ofs + len, io->len - ofs - len);
-  if (io->buf) zeromem(io->buf + io->len - len, len);
+  if (io->buf) mg_bzero(io->buf + io->len - len, len);
   io->len -= len;
   return len;
 }
@@ -2408,8 +2670,57 @@ static double mg_atod(const char *p, int len, int *numlen) {
   return d;
 }
 
+// Iterate over object or array elements
+size_t mg_json_next(struct mg_str obj, size_t ofs, struct mg_str *key,
+                    struct mg_str *val) {
+  if (ofs >= obj.len) {
+    ofs = 0;  // Out of boundaries, stop scanning
+  } else if (obj.len < 2 || (*obj.buf != '{' && *obj.buf != '[')) {
+    ofs = 0;  // Not an array or object, stop
+  } else {
+    struct mg_str sub = mg_str_n(obj.buf + ofs, obj.len - ofs);
+    if (ofs == 0) ofs++, sub.buf++, sub.len--;
+    if (*obj.buf == '[') {  // Iterate over an array
+      int n = 0, o = mg_json_get(sub, "$", &n);
+      if (n < 0 || o < 0 || (size_t) (o + n) > sub.len) {
+        ofs = 0;  // Error parsing key, stop scanning
+      } else {
+        if (key) *key = mg_str_n(NULL, 0);
+        if (val) *val = mg_str_n(sub.buf + o, (size_t) n);
+        ofs = (size_t) (&sub.buf[o + n] - obj.buf);
+      }
+    } else {  // Iterate over an object
+      int n = 0, o = mg_json_get(sub, "$", &n);
+      if (n < 0 || o < 0 || (size_t) (o + n) > sub.len) {
+        ofs = 0;  // Error parsing key, stop scanning
+      } else {
+        if (key) *key = mg_str_n(sub.buf + o, (size_t) n);
+        sub.buf += o + n, sub.len -= (size_t) (o + n);
+        while (sub.len > 0 && *sub.buf != ':') sub.len--, sub.buf++;
+        if (sub.len > 0 && *sub.buf == ':') sub.len--, sub.buf++;
+        n = 0, o = mg_json_get(sub, "$", &n);
+        if (n < 0 || o < 0 || (size_t) (o + n) > sub.len) {
+          ofs = 0;  // Error parsing value, stop scanning
+        } else {
+          if (val) *val = mg_str_n(sub.buf + o, (size_t) n);
+          ofs = (size_t) (&sub.buf[o + n] - obj.buf);
+        }
+      }
+    }
+    // MG_INFO(("SUB ofs %u %.*s", ofs, sub.len, sub.buf));
+    while (ofs && ofs < obj.len &&
+           (obj.buf[ofs] == ' ' || obj.buf[ofs] == '\t' ||
+            obj.buf[ofs] == '\n' || obj.buf[ofs] == '\r')) {
+      ofs++;
+    }
+    if (ofs && ofs < obj.len && obj.buf[ofs] == ',') ofs++;
+    if (ofs > obj.len) ofs = 0;
+  }
+  return ofs;
+}
+
 int mg_json_get(struct mg_str json, const char *path, int *toklen) {
-  const char *s = json.ptr;
+  const char *s = json.buf;
   int len = (int) json.len;
   enum { S_VALUE, S_KEY, S_COLON, S_COMMA_OR_EOO } expecting = S_VALUE;
   unsigned char nesting[MG_JSON_MAX_DEPTH];
@@ -2500,11 +2811,11 @@ int mg_json_get(struct mg_str json, const char *path, int *toklen) {
           if (i + 1 + n >= len) return MG_JSON_NOT_FOUND;
           if (depth < ed) return MG_JSON_NOT_FOUND;
           if (depth == ed && path[pos - 1] != '.') return MG_JSON_NOT_FOUND;
-          // printf("K %s [%.*s] [%.*s] %d %d %d\n", path, pos, path, n,
-          //  &s[i + 1], n, depth, ed);
-          // NOTE(cpq): in the check sequence below is important.
-          // strncmp() must go first: it fails fast if the remaining length of
-          // the path is smaller than `n`.
+          // printf("K %s [%.*s] [%.*s] %d %d %d %d %d\n", path, pos, path, n,
+          //        &s[i + 1], n, depth, ed, ci, ei);
+          //  NOTE(cpq): in the check sequence below is important.
+          //  strncmp() must go first: it fails fast if the remaining length
+          //  of the path is smaller than `n`.
           if (depth == ed && path[pos - 1] == '.' &&
               strncmp(&s[i + 1], &path[pos], (size_t) n) == 0 &&
               (path[pos + n] == '\0' || path[pos + n] == '.' ||
@@ -2516,6 +2827,7 @@ int mg_json_get(struct mg_str json, const char *path, int *toklen) {
         } else if (c == '}') {  // Empty object
           MG_EOO('}');
           expecting = S_COMMA_OR_EOO;
+          if (depth == ed && ei >= 0) ci++;
         } else {
           return MG_JSON_INVALID;
         }
@@ -2535,6 +2847,10 @@ int mg_json_get(struct mg_str json, const char *path, int *toklen) {
         } else if (c == ',') {
           expecting = (nesting[depth - 1] == '{') ? S_KEY : S_VALUE;
         } else if (c == ']' || c == '}') {
+          if (depth == ed && c == '}' && path[pos - 1] == '.')
+            return MG_JSON_NOT_FOUND;
+          if (depth == ed && c == ']' && path[pos - 1] == ',')
+            return MG_JSON_NOT_FOUND;
           MG_EOO('O');
           if (depth == ed && ei >= 0) ci++;
         } else {
@@ -2546,11 +2862,17 @@ int mg_json_get(struct mg_str json, const char *path, int *toklen) {
   return MG_JSON_NOT_FOUND;
 }
 
+struct mg_str mg_json_get_tok(struct mg_str json, const char *path) {
+  int len = 0, ofs = mg_json_get(json, path, &len);
+  return mg_str_n(ofs < 0 ? NULL : json.buf + ofs,
+                  (size_t) (len < 0 ? 0 : len));
+}
+
 bool mg_json_get_num(struct mg_str json, const char *path, double *v) {
   int n, toklen, found = 0;
   if ((n = mg_json_get(json, path, &toklen)) >= 0 &&
-      (json.ptr[n] == '-' || (json.ptr[n] >= '0' && json.ptr[n] <= '9'))) {
-    if (v != NULL) *v = mg_atod(json.ptr + n, toklen, NULL);
+      (json.buf[n] == '-' || (json.buf[n] >= '0' && json.buf[n] <= '9'))) {
+    if (v != NULL) *v = mg_atod(json.buf + n, toklen, NULL);
     found = 1;
   }
   return found;
@@ -2558,31 +2880,31 @@ bool mg_json_get_num(struct mg_str json, const char *path, double *v) {
 
 bool mg_json_get_bool(struct mg_str json, const char *path, bool *v) {
   int found = 0, off = mg_json_get(json, path, NULL);
-  if (off >= 0 && (json.ptr[off] == 't' || json.ptr[off] == 'f')) {
-    if (v != NULL) *v = json.ptr[off] == 't';
+  if (off >= 0 && (json.buf[off] == 't' || json.buf[off] == 'f')) {
+    if (v != NULL) *v = json.buf[off] == 't';
     found = 1;
   }
   return found;
 }
 
-static bool json_unescape(const char *s, size_t len, char *to, size_t n) {
+bool mg_json_unescape(struct mg_str s, char *to, size_t n) {
   size_t i, j;
-  for (i = 0, j = 0; i < len && j < n; i++, j++) {
-    if (s[i] == '\\' && i + 5 < len && s[i + 1] == 'u') {
-      //  \uXXXX escape. We could process a simple one-byte chars
-      // \u00xx from the ASCII range. More complex chars would require
-      // dragging in a UTF8 library, which is too much for us
-      if (s[i + 2] != '0' || s[i + 3] != '0') return false;  // Give up
-      ((unsigned char *) to)[j] = (unsigned char) mg_unhexn(s + i + 4, 2);
-
+  for (i = 0, j = 0; i < s.len && j < n; i++, j++) {
+    if (s.buf[i] == '\\' && i + 5 < s.len && s.buf[i + 1] == 'u') {
+      //  \uXXXX escape. We process simple one-byte chars \u00xx within ASCII
+      //  range. More complex chars would require dragging in a UTF8 library,
+      //  which is too much for us
+      if (mg_str_to_num(mg_str_n(s.buf + i + 2, 4), 16, &to[j],
+                        sizeof(uint8_t)) == false)
+        return false;
       i += 5;
-    } else if (s[i] == '\\' && i + 1 < len) {
-      char c = json_esc(s[i + 1], 0);
+    } else if (s.buf[i] == '\\' && i + 1 < s.len) {
+      char c = json_esc(s.buf[i + 1], 0);
       if (c == 0) return false;
       to[j] = c;
       i++;
     } else {
-      to[j] = s[i];
+      to[j] = s.buf[i];
     }
   }
   if (j >= n) return false;
@@ -2593,10 +2915,10 @@ static bool json_unescape(const char *s, size_t len, char *to, size_t n) {
 char *mg_json_get_str(struct mg_str json, const char *path) {
   char *result = NULL;
   int len = 0, off = mg_json_get(json, path, &len);
-  if (off >= 0 && len > 1 && json.ptr[off] == '"') {
+  if (off >= 0 && len > 1 && json.buf[off] == '"') {
     if ((result = (char *) calloc(1, (size_t) len)) != NULL &&
-        !json_unescape(json.ptr + off + 1, (size_t) (len - 2), result,
-                       (size_t) len)) {
+        !mg_json_unescape(mg_str_n(json.buf + off + 1, (size_t) (len - 2)),
+                          result, (size_t) len)) {
       free(result);
       result = NULL;
     }
@@ -2607,10 +2929,11 @@ char *mg_json_get_str(struct mg_str json, const char *path) {
 char *mg_json_get_b64(struct mg_str json, const char *path, int *slen) {
   char *result = NULL;
   int len = 0, off = mg_json_get(json, path, &len);
-  if (off >= 0 && json.ptr[off] == '"' && len > 1 &&
+  if (off >= 0 && json.buf[off] == '"' && len > 1 &&
       (result = (char *) calloc(1, (size_t) len)) != NULL) {
-    int k = mg_base64_decode(json.ptr + off + 1, len - 2, result);
-    if (slen != NULL) *slen = k;
+    size_t k = mg_base64_decode(json.buf + off + 1, (size_t) (len - 2), result,
+                                (size_t) len);
+    if (slen != NULL) *slen = (int) k;
   }
   return result;
 }
@@ -2618,9 +2941,13 @@ char *mg_json_get_b64(struct mg_str json, const char *path, int *slen) {
 char *mg_json_get_hex(struct mg_str json, const char *path, int *slen) {
   char *result = NULL;
   int len = 0, off = mg_json_get(json, path, &len);
-  if (off >= 0 && json.ptr[off] == '"' && len > 1 &&
+  if (off >= 0 && json.buf[off] == '"' && len > 1 &&
       (result = (char *) calloc(1, (size_t) len / 2)) != NULL) {
-    mg_unhex(json.ptr + off + 1, (size_t) (len - 2), (uint8_t *) result);
+    int i;
+    for (i = 0; i < len - 2; i += 2) {
+      mg_str_to_num(mg_str_n(json.buf + off + 1 + i, 2), 16, &result[i >> 1],
+                    sizeof(uint8_t));
+    }
     result[len / 2 - 1] = '\0';
     if (slen != NULL) *slen = len / 2 - 1;
   }
@@ -2642,7 +2969,7 @@ long mg_json_get_long(struct mg_str json, const char *path, long dflt) {
 
 
 
-static int s_level = MG_LL_INFO;
+int mg_log_level = MG_LL_INFO;
 static mg_pfn_t s_log_func = mg_pfn_stdout;
 static void *s_log_func_param = NULL;
 
@@ -2660,26 +2987,19 @@ static void logs(const char *buf, size_t len) {
   for (i = 0; i < len; i++) logc(((unsigned char *) buf)[i]);
 }
 
-void mg_log_set(int log_level) {
-  MG_DEBUG(("Setting log level to %d", log_level));
-  s_level = log_level;
-}
-
-bool mg_log_prefix(int level, const char *file, int line, const char *fname) {
-  if (level <= s_level) {
-    const char *p = strrchr(file, '/');
-    char buf[41];
-    size_t n;
-    if (p == NULL) p = strrchr(file, '\\');
-    n = mg_snprintf(buf, sizeof(buf), "%-6llx %d %s:%d:%s", mg_millis(), level,
-                    p == NULL ? file : p + 1, line, fname);
-    if (n > sizeof(buf) - 2) n = sizeof(buf) - 2;
-    while (n < sizeof(buf)) buf[n++] = ' ';
-    logs(buf, n - 1);
-    return true;
-  } else {
-    return false;
-  }
+#if MG_ENABLE_CUSTOM_LOG
+// Let user define their own mg_log_prefix() and mg_log()
+#else
+void mg_log_prefix(int level, const char *file, int line, const char *fname) {
+  const char *p = strrchr(file, '/');
+  char buf[41];
+  size_t n;
+  if (p == NULL) p = strrchr(file, '\\');
+  n = mg_snprintf(buf, sizeof(buf), "%-6llx %d %s:%d:%s", mg_millis(), level,
+                  p == NULL ? file : p + 1, line, fname);
+  if (n > sizeof(buf) - 2) n = sizeof(buf) - 2;
+  while (n < sizeof(buf)) buf[n++] = ' ';
+  logs(buf, n - 1);
 }
 
 void mg_log(const char *fmt, ...) {
@@ -2687,8 +3007,9 @@ void mg_log(const char *fmt, ...) {
   va_start(ap, fmt);
   mg_vxprintf(s_log_func, s_log_func_param, fmt, &ap);
   va_end(ap);
-  logc((unsigned char) '\n');
+  logs("\r\n", 2);
 }
+#endif
 
 static unsigned char nibble(unsigned c) {
   return (unsigned char) (c < 10 ? c + '0' : c + 'W');
@@ -2720,6 +3041,21 @@ void mg_hexdump(const void *buf, size_t len) {
 #endif
 
 
+
+//  This code implements the MD5 message-digest algorithm.
+//  The algorithm is due to Ron Rivest.  This code was
+//  written by Colin Plumb in 1993, no copyright is claimed.
+//  This code is in the public domain; do with it what you wish.
+//
+//  Equivalent code is available from RSA Data Security, Inc.
+//  This code has been tested against that, and is equivalent,
+//  except that you don't need to include two pages of legalese
+//  with every copy.
+//
+//  To compute the message digest of a chunk of bytes, declare an
+//  MD5Context structure, pass it to MD5Init, call MD5Update as
+//  needed on buffers full of bytes, and then call MD5Final, which
+//  will fill a supplied 16-byte array with the digest.
 
 #if defined(MG_ENABLE_MD5) && MG_ENABLE_MD5
 
@@ -2978,7 +3314,7 @@ static void mg_send_u32(struct mg_connection *c, uint32_t value) {
   mg_send(c, &value, sizeof(value));
 }
 
-static uint8_t compute_variable_length_size(size_t length) {
+static uint8_t varint_size(size_t length) {
   uint8_t bytes_needed = 0;
   do {
     bytes_needed++;
@@ -2987,34 +3323,32 @@ static uint8_t compute_variable_length_size(size_t length) {
   return bytes_needed;
 }
 
-static int encode_variable_length(uint8_t *buf, size_t value) {
-  int len = 0;
+static size_t encode_varint(uint8_t *buf, size_t value) {
+  size_t len = 0;
 
   do {
-    uint8_t byte = (uint8_t) (value % 128);
+    uint8_t b = (uint8_t) (value % 128);
     value /= 128;
-    if (value > 0) byte |= 0x80;
-    buf[len++] = byte;
+    if (value > 0) b |= 0x80;
+    buf[len++] = b;
   } while (value > 0);
 
   return len;
 }
 
-static uint32_t decode_variable_length(const char *buf,
-                                       uint32_t *bytes_consumed) {
-  uint32_t value = 0, multiplier = 1, offset;
+static size_t decode_varint(const uint8_t *buf, size_t len, size_t *value) {
+  size_t multiplier = 1, offset;
+  *value = 0;
 
-  for (offset = 0; offset < 4; offset++) {
-    uint8_t encoded_byte = ((uint8_t *) buf)[offset];
-    value += (encoded_byte & 0x7F) * multiplier;
+  for (offset = 0; offset < 4 && offset < len; offset++) {
+    uint8_t encoded_byte = buf[offset];
+    *value += (encoded_byte & 0x7f) * multiplier;
     multiplier *= 128;
 
-    if (!(encoded_byte & 0x80)) break;
+    if ((encoded_byte & 0x80) == 0) return offset + 1;
   }
 
-  if (bytes_consumed != NULL) *bytes_consumed = offset + 1;
-
-  return value;
+  return 0;
 }
 
 static int mqtt_prop_type_by_id(uint8_t prop_id) {
@@ -3043,11 +3377,19 @@ static size_t get_properties_length(struct mg_mqtt_prop *props, size_t count) {
         size += (uint32_t) (props[i].val.len + sizeof(uint16_t));
         break;
       case MQTT_PROP_TYPE_VARIABLE_INT:
-        size += compute_variable_length_size((uint32_t) props[i].iv);
+        size += varint_size((uint32_t) props[i].iv);
         break;
-      case MQTT_PROP_TYPE_INT: size += (uint32_t) sizeof(uint32_t); break;
-      case MQTT_PROP_TYPE_SHORT: size += (uint32_t) sizeof(uint16_t); break;
-      default: return size;  // cannot parse further down
+      case MQTT_PROP_TYPE_INT:
+        size += (uint32_t) sizeof(uint32_t);
+        break;
+      case MQTT_PROP_TYPE_SHORT:
+        size += (uint32_t) sizeof(uint16_t);
+        break;
+      case MQTT_PROP_TYPE_BYTE:
+        size += (uint32_t) sizeof(uint8_t);
+        break;
+      default:
+        return size;  // cannot parse further down
     }
   }
 
@@ -3058,7 +3400,7 @@ static size_t get_properties_length(struct mg_mqtt_prop *props, size_t count) {
 // size of the variable length of the content
 static size_t get_props_size(struct mg_mqtt_prop *props, size_t count) {
   size_t size = get_properties_length(props, count);
-  size += compute_variable_length_size(size);
+  size += varint_size(size);
   return size;
 }
 
@@ -3067,17 +3409,17 @@ static void mg_send_mqtt_properties(struct mg_connection *c,
   size_t total_size = get_properties_length(props, nprops);
   uint8_t buf_v[4] = {0, 0, 0, 0};
   uint8_t buf[4] = {0, 0, 0, 0};
-  int i, len = encode_variable_length(buf, total_size);
+  size_t i, len = encode_varint(buf, total_size);
 
   mg_send(c, buf, (size_t) len);
-  for (i = 0; i < (int) nprops; i++) {
+  for (i = 0; i < nprops; i++) {
     mg_send(c, &props[i].id, sizeof(props[i].id));
     switch (mqtt_prop_type_by_id(props[i].id)) {
       case MQTT_PROP_TYPE_STRING_PAIR:
         mg_send_u16(c, mg_htons((uint16_t) props[i].key.len));
-        mg_send(c, props[i].key.ptr, props[i].key.len);
+        mg_send(c, props[i].key.buf, props[i].key.len);
         mg_send_u16(c, mg_htons((uint16_t) props[i].val.len));
-        mg_send(c, props[i].val.ptr, props[i].val.len);
+        mg_send(c, props[i].val.buf, props[i].val.len);
         break;
       case MQTT_PROP_TYPE_BYTE:
         mg_send(c, &props[i].iv, sizeof(uint8_t));
@@ -3090,14 +3432,14 @@ static void mg_send_mqtt_properties(struct mg_connection *c,
         break;
       case MQTT_PROP_TYPE_STRING:
         mg_send_u16(c, mg_htons((uint16_t) props[i].val.len));
-        mg_send(c, props[i].val.ptr, props[i].val.len);
+        mg_send(c, props[i].val.buf, props[i].val.len);
         break;
       case MQTT_PROP_TYPE_BINARY_DATA:
         mg_send_u16(c, mg_htons((uint16_t) props[i].val.len));
-        mg_send(c, props[i].val.ptr, props[i].val.len);
+        mg_send(c, props[i].val.buf, props[i].val.len);
         break;
       case MQTT_PROP_TYPE_VARIABLE_INT:
-        len = encode_variable_length(buf_v, props[i].iv);
+        len = encode_varint(buf_v, props[i].iv);
         mg_send(c, buf_v, (size_t) len);
         break;
     }
@@ -3106,9 +3448,9 @@ static void mg_send_mqtt_properties(struct mg_connection *c,
 
 size_t mg_mqtt_next_prop(struct mg_mqtt_message *msg, struct mg_mqtt_prop *prop,
                          size_t ofs) {
-  uint8_t *i = (uint8_t *) msg->dgram.ptr + msg->props_start + ofs;
-  size_t new_pos = ofs;
-  uint32_t bytes_consumed;
+  uint8_t *i = (uint8_t *) msg->dgram.buf + msg->props_start + ofs;
+  uint8_t *end = (uint8_t *) msg->dgram.buf + msg->dgram.len;
+  size_t new_pos = ofs, len;
   prop->id = i[0];
 
   if (ofs >= msg->dgram.len || ofs >= msg->props_start + msg->props_size)
@@ -3118,10 +3460,10 @@ size_t mg_mqtt_next_prop(struct mg_mqtt_message *msg, struct mg_mqtt_prop *prop,
   switch (mqtt_prop_type_by_id(prop->id)) {
     case MQTT_PROP_TYPE_STRING_PAIR:
       prop->key.len = (uint16_t) ((((uint16_t) i[0]) << 8) | i[1]);
-      prop->key.ptr = (char *) i + 2;
+      prop->key.buf = (char *) i + 2;
       i += 2 + prop->key.len;
       prop->val.len = (uint16_t) ((((uint16_t) i[0]) << 8) | i[1]);
-      prop->val.ptr = (char *) i + 2;
+      prop->val.buf = (char *) i + 2;
       new_pos += 2 * sizeof(uint16_t) + prop->val.len + prop->key.len;
       break;
     case MQTT_PROP_TYPE_BYTE:
@@ -3139,33 +3481,33 @@ size_t mg_mqtt_next_prop(struct mg_mqtt_message *msg, struct mg_mqtt_prop *prop,
       break;
     case MQTT_PROP_TYPE_STRING:
       prop->val.len = (uint16_t) ((((uint16_t) i[0]) << 8) | i[1]);
-      prop->val.ptr = (char *) i + 2;
+      prop->val.buf = (char *) i + 2;
       new_pos += 2 + prop->val.len;
       break;
     case MQTT_PROP_TYPE_BINARY_DATA:
       prop->val.len = (uint16_t) ((((uint16_t) i[0]) << 8) | i[1]);
-      prop->val.ptr = (char *) i + 2;
+      prop->val.buf = (char *) i + 2;
       new_pos += 2 + prop->val.len;
       break;
     case MQTT_PROP_TYPE_VARIABLE_INT:
-      prop->iv = decode_variable_length((char *) i, &bytes_consumed);
-      new_pos += bytes_consumed;
+      len = decode_varint(i, (size_t) (end - i), (size_t *) &prop->iv);
+      new_pos = (!len) ? 0 : new_pos + len;
       break;
-    default: new_pos = 0;
+    default:
+      new_pos = 0;
   }
 
   return new_pos;
 }
 
 void mg_mqtt_login(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
-  char rnd[10], client_id[21];
+  char client_id[21];
   struct mg_str cid = opts->client_id;
   size_t total_len = 7 + 1 + 2 + 2;
   uint8_t hdr[8] = {0, 4, 'M', 'Q', 'T', 'T', opts->version, 0};
 
   if (cid.len == 0) {
-    mg_random(rnd, sizeof(rnd));
-    mg_hex(rnd, sizeof(rnd), client_id);
+    mg_random_str(client_id, sizeof(client_id) - 1);
     client_id[sizeof(client_id) - 1] = '\0';
     cid = mg_str(client_id);
   }
@@ -3181,7 +3523,7 @@ void mg_mqtt_login(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
     total_len += 2 + (uint32_t) opts->pass.len;
     hdr[7] |= MQTT_HAS_PASSWORD;
   }
-  if (opts->topic.len > 0 && opts->message.len > 0) {
+  if (opts->topic.len > 0) {  // allow zero-length msgs, message.len is size_t
     total_len += 4 + (uint32_t) opts->topic.len + (uint32_t) opts->message.len;
     hdr[7] |= MQTT_HAS_WILL;
   }
@@ -3202,47 +3544,54 @@ void mg_mqtt_login(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
   if (c->is_mqtt5) mg_send_mqtt_properties(c, opts->props, opts->num_props);
 
   mg_send_u16(c, mg_htons((uint16_t) cid.len));
-  mg_send(c, cid.ptr, cid.len);
+  mg_send(c, cid.buf, cid.len);
 
   if (hdr[7] & MQTT_HAS_WILL) {
     if (c->is_mqtt5)
       mg_send_mqtt_properties(c, opts->will_props, opts->num_will_props);
 
     mg_send_u16(c, mg_htons((uint16_t) opts->topic.len));
-    mg_send(c, opts->topic.ptr, opts->topic.len);
+    mg_send(c, opts->topic.buf, opts->topic.len);
     mg_send_u16(c, mg_htons((uint16_t) opts->message.len));
-    mg_send(c, opts->message.ptr, opts->message.len);
+    mg_send(c, opts->message.buf, opts->message.len);
   }
   if (opts->user.len > 0) {
     mg_send_u16(c, mg_htons((uint16_t) opts->user.len));
-    mg_send(c, opts->user.ptr, opts->user.len);
+    mg_send(c, opts->user.buf, opts->user.len);
   }
   if (opts->pass.len > 0) {
     mg_send_u16(c, mg_htons((uint16_t) opts->pass.len));
-    mg_send(c, opts->pass.ptr, opts->pass.len);
+    mg_send(c, opts->pass.buf, opts->pass.len);
   }
 }
 
-void mg_mqtt_pub(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
+uint16_t mg_mqtt_pub(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
+  uint16_t id = opts->retransmit_id;
   uint8_t flags = (uint8_t) (((opts->qos & 3) << 1) | (opts->retain ? 1 : 0));
   size_t len = 2 + opts->topic.len + opts->message.len;
-  MG_DEBUG(("%lu [%.*s] -> [%.*s]", c->id, (int) opts->topic.len,
-            (char *) opts->topic.ptr, (int) opts->message.len,
-            (char *) opts->message.ptr));
+  MG_DEBUG(("%lu [%.*s] <- [%.*s%c", c->id, (int) opts->topic.len,
+            (char *) opts->topic.buf,
+            (int) (opts->message.len <= 10 ? opts->message.len : 10),
+            (char *) opts->message.buf, opts->message.len <= 10 ? ']' : ' '));
   if (opts->qos > 0) len += 2;
   if (c->is_mqtt5) len += get_props_size(opts->props, opts->num_props);
 
+  if (opts->qos > 0 && id != 0) flags |= 1 << 3;
   mg_mqtt_send_header(c, MQTT_CMD_PUBLISH, flags, (uint32_t) len);
   mg_send_u16(c, mg_htons((uint16_t) opts->topic.len));
-  mg_send(c, opts->topic.ptr, opts->topic.len);
-  if (opts->qos > 0) {
-    if (++c->mgr->mqtt_id == 0) ++c->mgr->mqtt_id;
-    mg_send_u16(c, mg_htons(c->mgr->mqtt_id));
+  mg_send(c, opts->topic.buf, opts->topic.len);
+  if (opts->qos > 0) {  // need to send 'id' field
+    if (id == 0) {      // generate new one if not resending
+      if (++c->mgr->mqtt_id == 0) ++c->mgr->mqtt_id;
+      id = c->mgr->mqtt_id;
+    }
+    mg_send_u16(c, mg_htons(id));
   }
 
   if (c->is_mqtt5) mg_send_mqtt_properties(c, opts->props, opts->num_props);
 
-  mg_send(c, opts->message.ptr, opts->message.len);
+  if (opts->message.len > 0) mg_send(c, opts->message.buf, opts->message.len);
+  return id;
 }
 
 void mg_mqtt_sub(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
@@ -3256,7 +3605,7 @@ void mg_mqtt_sub(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
   if (c->is_mqtt5) mg_send_mqtt_properties(c, opts->props, opts->num_props);
 
   mg_send_u16(c, mg_htons((uint16_t) opts->topic.len));
-  mg_send(c, opts->topic.ptr, opts->topic.len);
+  mg_send(c, opts->topic.buf, opts->topic.len);
   mg_send(c, &qos_, sizeof(qos_));
 }
 
@@ -3266,7 +3615,7 @@ int mg_mqtt_parse(const uint8_t *buf, size_t len, uint8_t version,
   uint32_t n = 0, len_len = 0;
 
   memset(m, 0, sizeof(*m));
-  m->dgram.ptr = (char *) buf;
+  m->dgram.buf = (char *) buf;
   if (len < 2) return MQTT_INCOMPLETE;
   m->cmd = (uint8_t) (buf[0] >> 4);
   m->qos = (buf[0] >> 1) & 3;
@@ -3304,7 +3653,7 @@ int mg_mqtt_parse(const uint8_t *buf, size_t len, uint8_t version,
     case MQTT_CMD_PUBLISH: {
       if (p + 2 > end) return MQTT_MALFORMED;
       m->topic.len = (uint16_t) ((((uint16_t) p[0]) << 8) | p[1]);
-      m->topic.ptr = (char *) p + 2;
+      m->topic.buf = (char *) p + 2;
       p += 2 + m->topic.len;
       if (p > end) return MQTT_MALFORMED;
       if (m->qos > 0) {
@@ -3314,22 +3663,24 @@ int mg_mqtt_parse(const uint8_t *buf, size_t len, uint8_t version,
       }
       if (p > end) return MQTT_MALFORMED;
       if (version == 5 && p + 2 < end) {
-        m->props_size = decode_variable_length((char *) p, &len_len);
+        len_len =
+            (uint32_t) decode_varint(p, (size_t) (end - p), &m->props_size);
+        if (!len_len) return MQTT_MALFORMED;
         m->props_start = (size_t) (p + len_len - buf);
         p += len_len + m->props_size;
       }
       if (p > end) return MQTT_MALFORMED;
-      m->data.ptr = (char *) p;
+      m->data.buf = (char *) p;
       m->data.len = (size_t) (end - p);
       break;
     }
-    default: break;
+    default:
+      break;
   }
   return MQTT_OK;
 }
 
-static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
-                    void *fn_data) {
+static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data) {
   if (ev == MG_EV_READ) {
     for (;;) {
       uint8_t version = c->is_mqtt5 ? 5 : 4;
@@ -3341,7 +3692,7 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
         break;
       } else if (rc == MQTT_OK) {
         MG_VERBOSE(("%lu MQTT CMD %d len %d [%.*s]", c->id, mm.cmd,
-                    (int) mm.dgram.len, (int) mm.data.len, mm.data.ptr));
+                    (int) mm.dgram.len, (int) mm.data.len, mm.data.buf));
         switch (mm.cmd) {
           case MQTT_CMD_CONNACK:
             mg_call(c, MG_EV_MQTT_OPEN, &mm.ack);
@@ -3353,14 +3704,19 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
             }
             break;
           case MQTT_CMD_PUBLISH: {
-            MG_DEBUG(("%lu [%.*s] -> [%.*s]", c->id, (int) mm.topic.len,
-                      mm.topic.ptr, (int) mm.data.len, mm.data.ptr));
+            MG_DEBUG(("%lu [%.*s] -> [%.*s%c", c->id, (int) mm.topic.len,
+                      mm.topic.buf,
+                      (int) (mm.data.len <= 10 ? mm.data.len : 10), mm.data.buf,
+                      mm.data.len <= 10 ? ']' : ' '));
             if (mm.qos > 0) {
-              uint16_t id = mg_htons(mm.id);
+              uint16_t id = mg_ntohs(mm.id);
               uint32_t remaining_len = sizeof(id);
-              if (c->is_mqtt5) remaining_len += 1;
+              if (c->is_mqtt5) remaining_len += 2;  // 3.4.2
 
-              mg_mqtt_send_header(c, MQTT_CMD_PUBACK, 0, remaining_len);
+              mg_mqtt_send_header(
+                  c,
+                  (uint8_t) (mm.qos == 2 ? MQTT_CMD_PUBREC : MQTT_CMD_PUBACK),
+                  0, remaining_len);
               mg_send(c, &id, sizeof(id));
 
               if (c->is_mqtt5) {
@@ -3368,7 +3724,21 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
                 mg_send(c, &zero, sizeof(zero));
               }
             }
-            mg_call(c, MG_EV_MQTT_MSG, &mm);
+            mg_call(c, MG_EV_MQTT_MSG, &mm);  // let the app handle qos stuff
+            break;
+          }
+          case MQTT_CMD_PUBREC: {  // MQTT5: 3.5.2-1 TODO(): variable header rc
+            uint16_t id = mg_ntohs(mm.id);
+            uint32_t remaining_len = sizeof(id);  // MQTT5 3.6.2-1
+            mg_mqtt_send_header(c, MQTT_CMD_PUBREL, 2, remaining_len);
+            mg_send(c, &id, sizeof(id));  // MQTT5 3.6.1-1, flags = 2
+            break;
+          }
+          case MQTT_CMD_PUBREL: {  // MQTT5: 3.6.2-1 TODO(): variable header rc
+            uint16_t id = mg_ntohs(mm.id);
+            uint32_t remaining_len = sizeof(id);  // MQTT5 3.7.2-1
+            mg_mqtt_send_header(c, MQTT_CMD_PUBCOMP, 0, remaining_len);
+            mg_send(c, &id, sizeof(id));
             break;
           }
         }
@@ -3380,7 +3750,6 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
     }
   }
   (void) ev_data;
-  (void) fn_data;
 }
 
 void mg_mqtt_ping(struct mg_connection *nc) {
@@ -3435,6 +3804,7 @@ struct mg_connection *mg_mqtt_listen(struct mg_mgr *mgr, const char *url,
 
 
 
+
 size_t mg_vprintf(struct mg_connection *c, const char *fmt, va_list *ap) {
   size_t old = c->send.len;
   mg_vxprintf(mg_pfn_iobuf, &c->send, fmt, ap);
@@ -3451,15 +3821,16 @@ size_t mg_printf(struct mg_connection *c, const char *fmt, ...) {
 }
 
 static bool mg_atonl(struct mg_str str, struct mg_addr *addr) {
-  if (mg_vcasecmp(&str, "localhost") != 0) return false;
-  addr->ip = mg_htonl(0x7f000001);
+  uint32_t localhost = mg_htonl(0x7f000001);
+  if (mg_strcasecmp(str, mg_str("localhost")) != 0) return false;
+  memcpy(addr->ip, &localhost, sizeof(uint32_t));
   addr->is_ip6 = false;
   return true;
 }
 
 static bool mg_atone(struct mg_str str, struct mg_addr *addr) {
   if (str.len > 0) return false;
-  addr->ip = 0;
+  memset(addr->ip, 0, sizeof(addr->ip));
   addr->is_ip6 = false;
   return true;
 }
@@ -3468,18 +3839,18 @@ static bool mg_aton4(struct mg_str str, struct mg_addr *addr) {
   uint8_t data[4] = {0, 0, 0, 0};
   size_t i, num_dots = 0;
   for (i = 0; i < str.len; i++) {
-    if (str.ptr[i] >= '0' && str.ptr[i] <= '9') {
-      int octet = data[num_dots] * 10 + (str.ptr[i] - '0');
+    if (str.buf[i] >= '0' && str.buf[i] <= '9') {
+      int octet = data[num_dots] * 10 + (str.buf[i] - '0');
       if (octet > 255) return false;
       data[num_dots] = (uint8_t) octet;
-    } else if (str.ptr[i] == '.') {
-      if (num_dots >= 3 || i == 0 || str.ptr[i - 1] == '.') return false;
+    } else if (str.buf[i] == '.') {
+      if (num_dots >= 3 || i == 0 || str.buf[i - 1] == '.') return false;
       num_dots++;
     } else {
       return false;
     }
   }
-  if (num_dots != 3 || str.ptr[i - 1] == '.') return false;
+  if (num_dots != 3 || str.buf[i - 1] == '.') return false;
   memcpy(&addr->ip, data, sizeof(data));
   addr->is_ip6 = false;
   return true;
@@ -3487,58 +3858,66 @@ static bool mg_aton4(struct mg_str str, struct mg_addr *addr) {
 
 static bool mg_v4mapped(struct mg_str str, struct mg_addr *addr) {
   int i;
+  uint32_t ipv4;
   if (str.len < 14) return false;
-  if (str.ptr[0] != ':' || str.ptr[1] != ':' || str.ptr[6] != ':') return false;
+  if (str.buf[0] != ':' || str.buf[1] != ':' || str.buf[6] != ':') return false;
   for (i = 2; i < 6; i++) {
-    if (str.ptr[i] != 'f' && str.ptr[i] != 'F') return false;
+    if (str.buf[i] != 'f' && str.buf[i] != 'F') return false;
   }
-  if (!mg_aton4(mg_str_n(&str.ptr[7], str.len - 7), addr)) return false;
-  memset(addr->ip6, 0, sizeof(addr->ip6));
-  addr->ip6[10] = addr->ip6[11] = 255;
-  memcpy(&addr->ip6[12], &addr->ip, 4);
+  // struct mg_str s = mg_str_n(&str.buf[7], str.len - 7);
+  if (!mg_aton4(mg_str_n(&str.buf[7], str.len - 7), addr)) return false;
+  memcpy(&ipv4, addr->ip, sizeof(ipv4));
+  memset(addr->ip, 0, sizeof(addr->ip));
+  addr->ip[10] = addr->ip[11] = 255;
+  memcpy(&addr->ip[12], &ipv4, 4);
   addr->is_ip6 = true;
   return true;
 }
 
 static bool mg_aton6(struct mg_str str, struct mg_addr *addr) {
   size_t i, j = 0, n = 0, dc = 42;
-  if (str.len > 2 && str.ptr[0] == '[') str.ptr++, str.len -= 2;
+  addr->scope_id = 0;
+  if (str.len > 2 && str.buf[0] == '[') str.buf++, str.len -= 2;
   if (mg_v4mapped(str, addr)) return true;
   for (i = 0; i < str.len; i++) {
-    if ((str.ptr[i] >= '0' && str.ptr[i] <= '9') ||
-        (str.ptr[i] >= 'a' && str.ptr[i] <= 'f') ||
-        (str.ptr[i] >= 'A' && str.ptr[i] <= 'F')) {
-      unsigned long val;
+    if ((str.buf[i] >= '0' && str.buf[i] <= '9') ||
+        (str.buf[i] >= 'a' && str.buf[i] <= 'f') ||
+        (str.buf[i] >= 'A' && str.buf[i] <= 'F')) {
+      unsigned long val = 0;  // TODO(): This loops on chars, refactor
       if (i > j + 3) return false;
-      // MG_DEBUG(("%zu %zu [%.*s]", i, j, (int) (i - j + 1), &str.ptr[j]));
-      val = mg_unhexn(&str.ptr[j], i - j + 1);
-      addr->ip6[n] = (uint8_t) ((val >> 8) & 255);
-      addr->ip6[n + 1] = (uint8_t) (val & 255);
-    } else if (str.ptr[i] == ':') {
+      // MG_DEBUG(("%lu %lu [%.*s]", i, j, (int) (i - j + 1), &str.buf[j]));
+      mg_str_to_num(mg_str_n(&str.buf[j], i - j + 1), 16, &val, sizeof(val));
+      addr->ip[n] = (uint8_t) ((val >> 8) & 255);
+      addr->ip[n + 1] = (uint8_t) (val & 255);
+    } else if (str.buf[i] == ':') {
       j = i + 1;
-      if (i > 0 && str.ptr[i - 1] == ':') {
+      if (i > 0 && str.buf[i - 1] == ':') {
         dc = n;  // Double colon
-        if (i > 1 && str.ptr[i - 2] == ':') return false;
+        if (i > 1 && str.buf[i - 2] == ':') return false;
       } else if (i > 0) {
         n += 2;
       }
       if (n > 14) return false;
-      addr->ip6[n] = addr->ip6[n + 1] = 0;  // For trailing ::
+      addr->ip[n] = addr->ip[n + 1] = 0;  // For trailing ::
+    } else if (str.buf[i] == '%') {       // Scope ID, last in string
+      return mg_str_to_num(mg_str_n(&str.buf[i + 1], str.len - i - 1), 10,
+                           &addr->scope_id, sizeof(uint8_t));
     } else {
       return false;
     }
   }
   if (n < 14 && dc == 42) return false;
   if (n < 14) {
-    memmove(&addr->ip6[dc + (14 - n)], &addr->ip6[dc], n - dc + 2);
-    memset(&addr->ip6[dc], 0, 14 - n);
+    memmove(&addr->ip[dc + (14 - n)], &addr->ip[dc], n - dc + 2);
+    memset(&addr->ip[dc], 0, 14 - n);
   }
+
   addr->is_ip6 = true;
   return true;
 }
 
 bool mg_aton(struct mg_str str, struct mg_addr *addr) {
-  // MG_INFO(("[%.*s]", (int) str.len, str.ptr));
+  // MG_INFO(("[%.*s]", (int) str.len, str.buf));
   return mg_atone(str, addr) || mg_atonl(str, addr) || mg_aton4(str, addr) ||
          mg_aton6(str, addr);
 }
@@ -3548,8 +3927,9 @@ struct mg_connection *mg_alloc_conn(struct mg_mgr *mgr) {
       (struct mg_connection *) calloc(1, sizeof(*c) + mgr->extraconnsize);
   if (c != NULL) {
     c->mgr = mgr;
-    c->send.align = c->recv.align = MG_IO_SIZE;
+    c->send.align = c->recv.align = c->rtls.align = MG_IO_SIZE;
     c->id = ++mgr->nextid;
+    MG_PROF_INIT(c);
   }
   return c;
 }
@@ -3562,12 +3942,15 @@ void mg_close_conn(struct mg_connection *c) {
   // Order of operations is important. `MG_EV_CLOSE` event must be fired
   // before we deallocate received data, see #1331
   mg_call(c, MG_EV_CLOSE, NULL);
-  MG_DEBUG(("%lu %p closed", c->id, c->fd));
+  MG_DEBUG(("%lu %ld closed", c->id, c->fd));
+  MG_PROF_DUMP(c);
+  MG_PROF_FREE(c);
 
   mg_tls_free(c);
   mg_iobuf_free(&c->recv);
   mg_iobuf_free(&c->send);
-  memset(c, 0, sizeof(*c));
+  mg_iobuf_free(&c->rtls);
+  mg_bzero((unsigned char *) c, sizeof(*c));
   free(c);
 }
 
@@ -3585,8 +3968,8 @@ struct mg_connection *mg_connect(struct mg_mgr *mgr, const char *url,
     c->fn = fn;
     c->is_client = true;
     c->fn_data = fn_data;
-    MG_DEBUG(("%lu %p %s", c->id, c->fd, url));
-    mg_call(c, MG_EV_OPEN, NULL);
+    MG_DEBUG(("%lu %ld %s", c->id, c->fd, url));
+    mg_call(c, MG_EV_OPEN, (void *) url);
     mg_resolve(c, url);
   }
   return c;
@@ -3599,6 +3982,7 @@ struct mg_connection *mg_listen(struct mg_mgr *mgr, const char *url,
     MG_ERROR(("OOM %s", url));
   } else if (!mg_open_listener(c, url)) {
     MG_ERROR(("Failed: %s, errno %d", url, errno));
+    MG_PROF_FREE(c);
     free(c);
     c = NULL;
   } else {
@@ -3608,7 +3992,8 @@ struct mg_connection *mg_listen(struct mg_mgr *mgr, const char *url,
     c->fn = fn;
     c->fn_data = fn_data;
     mg_call(c, MG_EV_OPEN, NULL);
-    MG_DEBUG(("%lu %p %s", c->id, c->fd, url));
+    if (mg_url_is_ssl(url)) c->is_tls = 1;  // Accepted connection must
+    MG_DEBUG(("%lu %ld %s", c->id, c->fd, url));
   }
   return c;
 }
@@ -3637,6 +4022,14 @@ struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
   return t;
 }
 
+long mg_io_recv(struct mg_connection *c, void *buf, size_t len) {
+  if (c->rtls.len == 0) return MG_IO_WAIT;
+  if (len > c->rtls.len) len = c->rtls.len;
+  memcpy(buf, c->rtls.buf, len);
+  mg_iobuf_del(&c->rtls, 0, len);
+  return (long) len;
+}
+
 void mg_mgr_free(struct mg_mgr *mgr) {
   struct mg_connection *c;
   struct mg_timer *tmp, *t = mgr->timers;
@@ -3651,12 +4044,14 @@ void mg_mgr_free(struct mg_mgr *mgr) {
 #if MG_ENABLE_EPOLL
   if (mgr->epoll_fd >= 0) close(mgr->epoll_fd), mgr->epoll_fd = -1;
 #endif
+  mg_tls_ctx_free(mgr);
 }
 
 void mg_mgr_init(struct mg_mgr *mgr) {
   memset(mgr, 0, sizeof(*mgr));
 #if MG_ENABLE_EPOLL
-  if ((mgr->epoll_fd = epoll_create1(0)) < 0) MG_ERROR(("epoll: %d", errno));
+  if ((mgr->epoll_fd = epoll_create1(EPOLL_CLOEXEC)) < 0)
+    MG_ERROR(("epoll_create1 errno %d", errno));
 #else
   mgr->epoll_fd = -1;
 #endif
@@ -3670,11 +4065,2833 @@ void mg_mgr_init(struct mg_mgr *mgr) {
   // Ignore SIGPIPE signal, so if client cancels the request, it
   // won't kill the whole process.
   signal(SIGPIPE, SIG_IGN);
+#elif MG_ENABLE_TCPIP_DRIVER_INIT && defined(MG_TCPIP_DRIVER_INIT)
+  MG_TCPIP_DRIVER_INIT(mgr);
 #endif
+  mgr->pipe = MG_INVALID_SOCKET;
   mgr->dnstimeout = 3000;
   mgr->dns4.url = "udp://8.8.8.8:53";
   mgr->dns6.url = "udp://[2001:4860:4860::8888]:53";
+  mg_tls_ctx_init(mgr);
 }
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/net_builtin.c"
+#endif
+
+
+#if defined(MG_ENABLE_TCPIP) && MG_ENABLE_TCPIP
+#define MG_EPHEMERAL_PORT_BASE 32768
+#define PDIFF(a, b) ((size_t) (((char *) (b)) - ((char *) (a))))
+
+#ifndef MIP_TCP_KEEPALIVE_MS
+#define MIP_TCP_KEEPALIVE_MS 45000  // TCP keep-alive period, ms
+#endif
+
+#define MIP_TCP_ACK_MS 150    // Timeout for ACKing
+#define MIP_ARP_RESP_MS 100   // Timeout for ARP response
+#define MIP_TCP_SYN_MS 15000  // Timeout for connection establishment
+#define MIP_TCP_FIN_MS 1000   // Timeout for closing connection
+#define MIP_TCP_WIN 6000      // TCP window size
+
+struct connstate {
+  uint32_t seq, ack;           // TCP seq/ack counters
+  uint64_t timer;              // TCP keep-alive / ACK timer
+  uint32_t acked;              // Last ACK-ed number
+  size_t unacked;              // Not acked bytes
+  uint8_t mac[6];              // Peer MAC address
+  uint8_t ttype;               // Timer type. 0: ack, 1: keep-alive
+#define MIP_TTYPE_KEEPALIVE 0  // Connection is idle for long, send keepalive
+#define MIP_TTYPE_ACK 1        // Peer sent us data, we have to ack it soon
+#define MIP_TTYPE_ARP 2        // ARP resolve sent, waiting for response
+#define MIP_TTYPE_SYN 3        // SYN sent, waiting for response
+#define MIP_TTYPE_FIN 4  // FIN sent, waiting until terminating the connection
+  uint8_t tmiss;         // Number of keep-alive misses
+  struct mg_iobuf raw;   // For TLS only. Incoming raw data
+  bool fin_rcvd;         // We have received FIN from the peer
+  bool twclosure;        // 3-way closure done
+};
+
+#pragma pack(push, 1)
+
+struct lcp {
+  uint8_t addr, ctrl, proto[2], code, id, len[2];
+};
+
+struct eth {
+  uint8_t dst[6];  // Destination MAC address
+  uint8_t src[6];  // Source MAC address
+  uint16_t type;   // Ethernet type
+};
+
+struct ip {
+  uint8_t ver;    // Version
+  uint8_t tos;    // Unused
+  uint16_t len;   // Length
+  uint16_t id;    // Unused
+  uint16_t frag;  // Fragmentation
+#define IP_FRAG_OFFSET_MSK 0x1fff
+#define IP_MORE_FRAGS_MSK 0x2000
+  uint8_t ttl;    // Time to live
+  uint8_t proto;  // Upper level protocol
+  uint16_t csum;  // Checksum
+  uint32_t src;   // Source IP
+  uint32_t dst;   // Destination IP
+};
+
+struct ip6 {
+  uint8_t ver;      // Version
+  uint8_t opts[3];  // Options
+  uint16_t len;     // Length
+  uint8_t proto;    // Upper level protocol
+  uint8_t ttl;      // Time to live
+  uint8_t src[16];  // Source IP
+  uint8_t dst[16];  // Destination IP
+};
+
+struct icmp {
+  uint8_t type;
+  uint8_t code;
+  uint16_t csum;
+};
+
+struct arp {
+  uint16_t fmt;    // Format of hardware address
+  uint16_t pro;    // Format of protocol address
+  uint8_t hlen;    // Length of hardware address
+  uint8_t plen;    // Length of protocol address
+  uint16_t op;     // Operation
+  uint8_t sha[6];  // Sender hardware address
+  uint32_t spa;    // Sender protocol address
+  uint8_t tha[6];  // Target hardware address
+  uint32_t tpa;    // Target protocol address
+};
+
+struct tcp {
+  uint16_t sport;  // Source port
+  uint16_t dport;  // Destination port
+  uint32_t seq;    // Sequence number
+  uint32_t ack;    // Acknowledgement number
+  uint8_t off;     // Data offset
+  uint8_t flags;   // TCP flags
+#define TH_FIN 0x01
+#define TH_SYN 0x02
+#define TH_RST 0x04
+#define TH_PUSH 0x08
+#define TH_ACK 0x10
+#define TH_URG 0x20
+#define TH_ECE 0x40
+#define TH_CWR 0x80
+  uint16_t win;   // Window
+  uint16_t csum;  // Checksum
+  uint16_t urp;   // Urgent pointer
+};
+
+struct udp {
+  uint16_t sport;  // Source port
+  uint16_t dport;  // Destination port
+  uint16_t len;    // UDP length
+  uint16_t csum;   // UDP checksum
+};
+
+struct dhcp {
+  uint8_t op, htype, hlen, hops;
+  uint32_t xid;
+  uint16_t secs, flags;
+  uint32_t ciaddr, yiaddr, siaddr, giaddr;
+  uint8_t hwaddr[208];
+  uint32_t magic;
+  uint8_t options[32];
+};
+
+#pragma pack(pop)
+
+struct pkt {
+  struct mg_str raw;  // Raw packet data
+  struct mg_str pay;  // Payload data
+  struct eth *eth;
+  struct llc *llc;
+  struct arp *arp;
+  struct ip *ip;
+  struct ip6 *ip6;
+  struct icmp *icmp;
+  struct tcp *tcp;
+  struct udp *udp;
+  struct dhcp *dhcp;
+};
+
+static void mg_tcpip_call(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
+  if (ifp->fn != NULL) ifp->fn(ifp, ev, ev_data);
+}
+
+static void send_syn(struct mg_connection *c);
+
+static void mkpay(struct pkt *pkt, void *p) {
+  pkt->pay =
+      mg_str_n((char *) p, (size_t) (&pkt->raw.buf[pkt->raw.len] - (char *) p));
+}
+
+static uint32_t csumup(uint32_t sum, const void *buf, size_t len) {
+  size_t i;
+  const uint8_t *p = (const uint8_t *) buf;
+  for (i = 0; i < len; i++) sum += i & 1 ? p[i] : ((uint32_t) p[i]) << 8;
+  return sum;
+}
+
+static uint16_t csumfin(uint32_t sum) {
+  while (sum >> 16) sum = (sum & 0xffff) + (sum >> 16);
+  return mg_htons(~sum & 0xffff);
+}
+
+static uint16_t ipcsum(const void *buf, size_t len) {
+  uint32_t sum = csumup(0, buf, len);
+  return csumfin(sum);
+}
+
+static void settmout(struct mg_connection *c, uint8_t type) {
+  struct mg_tcpip_if *ifp = c->mgr->ifp;
+  struct connstate *s = (struct connstate *) (c + 1);
+  unsigned n = type == MIP_TTYPE_ACK   ? MIP_TCP_ACK_MS
+               : type == MIP_TTYPE_ARP ? MIP_ARP_RESP_MS
+               : type == MIP_TTYPE_SYN ? MIP_TCP_SYN_MS
+               : type == MIP_TTYPE_FIN ? MIP_TCP_FIN_MS
+                                       : MIP_TCP_KEEPALIVE_MS;
+  s->timer = ifp->now + n;
+  s->ttype = type;
+  MG_VERBOSE(("%lu %d -> %llx", c->id, type, s->timer));
+}
+
+static size_t ether_output(struct mg_tcpip_if *ifp, size_t len) {
+  size_t n = ifp->driver->tx(ifp->tx.buf, len, ifp);
+  if (n == len) ifp->nsent++;
+  return n;
+}
+
+void mg_tcpip_arp_request(struct mg_tcpip_if *ifp, uint32_t ip, uint8_t *mac) {
+  struct eth *eth = (struct eth *) ifp->tx.buf;
+  struct arp *arp = (struct arp *) (eth + 1);
+  memset(eth->dst, 255, sizeof(eth->dst));
+  memcpy(eth->src, ifp->mac, sizeof(eth->src));
+  eth->type = mg_htons(0x806);
+  memset(arp, 0, sizeof(*arp));
+  arp->fmt = mg_htons(1), arp->pro = mg_htons(0x800), arp->hlen = 6,
+  arp->plen = 4;
+  arp->op = mg_htons(1), arp->tpa = ip, arp->spa = ifp->ip;
+  memcpy(arp->sha, ifp->mac, sizeof(arp->sha));
+  if (mac != NULL) memcpy(arp->tha, mac, sizeof(arp->tha));
+  ether_output(ifp, PDIFF(eth, arp + 1));
+}
+
+static void onstatechange(struct mg_tcpip_if *ifp) {
+  if (ifp->state == MG_TCPIP_STATE_READY) {
+    MG_INFO(("READY, IP: %M", mg_print_ip4, &ifp->ip));
+    MG_INFO(("       GW: %M", mg_print_ip4, &ifp->gw));
+    MG_INFO(("      MAC: %M", mg_print_mac, &ifp->mac));
+  } else if (ifp->state == MG_TCPIP_STATE_IP) {
+    MG_ERROR(("Got IP"));
+    mg_tcpip_arp_request(ifp, ifp->gw, NULL);  // unsolicited GW ARP request
+  } else if (ifp->state == MG_TCPIP_STATE_UP) {
+    MG_ERROR(("Link up"));
+    srand((unsigned int) mg_millis());
+  } else if (ifp->state == MG_TCPIP_STATE_DOWN) {
+    MG_ERROR(("Link down"));
+  }
+  mg_tcpip_call(ifp, MG_TCPIP_EV_ST_CHG, &ifp->state);
+}
+
+static struct ip *tx_ip(struct mg_tcpip_if *ifp, uint8_t *mac_dst,
+                        uint8_t proto, uint32_t ip_src, uint32_t ip_dst,
+                        size_t plen) {
+  struct eth *eth = (struct eth *) ifp->tx.buf;
+  struct ip *ip = (struct ip *) (eth + 1);
+  memcpy(eth->dst, mac_dst, sizeof(eth->dst));
+  memcpy(eth->src, ifp->mac, sizeof(eth->src));  // Use our MAC
+  eth->type = mg_htons(0x800);
+  memset(ip, 0, sizeof(*ip));
+  ip->ver = 0x45;               // Version 4, header length 5 words
+  ip->frag = mg_htons(0x4000);  // Don't fragment
+  ip->len = mg_htons((uint16_t) (sizeof(*ip) + plen));
+  ip->ttl = 64;
+  ip->proto = proto;
+  ip->src = ip_src;
+  ip->dst = ip_dst;
+  ip->csum = ipcsum(ip, sizeof(*ip));
+  return ip;
+}
+
+static void tx_udp(struct mg_tcpip_if *ifp, uint8_t *mac_dst, uint32_t ip_src,
+                   uint16_t sport, uint32_t ip_dst, uint16_t dport,
+                   const void *buf, size_t len) {
+  struct ip *ip =
+      tx_ip(ifp, mac_dst, 17, ip_src, ip_dst, len + sizeof(struct udp));
+  struct udp *udp = (struct udp *) (ip + 1);
+  // MG_DEBUG(("UDP XX LEN %d %d", (int) len, (int) ifp->tx.len));
+  udp->sport = sport;
+  udp->dport = dport;
+  udp->len = mg_htons((uint16_t) (sizeof(*udp) + len));
+  udp->csum = 0;
+  uint32_t cs = csumup(0, udp, sizeof(*udp));
+  cs = csumup(cs, buf, len);
+  cs = csumup(cs, &ip->src, sizeof(ip->src));
+  cs = csumup(cs, &ip->dst, sizeof(ip->dst));
+  cs += (uint32_t) (ip->proto + sizeof(*udp) + len);
+  udp->csum = csumfin(cs);
+  memmove(udp + 1, buf, len);
+  // MG_DEBUG(("UDP LEN %d %d", (int) len, (int) ifp->frame_len));
+  ether_output(ifp, sizeof(struct eth) + sizeof(*ip) + sizeof(*udp) + len);
+}
+
+static void tx_dhcp(struct mg_tcpip_if *ifp, uint8_t *mac_dst, uint32_t ip_src,
+                    uint32_t ip_dst, uint8_t *opts, size_t optslen,
+                    bool ciaddr) {
+  // https://datatracker.ietf.org/doc/html/rfc2132#section-9.6
+  struct dhcp dhcp = {1, 1, 6, 0, 0, 0, 0, 0, 0, 0, 0, {0}, 0, {0}};
+  dhcp.magic = mg_htonl(0x63825363);
+  memcpy(&dhcp.hwaddr, ifp->mac, sizeof(ifp->mac));
+  memcpy(&dhcp.xid, ifp->mac + 2, sizeof(dhcp.xid));
+  memcpy(&dhcp.options, opts, optslen);
+  if (ciaddr) dhcp.ciaddr = ip_src;
+  tx_udp(ifp, mac_dst, ip_src, mg_htons(68), ip_dst, mg_htons(67), &dhcp,
+         sizeof(dhcp));
+}
+
+static const uint8_t broadcast[] = {255, 255, 255, 255, 255, 255};
+
+// RFC-2131 #4.3.6, #4.4.1; RFC-2132 #9.8
+static void tx_dhcp_request_sel(struct mg_tcpip_if *ifp, uint32_t ip_req,
+                                uint32_t ip_srv) {
+  uint8_t opts[] = {
+      53, 1, 3,                   // Type: DHCP request
+      12, 3, 'm', 'i', 'p',       // Host name: "mip"
+      54, 4, 0,   0,   0,   0,    // DHCP server ID
+      50, 4, 0,   0,   0,   0,    // Requested IP
+      55, 2, 1,   3,   255, 255,  // GW, mask [DNS] [SNTP]
+      255                         // End of options
+  };
+  uint8_t addopts = 0;
+  memcpy(opts + 10, &ip_srv, sizeof(ip_srv));
+  memcpy(opts + 16, &ip_req, sizeof(ip_req));
+  if (ifp->enable_req_dns) opts[24 + addopts++] = 6;    // DNS
+  if (ifp->enable_req_sntp) opts[24 + addopts++] = 42;  // SNTP
+  opts[21] += addopts;
+  tx_dhcp(ifp, (uint8_t *) broadcast, 0, 0xffffffff, opts,
+          sizeof(opts) + addopts - 2, false);
+  MG_DEBUG(("DHCP req sent"));
+}
+
+// RFC-2131 #4.3.6, #4.4.5 (renewing: unicast, rebinding: bcast)
+static void tx_dhcp_request_re(struct mg_tcpip_if *ifp, uint8_t *mac_dst,
+                               uint32_t ip_src, uint32_t ip_dst) {
+  uint8_t opts[] = {
+      53, 1, 3,  // Type: DHCP request
+      255        // End of options
+  };
+  tx_dhcp(ifp, mac_dst, ip_src, ip_dst, opts, sizeof(opts), true);
+  MG_DEBUG(("DHCP req sent"));
+}
+
+static void tx_dhcp_discover(struct mg_tcpip_if *ifp) {
+  uint8_t opts[] = {
+      53, 1, 1,     // Type: DHCP discover
+      55, 2, 1, 3,  // Parameters: ip, mask
+      255           // End of options
+  };
+  tx_dhcp(ifp, (uint8_t *) broadcast, 0, 0xffffffff, opts, sizeof(opts), false);
+  MG_DEBUG(("DHCP discover sent. Our MAC: %M", mg_print_mac, ifp->mac));
+}
+
+static struct mg_connection *getpeer(struct mg_mgr *mgr, struct pkt *pkt,
+                                     bool lsn) {
+  struct mg_connection *c = NULL;
+  for (c = mgr->conns; c != NULL; c = c->next) {
+    if (c->is_arplooking && pkt->arp &&
+        memcmp(&pkt->arp->spa, c->rem.ip, sizeof(pkt->arp->spa)) == 0)
+      break;
+    if (c->is_udp && pkt->udp && c->loc.port == pkt->udp->dport) break;
+    if (!c->is_udp && pkt->tcp && c->loc.port == pkt->tcp->dport &&
+        lsn == c->is_listening && (lsn || c->rem.port == pkt->tcp->sport))
+      break;
+  }
+  return c;
+}
+
+static void mac_resolved(struct mg_connection *c);
+
+static void rx_arp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  if (pkt->arp->op == mg_htons(1) && pkt->arp->tpa == ifp->ip) {
+    // ARP request. Make a response, then send
+    // MG_DEBUG(("ARP op %d %M: %M", mg_ntohs(pkt->arp->op), mg_print_ip4,
+    //          &pkt->arp->spa, mg_print_ip4, &pkt->arp->tpa));
+    struct eth *eth = (struct eth *) ifp->tx.buf;
+    struct arp *arp = (struct arp *) (eth + 1);
+    memcpy(eth->dst, pkt->eth->src, sizeof(eth->dst));
+    memcpy(eth->src, ifp->mac, sizeof(eth->src));
+    eth->type = mg_htons(0x806);
+    *arp = *pkt->arp;
+    arp->op = mg_htons(2);
+    memcpy(arp->tha, pkt->arp->sha, sizeof(pkt->arp->tha));
+    memcpy(arp->sha, ifp->mac, sizeof(pkt->arp->sha));
+    arp->tpa = pkt->arp->spa;
+    arp->spa = ifp->ip;
+    MG_DEBUG(("ARP: tell %M we're %M", mg_print_ip4, &arp->tpa, mg_print_mac,
+              &ifp->mac));
+    ether_output(ifp, PDIFF(eth, arp + 1));
+  } else if (pkt->arp->op == mg_htons(2)) {
+    if (memcmp(pkt->arp->tha, ifp->mac, sizeof(pkt->arp->tha)) != 0) return;
+    if (pkt->arp->spa == ifp->gw) {
+      // Got response for the GW ARP request. Set ifp->gwmac and IP -> READY
+      memcpy(ifp->gwmac, pkt->arp->sha, sizeof(ifp->gwmac));
+      if (ifp->state == MG_TCPIP_STATE_IP) {
+        ifp->state = MG_TCPIP_STATE_READY;
+        onstatechange(ifp);
+      }
+    } else {
+      struct mg_connection *c = getpeer(ifp->mgr, pkt, false);
+      if (c != NULL && c->is_arplooking) {
+        struct connstate *s = (struct connstate *) (c + 1);
+        memcpy(s->mac, pkt->arp->sha, sizeof(s->mac));
+        MG_DEBUG(("%lu ARP resolved %M -> %M", c->id, mg_print_ip4, c->rem.ip,
+                  mg_print_mac, s->mac));
+        c->is_arplooking = 0;
+        mac_resolved(c);
+      }
+    }
+  }
+}
+
+static void rx_icmp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  // MG_DEBUG(("ICMP %d", (int) len));
+  if (pkt->icmp->type == 8 && pkt->ip != NULL && pkt->ip->dst == ifp->ip) {
+    size_t hlen = sizeof(struct eth) + sizeof(struct ip) + sizeof(struct icmp);
+    size_t space = ifp->tx.len - hlen, plen = pkt->pay.len;
+    if (plen > space) plen = space;
+    struct ip *ip = tx_ip(ifp, pkt->eth->src, 1, ifp->ip, pkt->ip->src,
+                          sizeof(struct icmp) + plen);
+    struct icmp *icmp = (struct icmp *) (ip + 1);
+    memset(icmp, 0, sizeof(*icmp));        // Set csum to 0
+    memcpy(icmp + 1, pkt->pay.buf, plen);  // Copy RX payload to TX
+    icmp->csum = ipcsum(icmp, sizeof(*icmp) + plen);
+    ether_output(ifp, hlen + plen);
+  }
+}
+
+static void rx_dhcp_client(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  uint32_t ip = 0, gw = 0, mask = 0, lease = 0, dns = 0, sntp = 0;
+  uint8_t msgtype = 0, state = ifp->state;
+  // perform size check first, then access fields
+  uint8_t *p = pkt->dhcp->options,
+          *end = (uint8_t *) &pkt->raw.buf[pkt->raw.len];
+  if (end < (uint8_t *) (pkt->dhcp + 1)) return;
+  if (memcmp(&pkt->dhcp->xid, ifp->mac + 2, sizeof(pkt->dhcp->xid))) return;
+  while (p + 1 < end && p[0] != 255) {  // Parse options RFC-1533 #9
+    if (p[0] == 1 && p[1] == sizeof(ifp->mask) && p + 6 < end) {  // Mask
+      memcpy(&mask, p + 2, sizeof(mask));
+    } else if (p[0] == 3 && p[1] == sizeof(ifp->gw) && p + 6 < end) {  // GW
+      memcpy(&gw, p + 2, sizeof(gw));
+      ip = pkt->dhcp->yiaddr;
+    } else if (ifp->enable_req_dns && p[0] == 6 && p[1] == sizeof(dns) &&
+               p + 6 < end) {  // DNS
+      memcpy(&dns, p + 2, sizeof(dns));
+    } else if (ifp->enable_req_sntp && p[0] == 42 && p[1] == sizeof(sntp) &&
+               p + 6 < end) {  // SNTP
+      memcpy(&sntp, p + 2, sizeof(sntp));
+    } else if (p[0] == 51 && p[1] == 4 && p + 6 < end) {  // Lease
+      memcpy(&lease, p + 2, sizeof(lease));
+      lease = mg_ntohl(lease);
+    } else if (p[0] == 53 && p[1] == 1 && p + 6 < end) {  // Msg Type
+      msgtype = p[2];
+    }
+    p += p[1] + 2;
+  }
+  // Process message type, RFC-1533 (9.4); RFC-2131 (3.1, 4)
+  if (msgtype == 6 && ifp->ip == ip) {  // DHCPNACK, release IP
+    ifp->state = MG_TCPIP_STATE_UP, ifp->ip = 0;
+  } else if (msgtype == 2 && ifp->state == MG_TCPIP_STATE_UP && ip && gw &&
+             lease) {  // DHCPOFFER
+    // select IP, (4.4.1) (fallback to IP source addr on foul play)
+    tx_dhcp_request_sel(ifp, ip,
+                        pkt->dhcp->siaddr ? pkt->dhcp->siaddr : pkt->ip->src);
+    ifp->state = MG_TCPIP_STATE_REQ;  // REQUESTING state
+  } else if (msgtype == 5) {          // DHCPACK
+    if (ifp->state == MG_TCPIP_STATE_REQ && ip && gw && lease) {  // got an IP
+      ifp->lease_expire = ifp->now + lease * 1000;
+      MG_INFO(("Lease: %u sec (%lld)", lease, ifp->lease_expire / 1000));
+      // assume DHCP server = router until ARP resolves
+      memcpy(ifp->gwmac, pkt->eth->src, sizeof(ifp->gwmac));
+      ifp->ip = ip, ifp->gw = gw, ifp->mask = mask;
+      ifp->state = MG_TCPIP_STATE_IP;  // BOUND state
+      uint64_t rand;
+      mg_random(&rand, sizeof(rand));
+      srand((unsigned int) (rand + mg_millis()));
+      if (ifp->enable_req_dns && dns != 0)
+        mg_tcpip_call(ifp, MG_TCPIP_EV_DHCP_DNS, &dns);
+      if (ifp->enable_req_sntp && sntp != 0)
+        mg_tcpip_call(ifp, MG_TCPIP_EV_DHCP_SNTP, &sntp);
+    } else if (ifp->state == MG_TCPIP_STATE_READY && ifp->ip == ip) {  // renew
+      ifp->lease_expire = ifp->now + lease * 1000;
+      MG_INFO(("Lease: %u sec (%lld)", lease, ifp->lease_expire / 1000));
+    }  // TODO(): accept provided T1/T2 and store server IP for renewal (4.4)
+  }
+  if (ifp->state != state) onstatechange(ifp);
+}
+
+// Simple DHCP server that assigns a next IP address: ifp->ip + 1
+static void rx_dhcp_server(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  uint8_t op = 0, *p = pkt->dhcp->options,
+          *end = (uint8_t *) &pkt->raw.buf[pkt->raw.len];
+  if (end < (uint8_t *) (pkt->dhcp + 1)) return;
+  // struct dhcp *req = pkt->dhcp;
+  struct dhcp res = {2, 1, 6, 0, 0, 0, 0, 0, 0, 0, 0, {0}, 0, {0}};
+  res.yiaddr = ifp->ip;
+  ((uint8_t *) (&res.yiaddr))[3]++;                // Offer our IP + 1
+  while (p + 1 < end && p[0] != 255) {             // Parse options
+    if (p[0] == 53 && p[1] == 1 && p + 2 < end) {  // Message type
+      op = p[2];
+    }
+    p += p[1] + 2;
+  }
+  if (op == 1 || op == 3) {         // DHCP Discover or DHCP Request
+    uint8_t msg = op == 1 ? 2 : 5;  // Message type: DHCP OFFER or DHCP ACK
+    uint8_t opts[] = {
+        53, 1, msg,                 // Message type
+        1,  4, 0,   0,   0,   0,    // Subnet mask
+        54, 4, 0,   0,   0,   0,    // Server ID
+        12, 3, 'm', 'i', 'p',       // Host name: "mip"
+        51, 4, 255, 255, 255, 255,  // Lease time
+        255                         // End of options
+    };
+    memcpy(&res.hwaddr, pkt->dhcp->hwaddr, 6);
+    memcpy(opts + 5, &ifp->mask, sizeof(ifp->mask));
+    memcpy(opts + 11, &ifp->ip, sizeof(ifp->ip));
+    memcpy(&res.options, opts, sizeof(opts));
+    res.magic = pkt->dhcp->magic;
+    res.xid = pkt->dhcp->xid;
+    if (ifp->enable_get_gateway) {
+      ifp->gw = res.yiaddr;  // set gw IP, best-effort gwmac as DHCP server's
+      memcpy(ifp->gwmac, pkt->eth->src, sizeof(ifp->gwmac));
+    }
+    tx_udp(ifp, pkt->eth->src, ifp->ip, mg_htons(67),
+           op == 1 ? ~0U : res.yiaddr, mg_htons(68), &res, sizeof(res));
+  }
+}
+
+static void rx_udp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  struct mg_connection *c = getpeer(ifp->mgr, pkt, true);
+  if (c == NULL) {
+    // No UDP listener on this port. Should send ICMP, but keep silent.
+  } else {
+    c->rem.port = pkt->udp->sport;
+    memcpy(c->rem.ip, &pkt->ip->src, sizeof(uint32_t));
+    struct connstate *s = (struct connstate *) (c + 1);
+    memcpy(s->mac, pkt->eth->src, sizeof(s->mac));
+    if (c->recv.len >= MG_MAX_RECV_SIZE) {
+      mg_error(c, "max_recv_buf_size reached");
+    } else if (c->recv.size - c->recv.len < pkt->pay.len &&
+               !mg_iobuf_resize(&c->recv, c->recv.len + pkt->pay.len)) {
+      mg_error(c, "oom");
+    } else {
+      memcpy(&c->recv.buf[c->recv.len], pkt->pay.buf, pkt->pay.len);
+      c->recv.len += pkt->pay.len;
+      mg_call(c, MG_EV_READ, &pkt->pay.len);
+    }
+  }
+}
+
+static size_t tx_tcp(struct mg_tcpip_if *ifp, uint8_t *dst_mac, uint32_t dst_ip,
+                     uint8_t flags, uint16_t sport, uint16_t dport,
+                     uint32_t seq, uint32_t ack, const void *buf, size_t len) {
+#if 0
+  uint8_t opts[] = {2, 4, 5, 0xb4, 4, 2, 0, 0};  // MSS = 1460, SACK permitted
+  if (flags & TH_SYN) {
+    // Handshake? Set MSS
+    buf = opts;
+    len = sizeof(opts);
+  }
+#endif
+  struct ip *ip =
+      tx_ip(ifp, dst_mac, 6, ifp->ip, dst_ip, sizeof(struct tcp) + len);
+  struct tcp *tcp = (struct tcp *) (ip + 1);
+  memset(tcp, 0, sizeof(*tcp));
+  if (buf != NULL && len) memmove(tcp + 1, buf, len);
+  tcp->sport = sport;
+  tcp->dport = dport;
+  tcp->seq = seq;
+  tcp->ack = ack;
+  tcp->flags = flags;
+  tcp->win = mg_htons(MIP_TCP_WIN);
+  tcp->off = (uint8_t) (sizeof(*tcp) / 4 << 4);
+  // if (flags & TH_SYN) tcp->off = 0x70;  // Handshake? header size 28 bytes
+
+  uint32_t cs = 0;
+  uint16_t n = (uint16_t) (sizeof(*tcp) + len);
+  uint8_t pseudo[] = {0, ip->proto, (uint8_t) (n >> 8), (uint8_t) (n & 255)};
+  cs = csumup(cs, tcp, n);
+  cs = csumup(cs, &ip->src, sizeof(ip->src));
+  cs = csumup(cs, &ip->dst, sizeof(ip->dst));
+  cs = csumup(cs, pseudo, sizeof(pseudo));
+  tcp->csum = csumfin(cs);
+  MG_VERBOSE(("TCP %M:%hu -> %M:%hu fl %x len %u", mg_print_ip4, &ip->src,
+              mg_ntohs(tcp->sport), mg_print_ip4, &ip->dst,
+              mg_ntohs(tcp->dport), tcp->flags, len));
+  // mg_hexdump(ifp->tx.buf, PDIFF(ifp->tx.buf, tcp + 1) + len);
+  return ether_output(ifp, PDIFF(ifp->tx.buf, tcp + 1) + len);
+}
+
+static size_t tx_tcp_pkt(struct mg_tcpip_if *ifp, struct pkt *pkt,
+                         uint8_t flags, uint32_t seq, const void *buf,
+                         size_t len) {
+  uint32_t delta = (pkt->tcp->flags & (TH_SYN | TH_FIN)) ? 1 : 0;
+  return tx_tcp(ifp, pkt->eth->src, pkt->ip->src, flags, pkt->tcp->dport,
+                pkt->tcp->sport, seq, mg_htonl(mg_ntohl(pkt->tcp->seq) + delta),
+                buf, len);
+}
+
+static struct mg_connection *accept_conn(struct mg_connection *lsn,
+                                         struct pkt *pkt) {
+  struct mg_connection *c = mg_alloc_conn(lsn->mgr);
+  if (c == NULL) {
+    MG_ERROR(("OOM"));
+    return NULL;
+  }
+  struct connstate *s = (struct connstate *) (c + 1);
+  s->seq = mg_ntohl(pkt->tcp->ack), s->ack = mg_ntohl(pkt->tcp->seq);
+  memcpy(s->mac, pkt->eth->src, sizeof(s->mac));
+  settmout(c, MIP_TTYPE_KEEPALIVE);
+  memcpy(c->rem.ip, &pkt->ip->src, sizeof(uint32_t));
+  c->rem.port = pkt->tcp->sport;
+  MG_DEBUG(("%lu accepted %M", c->id, mg_print_ip_port, &c->rem));
+  LIST_ADD_HEAD(struct mg_connection, &lsn->mgr->conns, c);
+  c->is_accepted = 1;
+  c->is_hexdumping = lsn->is_hexdumping;
+  c->pfn = lsn->pfn;
+  c->loc = lsn->loc;
+  c->pfn_data = lsn->pfn_data;
+  c->fn = lsn->fn;
+  c->fn_data = lsn->fn_data;
+  mg_call(c, MG_EV_OPEN, NULL);
+  mg_call(c, MG_EV_ACCEPT, NULL);
+  return c;
+}
+
+static size_t trim_len(struct mg_connection *c, size_t len) {
+  struct mg_tcpip_if *ifp = c->mgr->ifp;
+  size_t eth_h_len = 14, ip_max_h_len = 24, tcp_max_h_len = 60, udp_h_len = 8;
+  size_t max_headers_len =
+      eth_h_len + ip_max_h_len + (c->is_udp ? udp_h_len : tcp_max_h_len);
+  size_t min_mtu = c->is_udp ? 68 /* RFC-791 */ : max_headers_len - eth_h_len;
+
+  // If the frame exceeds the available buffer, trim the length
+  if (len + max_headers_len > ifp->tx.len) {
+    len = ifp->tx.len - max_headers_len;
+  }
+  // Ensure the MTU isn't lower than the minimum allowed value
+  if (ifp->mtu < min_mtu) {
+    MG_ERROR(("MTU is lower than minimum, capping to %lu", min_mtu));
+    ifp->mtu = (uint16_t) min_mtu;
+  }
+  // If the total packet size exceeds the MTU, trim the length
+  if (len + max_headers_len - eth_h_len > ifp->mtu) {
+    len = ifp->mtu - max_headers_len + eth_h_len;
+    if (c->is_udp) {
+      MG_ERROR(("UDP datagram exceeds MTU. Truncating it."));
+    }
+  }
+
+  return len;
+}
+
+long mg_io_send(struct mg_connection *c, const void *buf, size_t len) {
+  struct mg_tcpip_if *ifp = c->mgr->ifp;
+  struct connstate *s = (struct connstate *) (c + 1);
+  uint32_t dst_ip = *(uint32_t *) c->rem.ip;
+  len = trim_len(c, len);
+  if (c->is_udp) {
+    tx_udp(ifp, s->mac, ifp->ip, c->loc.port, dst_ip, c->rem.port, buf, len);
+  } else {
+    size_t sent =
+        tx_tcp(ifp, s->mac, dst_ip, TH_PUSH | TH_ACK, c->loc.port, c->rem.port,
+               mg_htonl(s->seq), mg_htonl(s->ack), buf, len);
+    if (sent == 0) {
+      return MG_IO_WAIT;
+    } else if (sent == (size_t) -1) {
+      return MG_IO_ERR;
+    } else {
+      s->seq += (uint32_t) len;
+      if (s->ttype == MIP_TTYPE_ACK) settmout(c, MIP_TTYPE_KEEPALIVE);
+    }
+  }
+  return (long) len;
+}
+
+static void handle_tls_recv(struct mg_connection *c) {
+  size_t avail = mg_tls_pending(c);
+  size_t min = avail > MG_MAX_RECV_SIZE ? MG_MAX_RECV_SIZE : avail;
+  struct mg_iobuf *io = &c->recv;
+  if (io->size - io->len < min && !mg_iobuf_resize(io, io->len + min)) {
+    mg_error(c, "oom");
+  } else {
+    // Decrypt data directly into c->recv
+    long n = mg_tls_recv(c, &io->buf[io->len], io->size - io->len);
+    if (n == MG_IO_ERR) {
+      mg_error(c, "TLS recv error");
+    } else if (n > 0) {
+      // Decrypted successfully - trigger MG_EV_READ
+      io->len += (size_t) n;
+      mg_call(c, MG_EV_READ, &n);
+    }  // else n < 0: outstanding data to be moved to c->recv
+  }
+}
+
+static void read_conn(struct mg_connection *c, struct pkt *pkt) {
+  struct connstate *s = (struct connstate *) (c + 1);
+  struct mg_iobuf *io = c->is_tls ? &c->rtls : &c->recv;
+  uint32_t seq = mg_ntohl(pkt->tcp->seq);
+  uint32_t rem_ip;
+  memcpy(&rem_ip, c->rem.ip, sizeof(uint32_t));
+  if (pkt->tcp->flags & TH_FIN) {
+    // If we initiated the closure, we reply with ACK upon receiving FIN
+    // If we didn't initiate it, we reply with FIN as part of the normal TCP
+    // closure process
+    uint8_t flags = TH_ACK;
+    s->ack = (uint32_t) (mg_htonl(pkt->tcp->seq) + pkt->pay.len + 1);
+    s->fin_rcvd = true;
+    if (c->is_draining && s->ttype == MIP_TTYPE_FIN) {
+      if (s->seq == mg_htonl(pkt->tcp->ack)) {  // Simultaneous closure ?
+        s->seq++;                               // Yes. Increment our SEQ
+      } else {                                  // Otherwise,
+        s->seq = mg_htonl(pkt->tcp->ack);       // Set to peer's ACK
+      }
+      s->twclosure = true;
+    } else {
+      flags |= TH_FIN;
+      c->is_draining = 1;
+      settmout(c, MIP_TTYPE_FIN);
+    }
+    tx_tcp(c->mgr->ifp, s->mac, rem_ip, flags, c->loc.port, c->rem.port,
+           mg_htonl(s->seq), mg_htonl(s->ack), "", 0);
+  } else if (pkt->pay.len == 0) {  // this is an ACK
+    if (s->fin_rcvd && s->ttype == MIP_TTYPE_FIN) s->twclosure = true;
+  } else if (seq != s->ack) {
+    uint32_t ack = (uint32_t) (mg_htonl(pkt->tcp->seq) + pkt->pay.len);
+    if (s->ack == ack) {
+      MG_VERBOSE(("ignoring duplicate pkt"));
+    } else {
+      MG_VERBOSE(("SEQ != ACK: %x %x %x", seq, s->ack, ack));
+      tx_tcp(c->mgr->ifp, s->mac, rem_ip, TH_ACK, c->loc.port, c->rem.port,
+             mg_htonl(s->seq), mg_htonl(s->ack), "", 0);
+    }
+  } else if (io->size - io->len < pkt->pay.len &&
+             !mg_iobuf_resize(io, io->len + pkt->pay.len)) {
+    mg_error(c, "oom");
+  } else {
+    // Copy TCP payload into the IO buffer. If the connection is plain text,
+    // we copy to c->recv. If the connection is TLS, this data is encrypted,
+    // therefore we copy that encrypted data to the c->rtls iobuffer instead,
+    // and then call mg_tls_recv() to decrypt it. NOTE: mg_tls_recv() will
+    // call back mg_io_recv() which grabs raw data from c->rtls
+    memcpy(&io->buf[io->len], pkt->pay.buf, pkt->pay.len);
+    io->len += pkt->pay.len;
+
+    MG_VERBOSE(("%lu SEQ %x -> %x", c->id, mg_htonl(pkt->tcp->seq), s->ack));
+    // Advance ACK counter
+    s->ack = (uint32_t) (mg_htonl(pkt->tcp->seq) + pkt->pay.len);
+    s->unacked += pkt->pay.len;
+    // size_t diff = s->acked <= s->ack ? s->ack - s->acked : s->ack;
+    if (s->unacked > MIP_TCP_WIN / 2 && s->acked != s->ack) {
+      // Send ACK immediately
+      MG_VERBOSE(("%lu imm ACK %lu", c->id, s->acked));
+      tx_tcp(c->mgr->ifp, s->mac, rem_ip, TH_ACK, c->loc.port, c->rem.port,
+             mg_htonl(s->seq), mg_htonl(s->ack), NULL, 0);
+      s->unacked = 0;
+      s->acked = s->ack;
+      if (s->ttype != MIP_TTYPE_KEEPALIVE) settmout(c, MIP_TTYPE_KEEPALIVE);
+    } else {
+      // if not already running, setup a timer to send an ACK later
+      if (s->ttype != MIP_TTYPE_ACK) settmout(c, MIP_TTYPE_ACK);
+    }
+
+    if (c->is_tls && c->is_tls_hs) {
+      mg_tls_handshake(c);
+    } else if (c->is_tls) {
+      handle_tls_recv(c);
+    } else {
+      // Plain text connection, data is already in c->recv, trigger MG_EV_READ
+      mg_call(c, MG_EV_READ, &pkt->pay.len);
+    }
+  }
+}
+
+static void rx_tcp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  struct mg_connection *c = getpeer(ifp->mgr, pkt, false);
+  struct connstate *s = c == NULL ? NULL : (struct connstate *) (c + 1);
+#if 0
+  MG_INFO(("%lu %hhu %d", c ? c->id : 0, pkt->tcp->flags, (int) pkt->pay.len));
+#endif
+  if (c != NULL && c->is_connecting && pkt->tcp->flags == (TH_SYN | TH_ACK)) {
+    s->seq = mg_ntohl(pkt->tcp->ack), s->ack = mg_ntohl(pkt->tcp->seq) + 1;
+    tx_tcp_pkt(ifp, pkt, TH_ACK, pkt->tcp->ack, NULL, 0);
+    c->is_connecting = 0;  // Client connected
+    settmout(c, MIP_TTYPE_KEEPALIVE);
+    mg_call(c, MG_EV_CONNECT, NULL);  // Let user know
+    if (c->is_tls_hs) mg_tls_handshake(c);
+  } else if (c != NULL && c->is_connecting && pkt->tcp->flags != TH_ACK) {
+    // mg_hexdump(pkt->raw.buf, pkt->raw.len);
+    tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
+  } else if (c != NULL && pkt->tcp->flags & TH_RST) {
+    mg_error(c, "peer RST");  // RFC-1122 4.2.2.13
+  } else if (c != NULL) {
+#if 0
+    MG_DEBUG(("%lu %d %M:%hu -> %M:%hu", c->id, (int) pkt->raw.len,
+              mg_print_ip4, &pkt->ip->src, mg_ntohs(pkt->tcp->sport),
+              mg_print_ip4, &pkt->ip->dst, mg_ntohs(pkt->tcp->dport)));
+    mg_hexdump(pkt->pay.buf, pkt->pay.len);
+#endif
+    s->tmiss = 0;                         // Reset missed keep-alive counter
+    if (s->ttype == MIP_TTYPE_KEEPALIVE)  // Advance keep-alive timer
+      settmout(c,
+               MIP_TTYPE_KEEPALIVE);  // unless a former ACK timeout is pending
+    read_conn(c, pkt);  // Override timer with ACK timeout if needed
+  } else if ((c = getpeer(ifp->mgr, pkt, true)) == NULL) {
+    tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
+  } else if (pkt->tcp->flags & TH_RST) {
+    if (c->is_accepted) mg_error(c, "peer RST");  // RFC-1122 4.2.2.13
+    // ignore RST if not connected
+  } else if (pkt->tcp->flags & TH_SYN) {
+    // Use peer's source port as ISN, in order to recognise the handshake
+    uint32_t isn = mg_htonl((uint32_t) mg_ntohs(pkt->tcp->sport));
+    tx_tcp_pkt(ifp, pkt, TH_SYN | TH_ACK, isn, NULL, 0);
+  } else if (pkt->tcp->flags & TH_FIN) {
+    tx_tcp_pkt(ifp, pkt, TH_FIN | TH_ACK, pkt->tcp->ack, NULL, 0);
+  } else if (mg_htonl(pkt->tcp->ack) == mg_htons(pkt->tcp->sport) + 1U) {
+    accept_conn(c, pkt);
+  } else if (!c->is_accepted) {  // no peer
+    tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
+  } else {
+    // MG_VERBOSE(("dropped silently.."));
+  }
+}
+
+static void rx_ip(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  uint16_t frag = mg_ntohs(pkt->ip->frag);
+  if (frag & IP_MORE_FRAGS_MSK || frag & IP_FRAG_OFFSET_MSK) {
+    if (pkt->ip->proto == 17) pkt->udp = (struct udp *) (pkt->ip + 1);
+    if (pkt->ip->proto == 6) pkt->tcp = (struct tcp *) (pkt->ip + 1);
+    struct mg_connection *c = getpeer(ifp->mgr, pkt, false);
+    if (c) mg_error(c, "Received fragmented packet");
+  } else if (pkt->ip->proto == 1) {
+    pkt->icmp = (struct icmp *) (pkt->ip + 1);
+    if (pkt->pay.len < sizeof(*pkt->icmp)) return;
+    mkpay(pkt, pkt->icmp + 1);
+    rx_icmp(ifp, pkt);
+  } else if (pkt->ip->proto == 17) {
+    pkt->udp = (struct udp *) (pkt->ip + 1);
+    if (pkt->pay.len < sizeof(*pkt->udp)) return;
+    mkpay(pkt, pkt->udp + 1);
+    MG_VERBOSE(("UDP %M:%hu -> %M:%hu len %u", mg_print_ip4, &pkt->ip->src,
+                mg_ntohs(pkt->udp->sport), mg_print_ip4, &pkt->ip->dst,
+                mg_ntohs(pkt->udp->dport), (int) pkt->pay.len));
+    if (ifp->enable_dhcp_client && pkt->udp->dport == mg_htons(68)) {
+      pkt->dhcp = (struct dhcp *) (pkt->udp + 1);
+      mkpay(pkt, pkt->dhcp + 1);
+      rx_dhcp_client(ifp, pkt);
+    } else if (ifp->enable_dhcp_server && pkt->udp->dport == mg_htons(67)) {
+      pkt->dhcp = (struct dhcp *) (pkt->udp + 1);
+      mkpay(pkt, pkt->dhcp + 1);
+      rx_dhcp_server(ifp, pkt);
+    } else {
+      rx_udp(ifp, pkt);
+    }
+  } else if (pkt->ip->proto == 6) {
+    pkt->tcp = (struct tcp *) (pkt->ip + 1);
+    if (pkt->pay.len < sizeof(*pkt->tcp)) return;
+    mkpay(pkt, pkt->tcp + 1);
+    uint16_t iplen = mg_ntohs(pkt->ip->len);
+    uint16_t off = (uint16_t) (sizeof(*pkt->ip) + ((pkt->tcp->off >> 4) * 4U));
+    if (iplen >= off) pkt->pay.len = (size_t) (iplen - off);
+    MG_VERBOSE(("TCP %M:%hu -> %M:%hu len %u", mg_print_ip4, &pkt->ip->src,
+                mg_ntohs(pkt->tcp->sport), mg_print_ip4, &pkt->ip->dst,
+                mg_ntohs(pkt->tcp->dport), (int) pkt->pay.len));
+    rx_tcp(ifp, pkt);
+  }
+}
+
+static void rx_ip6(struct mg_tcpip_if *ifp, struct pkt *pkt) {
+  // MG_DEBUG(("IP %d", (int) len));
+  if (pkt->ip6->proto == 1 || pkt->ip6->proto == 58) {
+    pkt->icmp = (struct icmp *) (pkt->ip6 + 1);
+    if (pkt->pay.len < sizeof(*pkt->icmp)) return;
+    mkpay(pkt, pkt->icmp + 1);
+    rx_icmp(ifp, pkt);
+  } else if (pkt->ip6->proto == 17) {
+    pkt->udp = (struct udp *) (pkt->ip6 + 1);
+    if (pkt->pay.len < sizeof(*pkt->udp)) return;
+    // MG_DEBUG(("  UDP %u %u -> %u", len, mg_htons(udp->sport),
+    // mg_htons(udp->dport)));
+    mkpay(pkt, pkt->udp + 1);
+  }
+}
+
+static void mg_tcpip_rx(struct mg_tcpip_if *ifp, void *buf, size_t len) {
+  struct pkt pkt;
+  memset(&pkt, 0, sizeof(pkt));
+  pkt.raw.buf = (char *) buf;
+  pkt.raw.len = len;
+  pkt.eth = (struct eth *) buf;
+  // mg_hexdump(buf, len > 16 ? 16: len);
+  if (pkt.raw.len < sizeof(*pkt.eth)) return;  // Truncated - runt?
+  if (ifp->enable_mac_check &&
+      memcmp(pkt.eth->dst, ifp->mac, sizeof(pkt.eth->dst)) != 0 &&
+      memcmp(pkt.eth->dst, broadcast, sizeof(pkt.eth->dst)) != 0)
+    return;
+  if (ifp->enable_crc32_check && len > 4) {
+    len -= 4;  // TODO(scaprile): check on bigendian
+    uint32_t crc = mg_crc32(0, (const char *) buf, len);
+    if (memcmp((void *) ((size_t) buf + len), &crc, sizeof(crc))) return;
+  }
+  if (pkt.eth->type == mg_htons(0x806)) {
+    pkt.arp = (struct arp *) (pkt.eth + 1);
+    if (sizeof(*pkt.eth) + sizeof(*pkt.arp) > pkt.raw.len) return;  // Truncated
+    mg_tcpip_call(ifp, MG_TCPIP_EV_ARP, &pkt.raw);
+    rx_arp(ifp, &pkt);
+  } else if (pkt.eth->type == mg_htons(0x86dd)) {
+    pkt.ip6 = (struct ip6 *) (pkt.eth + 1);
+    if (pkt.raw.len < sizeof(*pkt.eth) + sizeof(*pkt.ip6)) return;  // Truncated
+    if ((pkt.ip6->ver >> 4) != 0x6) return;                         // Not IP
+    mkpay(&pkt, pkt.ip6 + 1);
+    rx_ip6(ifp, &pkt);
+  } else if (pkt.eth->type == mg_htons(0x800)) {
+    pkt.ip = (struct ip *) (pkt.eth + 1);
+    if (pkt.raw.len < sizeof(*pkt.eth) + sizeof(*pkt.ip)) return;  // Truncated
+    // Truncate frame to what IP header tells us
+    if ((size_t) mg_ntohs(pkt.ip->len) + sizeof(struct eth) < pkt.raw.len) {
+      pkt.raw.len = (size_t) mg_ntohs(pkt.ip->len) + sizeof(struct eth);
+    }
+    if (pkt.raw.len < sizeof(*pkt.eth) + sizeof(*pkt.ip)) return;  // Truncated
+    if ((pkt.ip->ver >> 4) != 4) return;                           // Not IP
+    mkpay(&pkt, pkt.ip + 1);
+    rx_ip(ifp, &pkt);
+  } else {
+    MG_DEBUG(("Unknown eth type %x", mg_htons(pkt.eth->type)));
+    if (mg_log_level >= MG_LL_VERBOSE) mg_hexdump(buf, len >= 32 ? 32 : len);
+  }
+}
+
+static void mg_tcpip_poll(struct mg_tcpip_if *ifp, uint64_t now) {
+  struct mg_connection *c;
+  bool expired_1000ms = mg_timer_expired(&ifp->timer_1000ms, 1000, now);
+  ifp->now = now;
+
+  if (expired_1000ms) {
+#if MG_ENABLE_TCPIP_PRINT_DEBUG_STATS
+    const char *names[] = {"down", "up", "req", "ip", "ready"};
+    MG_INFO(("Status: %s, IP: %M, rx:%u, tx:%u, dr:%u, er:%u",
+             names[ifp->state], mg_print_ip4, &ifp->ip, ifp->nrecv, ifp->nsent,
+             ifp->ndrop, ifp->nerr));
+#endif
+  }
+  // Handle gw ARP request timeout, order is important
+  if (expired_1000ms && ifp->state == MG_TCPIP_STATE_IP) {
+    ifp->state = MG_TCPIP_STATE_READY;  // keep best-effort MAC
+    onstatechange(ifp);
+  }
+  // Handle physical interface up/down status
+  if (expired_1000ms && ifp->driver->up) {
+    bool up = ifp->driver->up(ifp);
+    bool current = ifp->state != MG_TCPIP_STATE_DOWN;
+    if (!up && ifp->enable_dhcp_client) ifp->ip = 0;
+    if (up != current) {  // link state has changed
+      ifp->state = up == false ? MG_TCPIP_STATE_DOWN
+                   : ifp->enable_dhcp_client || ifp->ip == 0
+                       ? MG_TCPIP_STATE_UP
+                       : MG_TCPIP_STATE_IP;
+      onstatechange(ifp);
+    } else if (!ifp->enable_dhcp_client && ifp->state == MG_TCPIP_STATE_UP &&
+               ifp->ip) {
+      ifp->state = MG_TCPIP_STATE_IP;  // ifp->fn has set an IP
+      onstatechange(ifp);
+    }
+    if (ifp->state == MG_TCPIP_STATE_DOWN) MG_ERROR(("Network is down"));
+    mg_tcpip_call(ifp, MG_TCPIP_EV_TIMER_1S, NULL);
+  }
+  if (ifp->state == MG_TCPIP_STATE_DOWN) return;
+
+  // DHCP RFC-2131 (4.4)
+  if (ifp->enable_dhcp_client && expired_1000ms) {
+    if (ifp->state == MG_TCPIP_STATE_UP) {
+      tx_dhcp_discover(ifp);  // INIT (4.4.1)
+    } else if (ifp->state == MG_TCPIP_STATE_READY &&
+               ifp->lease_expire > 0) {  // BOUND / RENEWING / REBINDING
+      if (ifp->now >= ifp->lease_expire) {
+        ifp->state = MG_TCPIP_STATE_UP, ifp->ip = 0;  // expired, release IP
+        onstatechange(ifp);
+      } else if (ifp->now + 30UL * 60UL * 1000UL > ifp->lease_expire &&
+                 ((ifp->now / 1000) % 60) == 0) {
+        // hack: 30 min before deadline, try to rebind (4.3.6) every min
+        tx_dhcp_request_re(ifp, (uint8_t *) broadcast, ifp->ip, 0xffffffff);
+      }  // TODO(): Handle T1 (RENEWING) and T2 (REBINDING) (4.4.5)
+    }
+  }
+
+  // Read data from the network
+  if (ifp->driver->rx != NULL) {  // Polling driver. We must call it
+    size_t len =
+        ifp->driver->rx(ifp->recv_queue.buf, ifp->recv_queue.size, ifp);
+    if (len > 0) {
+      ifp->nrecv++;
+      mg_tcpip_rx(ifp, ifp->recv_queue.buf, len);
+    }
+  } else {  // Interrupt-based driver. Fills recv queue itself
+    char *buf;
+    size_t len = mg_queue_next(&ifp->recv_queue, &buf);
+    if (len > 0) {
+      mg_tcpip_rx(ifp, buf, len);
+      mg_queue_del(&ifp->recv_queue, len);
+    }
+  }
+
+  // Process timeouts
+  for (c = ifp->mgr->conns; c != NULL; c = c->next) {
+    if ((c->is_udp && !c->is_arplooking) || c->is_listening || c->is_resolving)
+      continue;
+    struct connstate *s = (struct connstate *) (c + 1);
+    uint32_t rem_ip;
+    memcpy(&rem_ip, c->rem.ip, sizeof(uint32_t));
+    if (ifp->now > s->timer) {
+      if (s->ttype == MIP_TTYPE_ARP) {
+        mg_error(c, "ARP timeout");
+      } else if (c->is_udp) {
+        continue;
+      } else if (s->ttype == MIP_TTYPE_ACK && s->acked != s->ack) {
+        MG_VERBOSE(("%lu ack %x %x", c->id, s->seq, s->ack));
+        tx_tcp(ifp, s->mac, rem_ip, TH_ACK, c->loc.port, c->rem.port,
+               mg_htonl(s->seq), mg_htonl(s->ack), NULL, 0);
+        s->acked = s->ack;
+      } else if (s->ttype == MIP_TTYPE_SYN) {
+        mg_error(c, "Connection timeout");
+      } else if (s->ttype == MIP_TTYPE_FIN) {
+        c->is_closing = 1;
+        continue;
+      } else {
+        if (s->tmiss++ > 2) {
+          mg_error(c, "keepalive");
+        } else {
+          MG_VERBOSE(("%lu keepalive", c->id));
+          tx_tcp(ifp, s->mac, rem_ip, TH_ACK, c->loc.port, c->rem.port,
+                 mg_htonl(s->seq - 1), mg_htonl(s->ack), NULL, 0);
+        }
+      }
+
+      settmout(c, MIP_TTYPE_KEEPALIVE);
+    }
+  }
+}
+
+// This function executes in interrupt context, thus it should copy data
+// somewhere fast. Note that newlib's malloc is not thread safe, thus use
+// our lock-free queue with preallocated buffer to copy data and return asap
+void mg_tcpip_qwrite(void *buf, size_t len, struct mg_tcpip_if *ifp) {
+  char *p;
+  if (mg_queue_book(&ifp->recv_queue, &p, len) >= len) {
+    memcpy(p, buf, len);
+    mg_queue_add(&ifp->recv_queue, len);
+    ifp->nrecv++;
+  } else {
+    ifp->ndrop++;
+  }
+}
+
+void mg_tcpip_init(struct mg_mgr *mgr, struct mg_tcpip_if *ifp) {
+  // If MAC address is not set, make a random one
+  if (ifp->mac[0] == 0 && ifp->mac[1] == 0 && ifp->mac[2] == 0 &&
+      ifp->mac[3] == 0 && ifp->mac[4] == 0 && ifp->mac[5] == 0) {
+    ifp->mac[0] = 0x02;  // Locally administered, unicast
+    mg_random(&ifp->mac[1], sizeof(ifp->mac) - 1);
+    MG_INFO(("MAC not set. Generated random: %M", mg_print_mac, ifp->mac));
+  }
+
+  if (ifp->driver->init && !ifp->driver->init(ifp)) {
+    MG_ERROR(("driver init failed"));
+  } else {
+    size_t framesize = 1540;
+    ifp->tx.buf = (char *) calloc(1, framesize), ifp->tx.len = framesize;
+    if (ifp->recv_queue.size == 0)
+      ifp->recv_queue.size = ifp->driver->rx ? framesize : 8192;
+    ifp->recv_queue.buf = (char *) calloc(1, ifp->recv_queue.size);
+    ifp->timer_1000ms = mg_millis();
+    mgr->ifp = ifp;
+    ifp->mgr = mgr;
+    ifp->mtu = MG_TCPIP_MTU_DEFAULT;
+    mgr->extraconnsize = sizeof(struct connstate);
+    if (ifp->ip == 0) ifp->enable_dhcp_client = true;
+    memset(ifp->gwmac, 255, sizeof(ifp->gwmac));  // Set best-effort to bcast
+    mg_random(&ifp->eport, sizeof(ifp->eport));   // Random from 0 to 65535
+    ifp->eport |= MG_EPHEMERAL_PORT_BASE;         // Random from
+                                           // MG_EPHEMERAL_PORT_BASE to 65535
+    if (ifp->tx.buf == NULL || ifp->recv_queue.buf == NULL) MG_ERROR(("OOM"));
+  }
+}
+
+void mg_tcpip_free(struct mg_tcpip_if *ifp) {
+  free(ifp->recv_queue.buf);
+  free(ifp->tx.buf);
+}
+
+static void send_syn(struct mg_connection *c) {
+  struct connstate *s = (struct connstate *) (c + 1);
+  uint32_t isn = mg_htonl((uint32_t) mg_ntohs(c->loc.port));
+  uint32_t rem_ip;
+  memcpy(&rem_ip, c->rem.ip, sizeof(uint32_t));
+  tx_tcp(c->mgr->ifp, s->mac, rem_ip, TH_SYN, c->loc.port, c->rem.port, isn, 0,
+         NULL, 0);
+}
+
+static void mac_resolved(struct mg_connection *c) {
+  if (c->is_udp) {
+    c->is_connecting = 0;
+    mg_call(c, MG_EV_CONNECT, NULL);
+  } else {
+    send_syn(c);
+    settmout(c, MIP_TTYPE_SYN);
+  }
+}
+
+void mg_connect_resolved(struct mg_connection *c) {
+  struct mg_tcpip_if *ifp = c->mgr->ifp;
+  uint32_t rem_ip;
+  memcpy(&rem_ip, c->rem.ip, sizeof(uint32_t));
+  c->is_resolving = 0;
+  if (ifp->eport < MG_EPHEMERAL_PORT_BASE) ifp->eport = MG_EPHEMERAL_PORT_BASE;
+  memcpy(c->loc.ip, &ifp->ip, sizeof(uint32_t));
+  c->loc.port = mg_htons(ifp->eport++);
+  MG_DEBUG(("%lu %M -> %M", c->id, mg_print_ip_port, &c->loc, mg_print_ip_port,
+            &c->rem));
+  mg_call(c, MG_EV_RESOLVE, NULL);
+  c->is_connecting = 1;
+  if (c->is_udp && (rem_ip == 0xffffffff || rem_ip == (ifp->ip | ~ifp->mask))) {
+    struct connstate *s = (struct connstate *) (c + 1);
+    memset(s->mac, 0xFF, sizeof(s->mac));  // global or local broadcast
+    mac_resolved(c);
+  } else if (ifp->ip && ((rem_ip & ifp->mask) == (ifp->ip & ifp->mask)) &&
+             rem_ip != ifp->gw) {  // skip if gw (onstatechange -> READY -> ARP)
+    // If we're in the same LAN, fire an ARP lookup.
+    MG_DEBUG(("%lu ARP lookup...", c->id));
+    mg_tcpip_arp_request(ifp, rem_ip, NULL);
+    settmout(c, MIP_TTYPE_ARP);
+    c->is_arplooking = 1;
+  } else if ((*((uint8_t *) &rem_ip) & 0xE0) == 0xE0) {
+    struct connstate *s = (struct connstate *) (c + 1);  // 224 to 239, E0 to EF
+    uint8_t mcastp[3] = {0x01, 0x00, 0x5E};              // multicast group
+    memcpy(s->mac, mcastp, 3);
+    memcpy(s->mac + 3, ((uint8_t *) &rem_ip) + 1, 3);  // 23 LSb
+    s->mac[3] &= 0x7F;
+    mac_resolved(c);
+  } else {
+    struct connstate *s = (struct connstate *) (c + 1);
+    memcpy(s->mac, ifp->gwmac, sizeof(ifp->gwmac));
+    mac_resolved(c);
+  }
+}
+
+bool mg_open_listener(struct mg_connection *c, const char *url) {
+  c->loc.port = mg_htons(mg_url_port(url));
+  return true;
+}
+
+static void write_conn(struct mg_connection *c) {
+  long len = c->is_tls ? mg_tls_send(c, c->send.buf, c->send.len)
+                       : mg_io_send(c, c->send.buf, c->send.len);
+  if (len == MG_IO_ERR) {
+    mg_error(c, "tx err");
+  } else if (len > 0) {
+    mg_iobuf_del(&c->send, 0, (size_t) len);
+    mg_call(c, MG_EV_WRITE, &len);
+  }
+}
+
+static void init_closure(struct mg_connection *c) {
+  struct connstate *s = (struct connstate *) (c + 1);
+  if (c->is_udp == false && c->is_listening == false &&
+      c->is_connecting == false) {  // For TCP conns,
+    uint32_t rem_ip;
+    memcpy(&rem_ip, c->rem.ip, sizeof(uint32_t));
+    tx_tcp(c->mgr->ifp, s->mac, rem_ip, TH_FIN | TH_ACK, c->loc.port,
+           c->rem.port, mg_htonl(s->seq), mg_htonl(s->ack), NULL, 0);
+    settmout(c, MIP_TTYPE_FIN);
+  }
+}
+
+static void close_conn(struct mg_connection *c) {
+  struct connstate *s = (struct connstate *) (c + 1);
+  mg_iobuf_free(&s->raw);  // For TLS connections, release raw data
+  mg_close_conn(c);
+}
+
+static bool can_write(struct mg_connection *c) {
+  return c->is_connecting == 0 && c->is_resolving == 0 && c->send.len > 0 &&
+         c->is_tls_hs == 0 && c->is_arplooking == 0;
+}
+
+void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
+  struct mg_connection *c, *tmp;
+  uint64_t now = mg_millis();
+  mg_timer_poll(&mgr->timers, now);
+  if (mgr->ifp == NULL || mgr->ifp->driver == NULL) return;
+  mg_tcpip_poll(mgr->ifp, now);
+  for (c = mgr->conns; c != NULL; c = tmp) {
+    tmp = c->next;
+    struct connstate *s = (struct connstate *) (c + 1);
+    mg_call(c, MG_EV_POLL, &now);
+    MG_VERBOSE(("%lu .. %c%c%c%c%c %lu %lu", c->id, c->is_tls ? 'T' : 't',
+                c->is_connecting ? 'C' : 'c', c->is_tls_hs ? 'H' : 'h',
+                c->is_resolving ? 'R' : 'r', c->is_closing ? 'C' : 'c',
+                mg_tls_pending(c), c->rtls.len));
+    // order is important, TLS conn close with > 1 record in buffer (below)
+    if (c->is_tls && (c->rtls.len > 0 || mg_tls_pending(c) > 0))
+      handle_tls_recv(c);
+    if (can_write(c)) write_conn(c);
+    if (c->is_draining && c->send.len == 0 && s->ttype != MIP_TTYPE_FIN)
+      init_closure(c);
+    // For non-TLS, close immediately upon completing the 3-way closure
+    // For TLS, handle any pending data (above) until MIP_TTYPE_FIN expires
+    if (s->twclosure &&
+        (!c->is_tls || (c->rtls.len == 0 && mg_tls_pending(c) == 0)))
+      c->is_closing = 1;
+    if (c->is_closing) close_conn(c);
+  }
+  (void) ms;
+}
+
+bool mg_send(struct mg_connection *c, const void *buf, size_t len) {
+  struct mg_tcpip_if *ifp = c->mgr->ifp;
+  bool res = false;
+  uint32_t rem_ip;
+  memcpy(&rem_ip, c->rem.ip, sizeof(uint32_t));
+  if (ifp->ip == 0 || ifp->state != MG_TCPIP_STATE_READY) {
+    mg_error(c, "net down");
+  } else if (c->is_udp && (c->is_arplooking || c->is_resolving)) {
+    // Fail to send, no target MAC or IP
+    MG_VERBOSE(("still resolving..."));
+  } else if (c->is_udp) {
+    struct connstate *s = (struct connstate *) (c + 1);
+    len = trim_len(c, len);  // Trimming length if necessary
+    tx_udp(ifp, s->mac, ifp->ip, c->loc.port, rem_ip, c->rem.port, buf, len);
+    res = true;
+  } else {
+    res = mg_iobuf_add(&c->send, c->send.len, buf, len);
+  }
+  return res;
+}
+#endif  // MG_ENABLE_TCPIP
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_ch32v307.c"
+#endif
+
+
+
+
+#if MG_OTA == MG_OTA_CH32V307
+// RM: https://www.wch-ic.com/downloads/CH32FV2x_V3xRM_PDF.html
+
+static bool mg_ch32v307_write(void *, const void *, size_t);
+static bool mg_ch32v307_swap(void);
+
+static struct mg_flash s_mg_flash_ch32v307 = {
+    (void *) 0x08000000,  // Start
+    480 * 1024,           // Size, first 320k is 0-wait
+    4 * 1024,             // Sector size, 4k
+    4,                    // Align, 32 bit
+    mg_ch32v307_write,
+    mg_ch32v307_swap,
+};
+
+#define FLASH_BASE 0x40022000
+#define FLASH_ACTLR (FLASH_BASE + 0)
+#define FLASH_KEYR (FLASH_BASE + 4)
+#define FLASH_OBKEYR (FLASH_BASE + 8)
+#define FLASH_STATR (FLASH_BASE + 12)
+#define FLASH_CTLR (FLASH_BASE + 16)
+#define FLASH_ADDR (FLASH_BASE + 20)
+#define FLASH_OBR (FLASH_BASE + 28)
+#define FLASH_WPR (FLASH_BASE + 32)
+
+MG_IRAM static void flash_unlock(void) {
+  static bool unlocked;
+  if (unlocked == false) {
+    MG_REG(FLASH_KEYR) = 0x45670123;
+    MG_REG(FLASH_KEYR) = 0xcdef89ab;
+    unlocked = true;
+  }
+}
+
+MG_IRAM static void flash_wait(void) {
+  while (MG_REG(FLASH_STATR) & MG_BIT(0)) (void) 0;
+}
+
+MG_IRAM static void mg_ch32v307_erase(void *addr) {
+  // MG_INFO(("%p", addr));
+  flash_unlock();
+  flash_wait();
+  MG_REG(FLASH_ADDR) = (uint32_t) addr;
+  MG_REG(FLASH_CTLR) |= MG_BIT(1) | MG_BIT(6);  // PER | STRT;
+  flash_wait();
+}
+
+MG_IRAM static bool is_page_boundary(const void *addr) {
+  uint32_t val = (uint32_t) addr;
+  return (val & (s_mg_flash_ch32v307.secsz - 1)) == 0;
+}
+
+MG_IRAM static bool mg_ch32v307_write(void *addr, const void *buf, size_t len) {
+  // MG_INFO(("%p %p %lu", addr, buf, len));
+  // mg_hexdump(buf, len);
+  flash_unlock();
+  const uint16_t *src = (uint16_t *) buf, *end = &src[len / 2];
+  uint16_t *dst = (uint16_t *) addr;
+  MG_REG(FLASH_CTLR) |= MG_BIT(0);  // Set PG
+  // MG_INFO(("CTLR: %#lx", MG_REG(FLASH_CTLR)));
+  while (src < end) {
+    if (is_page_boundary(dst)) mg_ch32v307_erase(dst);
+    *dst++ = *src++;
+    flash_wait();
+  }
+  MG_REG(FLASH_CTLR) &= ~MG_BIT(0);  // Clear PG
+  return true;
+}
+
+MG_IRAM bool mg_ch32v307_swap(void) {
+  return true;
+}
+
+// just overwrite instead of swap
+MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
+  // no stdlib calls here
+  for (size_t ofs = 0; ofs < s; ofs += ss) {
+    mg_ch32v307_write(p1 + ofs, p2 + ofs, ss);
+  }
+  *((volatile uint32_t *) 0xbeef0000) |= 1U << 7;  // NVIC_SystemReset()
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_ch32v307);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_ch32v307);
+}
+
+bool mg_ota_end(void) {
+  if (mg_ota_flash_end(&s_mg_flash_ch32v307)) {
+    // Swap partitions. Pray power does not go away
+    MG_INFO(("Swapping partitions, size %u (%u sectors)",
+             s_mg_flash_ch32v307.size,
+             s_mg_flash_ch32v307.size / s_mg_flash_ch32v307.secsz));
+    MG_INFO(("Do NOT power off..."));
+    mg_log_level = MG_LL_NONE;
+    // TODO() disable IRQ, s_flash_irq_disabled = true;
+    // Runs in RAM, will reset when finished
+    single_bank_swap(
+        (char *) s_mg_flash_ch32v307.start,
+        (char *) s_mg_flash_ch32v307.start + s_mg_flash_ch32v307.size / 2,
+        s_mg_flash_ch32v307.size / 2, s_mg_flash_ch32v307.secsz);
+  }
+  return false;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_dummy.c"
+#endif
+
+
+
+#if MG_OTA == MG_OTA_NONE
+bool mg_ota_begin(size_t new_firmware_size) {
+  (void) new_firmware_size;
+  return true;
+}
+bool mg_ota_write(const void *buf, size_t len) {
+  (void) buf, (void) len;
+  return true;
+}
+bool mg_ota_end(void) {
+  return true;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_esp32.c"
+#endif
+
+
+#if MG_ARCH == MG_ARCH_ESP32 && MG_OTA == MG_OTA_ESP32
+
+static const esp_partition_t *s_ota_update_partition;
+static esp_ota_handle_t s_ota_update_handle;
+static bool s_ota_success;
+
+// Those empty macros do nothing, but mark places in the code which could
+// potentially trigger a watchdog reboot due to the log flash erase operation
+#define disable_wdt()
+#define enable_wdt()
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  if (s_ota_update_partition != NULL) {
+    MG_ERROR(("Update in progress. Call mg_ota_end() ?"));
+    return false;
+  } else {
+    s_ota_success = false;
+    disable_wdt();
+    s_ota_update_partition = esp_ota_get_next_update_partition(NULL);
+    esp_err_t err = esp_ota_begin(s_ota_update_partition, new_firmware_size,
+                                  &s_ota_update_handle);
+    enable_wdt();
+    MG_DEBUG(("esp_ota_begin(): %d", err));
+    s_ota_success = (err == ESP_OK);
+  }
+  return s_ota_success;
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  disable_wdt();
+  esp_err_t err = esp_ota_write(s_ota_update_handle, buf, len);
+  enable_wdt();
+  MG_INFO(("esp_ota_write(): %d", err));
+  s_ota_success = err == ESP_OK;
+  return s_ota_success;
+}
+
+bool mg_ota_end(void) {
+  esp_err_t err = esp_ota_end(s_ota_update_handle);
+  MG_DEBUG(("esp_ota_end(%p): %d", s_ota_update_handle, err));
+  if (s_ota_success && err == ESP_OK) {
+    err = esp_ota_set_boot_partition(s_ota_update_partition);
+    s_ota_success = (err == ESP_OK);
+  }
+  MG_DEBUG(("Finished ESP32 OTA, success: %d", s_ota_success));
+  s_ota_update_partition = NULL;
+  return s_ota_success;
+}
+
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_imxrt.c"
+#endif
+
+
+
+
+#if MG_OTA >= MG_OTA_RT1020 && MG_OTA <= MG_OTA_RT1170
+
+static bool mg_imxrt_write(void *, const void *, size_t);
+static bool mg_imxrt_swap(void);
+
+#if MG_OTA <= MG_OTA_RT1060
+#define MG_IMXRT_FLASH_START 0x60000000
+#define FLEXSPI_NOR_INSTANCE 0
+#elif MG_OTA == MG_OTA_RT1064
+#define MG_IMXRT_FLASH_START 0x70000000
+#define FLEXSPI_NOR_INSTANCE 1
+#else // RT1170
+#define MG_IMXRT_FLASH_START 0x30000000
+#define FLEXSPI_NOR_INSTANCE 1
+#endif
+
+// TODO(): fill at init, support more devices in a dynamic way
+// TODO(): then, check alignment is <= 256, see Wizard's #251
+static struct mg_flash s_mg_flash_imxrt = {
+    (void *) MG_IMXRT_FLASH_START,  // Start,
+    4 * 1024 * 1024,                // Size, 4mb
+    4 * 1024,                       // Sector size, 4k
+    256,                            // Align,
+    mg_imxrt_write,
+    mg_imxrt_swap,
+};
+
+struct mg_flexspi_lut_seq {
+  uint8_t seqNum;
+  uint8_t seqId;
+  uint16_t reserved;
+};
+
+struct mg_flexspi_mem_config {
+  uint32_t tag;
+  uint32_t version;
+  uint32_t reserved0;
+  uint8_t readSampleClkSrc;
+  uint8_t csHoldTime;
+  uint8_t csSetupTime;
+  uint8_t columnAddressWidth;
+  uint8_t deviceModeCfgEnable;
+  uint8_t deviceModeType;
+  uint16_t waitTimeCfgCommands;
+  struct mg_flexspi_lut_seq deviceModeSeq;
+  uint32_t deviceModeArg;
+  uint8_t configCmdEnable;
+  uint8_t configModeType[3];
+  struct mg_flexspi_lut_seq configCmdSeqs[3];
+  uint32_t reserved1;
+  uint32_t configCmdArgs[3];
+  uint32_t reserved2;
+  uint32_t controllerMiscOption;
+  uint8_t deviceType;
+  uint8_t sflashPadType;
+  uint8_t serialClkFreq;
+  uint8_t lutCustomSeqEnable;
+  uint32_t reserved3[2];
+  uint32_t sflashA1Size;
+  uint32_t sflashA2Size;
+  uint32_t sflashB1Size;
+  uint32_t sflashB2Size;
+  uint32_t csPadSettingOverride;
+  uint32_t sclkPadSettingOverride;
+  uint32_t dataPadSettingOverride;
+  uint32_t dqsPadSettingOverride;
+  uint32_t timeoutInMs;
+  uint32_t commandInterval;
+  uint16_t dataValidTime[2];
+  uint16_t busyOffset;
+  uint16_t busyBitPolarity;
+  uint32_t lookupTable[64];
+  struct mg_flexspi_lut_seq lutCustomSeq[12];
+  uint32_t reserved4[4];
+};
+
+struct mg_flexspi_nor_config {
+  struct mg_flexspi_mem_config memConfig;
+  uint32_t pageSize;
+  uint32_t sectorSize;
+  uint8_t ipcmdSerialClkFreq;
+  uint8_t isUniformBlockSize;
+  uint8_t reserved0[2];
+  uint8_t serialNorType;
+  uint8_t needExitNoCmdMode;
+  uint8_t halfClkForNonReadCmd;
+  uint8_t needRestoreNoCmdMode;
+  uint32_t blockSize;
+  uint32_t reserve2[11];
+};
+
+/* FLEXSPI memory config block related defintions */
+#define MG_FLEXSPI_CFG_BLK_TAG (0x42464346UL)      // ascii "FCFB" Big Endian
+#define MG_FLEXSPI_CFG_BLK_VERSION (0x56010400UL)  // V1.4.0
+
+#define MG_FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)       \
+  (MG_FLEXSPI_LUT_OPERAND0(op0) | MG_FLEXSPI_LUT_NUM_PADS0(pad0) | \
+   MG_FLEXSPI_LUT_OPCODE0(cmd0) | MG_FLEXSPI_LUT_OPERAND1(op1) |   \
+   MG_FLEXSPI_LUT_NUM_PADS1(pad1) | MG_FLEXSPI_LUT_OPCODE1(cmd1))
+
+#define MG_CMD_SDR 0x01
+#define MG_CMD_DDR 0x21
+#define MG_DUMMY_SDR 0x0C
+#define MG_DUMMY_DDR 0x2C
+#define MG_RADDR_SDR 0x02
+#define MG_RADDR_DDR 0x22
+#define MG_READ_SDR 0x09
+#define MG_READ_DDR 0x29
+#define MG_WRITE_SDR 0x08
+#define MG_WRITE_DDR 0x28
+#define MG_STOP 0
+
+#define MG_FLEXSPI_1PAD 0
+#define MG_FLEXSPI_2PAD 1
+#define MG_FLEXSPI_4PAD 2
+#define MG_FLEXSPI_8PAD 3
+
+#define MG_FLEXSPI_QSPI_LUT                                                    \
+  {                                                                            \
+    [0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0xEB, MG_RADDR_SDR,  \
+                             MG_FLEXSPI_4PAD, 0x18),                           \
+    [1] = MG_FLEXSPI_LUT_SEQ(MG_DUMMY_SDR, MG_FLEXSPI_4PAD, 0x06, MG_READ_SDR, \
+                             MG_FLEXSPI_4PAD, 0x04),                           \
+    [4 * 1 + 0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0x05,        \
+                                     MG_READ_SDR, MG_FLEXSPI_1PAD, 0x04),      \
+    [4 * 3 + 0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0x06,        \
+                                     MG_STOP, MG_FLEXSPI_1PAD, 0x0),           \
+    [4 * 5 + 0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0x20,        \
+                                     MG_RADDR_SDR, MG_FLEXSPI_1PAD, 0x18),     \
+    [4 * 8 + 0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0xD8,        \
+                                     MG_RADDR_SDR, MG_FLEXSPI_1PAD, 0x18),     \
+    [4 * 9 + 0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0x02,        \
+                                     MG_RADDR_SDR, MG_FLEXSPI_1PAD, 0x18),     \
+    [4 * 9 + 1] = MG_FLEXSPI_LUT_SEQ(MG_WRITE_SDR, MG_FLEXSPI_1PAD, 0x04,      \
+                                     MG_STOP, MG_FLEXSPI_1PAD, 0x0),           \
+    [4 * 11 + 0] = MG_FLEXSPI_LUT_SEQ(MG_CMD_SDR, MG_FLEXSPI_1PAD, 0x60,       \
+                                      MG_STOP, MG_FLEXSPI_1PAD, 0x0),          \
+  }
+
+#define MG_FLEXSPI_LUT_OPERAND0(x) (((uint32_t) (((uint32_t) (x)))) & 0xFFU)
+#define MG_FLEXSPI_LUT_NUM_PADS0(x) \
+  (((uint32_t) (((uint32_t) (x)) << 8U)) & 0x300U)
+#define MG_FLEXSPI_LUT_OPCODE0(x) \
+  (((uint32_t) (((uint32_t) (x)) << 10U)) & 0xFC00U)
+#define MG_FLEXSPI_LUT_OPERAND1(x) \
+  (((uint32_t) (((uint32_t) (x)) << 16U)) & 0xFF0000U)
+#define MG_FLEXSPI_LUT_NUM_PADS1(x) \
+  (((uint32_t) (((uint32_t) (x)) << 24U)) & 0x3000000U)
+#define MG_FLEXSPI_LUT_OPCODE1(x) \
+  (((uint32_t) (((uint32_t) (x)) << 26U)) & 0xFC000000U)
+
+#if MG_OTA == MG_OTA_RT1020
+// RT102X boards support ROM API version 1.4
+struct mg_flexspi_nor_driver_interface {
+  uint32_t version;
+  int (*init)(uint32_t instance, struct mg_flexspi_nor_config *config);
+  int (*program)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                 uint32_t dst_addr, const uint32_t *src);
+  uint32_t reserved;
+  int (*erase)(uint32_t instance, struct mg_flexspi_nor_config *config,
+               uint32_t start, uint32_t lengthInBytes);
+  uint32_t reserved2;
+  int (*update_lut)(uint32_t instance, uint32_t seqIndex,
+                    const uint32_t *lutBase, uint32_t seqNumber);
+  int (*xfer)(uint32_t instance, char *xfer);
+  void (*clear_cache)(uint32_t instance);
+};
+#elif MG_OTA <= MG_OTA_RT1064
+// RT104x and RT106x support ROM API version 1.5
+struct mg_flexspi_nor_driver_interface {
+  uint32_t version;
+  int (*init)(uint32_t instance, struct mg_flexspi_nor_config *config);
+  int (*program)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                 uint32_t dst_addr, const uint32_t *src);
+  int (*erase_all)(uint32_t instance, struct mg_flexspi_nor_config *config);
+  int (*erase)(uint32_t instance, struct mg_flexspi_nor_config *config,
+               uint32_t start, uint32_t lengthInBytes);
+  int (*read)(uint32_t instance, struct mg_flexspi_nor_config *config,
+              uint32_t *dst, uint32_t addr, uint32_t lengthInBytes);
+  void (*clear_cache)(uint32_t instance);
+  int (*xfer)(uint32_t instance, char *xfer);
+  int (*update_lut)(uint32_t instance, uint32_t seqIndex,
+                    const uint32_t *lutBase, uint32_t seqNumber);
+  int (*get_config)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                    uint32_t *option);
+};
+#else
+// RT117x support ROM API version 1.7
+struct mg_flexspi_nor_driver_interface {
+  uint32_t version;
+  int (*init)(uint32_t instance, struct mg_flexspi_nor_config *config);
+  int (*program)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                 uint32_t dst_addr, const uint32_t *src);
+  int (*erase_all)(uint32_t instance, struct mg_flexspi_nor_config *config);
+  int (*erase)(uint32_t instance, struct mg_flexspi_nor_config *config,
+               uint32_t start, uint32_t lengthInBytes);
+  int (*read)(uint32_t instance, struct mg_flexspi_nor_config *config,
+              uint32_t *dst, uint32_t addr, uint32_t lengthInBytes);
+  uint32_t reserved;
+  int (*xfer)(uint32_t instance, char *xfer);
+  int (*update_lut)(uint32_t instance, uint32_t seqIndex,
+                    const uint32_t *lutBase, uint32_t seqNumber);
+  int (*get_config)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                    uint32_t *option);
+  int (*erase_sector)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                      uint32_t address);
+  int (*erase_block)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                     uint32_t address);
+  void (*hw_reset)(uint32_t instance, uint32_t resetLogic);
+  int (*wait_busy)(uint32_t instance, struct mg_flexspi_nor_config *config,
+                  bool isParallelMode, uint32_t address);
+  int (*set_clock_source)(uint32_t instance, uint32_t clockSrc);
+  void (*config_clock)(uint32_t instance, uint32_t freqOption,
+                  uint32_t sampleClkMode);
+};
+#endif
+
+#if MG_OTA <= MG_OTA_RT1064
+#define MG_FLEXSPI_BASE 0x402A8000
+#define flexspi_nor                                                          \
+  (*((struct mg_flexspi_nor_driver_interface **) (*(uint32_t *) 0x0020001c + \
+                                                  16)))
+#else
+#define MG_FLEXSPI_BASE 0x400CC000
+#define flexspi_nor                                                          \
+  (*((struct mg_flexspi_nor_driver_interface **) (*(uint32_t *) 0x0021001c + \
+                                                  12)))
+#endif
+
+static bool s_flash_irq_disabled;
+
+MG_IRAM static bool flash_page_start(volatile uint32_t *dst) {
+  char *base = (char *) s_mg_flash_imxrt.start, *end = base + s_mg_flash_imxrt.size;
+  volatile char *p = (char *) dst;
+  return p >= base && p < end && ((p - base) % s_mg_flash_imxrt.secsz) == 0;
+}
+
+// Note: the get_config function below works both for RT1020 and 1060
+// must reside in RAM, as flash will be erased
+static struct mg_flexspi_nor_config default_config = {
+  .memConfig = {.tag = MG_FLEXSPI_CFG_BLK_TAG,
+                .version = MG_FLEXSPI_CFG_BLK_VERSION,
+                .readSampleClkSrc = 1,  // ReadSampleClk_LoopbackFromDqsPad
+                .csHoldTime = 3,
+                .csSetupTime = 3,
+                .controllerMiscOption = MG_BIT(4),
+                .deviceType = 1,  // serial NOR
+                .sflashPadType = 4,
+                .serialClkFreq = 7,  // 133MHz
+                .sflashA1Size = 8 * 1024 * 1024,
+                .lookupTable = MG_FLEXSPI_QSPI_LUT},
+  .pageSize = 256,
+  .sectorSize = 4 * 1024,
+  .ipcmdSerialClkFreq = 1,
+  .blockSize = 64 * 1024,
+  .isUniformBlockSize = false
+};
+MG_IRAM static int flexspi_nor_get_config(
+  struct mg_flexspi_nor_config **config) {
+  *config = &default_config;
+  return 0;
+}
+
+#if 0
+// ROM API get_config call (ROM version >= 1.5)
+MG_IRAM static int flexspi_nor_get_config(
+    struct mg_flexspi_nor_config **config) {
+  uint32_t options[] = {0xc0000000, 0x00};
+
+  MG_ARM_DISABLE_IRQ();
+  uint32_t status =
+      flexspi_nor->get_config(FLEXSPI_NOR_INSTANCE, *config, options);
+  if (!s_flash_irq_disabled) {
+    MG_ARM_ENABLE_IRQ();
+  }
+  if (status) {
+    MG_ERROR(("Failed to extract flash configuration: status %u", status));
+  }
+  return status;
+}
+#endif
+
+MG_IRAM static void mg_spin(volatile uint32_t count) {
+  while (count--) (void) 0;
+}
+
+MG_IRAM static void flash_wait(void) {
+  while ((*((volatile uint32_t *) (MG_FLEXSPI_BASE + 0xE0)) & MG_BIT(1)) == 0)
+    mg_spin(1);
+}
+
+MG_IRAM static bool flash_erase(struct mg_flexspi_nor_config *config,
+                                void *addr) {
+  if (flash_page_start(addr) == false) {
+    MG_ERROR(("%p is not on a sector boundary", addr));
+    return false;
+  }
+
+  void *dst = (void *) ((char *) addr - (char *) s_mg_flash_imxrt.start);
+
+  bool ok = (flexspi_nor->erase(FLEXSPI_NOR_INSTANCE, config, (uint32_t) dst,
+                                s_mg_flash_imxrt.secsz) == 0);
+  MG_DEBUG(("Sector starting at %p erasure: %s", addr, ok ? "ok" : "fail"));
+  return ok;
+}
+
+#if 0
+// standalone erase call
+MG_IRAM static bool mg_imxrt_erase(void *addr) {
+  struct mg_flexspi_nor_config config, *config_ptr = &config;
+  bool ret;
+  // Interrupts must be disabled before calls to ROM API in RT1020 and 1060
+  MG_ARM_DISABLE_IRQ();
+  ret = (flexspi_nor_get_config(&config_ptr) == 0);
+  if (ret) ret = flash_erase(config_ptr, addr);
+  MG_ARM_ENABLE_IRQ();
+  return ret;
+}
+#endif
+
+MG_IRAM bool mg_imxrt_swap(void) {
+  return true;
+}
+
+MG_IRAM static bool mg_imxrt_write(void *addr, const void *buf, size_t len) {
+  struct mg_flexspi_nor_config config, *config_ptr = &config;
+  bool ok = false;
+  // Interrupts must be disabled before calls to ROM API in RT1020 and 1060
+  MG_ARM_DISABLE_IRQ();
+  if (flexspi_nor_get_config(&config_ptr) != 0) goto fwxit;
+  if ((len % s_mg_flash_imxrt.align) != 0) {
+    MG_ERROR(("%lu is not aligned to %lu", len, s_mg_flash_imxrt.align));
+    goto fwxit;
+  }
+  if ((char *) addr < (char *) s_mg_flash_imxrt.start) {
+    MG_ERROR(("Invalid flash write address: %p", addr));
+    goto fwxit;
+  }
+
+  uint32_t *dst = (uint32_t *) addr;
+  uint32_t *src = (uint32_t *) buf;
+  uint32_t *end = (uint32_t *) ((char *) buf + len);
+  ok = true;
+
+  while (ok && src < end) {
+    if (flash_page_start(dst) && flash_erase(config_ptr, dst) == false) {
+      ok = false;
+      break;
+    }
+    uint32_t status;
+    uint32_t dst_ofs = (uint32_t) dst - (uint32_t) s_mg_flash_imxrt.start;
+    if ((char *) buf >= (char *) s_mg_flash_imxrt.start) {
+      // If we copy from FLASH to FLASH, then we first need to copy the source
+      // to RAM
+      size_t tmp_buf_size = s_mg_flash_imxrt.align / sizeof(uint32_t);
+      uint32_t tmp[tmp_buf_size];
+
+      for (size_t i = 0; i < tmp_buf_size; i++) {
+        flash_wait();
+        tmp[i] = src[i];
+      }
+      status = flexspi_nor->program(FLEXSPI_NOR_INSTANCE, config_ptr,
+                                    (uint32_t) dst_ofs, tmp);
+    } else {
+      status = flexspi_nor->program(FLEXSPI_NOR_INSTANCE, config_ptr,
+                                    (uint32_t) dst_ofs, src);
+    }
+    src = (uint32_t *) ((char *) src + s_mg_flash_imxrt.align);
+    dst = (uint32_t *) ((char *) dst + s_mg_flash_imxrt.align);
+    if (status != 0) {
+      ok = false;
+    }
+  }
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s.", len, dst, ok ? "ok" : "fail"));
+fwxit:
+  if (!s_flash_irq_disabled) MG_ARM_ENABLE_IRQ();
+  return ok;
+}
+
+// just overwrite instead of swap
+MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
+  // no stdlib calls here
+  for (size_t ofs = 0; ofs < s; ofs += ss) {
+    mg_imxrt_write(p1 + ofs, p2 + ofs, ss);
+  }
+  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_imxrt);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_imxrt);
+}
+
+bool mg_ota_end(void) {
+  if (mg_ota_flash_end(&s_mg_flash_imxrt)) {
+    if (0) {  // is_dualbank()
+      // TODO(): no devices so far
+      *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+    } else {
+      // Swap partitions. Pray power does not go away
+      MG_INFO(("Swapping partitions, size %u (%u sectors)",
+               s_mg_flash_imxrt.size,
+               s_mg_flash_imxrt.size / s_mg_flash_imxrt.secsz));
+      MG_INFO(("Do NOT power off..."));
+      mg_log_level = MG_LL_NONE;
+      s_flash_irq_disabled = true;
+      // Runs in RAM, will reset when finished
+      single_bank_swap(
+          (char *) s_mg_flash_imxrt.start,
+          (char *) s_mg_flash_imxrt.start + s_mg_flash_imxrt.size / 2,
+          s_mg_flash_imxrt.size / 2, s_mg_flash_imxrt.secsz);
+    }
+  }
+  return false;
+}
+
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_mcxn.c"
+#endif
+
+
+
+
+#if MG_OTA == MG_OTA_MCXN
+
+// - Flash phrase: 16 bytes; smallest portion programmed in one operation.
+// - Flash page: 128 bytes; largest portion programmed in one operation.
+// - Flash sector: 8 KB; smallest portion that can be erased in one operation.
+// - Flash API mg_flash_driver->program: "start" and "len" must be page-size
+// aligned; to use 'phrase', FMU register access is needed. Using ROM
+
+static bool mg_mcxn_write(void *, const void *, size_t);
+static bool mg_mcxn_swap(void);
+
+static struct mg_flash s_mg_flash_mcxn = {
+    (void *) 0,  // Start, filled at init
+    0,           // Size, filled at init
+    0,           // Sector size, filled at init
+    0,           // Align, filled at init
+    mg_mcxn_write,
+    mg_mcxn_swap,
+};
+
+struct mg_flash_config {
+  uint32_t addr;
+  uint32_t size;
+  uint32_t blocks;
+  uint32_t page_size;
+  uint32_t sector_size;
+  uint32_t ffr[6];
+  uint32_t reserved0[5];
+  uint32_t *bootctx;
+  bool useahb;
+};
+
+struct mg_flash_driver_interface {
+  uint32_t version;
+  uint32_t (*init)(struct mg_flash_config *);
+  uint32_t (*erase)(struct mg_flash_config *, uint32_t start, uint32_t len,
+                    uint32_t key);
+  uint32_t (*program)(struct mg_flash_config *, uint32_t start, uint8_t *src,
+                      uint32_t len);
+  uint32_t (*verify_erase)(struct mg_flash_config *, uint32_t start,
+                           uint32_t len);
+  uint32_t (*verify_program)(struct mg_flash_config *, uint32_t start,
+                             uint32_t len, const uint8_t *expected,
+                             uint32_t *addr, uint32_t *failed);
+  uint32_t reserved1[12];
+  uint32_t (*read)(struct mg_flash_config *, uint32_t start, uint8_t *dest,
+                   uint32_t len);
+  uint32_t reserved2[4];
+  uint32_t (*deinit)(struct mg_flash_config *);
+};
+#define mg_flash_driver \
+  ((struct mg_flash_driver_interface *) (*((uint32_t *) 0x1303fc00 + 4)))
+#define MG_MCXN_FLASK_KEY (('k' << 24) | ('e' << 16) | ('f' << 8) | 'l')
+
+MG_IRAM static bool flash_sector_start(volatile uint32_t *dst) {
+  char *base = (char *) s_mg_flash_mcxn.start,
+       *end = base + s_mg_flash_mcxn.size;
+  volatile char *p = (char *) dst;
+  return p >= base && p < end && ((p - base) % s_mg_flash_mcxn.secsz) == 0;
+}
+
+MG_IRAM static bool flash_erase(struct mg_flash_config *config, void *addr) {
+  if (flash_sector_start(addr) == false) {
+    MG_ERROR(("%p is not on a sector boundary", addr));
+    return false;
+  }
+  uint32_t dst =
+      (uint32_t) addr - (uint32_t) s_mg_flash_mcxn.start;  // future-proof
+  uint32_t status = mg_flash_driver->erase(config, dst, s_mg_flash_mcxn.secsz,
+                                           MG_MCXN_FLASK_KEY);
+  bool ok = (status == 0);
+  if (!ok) MG_ERROR(("Flash write error: %lu", status));
+  MG_DEBUG(("Sector starting at %p erasure: %s", addr, ok ? "ok" : "fail"));
+  return ok;
+}
+
+#if 0
+// read-while-write, no need to disable IRQs for standalone usage
+MG_IRAM static bool mg_mcxn_erase(void *addr) {
+  uint32_t status;
+  struct mg_flash_config config;
+  if ((status = mg_flash_driver->init(&config)) != 0) {
+    MG_ERROR(("Flash driver init error: %lu", status));
+    return false;
+  }
+  bool ok = flash_erase(&config, addr);
+  mg_flash_driver->deinit(&config);
+  return ok;
+}
+#endif
+
+MG_IRAM static bool mg_mcxn_swap(void) {
+  // TODO(): no devices so far
+  return true;
+}
+
+static bool s_flash_irq_disabled;
+
+MG_IRAM static bool mg_mcxn_write(void *addr, const void *buf, size_t len) {
+  bool ok = false;
+  uint32_t status;
+  struct mg_flash_config config;
+  if ((status = mg_flash_driver->init(&config)) != 0) {
+    MG_ERROR(("Flash driver init error: %lu", status));
+    return false;
+  }
+  if ((len % s_mg_flash_mcxn.align) != 0) {
+    MG_ERROR(("%lu is not aligned to %lu", len, s_mg_flash_mcxn.align));
+    goto fwxit;
+  }
+  if ((((size_t) addr - (size_t) s_mg_flash_mcxn.start) %
+       s_mg_flash_mcxn.align) != 0) {
+    MG_ERROR(("%p is not on a page boundary", addr));
+    goto fwxit;
+  }
+
+  uint32_t *dst = (uint32_t *) addr;
+  uint32_t *src = (uint32_t *) buf;
+  uint32_t *end = (uint32_t *) ((char *) buf + len);
+  ok = true;
+
+  MG_ARM_DISABLE_IRQ();
+  while (ok && src < end) {
+    if (flash_sector_start(dst) && flash_erase(&config, dst) == false) {
+      ok = false;
+      break;
+    }
+    uint32_t dst_ofs = (uint32_t) dst - (uint32_t) s_mg_flash_mcxn.start;
+    // assume source is in RAM or in a different bank or read-while-write
+    status = mg_flash_driver->program(&config, dst_ofs, (uint8_t *) src,
+                                      s_mg_flash_mcxn.align);
+    src = (uint32_t *) ((char *) src + s_mg_flash_mcxn.align);
+    dst = (uint32_t *) ((char *) dst + s_mg_flash_mcxn.align);
+    if (status != 0) {
+      MG_ERROR(("Flash write error: %lu", status));
+      ok = false;
+    }
+  }
+  if (!s_flash_irq_disabled) MG_ARM_ENABLE_IRQ();
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s.", len, dst, ok ? "ok" : "fail"));
+
+fwxit:
+  mg_flash_driver->deinit(&config);
+  return ok;
+}
+
+// try to swap (honor dual image), otherwise just overwrite
+MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
+  char *tmp = malloc(ss);
+  // no stdlib calls here
+  for (size_t ofs = 0; ofs < s; ofs += ss) {
+    if (tmp != NULL)
+      for (size_t i = 0; i < ss; i++) tmp[i] = p1[ofs + i];
+    mg_mcxn_write(p1 + ofs, p2 + ofs, ss);
+    if (tmp != NULL) mg_mcxn_write(p2 + ofs, tmp, ss);
+  }
+  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  uint32_t status;
+  struct mg_flash_config config;
+  if ((status = mg_flash_driver->init(&config)) != 0) {
+    MG_ERROR(("Flash driver init error: %lu", status));
+    return false;
+  }
+  s_mg_flash_mcxn.start = (void *) config.addr;
+  s_mg_flash_mcxn.size = config.size;
+  s_mg_flash_mcxn.secsz = config.sector_size;
+  s_mg_flash_mcxn.align = config.page_size;
+  mg_flash_driver->deinit(&config);
+  MG_DEBUG(
+      ("%lu-byte flash @%p, using %lu-byte sectors with %lu-byte-aligned pages",
+       s_mg_flash_mcxn.size, s_mg_flash_mcxn.start, s_mg_flash_mcxn.secsz,
+       s_mg_flash_mcxn.align));
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_mcxn);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_mcxn);
+}
+
+bool mg_ota_end(void) {
+  if (mg_ota_flash_end(&s_mg_flash_mcxn)) {
+    if (0) {  // is_dualbank()
+      // TODO(): no devices so far
+      *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+    } else {
+      // Swap partitions. Pray power does not go away
+      MG_INFO(("Swapping partitions, size %u (%u sectors)",
+               s_mg_flash_mcxn.size,
+               s_mg_flash_mcxn.size / s_mg_flash_mcxn.secsz));
+      MG_INFO(("Do NOT power off..."));
+      mg_log_level = MG_LL_NONE;
+      s_flash_irq_disabled = true;
+      // Runs in RAM, will reset when finished
+      single_bank_swap(
+          (char *) s_mg_flash_mcxn.start,
+          (char *) s_mg_flash_mcxn.start + s_mg_flash_mcxn.size / 2,
+          s_mg_flash_mcxn.size / 2, s_mg_flash_mcxn.secsz);
+    }
+  }
+  return false;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_picosdk.c"
+#endif
+
+
+
+
+#if MG_OTA == MG_OTA_PICOSDK
+
+// Both RP2040 and RP2350 have no flash, low-level flash access support in
+// bootrom, and high-level support in Pico-SDK (2.0+ for the RP2350)
+// - The RP2350 in RISC-V mode is not tested
+// NOTE(): See OTA design notes
+
+static bool mg_picosdk_write(void *, const void *, size_t);
+static bool mg_picosdk_swap(void);
+
+static struct mg_flash s_mg_flash_picosdk = {
+    (void *) 0x10000000,  // Start; functions handle offset
+#ifdef PICO_FLASH_SIZE_BYTES
+    PICO_FLASH_SIZE_BYTES,  // Size, from board definitions
+#else
+    0x200000,  // Size, guess... is 2M enough ?
+#endif
+    FLASH_SECTOR_SIZE,  // Sector size, from hardware_flash
+    FLASH_PAGE_SIZE,    // Align, from hardware_flash
+    mg_picosdk_write,      mg_picosdk_swap,
+};
+
+#define MG_MODULO2(x, m) ((x) & ((m) -1))
+
+static bool __no_inline_not_in_flash_func(flash_sector_start)(
+    volatile uint32_t *dst) {
+  char *base = (char *) s_mg_flash_picosdk.start,
+       *end = base + s_mg_flash_picosdk.size;
+  volatile char *p = (char *) dst;
+  return p >= base && p < end &&
+         MG_MODULO2(p - base, s_mg_flash_picosdk.secsz) == 0;
+}
+
+static bool __no_inline_not_in_flash_func(flash_erase)(void *addr) {
+  if (flash_sector_start(addr) == false) {
+    MG_ERROR(("%p is not on a sector boundary", addr));
+    return false;
+  }
+  void *dst = (void *) ((char *) addr - (char *) s_mg_flash_picosdk.start);
+  flash_range_erase((uint32_t) dst, s_mg_flash_picosdk.secsz);
+  MG_DEBUG(("Sector starting at %p erasure", addr));
+  return true;
+}
+
+static bool __no_inline_not_in_flash_func(mg_picosdk_swap)(void) {
+  // TODO(): RP2350 might have some A/B functionality (DS 5.1)
+  return true;
+}
+
+static bool s_flash_irq_disabled;
+
+static bool __no_inline_not_in_flash_func(mg_picosdk_write)(void *addr,
+                                                            const void *buf,
+                                                            size_t len) {
+  if ((len % s_mg_flash_picosdk.align) != 0) {
+    MG_ERROR(("%lu is not aligned to %lu", len, s_mg_flash_picosdk.align));
+    return false;
+  }
+  if ((((size_t) addr - (size_t) s_mg_flash_picosdk.start) %
+       s_mg_flash_picosdk.align) != 0) {
+    MG_ERROR(("%p is not on a page boundary", addr));
+    return false;
+  }
+
+  uint32_t *dst = (uint32_t *) addr;
+  uint32_t *src = (uint32_t *) buf;
+  uint32_t *end = (uint32_t *) ((char *) buf + len);
+
+#ifndef __riscv
+  MG_ARM_DISABLE_IRQ();
+#else
+  asm volatile("csrrc zero, mstatus, %0" : : "i"(1 << 3) : "memory");
+#endif
+  while (src < end) {
+    uint32_t dst_ofs = (uint32_t) dst - (uint32_t) s_mg_flash_picosdk.start;
+    if (flash_sector_start(dst) && flash_erase(dst) == false) break;
+    // flash_range_program() runs in RAM and handles writing up to
+    // FLASH_PAGE_SIZE bytes. Source must not be in flash
+    flash_range_program((uint32_t) dst_ofs, (uint8_t *) src,
+                        s_mg_flash_picosdk.align);
+    src = (uint32_t *) ((char *) src + s_mg_flash_picosdk.align);
+    dst = (uint32_t *) ((char *) dst + s_mg_flash_picosdk.align);
+  }
+  if (!s_flash_irq_disabled) {
+#ifndef __riscv
+    MG_ARM_ENABLE_IRQ();
+#else
+    asm volatile("csrrs mstatus, %0" : : "i"(1 << 3) : "memory");
+#endif
+  }
+  MG_DEBUG(("Flash write %lu bytes @ %p.", len, dst));
+  return true;
+}
+
+// just overwrite instead of swap
+static void __no_inline_not_in_flash_func(single_bank_swap)(char *p1, char *p2,
+                                                            size_t s,
+                                                            size_t ss) {
+  char *tmp = malloc(ss);
+  if (tmp == NULL) return;
+#if PICO_RP2040
+  uint32_t xip[256 / sizeof(uint32_t)];
+  void *dst = (void *) ((char *) p1 - (char *) s_mg_flash_picosdk.start);
+  size_t count = MG_ROUND_UP(s, ss);
+  // use SDK function calls to get BootROM function pointers
+  rom_connect_internal_flash_fn connect = (rom_connect_internal_flash_fn) rom_func_lookup(ROM_FUNC_CONNECT_INTERNAL_FLASH);
+  rom_flash_exit_xip_fn xit = (rom_flash_exit_xip_fn) rom_func_lookup(ROM_FUNC_FLASH_EXIT_XIP);
+  rom_flash_range_program_fn program = (rom_flash_range_program_fn) rom_func_lookup(ROM_FUNC_FLASH_RANGE_PROGRAM);
+  rom_flash_flush_cache_fn flush = (rom_flash_flush_cache_fn) rom_func_lookup(ROM_FUNC_FLASH_FLUSH_CACHE);
+  // no stdlib calls here.
+  MG_ARM_DISABLE_IRQ();
+  // 2nd bootloader (XIP) is in flash, SDK functions copy it to RAM on entry
+  for (size_t i = 0; i < 256 / sizeof(uint32_t); i++)
+    xip[i] = ((uint32_t *) (s_mg_flash_picosdk.start))[i];
+  flash_range_erase((uint32_t) dst, count);
+  // flash has been erased, no XIP to copy. Only BootROM calls possible
+  for (uint32_t ofs = 0; ofs < s; ofs += ss) {
+    for (size_t i = 0; i < ss; i++) tmp[i] = p2[ofs + i];
+    __compiler_memory_barrier();
+    connect();
+    xit();
+    program((uint32_t) dst + ofs, tmp, ss);
+    flush();
+    ((void (*)(void))((intptr_t) xip + 1))(); // enter XIP again
+  }
+  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;  // AIRCR = SYSRESETREQ
+#else
+  // RP2350 has BootRAM and copies second bootloader there, SDK uses that copy,
+  // It might also be able to take advantage of partition swapping
+  rom_reboot_fn reboot = (rom_reboot_fn) rom_func_lookup(ROM_FUNC_REBOOT);
+  for (size_t ofs = 0; ofs < s; ofs += ss) {
+    for (size_t i = 0; i < ss; i++) tmp[i] = p2[ofs + i];
+    mg_picosdk_write(p1 + ofs, tmp, ss);
+  }
+  reboot(BOOT_TYPE_NORMAL | 0x100, 1, 0, 0); // 0x100: NO_RETURN_ON_SUCCESS
+#endif
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_picosdk);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_picosdk);
+}
+
+bool mg_ota_end(void) {
+  if (mg_ota_flash_end(&s_mg_flash_picosdk)) {
+    // Swap partitions. Pray power does not go away
+    MG_INFO(("Swapping partitions, size %u (%u sectors)",
+             s_mg_flash_picosdk.size,
+             s_mg_flash_picosdk.size / s_mg_flash_picosdk.secsz));
+    MG_INFO(("Do NOT power off..."));
+    mg_log_level = MG_LL_NONE;
+    s_flash_irq_disabled = true;
+    // Runs in RAM, will reset when finished or return on failure
+    single_bank_swap(
+        (char *) s_mg_flash_picosdk.start,
+        (char *) s_mg_flash_picosdk.start + s_mg_flash_picosdk.size / 2,
+        s_mg_flash_picosdk.size / 2, s_mg_flash_picosdk.secsz);
+  }
+  return false;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_stm32f.c"
+#endif
+
+
+
+
+#if MG_OTA == MG_OTA_STM32F
+
+static bool mg_stm32f_write(void *, const void *, size_t);
+static bool mg_stm32f_swap(void);
+
+static struct mg_flash s_mg_flash_stm32f = {
+    (void *) 0x08000000,  // Start
+    0,                    // Size, FLASH_SIZE_REG
+    0,                    // Irregular sector size
+    32,                   // Align, 256 bit
+    mg_stm32f_write,
+    mg_stm32f_swap,
+};
+
+#define MG_FLASH_BASE 0x40023c00
+#define MG_FLASH_KEYR 0x04
+#define MG_FLASH_SR 0x0c
+#define MG_FLASH_CR 0x10
+#define MG_FLASH_OPTCR 0x14
+#define MG_FLASH_SIZE_REG_F7 0x1FF0F442
+#define MG_FLASH_SIZE_REG_F4 0x1FFF7A22
+
+#define STM_DBGMCU_IDCODE 0xE0042000
+#define STM_DEV_ID (MG_REG(STM_DBGMCU_IDCODE) & (MG_BIT(12) - 1))
+#define SYSCFG_MEMRMP 0x40013800
+
+#define MG_FLASH_SIZE_REG_LOCATION \
+  ((STM_DEV_ID >= 0x449) ? MG_FLASH_SIZE_REG_F7 : MG_FLASH_SIZE_REG_F4)
+
+static size_t flash_size(void) {
+  return (MG_REG(MG_FLASH_SIZE_REG_LOCATION) & 0xFFFF) * 1024;
+}
+
+MG_IRAM static int is_dualbank(void) {
+  // only F42x/F43x series (0x419) support dual bank
+  return STM_DEV_ID == 0x419;
+}
+
+MG_IRAM static void flash_unlock(void) {
+  static bool unlocked = false;
+  if (unlocked == false) {
+    MG_REG(MG_FLASH_BASE + MG_FLASH_KEYR) = 0x45670123;
+    MG_REG(MG_FLASH_BASE + MG_FLASH_KEYR) = 0xcdef89ab;
+    unlocked = true;
+  }
+}
+
+#define MG_FLASH_CONFIG_16_64_128 1   // used by STM32F7
+#define MG_FLASH_CONFIG_32_128_256 2  // used by STM32F4 and F2
+
+MG_IRAM static bool flash_page_start(volatile uint32_t *dst) {
+  char *base = (char *) s_mg_flash_stm32f.start;
+  char *end = base + s_mg_flash_stm32f.size;
+
+  if (is_dualbank() && dst >= (uint32_t *) (base + (end - base) / 2)) {
+    dst = (uint32_t *) ((uint32_t) dst - (end - base) / 2);
+  }
+
+  uint32_t flash_config = MG_FLASH_CONFIG_16_64_128;
+  if (STM_DEV_ID >= 0x449) {
+    flash_config = MG_FLASH_CONFIG_32_128_256;
+  }
+
+  volatile char *p = (char *) dst;
+  if (p >= base && p < end) {
+    if (p < base + 16 * 1024 * 4 * flash_config) {
+      if ((p - base) % (16 * 1024 * flash_config) == 0) return true;
+    } else if (p == base + 16 * 1024 * 4 * flash_config) {
+      return true;
+    } else if ((p - base) % (128 * 1024 * flash_config) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+MG_IRAM static int flash_sector(volatile uint32_t *addr) {
+  char *base = (char *) s_mg_flash_stm32f.start;
+  char *end = base + s_mg_flash_stm32f.size;
+  bool addr_in_bank_2 = false;
+  if (is_dualbank() && addr >= (uint32_t *) (base + (end - base) / 2)) {
+    addr = (uint32_t *) ((uint32_t) addr - (end - base) / 2);
+    addr_in_bank_2 = true;
+  }
+  volatile char *p = (char *) addr;
+  uint32_t flash_config = MG_FLASH_CONFIG_16_64_128;
+  if (STM_DEV_ID >= 0x449) {
+    flash_config = MG_FLASH_CONFIG_32_128_256;
+  }
+  int sector = -1;
+  if (p >= base && p < end) {
+    if (p < base + 16 * 1024 * 4 * flash_config) {
+      sector = (p - base) / (16 * 1024 * flash_config);
+    } else if (p >= base + 64 * 1024 * flash_config &&
+               p < base + 128 * 1024 * flash_config) {
+      sector = 4;
+    } else {
+      sector = (p - base) / (128 * 1024 * flash_config) + 4;
+    }
+  }
+  if (sector == -1) return -1;
+  if (addr_in_bank_2) sector += 12;  // a bank has 12 sectors
+  return sector;
+}
+
+MG_IRAM static bool flash_is_err(void) {
+  return MG_REG(MG_FLASH_BASE + MG_FLASH_SR) & ((MG_BIT(7) - 1) << 1);
+}
+
+MG_IRAM static void flash_wait(void) {
+  while (MG_REG(MG_FLASH_BASE + MG_FLASH_SR) & (MG_BIT(16))) (void) 0;
+}
+
+MG_IRAM static void flash_clear_err(void) {
+  flash_wait();                                // Wait until ready
+  MG_REG(MG_FLASH_BASE + MG_FLASH_SR) = 0xf2;  // Clear all errors
+}
+
+MG_IRAM static bool mg_stm32f_erase(void *addr) {
+  bool ok = false;
+  if (flash_page_start(addr) == false) {
+    MG_ERROR(("%p is not on a sector boundary", addr));
+  } else {
+    int sector = flash_sector(addr);
+    if (sector < 0) return false;
+    uint32_t sector_reg = sector;
+    if (is_dualbank() && sector >= 12) {
+      // 3.9.8 Flash control register (FLASH_CR) for F42xxx and F43xxx
+      // BITS[7:3]
+      sector_reg -= 12;
+      sector_reg |= MG_BIT(4);
+    }
+    flash_unlock();
+    flash_wait();
+    uint32_t cr = MG_BIT(1);       // SER
+    cr |= MG_BIT(16);              // STRT
+    cr |= (sector_reg & 31) << 3;  // sector
+    MG_REG(MG_FLASH_BASE + MG_FLASH_CR) = cr;
+    ok = !flash_is_err();
+    MG_DEBUG(("Erase sector %lu @ %p %s. CR %#lx SR %#lx", sector, addr,
+              ok ? "ok" : "fail", MG_REG(MG_FLASH_BASE + MG_FLASH_CR),
+              MG_REG(MG_FLASH_BASE + MG_FLASH_SR)));
+    // After we have erased the sector, set CR flags for programming
+    // 2 << 8 is word write parallelism, bit(0) is PG. RM0385, section 3.7.5
+    MG_REG(MG_FLASH_BASE + MG_FLASH_CR) = MG_BIT(0) | (2 << 8);
+    flash_clear_err();
+  }
+  return ok;
+}
+
+MG_IRAM static bool mg_stm32f_swap(void) {
+  // STM32 F42x/F43x support dual bank, however, the memory mapping
+  // change will not be carried through a hard reset. Therefore, we will use
+  // the single bank approach for this family as well.
+  return true;
+}
+
+static bool s_flash_irq_disabled;
+
+MG_IRAM static bool mg_stm32f_write(void *addr, const void *buf, size_t len) {
+  if ((len % s_mg_flash_stm32f.align) != 0) {
+    MG_ERROR(("%lu is not aligned to %lu", len, s_mg_flash_stm32f.align));
+    return false;
+  }
+  uint32_t *dst = (uint32_t *) addr;
+  uint32_t *src = (uint32_t *) buf;
+  uint32_t *end = (uint32_t *) ((char *) buf + len);
+  bool ok = true;
+  MG_ARM_DISABLE_IRQ();
+  flash_unlock();
+  flash_clear_err();
+  MG_REG(MG_FLASH_BASE + MG_FLASH_CR) = MG_BIT(0) | MG_BIT(9);  // PG, 32-bit
+  flash_wait();
+  MG_DEBUG(("Writing flash @ %p, %lu bytes", addr, len));
+  while (ok && src < end) {
+    if (flash_page_start(dst) && mg_stm32f_erase(dst) == false) break;
+    *(volatile uint32_t *) dst++ = *src++;
+    MG_DSB();  // ensure flash is written with no errors
+    flash_wait();
+    if (flash_is_err()) ok = false;
+  }
+  if (!s_flash_irq_disabled) MG_ARM_ENABLE_IRQ();
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, dst,
+            ok ? "ok" : "fail", MG_REG(MG_FLASH_BASE + MG_FLASH_CR),
+            MG_REG(MG_FLASH_BASE + MG_FLASH_SR)));
+  MG_REG(MG_FLASH_BASE + MG_FLASH_CR) &= ~MG_BIT(0);  // Clear programming flag
+  return ok;
+}
+
+// just overwrite instead of swap
+MG_IRAM void single_bank_swap(char *p1, char *p2, size_t size) {
+  // no stdlib calls here
+  mg_stm32f_write(p1, p2, size);
+  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  s_mg_flash_stm32f.size = flash_size();
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_stm32f);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_stm32f);
+}
+
+bool mg_ota_end(void) {
+  if (mg_ota_flash_end(&s_mg_flash_stm32f)) {
+    // Swap partitions. Pray power does not go away
+    MG_INFO(("Swapping partitions, size %u (%u sectors)",
+             s_mg_flash_stm32f.size, STM_DEV_ID == 0x449 ? 8 : 12));
+    MG_INFO(("Do NOT power off..."));
+    mg_log_level = MG_LL_NONE;
+    s_flash_irq_disabled = true;
+    char *p1 = (char *) s_mg_flash_stm32f.start;
+    char *p2 = p1 + s_mg_flash_stm32f.size / 2;
+    size_t size = s_mg_flash_stm32f.size / 2;
+    // Runs in RAM, will reset when finished
+    single_bank_swap(p1, p2, size);
+  }
+  return false;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_stm32h5.c"
+#endif
+
+
+
+
+#if MG_OTA == MG_OTA_STM32H5
+
+static bool mg_stm32h5_write(void *, const void *, size_t);
+static bool mg_stm32h5_swap(void);
+
+static struct mg_flash s_mg_flash_stm32h5 = {
+    (void *) 0x08000000,  // Start
+    2 * 1024 * 1024,      // Size, 2Mb
+    8 * 1024,             // Sector size, 8k
+    16,                   // Align, 128 bit
+    mg_stm32h5_write,
+    mg_stm32h5_swap,
+};
+
+#define MG_FLASH_BASE 0x40022000          // Base address of the flash controller
+#define FLASH_KEYR (MG_FLASH_BASE + 0x4)  // See RM0481 7.11
+#define FLASH_OPTKEYR (MG_FLASH_BASE + 0xc)
+#define FLASH_OPTCR (MG_FLASH_BASE + 0x1c)
+#define FLASH_NSSR (MG_FLASH_BASE + 0x20)
+#define FLASH_NSCR (MG_FLASH_BASE + 0x28)
+#define FLASH_NSCCR (MG_FLASH_BASE + 0x30)
+#define FLASH_OPTSR_CUR (MG_FLASH_BASE + 0x50)
+#define FLASH_OPTSR_PRG (MG_FLASH_BASE + 0x54)
+
+static void flash_unlock(void) {
+  static bool unlocked = false;
+  if (unlocked == false) {
+    MG_REG(FLASH_KEYR) = 0x45670123;
+    MG_REG(FLASH_KEYR) = 0Xcdef89ab;
+    MG_REG(FLASH_OPTKEYR) = 0x08192a3b;
+    MG_REG(FLASH_OPTKEYR) = 0x4c5d6e7f;
+    unlocked = true;
+  }
+}
+
+static int flash_page_start(volatile uint32_t *dst) {
+  char *base = (char *) s_mg_flash_stm32h5.start,
+       *end = base + s_mg_flash_stm32h5.size;
+  volatile char *p = (char *) dst;
+  return p >= base && p < end && ((p - base) % s_mg_flash_stm32h5.secsz) == 0;
+}
+
+static bool flash_is_err(void) {
+  return MG_REG(FLASH_NSSR) & ((MG_BIT(8) - 1) << 17);  // RM0481 7.11.9
+}
+
+static void flash_wait(void) {
+  while ((MG_REG(FLASH_NSSR) & MG_BIT(0)) &&
+         (MG_REG(FLASH_NSSR) & MG_BIT(16)) == 0) {
+    (void) 0;
+  }
+}
+
+static void flash_clear_err(void) {
+  flash_wait();                                    // Wait until ready
+  MG_REG(FLASH_NSCCR) = ((MG_BIT(9) - 1) << 16U);  // Clear all errors
+}
+
+static bool flash_bank_is_swapped(void) {
+  return MG_REG(FLASH_OPTCR) & MG_BIT(31);  // RM0481 7.11.8
+}
+
+static bool mg_stm32h5_erase(void *location) {
+  bool ok = false;
+  if (flash_page_start(location) == false) {
+    MG_ERROR(("%p is not on a sector boundary"));
+  } else {
+    uintptr_t diff = (char *) location - (char *) s_mg_flash_stm32h5.start;
+    uint32_t sector = diff / s_mg_flash_stm32h5.secsz;
+    uint32_t saved_cr = MG_REG(FLASH_NSCR);  // Save CR value
+    flash_unlock();
+    flash_clear_err();
+    MG_REG(FLASH_NSCR) = 0;
+    if ((sector < 128 && flash_bank_is_swapped()) ||
+        (sector > 127 && !flash_bank_is_swapped())) {
+      MG_REG(FLASH_NSCR) |= MG_BIT(31);  // Set FLASH_CR_BKSEL
+    }
+    if (sector > 127) sector -= 128;
+    MG_REG(FLASH_NSCR) |= MG_BIT(2) | (sector << 6);  // Erase | sector_num
+    MG_REG(FLASH_NSCR) |= MG_BIT(5);                  // Start erasing
+    flash_wait();
+    ok = !flash_is_err();
+    MG_DEBUG(("Erase sector %lu @ %p: %s. CR %#lx SR %#lx", sector, location,
+              ok ? "ok" : "fail", MG_REG(FLASH_NSCR), MG_REG(FLASH_NSSR)));
+    // mg_hexdump(location, 32);
+    MG_REG(FLASH_NSCR) = saved_cr;  // Restore saved CR
+  }
+  return ok;
+}
+
+static bool mg_stm32h5_swap(void) {
+  uint32_t desired = flash_bank_is_swapped() ? 0 : MG_BIT(31);
+  flash_unlock();
+  flash_clear_err();
+  // printf("OPTSR_PRG 1 %#lx\n", FLASH->OPTSR_PRG);
+  MG_SET_BITS(MG_REG(FLASH_OPTSR_PRG), MG_BIT(31), desired);
+  // printf("OPTSR_PRG 2 %#lx\n", FLASH->OPTSR_PRG);
+  MG_REG(FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART
+  while ((MG_REG(FLASH_OPTSR_CUR) & MG_BIT(31)) != desired) (void) 0;
+  return true;
+}
+
+static bool mg_stm32h5_write(void *addr, const void *buf, size_t len) {
+  if ((len % s_mg_flash_stm32h5.align) != 0) {
+    MG_ERROR(("%lu is not aligned to %lu", len, s_mg_flash_stm32h5.align));
+    return false;
+  }
+  uint32_t *dst = (uint32_t *) addr;
+  uint32_t *src = (uint32_t *) buf;
+  uint32_t *end = (uint32_t *) ((char *) buf + len);
+  bool ok = true;
+  MG_ARM_DISABLE_IRQ();
+  flash_unlock();
+  flash_clear_err();
+  MG_REG(FLASH_NSCR) = MG_BIT(1);  // Set programming flag
+  while (ok && src < end) {
+    if (flash_page_start(dst) && mg_stm32h5_erase(dst) == false) {
+      ok = false;
+      break;
+    }
+    *(volatile uint32_t *) dst++ = *src++;
+    flash_wait();
+    if (flash_is_err()) ok = false;
+  }
+  MG_ARM_ENABLE_IRQ();
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, dst,
+            flash_is_err() ? "fail" : "ok", MG_REG(FLASH_NSCR),
+            MG_REG(FLASH_NSSR)));
+  MG_REG(FLASH_NSCR) = 0;  // Clear flags
+  return ok;
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_stm32h5);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_stm32h5);
+}
+
+// Actual bank swap is deferred until reset, it is safe to execute in flash
+bool mg_ota_end(void) {
+  if(!mg_ota_flash_end(&s_mg_flash_stm32h5)) return false;
+  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+  return true;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/ota_stm32h7.c"
+#endif
+
+
+
+
+#if MG_OTA == MG_OTA_STM32H7 || MG_OTA == MG_OTA_STM32H7_DUAL_CORE
+
+// - H723/735 RM 4.3.3: Note: The application can simultaneously request a read
+// and a write operation through the AXI interface.
+//   - We only need IRAM for partition swapping in the H723, however, all
+//   related functions must reside in IRAM for this to be possible.
+// - Linker files for other devices won't define a .iram section so there's no
+// associated penalty
+
+static bool mg_stm32h7_write(void *, const void *, size_t);
+static bool mg_stm32h7_swap(void);
+
+static struct mg_flash s_mg_flash_stm32h7 = {
+    (void *) 0x08000000,  // Start
+    0,                    // Size, FLASH_SIZE_REG
+    128 * 1024,           // Sector size, 128k
+    32,                   // Align, 256 bit
+    mg_stm32h7_write,
+    mg_stm32h7_swap,
+};
+
+#define FLASH_BASE1 0x52002000  // Base address for bank1
+#define FLASH_BASE2 0x52002100  // Base address for bank2
+#define FLASH_KEYR 0x04         // See RM0433 4.9.2
+#define FLASH_OPTKEYR 0x08
+#define FLASH_OPTCR 0x18
+#define FLASH_SR 0x10
+#define FLASH_CR 0x0c
+#define FLASH_CCR 0x14
+#define FLASH_OPTSR_CUR 0x1c
+#define FLASH_OPTSR_PRG 0x20
+#define FLASH_SIZE_REG 0x1ff1e880
+
+#define IS_DUALCORE() (MG_OTA == MG_OTA_STM32H7_DUAL_CORE)
+
+MG_IRAM static bool is_dualbank(void) {
+  if (IS_DUALCORE()) {
+    // H745/H755 and H747/H757 are running on dual core.
+    // Using only the 1st bank (mapped to CM7), in order not to interfere
+    // with the 2nd bank (CM4), possibly causing CM4 to boot unexpectedly.
+    return false;
+  }
+  return (s_mg_flash_stm32h7.size < 2 * 1024 * 1024) ? false : true;
+}
+
+MG_IRAM static void flash_unlock(void) {
+  static bool unlocked = false;
+  if (unlocked == false) {
+    MG_REG(FLASH_BASE1 + FLASH_KEYR) = 0x45670123;
+    MG_REG(FLASH_BASE1 + FLASH_KEYR) = 0xcdef89ab;
+    if (is_dualbank()) {
+      MG_REG(FLASH_BASE2 + FLASH_KEYR) = 0x45670123;
+      MG_REG(FLASH_BASE2 + FLASH_KEYR) = 0xcdef89ab;
+    }
+    MG_REG(FLASH_BASE1 + FLASH_OPTKEYR) = 0x08192a3b;  // opt reg is "shared"
+    MG_REG(FLASH_BASE1 + FLASH_OPTKEYR) = 0x4c5d6e7f;  // thus unlock once
+    unlocked = true;
+  }
+}
+
+MG_IRAM static bool flash_page_start(volatile uint32_t *dst) {
+  char *base = (char *) s_mg_flash_stm32h7.start,
+       *end = base + s_mg_flash_stm32h7.size;
+  volatile char *p = (char *) dst;
+  return p >= base && p < end && ((p - base) % s_mg_flash_stm32h7.secsz) == 0;
+}
+
+MG_IRAM static bool flash_is_err(uint32_t bank) {
+  return MG_REG(bank + FLASH_SR) & ((MG_BIT(11) - 1) << 17);  // RM0433 4.9.5
+}
+
+MG_IRAM static void flash_wait(uint32_t bank) {
+  while (MG_REG(bank + FLASH_SR) & (MG_BIT(0) | MG_BIT(2))) (void) 0;
+}
+
+MG_IRAM static void flash_clear_err(uint32_t bank) {
+  flash_wait(bank);                                      // Wait until ready
+  MG_REG(bank + FLASH_CCR) = ((MG_BIT(11) - 1) << 16U);  // Clear all errors
+}
+
+MG_IRAM static bool flash_bank_is_swapped(uint32_t bank) {
+  return MG_REG(bank + FLASH_OPTCR) & MG_BIT(31);  // RM0433 4.9.7
+}
+
+// Figure out flash bank based on the address
+MG_IRAM static uint32_t flash_bank(void *addr) {
+  size_t ofs = (char *) addr - (char *) s_mg_flash_stm32h7.start;
+  if (!is_dualbank()) return FLASH_BASE1;
+  return ofs < s_mg_flash_stm32h7.size / 2 ? FLASH_BASE1 : FLASH_BASE2;
+}
+
+// read-while-write, no need to disable IRQs for standalone usage
+MG_IRAM static bool mg_stm32h7_erase(void *addr) {
+  bool ok = false;
+  if (flash_page_start(addr) == false) {
+    MG_ERROR(("%p is not on a sector boundary", addr));
+  } else {
+    uintptr_t diff = (char *) addr - (char *) s_mg_flash_stm32h7.start;
+    uint32_t sector = diff / s_mg_flash_stm32h7.secsz;
+    uint32_t bank = flash_bank(addr);
+    uint32_t saved_cr = MG_REG(bank + FLASH_CR);  // Save CR value
+
+    flash_unlock();
+    if (sector > 7) sector -= 8;
+
+    flash_clear_err(bank);
+    MG_REG(bank + FLASH_CR) = MG_BIT(5);             // 32-bit write parallelism
+    MG_REG(bank + FLASH_CR) |= (sector & 7U) << 8U;  // Sector to erase
+    MG_REG(bank + FLASH_CR) |= MG_BIT(2);            // Sector erase bit
+    MG_REG(bank + FLASH_CR) |= MG_BIT(7);            // Start erasing
+    ok = !flash_is_err(bank);
+    MG_DEBUG(("Erase sector %lu @ %p %s. CR %#lx SR %#lx", sector, addr,
+              ok ? "ok" : "fail", MG_REG(bank + FLASH_CR),
+              MG_REG(bank + FLASH_SR)));
+    MG_REG(bank + FLASH_CR) = saved_cr;  // Restore CR
+  }
+  return ok;
+}
+
+MG_IRAM static bool mg_stm32h7_swap(void) {
+  if (!is_dualbank()) return true;
+  uint32_t bank = FLASH_BASE1;
+  uint32_t desired = flash_bank_is_swapped(bank) ? 0 : MG_BIT(31);
+  flash_unlock();
+  flash_clear_err(bank);
+  // printf("OPTSR_PRG 1 %#lx\n", FLASH->OPTSR_PRG);
+  MG_SET_BITS(MG_REG(bank + FLASH_OPTSR_PRG), MG_BIT(31), desired);
+  // printf("OPTSR_PRG 2 %#lx\n", FLASH->OPTSR_PRG);
+  MG_REG(bank + FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART
+  while ((MG_REG(bank + FLASH_OPTSR_CUR) & MG_BIT(31)) != desired) (void) 0;
+  return true;
+}
+
+static bool s_flash_irq_disabled;
+
+MG_IRAM static bool mg_stm32h7_write(void *addr, const void *buf, size_t len) {
+  if ((len % s_mg_flash_stm32h7.align) != 0) {
+    MG_ERROR(("%lu is not aligned to %lu", len, s_mg_flash_stm32h7.align));
+    return false;
+  }
+  uint32_t bank = flash_bank(addr);
+  uint32_t *dst = (uint32_t *) addr;
+  uint32_t *src = (uint32_t *) buf;
+  uint32_t *end = (uint32_t *) ((char *) buf + len);
+  bool ok = true;
+  MG_ARM_DISABLE_IRQ();
+  flash_unlock();
+  flash_clear_err(bank);
+  MG_REG(bank + FLASH_CR) = MG_BIT(1);   // Set programming flag
+  MG_REG(bank + FLASH_CR) |= MG_BIT(5);  // 32-bit write parallelism
+  while (ok && src < end) {
+    if (flash_page_start(dst) && mg_stm32h7_erase(dst) == false) {
+      ok = false;
+      break;
+    }
+    *(volatile uint32_t *) dst++ = *src++;
+    flash_wait(bank);
+    if (flash_is_err(bank)) ok = false;
+  }
+  if (!s_flash_irq_disabled) MG_ARM_ENABLE_IRQ();
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, dst,
+            ok ? "ok" : "fail", MG_REG(bank + FLASH_CR),
+            MG_REG(bank + FLASH_SR)));
+  MG_REG(bank + FLASH_CR) &= ~MG_BIT(1);  // Clear programming flag
+  return ok;
+}
+
+// just overwrite instead of swap
+MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
+  // no stdlib calls here
+  for (size_t ofs = 0; ofs < s; ofs += ss) {
+    mg_stm32h7_write(p1 + ofs, p2 + ofs, ss);
+  }
+  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+}
+
+bool mg_ota_begin(size_t new_firmware_size) {
+  s_mg_flash_stm32h7.size = MG_REG(FLASH_SIZE_REG) * 1024;
+  if (IS_DUALCORE()) {
+    // Using only the 1st bank (mapped to CM7)
+    s_mg_flash_stm32h7.size /= 2;
+  }
+  return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_stm32h7);
+}
+
+bool mg_ota_write(const void *buf, size_t len) {
+  return mg_ota_flash_write(buf, len, &s_mg_flash_stm32h7);
+}
+
+bool mg_ota_end(void) {
+  if (mg_ota_flash_end(&s_mg_flash_stm32h7)) {
+    if (is_dualbank()) {
+      // Bank swap is deferred until reset, been executing in flash, reset
+      *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+    } else {
+      // Swap partitions. Pray power does not go away
+      MG_INFO(("Swapping partitions, size %u (%u sectors)",
+               s_mg_flash_stm32h7.size,
+               s_mg_flash_stm32h7.size / s_mg_flash_stm32h7.secsz));
+      MG_INFO(("Do NOT power off..."));
+      mg_log_level = MG_LL_NONE;
+      s_flash_irq_disabled = true;
+      // Runs in RAM, will reset when finished
+      single_bank_swap(
+          (char *) s_mg_flash_stm32h7.start,
+          (char *) s_mg_flash_stm32h7.start + s_mg_flash_stm32h7.size / 2,
+          s_mg_flash_stm32h7.size / 2, s_mg_flash_stm32h7.secsz);
+    }
+  }
+  return false;
+}
+#endif
 
 #ifdef MG_ENABLE_LINES
 #line 1 "src/printf.c"
@@ -3782,7 +6999,7 @@ size_t mg_print_ip6(void (*out)(char, void *), void *arg, va_list *ap) {
 
 size_t mg_print_ip(void (*out)(char, void *), void *arg, va_list *ap) {
   struct mg_addr *addr = va_arg(*ap, struct mg_addr *);
-  if (addr->is_ip6) return print_ip6(out, arg, (uint16_t *) addr->ip6);
+  if (addr->is_ip6) return print_ip6(out, arg, (uint16_t *) addr->ip);
   return print_ip4(out, arg, (uint8_t *) &addr->ip);
 }
 
@@ -3870,7 +7087,9 @@ size_t mg_print_esc(void (*out)(char, void *), void *arg, va_list *ap) {
 
 
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) && (__GNUC__ > 4) ||                                \
+     (defined(__GNUC_MINOR__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 1)) || \
+    defined(__clang__)
 #define MG_MEMORY_BARRIER() __sync_synchronize()
 #elif defined(_MSC_VER) && _MSC_VER >= 1700
 #define MG_MEMORY_BARRIER() MemoryBarrier()
@@ -3960,7 +7179,9 @@ void mg_rpc_add(struct mg_rpc **head, struct mg_str method,
                 void (*fn)(struct mg_rpc_req *), void *fn_data) {
   struct mg_rpc *rpc = (struct mg_rpc *) calloc(1, sizeof(*rpc));
   if (rpc != NULL) {
-    rpc->method = mg_strdup(method), rpc->fn = fn, rpc->fn_data = fn_data;
+    rpc->method = mg_strdup(method);
+    rpc->fn = fn;
+    rpc->fn_data = fn_data;
     rpc->next = *head, *head = rpc;
   }
 }
@@ -3970,7 +7191,7 @@ void mg_rpc_del(struct mg_rpc **head, void (*fn)(struct mg_rpc_req *)) {
   while ((r = *head) != NULL) {
     if (r->fn == fn || fn == NULL) {
       *head = r->next;
-      free((void *) r->method.ptr);
+      free((void *) r->method.buf);
       free(r);
     } else {
       head = &(*head)->next;
@@ -3985,21 +7206,21 @@ static void mg_rpc_call(struct mg_rpc_req *r, struct mg_str method) {
     r->rpc = h;
     h->fn(r);
   } else {
-    mg_rpc_err(r, -32601, "\"%.*s not found\"", (int) method.len, method.ptr);
+    mg_rpc_err(r, -32601, "\"%.*s not found\"", (int) method.len, method.buf);
   }
 }
 
 void mg_rpc_process(struct mg_rpc_req *r) {
   int len, off = mg_json_get(r->frame, "$.method", &len);
-  if (off > 0 && r->frame.ptr[off] == '"') {
-    struct mg_str method = mg_str_n(&r->frame.ptr[off + 1], (size_t) len - 2);
+  if (off > 0 && r->frame.buf[off] == '"') {
+    struct mg_str method = mg_str_n(&r->frame.buf[off + 1], (size_t) len - 2);
     mg_rpc_call(r, method);
   } else if ((off = mg_json_get(r->frame, "$.result", &len)) > 0 ||
              (off = mg_json_get(r->frame, "$.error", &len)) > 0) {
     mg_rpc_call(r, mg_str(""));  // JSON response! call "" method handler
   } else {
     mg_rpc_err(r, -32700, "%m", mg_print_esc, (int) r->frame.len,
-               r->frame.ptr);  // Invalid
+               r->frame.buf);  // Invalid
   }
 }
 
@@ -4007,7 +7228,7 @@ void mg_rpc_vok(struct mg_rpc_req *r, const char *fmt, va_list *ap) {
   int len, off = mg_json_get(r->frame, "$.id", &len);
   if (off > 0) {
     mg_xprintf(r->pfn, r->pfn_data, "{%m:%.*s,%m:", mg_print_esc, 0, "id", len,
-               &r->frame.ptr[off], mg_print_esc, 0, "result");
+               &r->frame.buf[off], mg_print_esc, 0, "result");
     mg_vxprintf(r->pfn, r->pfn_data, fmt == NULL ? "null" : fmt, ap);
     mg_xprintf(r->pfn, r->pfn_data, "}");
   }
@@ -4025,7 +7246,7 @@ void mg_rpc_verr(struct mg_rpc_req *r, int code, const char *fmt, va_list *ap) {
   mg_xprintf(r->pfn, r->pfn_data, "{");
   if (off > 0) {
     mg_xprintf(r->pfn, r->pfn_data, "%m:%.*s,", mg_print_esc, 0, "id", len,
-               &r->frame.ptr[off]);
+               &r->frame.buf[off]);
   }
   mg_xprintf(r->pfn, r->pfn_data, "%m:{%m:%d,%m:", mg_print_esc, 0, "error",
              mg_print_esc, 0, "code", code, mg_print_esc, 0, "message");
@@ -4046,7 +7267,7 @@ static size_t print_methods(mg_pfn_t pfn, void *pfn_data, va_list *ap) {
   for (h = *head; h != NULL; h = h->next) {
     if (h->method.len == 0) continue;  // Ignore response handler
     len += mg_xprintf(pfn, pfn_data, "%s%m", h == *head ? "" : ",",
-                      mg_print_esc, (int) h->method.len, h->method.ptr);
+                      mg_print_esc, (int) h->method.len, h->method.buf);
   }
   return len;
 }
@@ -4268,6 +7489,348 @@ void mg_sha1_final(unsigned char digest[20], mg_sha1_ctx *context) {
 }
 
 #ifdef MG_ENABLE_LINES
+#line 1 "src/sha256.c"
+#endif
+// https://github.com/B-Con/crypto-algorithms
+// Author:     Brad Conte (brad AT bradconte.com)
+// Disclaimer: This code is presented "as is" without any guarantees.
+// Details:    Defines the API for the corresponding SHA1 implementation.
+// Copyright:  public domain
+
+
+
+#define ror(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+#define ch(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define maj(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define ep0(x) (ror(x, 2) ^ ror(x, 13) ^ ror(x, 22))
+#define ep1(x) (ror(x, 6) ^ ror(x, 11) ^ ror(x, 25))
+#define sig0(x) (ror(x, 7) ^ ror(x, 18) ^ ((x) >> 3))
+#define sig1(x) (ror(x, 17) ^ ror(x, 19) ^ ((x) >> 10))
+
+static const uint32_t mg_sha256_k[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+void mg_sha256_init(mg_sha256_ctx *ctx) {
+  ctx->len = 0;
+  ctx->bits = 0;
+  ctx->state[0] = 0x6a09e667;
+  ctx->state[1] = 0xbb67ae85;
+  ctx->state[2] = 0x3c6ef372;
+  ctx->state[3] = 0xa54ff53a;
+  ctx->state[4] = 0x510e527f;
+  ctx->state[5] = 0x9b05688c;
+  ctx->state[6] = 0x1f83d9ab;
+  ctx->state[7] = 0x5be0cd19;
+}
+
+static void mg_sha256_chunk(mg_sha256_ctx *ctx) {
+  int i, j;
+  uint32_t a, b, c, d, e, f, g, h;
+  uint32_t m[64];
+  for (i = 0, j = 0; i < 16; ++i, j += 4)
+    m[i] = (uint32_t) (((uint32_t) ctx->buffer[j] << 24) |
+                       ((uint32_t) ctx->buffer[j + 1] << 16) |
+                       ((uint32_t) ctx->buffer[j + 2] << 8) |
+                       ((uint32_t) ctx->buffer[j + 3]));
+  for (; i < 64; ++i)
+    m[i] = sig1(m[i - 2]) + m[i - 7] + sig0(m[i - 15]) + m[i - 16];
+
+  a = ctx->state[0];
+  b = ctx->state[1];
+  c = ctx->state[2];
+  d = ctx->state[3];
+  e = ctx->state[4];
+  f = ctx->state[5];
+  g = ctx->state[6];
+  h = ctx->state[7];
+
+  for (i = 0; i < 64; ++i) {
+    uint32_t t1 = h + ep1(e) + ch(e, f, g) + mg_sha256_k[i] + m[i];
+    uint32_t t2 = ep0(a) + maj(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  ctx->state[0] += a;
+  ctx->state[1] += b;
+  ctx->state[2] += c;
+  ctx->state[3] += d;
+  ctx->state[4] += e;
+  ctx->state[5] += f;
+  ctx->state[6] += g;
+  ctx->state[7] += h;
+}
+
+void mg_sha256_update(mg_sha256_ctx *ctx, const unsigned char *data,
+                      size_t len) {
+  size_t i;
+  for (i = 0; i < len; i++) {
+    ctx->buffer[ctx->len] = data[i];
+    if ((++ctx->len) == 64) {
+      mg_sha256_chunk(ctx);
+      ctx->bits += 512;
+      ctx->len = 0;
+    }
+  }
+}
+
+// TODO: make final reusable (remove side effects)
+void mg_sha256_final(unsigned char digest[32], mg_sha256_ctx *ctx) {
+  uint32_t i = ctx->len;
+  if (i < 56) {
+    ctx->buffer[i++] = 0x80;
+    while (i < 56) {
+      ctx->buffer[i++] = 0x00;
+    }
+  } else {
+    ctx->buffer[i++] = 0x80;
+    while (i < 64) {
+      ctx->buffer[i++] = 0x00;
+    }
+    mg_sha256_chunk(ctx);
+    memset(ctx->buffer, 0, 56);
+  }
+
+  ctx->bits += ctx->len * 8;
+  ctx->buffer[63] = (uint8_t) ((ctx->bits) & 0xff);
+  ctx->buffer[62] = (uint8_t) ((ctx->bits >> 8) & 0xff);
+  ctx->buffer[61] = (uint8_t) ((ctx->bits >> 16) & 0xff);
+  ctx->buffer[60] = (uint8_t) ((ctx->bits >> 24) & 0xff);
+  ctx->buffer[59] = (uint8_t) ((ctx->bits >> 32) & 0xff);
+  ctx->buffer[58] = (uint8_t) ((ctx->bits >> 40) & 0xff);
+  ctx->buffer[57] = (uint8_t) ((ctx->bits >> 48) & 0xff);
+  ctx->buffer[56] = (uint8_t) ((ctx->bits >> 56) & 0xff);
+  mg_sha256_chunk(ctx);
+
+  for (i = 0; i < 4; ++i) {
+    digest[i] = (uint8_t) ((ctx->state[0] >> (24 - i * 8)) & 0xff);
+    digest[i + 4] = (uint8_t) ((ctx->state[1] >> (24 - i * 8)) & 0xff);
+    digest[i + 8] = (uint8_t) ((ctx->state[2] >> (24 - i * 8)) & 0xff);
+    digest[i + 12] = (uint8_t) ((ctx->state[3] >> (24 - i * 8)) & 0xff);
+    digest[i + 16] = (uint8_t) ((ctx->state[4] >> (24 - i * 8)) & 0xff);
+    digest[i + 20] = (uint8_t) ((ctx->state[5] >> (24 - i * 8)) & 0xff);
+    digest[i + 24] = (uint8_t) ((ctx->state[6] >> (24 - i * 8)) & 0xff);
+    digest[i + 28] = (uint8_t) ((ctx->state[7] >> (24 - i * 8)) & 0xff);
+  }
+}
+
+void mg_sha256(uint8_t dst[32], uint8_t *data, size_t datasz) {
+  mg_sha256_ctx ctx;
+  mg_sha256_init(&ctx);
+  mg_sha256_update(&ctx, data, datasz);
+  mg_sha256_final(dst, &ctx);
+}
+
+void mg_hmac_sha256(uint8_t dst[32], uint8_t *key, size_t keysz, uint8_t *data,
+                    size_t datasz) {
+  mg_sha256_ctx ctx;
+  uint8_t k[64] = {0};
+  uint8_t o_pad[64], i_pad[64];
+  unsigned int i;
+  memset(i_pad, 0x36, sizeof(i_pad));
+  memset(o_pad, 0x5c, sizeof(o_pad));
+  if (keysz < 64) {
+    if (keysz > 0) memmove(k, key, keysz);
+  } else {
+    mg_sha256_init(&ctx);
+    mg_sha256_update(&ctx, key, keysz);
+    mg_sha256_final(k, &ctx);
+  }
+  for (i = 0; i < sizeof(k); i++) {
+    i_pad[i] ^= k[i];
+    o_pad[i] ^= k[i];
+  }
+  mg_sha256_init(&ctx);
+  mg_sha256_update(&ctx, i_pad, sizeof(i_pad));
+  mg_sha256_update(&ctx, data, datasz);
+  mg_sha256_final(dst, &ctx);
+  mg_sha256_init(&ctx);
+  mg_sha256_update(&ctx, o_pad, sizeof(o_pad));
+  mg_sha256_update(&ctx, dst, 32);
+  mg_sha256_final(dst, &ctx);
+}
+
+//=====================================
+// TODO: rename macros
+#define ROTR64(x, n) (((x) >> (n)) | ((x) << (64 - (n))))
+#define CH(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTR64(x, 28) ^ ROTR64(x, 34) ^ ROTR64(x, 39))
+#define EP1(x) (ROTR64(x, 14) ^ ROTR64(x, 18) ^ ROTR64(x, 41))
+#define SIG0(x) (ROTR64(x, 1) ^ ROTR64(x, 8) ^ ((x) >> 7))
+#define SIG1(x) (ROTR64(x, 19) ^ ROTR64(x, 61) ^ ((x) >> 6))
+
+static const uint64_t mg_sha256_k2[80] = {
+    0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f,
+    0xe9b5dba58189dbbc, 0x3956c25bf348b538, 0x59f111f1b605d019,
+    0x923f82a4af194f9b, 0xab1c5ed5da6d8118, 0xd807aa98a3030242,
+    0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+    0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235,
+    0xc19bf174cf692694, 0xe49b69c19ef14ad2, 0xefbe4786384f25e3,
+    0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65, 0x2de92c6f592b0275,
+    0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+    0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f,
+    0xbf597fc7beef0ee4, 0xc6e00bf33da88fc2, 0xd5a79147930aa725,
+    0x06ca6351e003826f, 0x142929670a0e6e70, 0x27b70a8546d22ffc,
+    0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+    0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6,
+    0x92722c851482353b, 0xa2bfe8a14cf10364, 0xa81a664bbc423001,
+    0xc24b8b70d0f89791, 0xc76c51a30654be30, 0xd192e819d6ef5218,
+    0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+    0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99,
+    0x34b0bcb5e19b48a8, 0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb,
+    0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3, 0x748f82ee5defb2fc,
+    0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+    0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915,
+    0xc67178f2e372532b, 0xca273eceea26619c, 0xd186b8c721c0c207,
+    0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178, 0x06f067aa72176fba,
+    0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+    0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc,
+    0x431d67c49c100d4c, 0x4cc5d4becb3e42b6, 0x597f299cfc657e2a,
+    0x5fcb6fab3ad6faec, 0x6c44198c4a475817};
+
+static void mg_sha384_transform(mg_sha384_ctx *ctx, const uint8_t data[]) {
+  uint64_t m[80];
+  uint64_t a, b, c, d, e, f, g, h;
+  int i, j;
+
+  for (i = 0, j = 0; i < 16; ++i, j += 8)
+    m[i] = ((uint64_t) data[j] << 56) | ((uint64_t) data[j + 1] << 48) |
+           ((uint64_t) data[j + 2] << 40) | ((uint64_t) data[j + 3] << 32) |
+           ((uint64_t) data[j + 4] << 24) | ((uint64_t) data[j + 5] << 16) |
+           ((uint64_t) data[j + 6] << 8) | ((uint64_t) data[j + 7]);
+  for (; i < 80; ++i)
+    m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+
+  a = ctx->state[0];
+  b = ctx->state[1];
+  c = ctx->state[2];
+  d = ctx->state[3];
+  e = ctx->state[4];
+  f = ctx->state[5];
+  g = ctx->state[6];
+  h = ctx->state[7];
+
+  for (i = 0; i < 80; ++i) {
+    uint64_t t1 = h + EP1(e) + CH(e, f, g) + mg_sha256_k2[i] + m[i];
+    uint64_t t2 = EP0(a) + MAJ(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  ctx->state[0] += a;
+  ctx->state[1] += b;
+  ctx->state[2] += c;
+  ctx->state[3] += d;
+  ctx->state[4] += e;
+  ctx->state[5] += f;
+  ctx->state[6] += g;
+  ctx->state[7] += h;
+}
+
+void mg_sha384_init(mg_sha384_ctx *ctx) {
+  ctx->datalen = 0;
+  ctx->bitlen[0] = 0;
+  ctx->bitlen[1] = 0;
+  ctx->state[0] = 0xcbbb9d5dc1059ed8;
+  ctx->state[1] = 0x629a292a367cd507;
+  ctx->state[2] = 0x9159015a3070dd17;
+  ctx->state[3] = 0x152fecd8f70e5939;
+  ctx->state[4] = 0x67332667ffc00b31;
+  ctx->state[5] = 0x8eb44a8768581511;
+  ctx->state[6] = 0xdb0c2e0d64f98fa7;
+  ctx->state[7] = 0x47b5481dbefa4fa4;
+}
+
+void mg_sha384_update(mg_sha384_ctx *ctx, const uint8_t *data, size_t len) {
+  size_t i;
+  for (i = 0; i < len; ++i) {
+    ctx->buffer[ctx->datalen] = data[i];
+    ctx->datalen++;
+    if (ctx->datalen == 128) {
+      mg_sha384_transform(ctx, ctx->buffer);
+      ctx->bitlen[1] += 1024;
+      if (ctx->bitlen[1] < 1024) ctx->bitlen[0]++;
+      ctx->datalen = 0;
+    }
+  }
+}
+
+void mg_sha384_final(uint8_t hash[48], mg_sha384_ctx *ctx) {
+  size_t i = ctx->datalen;
+
+  if (ctx->datalen < 112) {
+    ctx->buffer[i++] = 0x80;
+    while (i < 112) ctx->buffer[i++] = 0x00;
+  } else {
+    ctx->buffer[i++] = 0x80;
+    while (i < 128) ctx->buffer[i++] = 0x00;
+    mg_sha384_transform(ctx, ctx->buffer);
+    memset(ctx->buffer, 0, 112);
+  }
+
+  ctx->bitlen[1] += ctx->datalen * 8;
+  if (ctx->bitlen[1] < ctx->datalen * 8) ctx->bitlen[0]++;
+  ctx->buffer[127] = (uint8_t) (ctx->bitlen[1]);
+  ctx->buffer[126] = (uint8_t) (ctx->bitlen[1] >> 8);
+  ctx->buffer[125] = (uint8_t) (ctx->bitlen[1] >> 16);
+  ctx->buffer[124] = (uint8_t) (ctx->bitlen[1] >> 24);
+  ctx->buffer[123] = (uint8_t) (ctx->bitlen[1] >> 32);
+  ctx->buffer[122] = (uint8_t) (ctx->bitlen[1] >> 40);
+  ctx->buffer[121] = (uint8_t) (ctx->bitlen[1] >> 48);
+  ctx->buffer[120] = (uint8_t) (ctx->bitlen[1] >> 56);
+  ctx->buffer[119] = (uint8_t) (ctx->bitlen[0]);
+  ctx->buffer[118] = (uint8_t) (ctx->bitlen[0] >> 8);
+  ctx->buffer[117] = (uint8_t) (ctx->bitlen[0] >> 16);
+  ctx->buffer[116] = (uint8_t) (ctx->bitlen[0] >> 24);
+  ctx->buffer[115] = (uint8_t) (ctx->bitlen[0] >> 32);
+  ctx->buffer[114] = (uint8_t) (ctx->bitlen[0] >> 40);
+  ctx->buffer[113] = (uint8_t) (ctx->bitlen[0] >> 48);
+  ctx->buffer[112] = (uint8_t) (ctx->bitlen[0] >> 56);
+  mg_sha384_transform(ctx, ctx->buffer);
+
+  for (i = 0; i < 6; ++i) {
+    hash[i * 8] = (uint8_t) ((ctx->state[i] >> 56) & 0xff);
+    hash[i * 8 + 1] = (uint8_t) ((ctx->state[i] >> 48) & 0xff);
+    hash[i * 8 + 2] = (uint8_t) ((ctx->state[i] >> 40) & 0xff);
+    hash[i * 8 + 3] = (uint8_t) ((ctx->state[i] >> 32) & 0xff);
+    hash[i * 8 + 4] = (uint8_t) ((ctx->state[i] >> 24) & 0xff);
+    hash[i * 8 + 5] = (uint8_t) ((ctx->state[i] >> 16) & 0xff);
+    hash[i * 8 + 6] = (uint8_t) ((ctx->state[i] >> 8) & 0xff);
+    hash[i * 8 + 7] = (uint8_t) (ctx->state[i] & 0xff);
+  }
+}
+
+void mg_sha384(uint8_t dst[48], uint8_t *data, size_t datasz) {
+  mg_sha384_ctx ctx;
+  mg_sha384_init(&ctx);
+  mg_sha384_update(&ctx, data, datasz);
+  mg_sha384_final(dst, &ctx);
+}
+
+#ifdef MG_ENABLE_LINES
 #line 1 "src/sntp.c"
 #endif
 
@@ -4279,6 +7842,12 @@ void mg_sha1_final(unsigned char digest[20], mg_sha1_ctx *context) {
 #define SNTP_TIME_OFFSET 2208988800U  // (1970 - 1900) in seconds
 #define SNTP_MAX_FRAC 4294967295.0    // 2 ** 32 - 1
 
+static uint64_t s_boot_timestamp = 0;  // Updated by SNTP
+
+uint64_t mg_now(void) {
+  return mg_millis() + s_boot_timestamp;
+}
+
 static int64_t gettimestamp(const uint32_t *data) {
   uint32_t sec = mg_ntohl(data[0]), frac = mg_ntohl(data[1]);
   if (sec) sec -= SNTP_TIME_OFFSET;
@@ -4286,7 +7855,7 @@ static int64_t gettimestamp(const uint32_t *data) {
 }
 
 int64_t mg_sntp_parse(const unsigned char *buf, size_t len) {
-  int64_t res = -1;
+  int64_t epoch_milliseconds = -1;
   int mode = len > 0 ? buf[0] & 7 : 0;
   int version = len > 0 ? (buf[0] >> 3) & 7 : 0;
   if (len < 48) {
@@ -4297,35 +7866,39 @@ int64_t mg_sntp_parse(const unsigned char *buf, size_t len) {
     MG_ERROR(("%s", "server sent a kiss of death"));
   } else if (version == 4 || version == 3) {
     // int64_t ref = gettimestamp((uint32_t *) &buf[16]);
-    int64_t t0 = gettimestamp((uint32_t *) &buf[24]);
-    int64_t t1 = gettimestamp((uint32_t *) &buf[32]);
-    int64_t t2 = gettimestamp((uint32_t *) &buf[40]);
-    int64_t t3 = (int64_t) mg_millis();
-    int64_t delta = (t3 - t0) - (t2 - t1);
-    MG_VERBOSE(("%lld %lld %lld %lld delta:%lld", t0, t1, t2, t3, delta));
-    res = t2 + delta / 2;
+    int64_t origin_time = gettimestamp((uint32_t *) &buf[24]);
+    int64_t receive_time = gettimestamp((uint32_t *) &buf[32]);
+    int64_t transmit_time = gettimestamp((uint32_t *) &buf[40]);
+    int64_t now = (int64_t) mg_millis();
+    int64_t latency = (now - origin_time) - (transmit_time - receive_time);
+    epoch_milliseconds = transmit_time + latency / 2;
+    s_boot_timestamp = (uint64_t) (epoch_milliseconds - now);
   } else {
     MG_ERROR(("unexpected version: %d", version));
   }
-  return res;
+  return epoch_milliseconds;
 }
 
-static void sntp_cb(struct mg_connection *c, int ev, void *evd, void *fnd) {
-  if (ev == MG_EV_READ) {
-    int64_t milliseconds = mg_sntp_parse(c->recv.buf, c->recv.len);
-    if (milliseconds > 0) {
-      MG_INFO(("%lu got time: %lld ms from epoch", c->id, milliseconds));
-      mg_call(c, MG_EV_SNTP_TIME, (uint64_t *) &milliseconds);
-      MG_VERBOSE(("%u.%u", (unsigned) (milliseconds / 1000),
-                  (unsigned) (milliseconds % 1000)));
-    }
-    mg_iobuf_del(&c->recv, 0, c->recv.len);  // Free receive buffer
+static void sntp_cb(struct mg_connection *c, int ev, void *ev_data) {
+  uint64_t *expiration_time = (uint64_t *) c->data;
+  if (ev == MG_EV_OPEN) {
+    *expiration_time = mg_millis() + 3000;  // Store expiration time in 3s
   } else if (ev == MG_EV_CONNECT) {
     mg_sntp_request(c);
+  } else if (ev == MG_EV_READ) {
+    int64_t milliseconds = mg_sntp_parse(c->recv.buf, c->recv.len);
+    if (milliseconds > 0) {
+      s_boot_timestamp = (uint64_t) milliseconds - mg_millis();
+      mg_call(c, MG_EV_SNTP_TIME, (uint64_t *) &milliseconds);
+      MG_DEBUG(("%lu got time: %lld ms from epoch", c->id, milliseconds));
+    }
+    // mg_iobuf_del(&c->recv, 0, c->recv.len);  // Free receive buffer
+    c->is_closing = 1;
+  } else if (ev == MG_EV_POLL) {
+    if (mg_millis() > *expiration_time) c->is_closing = 1;
   } else if (ev == MG_EV_CLOSE) {
   }
-  (void) fnd;
-  (void) evd;
+  (void) ev_data;
 }
 
 void mg_sntp_request(struct mg_connection *c) {
@@ -4347,7 +7920,10 @@ struct mg_connection *mg_sntp_connect(struct mg_mgr *mgr, const char *url,
                                       mg_event_handler_t fn, void *fnd) {
   struct mg_connection *c = NULL;
   if (url == NULL) url = "udp://time.google.com:123";
-  if ((c = mg_connect(mgr, url, fn, fnd)) != NULL) c->pfn = sntp_cb;
+  if ((c = mg_connect(mgr, url, fn, fnd)) != NULL) {
+    c->pfn = sntp_cb;
+    sntp_cb(c, MG_EV_OPEN, (void *) url);
+  }
   return c;
 }
 
@@ -4413,12 +7989,13 @@ static socklen_t tousa(struct mg_addr *a, union usa *usa) {
   memset(usa, 0, sizeof(*usa));
   usa->sin.sin_family = AF_INET;
   usa->sin.sin_port = a->port;
-  *(uint32_t *) &usa->sin.sin_addr = a->ip;
+  memcpy(&usa->sin.sin_addr, a->ip, sizeof(uint32_t));
 #if MG_ENABLE_IPV6
   if (a->is_ip6) {
     usa->sin.sin_family = AF_INET6;
     usa->sin6.sin6_port = a->port;
-    memcpy(&usa->sin6.sin6_addr, a->ip6, sizeof(a->ip6));
+    usa->sin6.sin6_scope_id = a->scope_id;
+    memcpy(&usa->sin6.sin6_addr, a->ip, sizeof(a->ip));
     len = sizeof(usa->sin6);
   }
 #endif
@@ -4428,11 +8005,12 @@ static socklen_t tousa(struct mg_addr *a, union usa *usa) {
 static void tomgaddr(union usa *usa, struct mg_addr *a, bool is_ip6) {
   a->is_ip6 = is_ip6;
   a->port = usa->sin.sin_port;
-  memcpy(&a->ip, &usa->sin.sin_addr, sizeof(a->ip));
+  memcpy(&a->ip, &usa->sin.sin_addr, sizeof(uint32_t));
 #if MG_ENABLE_IPV6
   if (is_ip6) {
-    memcpy(a->ip6, &usa->sin6.sin6_addr, sizeof(a->ip6));
+    memcpy(a->ip, &usa->sin6.sin6_addr, sizeof(a->ip));
     a->port = usa->sin6.sin6_port;
+    a->scope_id = (uint8_t) usa->sin6.sin6_scope_id;
   }
 #endif
 }
@@ -4452,12 +8030,8 @@ static void iolog(struct mg_connection *c, char *buf, long n, bool r) {
     c->is_closing = 1;  // Termination. Don't call mg_error(): #1529
   } else if (n > 0) {
     if (c->is_hexdumping) {
-      union usa usa;
-      socklen_t slen = sizeof(usa.sin);
-      if (getsockname(FD(c), &usa.sa, &slen) < 0) (void) 0;  // Ignore result
       MG_INFO(("\n-- %lu %M %s %M %ld", c->id, mg_print_ip_port, &c->loc,
                r ? "<-" : "->", mg_print_ip_port, &c->rem, n));
-
       mg_hexdump(buf, (size_t) n);
     }
     if (r) {
@@ -4484,8 +8058,9 @@ long mg_io_send(struct mg_connection *c, const void *buf, size_t len) {
   } else {
     n = send(FD(c), (char *) buf, len, MSG_NONBLOCKING);
   }
+  MG_VERBOSE(("%lu %ld %d", c->id, n, MG_SOCK_ERR(n)));
   if (MG_SOCK_PENDING(n)) return MG_IO_WAIT;
-  if (MG_SOCK_RESET(n)) return MG_IO_RESET;
+  if (MG_SOCK_RESET(n)) return MG_IO_RESET; // MbedTLS, see #1507
   if (n <= 0) return MG_IO_ERR;
   return n;
 }
@@ -4493,8 +8068,8 @@ long mg_io_send(struct mg_connection *c, const void *buf, size_t len) {
 bool mg_send(struct mg_connection *c, const void *buf, size_t len) {
   if (c->is_udp) {
     long n = mg_io_send(c, buf, len);
-    MG_DEBUG(("%lu %p %d:%d %ld err %d", c->id, c->fd, (int) c->send.len,
-              (int) c->recv.len, n, MG_SOCK_ERR(n)));
+    MG_DEBUG(("%lu %ld %lu:%lu:%lu %ld err %d", c->id, c->fd, c->send.len,
+              c->recv.len, c->rtls.len, n, MG_SOCK_ERR(n)));
     iolog(c, (char *) buf, n, false);
     return n > 0;
   } else {
@@ -4554,8 +8129,7 @@ bool mg_open_listener(struct mg_connection *c, const char *url) {
                                 (char *) &on, sizeof(on))) != 0) {
       // "Using SO_REUSEADDR and SO_EXCLUSIVEADDRUSE"
       MG_ERROR(("setsockopt(SO_EXCLUSIVEADDRUSE): %d %d", on, MG_SOCK_ERR(rc)));
-#endif
-#if defined(SO_REUSEADDR) && (!defined(LWIP_SOCKET) || SO_REUSE)
+#elif defined(SO_REUSEADDR) && (!defined(LWIP_SOCKET) || SO_REUSE)
     } else if ((rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *) &on,
                                 sizeof(on))) != 0) {
       // 1. SO_REUSEADDR semantics on UNIX and Windows is different.  On
@@ -4569,7 +8143,8 @@ bool mg_open_listener(struct mg_connection *c, const char *url) {
       // won't work! (setsockopt will return EINVAL)
       MG_ERROR(("setsockopt(SO_REUSEADDR): %d", MG_SOCK_ERR(rc)));
 #endif
-#if defined(IPV6_V6ONLY)
+#if MG_IPV6_V6ONLY
+      // Bind only to the V6 address, not V4 address on this port
     } else if (c->loc.is_ip6 &&
                (rc = setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &on,
                                 sizeof(on))) != 0) {
@@ -4595,7 +8170,7 @@ bool mg_open_listener(struct mg_connection *c, const char *url) {
   return success;
 }
 
-long mg_io_recv(struct mg_connection *c, void *buf, size_t len) {
+static long recv_raw(struct mg_connection *c, void *buf, size_t len) {
   long n = 0;
   if (c->is_udp) {
     union usa usa;
@@ -4605,28 +8180,64 @@ long mg_io_recv(struct mg_connection *c, void *buf, size_t len) {
   } else {
     n = recv(FD(c), (char *) buf, len, MSG_NONBLOCKING);
   }
+  MG_VERBOSE(("%lu %ld %d", c->id, n, MG_SOCK_ERR(n)));
   if (MG_SOCK_PENDING(n)) return MG_IO_WAIT;
-  if (MG_SOCK_RESET(n)) return MG_IO_RESET;
+  if (MG_SOCK_RESET(n)) return MG_IO_RESET; // MbedTLS, see #1507
   if (n <= 0) return MG_IO_ERR;
   return n;
+}
+
+static bool ioalloc(struct mg_connection *c, struct mg_iobuf *io) {
+  bool res = false;
+  if (io->len >= MG_MAX_RECV_SIZE) {
+    int x = MG_MAX_RECV_SIZE;
+    mg_error(c, "MG_MAX_RECV_SIZE");
+  } else if (io->size <= io->len &&
+             !mg_iobuf_resize(io, io->size + MG_IO_SIZE)) {
+    mg_error(c, "OOM");
+  } else {
+    res = true;
+  }
+  return res;
 }
 
 // NOTE(lsm): do only one iteration of reads, cause some systems
 // (e.g. FreeRTOS stack) return 0 instead of -1/EWOULDBLOCK when no data
 static void read_conn(struct mg_connection *c) {
-  long n = -1;
-  if (c->recv.len >= MG_MAX_RECV_SIZE) {
-    mg_error(c, "max_recv_buf_size reached");
-  } else if (c->recv.size <= c->recv.len &&
-             !mg_iobuf_resize(&c->recv, c->recv.size + MG_IO_SIZE)) {
-    mg_error(c, "oom");
-  } else {
+  if (ioalloc(c, &c->recv)) {
     char *buf = (char *) &c->recv.buf[c->recv.len];
     size_t len = c->recv.size - c->recv.len;
-    n = c->is_tls ? mg_tls_recv(c, buf, len) : mg_io_recv(c, buf, len);
-    MG_DEBUG(("%lu %p snd %ld/%ld rcv %ld/%ld n=%ld err=%d", c->id, c->fd,
-              (long) c->send.len, (long) c->send.size, (long) c->recv.len,
-              (long) c->recv.size, n, MG_SOCK_ERR(n)));
+    long n = -1;
+    if (c->is_tls) {
+      // Do not read to the raw TLS buffer if it already has enough.
+      // This is to prevent overflowing c->rtls if our reads are slow
+      long m;
+      if (c->rtls.len < 16 * 1024 + 40) {  // TLS record, header, MAC, padding
+        if (!ioalloc(c, &c->rtls)) return;
+        n = recv_raw(c, (char *) &c->rtls.buf[c->rtls.len],
+                     c->rtls.size - c->rtls.len);
+        if (n > 0) c->rtls.len += (size_t) n;
+      }
+      // there can still be > 16K from last iteration, always mg_tls_recv()
+      m = c->is_tls_hs ? (long) MG_IO_WAIT : mg_tls_recv(c, buf, len);
+      if (n == MG_IO_ERR || n == MG_IO_RESET) { // Windows, see #3031
+        if (c->rtls.len == 0 || m < 0) {
+          // Close only when we have fully drained both rtls and TLS buffers
+          c->is_closing = 1;  // or there's nothing we can do about it.
+          m = MG_IO_ERR;
+        } else { // see #2885
+          // TLS buffer is capped to max record size, even though, there can
+          // be more than one record, give TLS a chance to process them.
+        }
+      } else if (c->is_tls_hs) {
+        mg_tls_handshake(c);
+      }
+      n = m;
+    } else {
+      n = recv_raw(c, buf, len);
+    }
+    MG_DEBUG(("%lu %ld %lu:%lu:%lu %ld err %d", c->id, c->fd, c->send.len,
+              c->recv.len, c->rtls.len, n, MG_SOCK_ERR(n)));
     iolog(c, buf, n, true);
   }
 }
@@ -4635,7 +8246,7 @@ static void write_conn(struct mg_connection *c) {
   char *buf = (char *) c->send.buf;
   size_t len = c->send.len;
   long n = c->is_tls ? mg_tls_send(c, buf, len) : mg_io_send(c, buf, len);
-  MG_DEBUG(("%lu %p snd %ld/%ld rcv %ld/%ld n=%ld err=%d", c->id, c->fd,
+  MG_DEBUG(("%lu %ld snd %ld/%ld rcv %ld/%ld n=%ld err=%d", c->id, c->fd,
             (long) c->send.len, (long) c->send.size, (long) c->recv.len,
             (long) c->recv.size, n, MG_SOCK_ERR(n)));
   iolog(c, buf, n, false);
@@ -4660,6 +8271,7 @@ static void connect_conn(struct mg_connection *c) {
   // Use getpeername() to test whether we have connected
   if (getpeername(FD(c), &usa.sa, &n) == 0) {
     c->is_connecting = 0;
+    setlocaddr(FD(c), &c->loc);
     mg_call(c, MG_EV_CONNECT, NULL);
     MG_EPOLL_MOD(c, 0);
     if (c->is_tls_hs) mg_tls_handshake(c);
@@ -4687,8 +8299,9 @@ static void setsockopts(struct mg_connection *c) {
 
 void mg_connect_resolved(struct mg_connection *c) {
   int type = c->is_udp ? SOCK_DGRAM : SOCK_STREAM;
+  int proto = type == SOCK_DGRAM ? IPPROTO_UDP : IPPROTO_TCP;
   int rc, af = c->rem.is_ip6 ? AF_INET6 : AF_INET;  // c->rem has resolved IP
-  c->fd = S2PTR(socket(af, type, 0));               // Create outbound socket
+  c->fd = S2PTR(socket(af, type, proto));           // Create outbound socket
   c->is_resolving = 0;                              // Clear resolving flag
   if (FD(c) == MG_INVALID_SOCKET) {
     mg_error(c, "socket(): %d", MG_SOCK_ERR(-1));
@@ -4700,6 +8313,7 @@ void mg_connect_resolved(struct mg_connection *c) {
     if ((rc = bind(c->fd, &usa.sa, slen)) != 0)
       MG_ERROR(("bind: %d", MG_SOCK_ERR(rc)));
 #endif
+    setlocaddr(FD(c), &c->loc);
     mg_call(c, MG_EV_RESOLVE, NULL);
     mg_call(c, MG_EV_CONNECT, NULL);
   } else {
@@ -4711,9 +8325,10 @@ void mg_connect_resolved(struct mg_connection *c) {
     mg_call(c, MG_EV_RESOLVE, NULL);
     rc = connect(FD(c), &usa.sa, slen);  // Attempt to connect
     if (rc == 0) {                       // Success
-      mg_call(c, MG_EV_CONNECT, NULL);   // Send MG_EV_CONNECT to the user
-    } else if (MG_SOCK_PENDING(rc)) {    // Need to wait for TCP handshake
-      MG_DEBUG(("%lu %p -> %M pend", c->id, c->fd, mg_print_ip_port, &c->rem));
+      setlocaddr(FD(c), &c->loc);
+      mg_call(c, MG_EV_CONNECT, NULL);  // Send MG_EV_CONNECT to the user
+    } else if (MG_SOCK_PENDING(rc)) {   // Need to wait for TCP handshake
+      MG_DEBUG(("%lu %ld -> %M pend", c->id, c->fd, mg_print_ip_port, &c->rem));
       c->is_connecting = 1;
     } else {
       mg_error(c, "connect: %d", MG_SOCK_ERR(rc));
@@ -4737,7 +8352,7 @@ static void accept_conn(struct mg_mgr *mgr, struct mg_connection *lsn) {
   socklen_t sa_len = sizeof(usa);
   MG_SOCKET_TYPE fd = raccept(FD(lsn), &usa, &sa_len);
   if (fd == MG_INVALID_SOCKET) {
-#if MG_ARCH == MG_ARCH_AZURERTOS
+#if MG_ARCH == MG_ARCH_AZURERTOS || defined(__ECOS)
     // AzureRTOS, in non-block socket mode can mark listening socket readable
     // even it is not. See comment for 'select' func implementation in
     // nx_bsd.c That's not an error, just should try later
@@ -4745,7 +8360,7 @@ static void accept_conn(struct mg_mgr *mgr, struct mg_connection *lsn) {
 #endif
       MG_ERROR(("%lu accept failed, errno %d", lsn->id, MG_SOCK_ERR(-1)));
 #if (MG_ARCH != MG_ARCH_WIN32) && !MG_ENABLE_FREERTOS_TCP && \
-    (MG_ARCH != MG_ARCH_TIRTOS) && !MG_ENABLE_POLL
+    (MG_ARCH != MG_ARCH_TIRTOS) && !MG_ENABLE_POLL && !MG_ENABLE_EPOLL
   } else if ((long) fd >= FD_SETSIZE) {
     MG_ERROR(("%ld > %ld", (long) fd, (long) FD_SETSIZE));
     closesocket(fd);
@@ -4767,69 +8382,11 @@ static void accept_conn(struct mg_mgr *mgr, struct mg_connection *lsn) {
     c->pfn_data = lsn->pfn_data;
     c->fn = lsn->fn;
     c->fn_data = lsn->fn_data;
-    MG_DEBUG(("%lu %p accepted %M -> %M", c->id, c->fd, mg_print_ip_port,
+    MG_DEBUG(("%lu %ld accepted %M -> %M", c->id, c->fd, mg_print_ip_port,
               &c->rem, mg_print_ip_port, &c->loc));
     mg_call(c, MG_EV_OPEN, NULL);
     mg_call(c, MG_EV_ACCEPT, NULL);
   }
-}
-
-static bool mg_socketpair(MG_SOCKET_TYPE sp[2], union usa usa[2], bool udp) {
-  MG_SOCKET_TYPE sock;
-  socklen_t n = sizeof(usa[0].sin);
-  bool success = false;
-
-  sock = sp[0] = sp[1] = MG_INVALID_SOCKET;
-  (void) memset(&usa[0], 0, sizeof(usa[0]));
-  usa[0].sin.sin_family = AF_INET;
-  *(uint32_t *) &usa->sin.sin_addr = mg_htonl(0x7f000001U);  // 127.0.0.1
-  usa[1] = usa[0];
-
-  if (udp && (sp[0] = socket(AF_INET, SOCK_DGRAM, 0)) != MG_INVALID_SOCKET &&
-      (sp[1] = socket(AF_INET, SOCK_DGRAM, 0)) != MG_INVALID_SOCKET &&
-      bind(sp[0], &usa[0].sa, n) == 0 && bind(sp[1], &usa[1].sa, n) == 0 &&
-      getsockname(sp[0], &usa[0].sa, &n) == 0 &&
-      getsockname(sp[1], &usa[1].sa, &n) == 0 &&
-      connect(sp[0], &usa[1].sa, n) == 0 &&
-      connect(sp[1], &usa[0].sa, n) == 0) {
-    success = true;
-  } else if (!udp &&
-             (sock = socket(AF_INET, SOCK_STREAM, 0)) != MG_INVALID_SOCKET &&
-             bind(sock, &usa[0].sa, n) == 0 &&
-             listen(sock, MG_SOCK_LISTEN_BACKLOG_SIZE) == 0 &&
-             getsockname(sock, &usa[0].sa, &n) == 0 &&
-             (sp[0] = socket(AF_INET, SOCK_STREAM, 0)) != MG_INVALID_SOCKET &&
-             connect(sp[0], &usa[0].sa, n) == 0 &&
-             (sp[1] = raccept(sock, &usa[1], &n)) != MG_INVALID_SOCKET) {
-    success = true;
-  }
-  if (success) {
-    mg_set_non_blocking_mode(sp[1]);
-  } else {
-    if (sp[0] != MG_INVALID_SOCKET) closesocket(sp[0]);
-    if (sp[1] != MG_INVALID_SOCKET) closesocket(sp[1]);
-    sp[0] = sp[1] = MG_INVALID_SOCKET;
-  }
-  if (sock != MG_INVALID_SOCKET) closesocket(sock);
-  return success;
-}
-
-int mg_mkpipe(struct mg_mgr *mgr, mg_event_handler_t fn, void *fn_data,
-              bool udp) {
-  union usa usa[2];
-  MG_SOCKET_TYPE sp[2] = {MG_INVALID_SOCKET, MG_INVALID_SOCKET};
-  struct mg_connection *c = NULL;
-  if (!mg_socketpair(sp, usa, udp)) {
-    MG_ERROR(("Cannot create socket pair"));
-  } else if ((c = mg_wrapfd(mgr, (int) sp[1], fn, fn_data)) == NULL) {
-    closesocket(sp[0]);
-    closesocket(sp[1]);
-    sp[0] = sp[1] = MG_INVALID_SOCKET;
-  } else {
-    tomgaddr(&usa[0], &c->rem, false);
-    MG_DEBUG(("%lu %p pipe %lu", c->id, c->fd, (unsigned long) sp[0]));
-  }
-  return (int) sp[0];
 }
 
 static bool can_read(const struct mg_connection *c) {
@@ -4854,6 +8411,7 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     if (can_read(c))
       FreeRTOS_FD_SET(c->fd, mgr->ss, eSELECT_READ | eSELECT_EXCEPT);
     if (can_write(c)) FreeRTOS_FD_SET(c->fd, mgr->ss, eSELECT_WRITE);
+    if (c->is_closing) ms = 1;
   }
   FreeRTOS_select(mgr->ss, pdMS_TO_TICKS(ms));
   for (c = mgr->conns; c != NULL; c = c->next) {
@@ -4868,8 +8426,9 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
   size_t max = 1;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) {
     c->is_readable = c->is_writable = 0;
-    if (mg_tls_pending(c) > 0) ms = 1, c->is_readable = 1;
+    if (c->rtls.len > 0 || mg_tls_pending(c) > 0) ms = 1, c->is_readable = 1;
     if (can_write(c)) MG_EPOLL_MOD(c, 1);
+    if (c->is_closing) ms = 1;
     max++;
   }
   struct epoll_event *evs = (struct epoll_event *) alloca(max * sizeof(evs[0]));
@@ -4883,6 +8442,7 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
       bool wr = evs[i].events & EPOLLOUT;
       c->is_readable = can_read(c) && rd ? 1U : 0;
       c->is_writable = can_write(c) && wr ? 1U : 0;
+      if (c->rtls.len > 0 || mg_tls_pending(c) > 0) c->is_readable = 1;
     }
   }
   (void) skip_iotest;
@@ -4894,11 +8454,12 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
   n = 0;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) {
     c->is_readable = c->is_writable = 0;
+    if (c->is_closing) ms = 1;
     if (skip_iotest(c)) {
       // Socket not valid, ignore
-    } else if (mg_tls_pending(c) > 0) {
-      ms = 1;  // Don't wait if TLS is ready
     } else {
+      // Don't wait if TLS is ready
+      if (c->rtls.len > 0 || mg_tls_pending(c) > 0) ms = 1;
       fds[n].fd = FD(c);
       if (can_read(c)) fds[n].events |= POLLIN;
       if (can_write(c)) fds[n].events |= POLLOUT;
@@ -4917,8 +8478,6 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) {
     if (skip_iotest(c)) {
       // Socket not valid, ignore
-    } else if (mg_tls_pending(c) > 0) {
-      c->is_readable = 1;
     } else {
       if (fds[n].revents & POLLERR) {
         mg_error(c, "socket error");
@@ -4926,6 +8485,7 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
         c->is_readable =
             (unsigned) (fds[n].revents & (POLLIN | POLLHUP) ? 1 : 0);
         c->is_writable = (unsigned) (fds[n].revents & POLLOUT ? 1 : 0);
+        if (c->rtls.len > 0 || mg_tls_pending(c) > 0) c->is_readable = 1;
       }
       n++;
     }
@@ -4947,8 +8507,9 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     FD_SET(FD(c), &eset);
     if (can_read(c)) FD_SET(FD(c), &rset);
     if (can_write(c)) FD_SET(FD(c), &wset);
-    if (mg_tls_pending(c) > 0) tvp = &tv_zero;
+    if (c->rtls.len > 0 || mg_tls_pending(c) > 0) tvp = &tv_zero;
     if (FD(c) > maxfd) maxfd = FD(c);
+    if (c->is_closing) tvp = &tv_zero;
   }
 
   if ((rc = select((int) maxfd + 1, &rset, &wset, &eset, tvp)) < 0) {
@@ -4968,10 +8529,96 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     } else {
       c->is_readable = FD(c) != MG_INVALID_SOCKET && FD_ISSET(FD(c), &rset);
       c->is_writable = FD(c) != MG_INVALID_SOCKET && FD_ISSET(FD(c), &wset);
-      if (mg_tls_pending(c) > 0) c->is_readable = 1;
+      if (c->rtls.len > 0 || mg_tls_pending(c) > 0) c->is_readable = 1;
     }
   }
 #endif
+}
+
+static bool mg_socketpair(MG_SOCKET_TYPE sp[2], union usa usa[2]) {
+  socklen_t n = sizeof(usa[0].sin);
+  bool success = false;
+
+  sp[0] = sp[1] = MG_INVALID_SOCKET;
+  (void) memset(&usa[0], 0, sizeof(usa[0]));
+  usa[0].sin.sin_family = AF_INET;
+  *(uint32_t *) &usa->sin.sin_addr = mg_htonl(0x7f000001U);  // 127.0.0.1
+  usa[1] = usa[0];
+
+  if ((sp[0] = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) != MG_INVALID_SOCKET &&
+      (sp[1] = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) != MG_INVALID_SOCKET &&
+      bind(sp[0], &usa[0].sa, n) == 0 &&          //
+      bind(sp[1], &usa[1].sa, n) == 0 &&          //
+      getsockname(sp[0], &usa[0].sa, &n) == 0 &&  //
+      getsockname(sp[1], &usa[1].sa, &n) == 0 &&  //
+      connect(sp[0], &usa[1].sa, n) == 0 &&       //
+      connect(sp[1], &usa[0].sa, n) == 0) {       //
+    success = true;
+  }
+  if (!success) {
+    if (sp[0] != MG_INVALID_SOCKET) closesocket(sp[0]);
+    if (sp[1] != MG_INVALID_SOCKET) closesocket(sp[1]);
+    sp[0] = sp[1] = MG_INVALID_SOCKET;
+  }
+  return success;
+}
+
+// mg_wakeup() event handler
+static void wufn(struct mg_connection *c, int ev, void *ev_data) {
+  if (ev == MG_EV_READ) {
+    unsigned long *id = (unsigned long *) c->recv.buf;
+    // MG_INFO(("Got data"));
+    // mg_hexdump(c->recv.buf, c->recv.len);
+    if (c->recv.len >= sizeof(*id)) {
+      struct mg_connection *t;
+      for (t = c->mgr->conns; t != NULL; t = t->next) {
+        if (t->id == *id) {
+          struct mg_str data = mg_str_n((char *) c->recv.buf + sizeof(*id),
+                                        c->recv.len - sizeof(*id));
+          mg_call(t, MG_EV_WAKEUP, &data);
+        }
+      }
+    }
+    c->recv.len = 0;  // Consume received data
+  } else if (ev == MG_EV_CLOSE) {
+    closesocket(c->mgr->pipe);         // When we're closing, close the other
+    c->mgr->pipe = MG_INVALID_SOCKET;  // side of the socketpair, too
+  }
+  (void) ev_data;
+}
+
+bool mg_wakeup_init(struct mg_mgr *mgr) {
+  bool ok = false;
+  if (mgr->pipe == MG_INVALID_SOCKET) {
+    union usa usa[2];
+    MG_SOCKET_TYPE sp[2] = {MG_INVALID_SOCKET, MG_INVALID_SOCKET};
+    struct mg_connection *c = NULL;
+    if (!mg_socketpair(sp, usa)) {
+      MG_ERROR(("Cannot create socket pair"));
+    } else if ((c = mg_wrapfd(mgr, (int) sp[1], wufn, NULL)) == NULL) {
+      closesocket(sp[0]);
+      closesocket(sp[1]);
+      sp[0] = sp[1] = MG_INVALID_SOCKET;
+    } else {
+      tomgaddr(&usa[0], &c->rem, false);
+      MG_DEBUG(("%lu %p pipe %lu", c->id, c->fd, (unsigned long) sp[0]));
+      mgr->pipe = sp[0];
+      ok = true;
+    }
+  }
+  return ok;
+}
+
+bool mg_wakeup(struct mg_mgr *mgr, unsigned long conn_id, const void *buf,
+               size_t len) {
+  if (mgr->pipe != MG_INVALID_SOCKET && conn_id > 0) {
+    char *extended_buf = (char *) alloca(len + sizeof(conn_id));
+    memcpy(extended_buf, &conn_id, sizeof(conn_id));
+    memcpy(extended_buf + sizeof(conn_id), buf, len);
+    send(mgr->pipe, extended_buf, len + sizeof(conn_id), MSG_NONBLOCKING);
+    return true;
+  }
+  return false;
 }
 
 void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
@@ -4990,18 +8637,19 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
       long n = 0;
       mg_call(c, MG_EV_READ, &n);
     }
-    MG_VERBOSE(("%lu %c%c %c%c%c%c%c", c->id, c->is_readable ? 'r' : '-',
-                c->is_writable ? 'w' : '-', c->is_tls ? 'T' : 't',
-                c->is_connecting ? 'C' : 'c', c->is_tls_hs ? 'H' : 'h',
-                c->is_resolving ? 'R' : 'r', c->is_closing ? 'C' : 'c'));
+    MG_VERBOSE(("%lu %c%c %c%c%c%c%c %lu %lu", c->id,
+                c->is_readable ? 'r' : '-', c->is_writable ? 'w' : '-',
+                c->is_tls ? 'T' : 't', c->is_connecting ? 'C' : 'c',
+                c->is_tls_hs ? 'H' : 'h', c->is_resolving ? 'R' : 'r',
+                c->is_closing ? 'C' : 'c', mg_tls_pending(c), c->rtls.len));
     if (c->is_resolving || c->is_closing) {
       // Do nothing
     } else if (c->is_listening && c->is_udp == 0) {
       if (c->is_readable) accept_conn(mgr, c);
     } else if (c->is_connecting) {
       if (c->is_readable || c->is_writable) connect_conn(c);
-    } else if (c->is_tls_hs) {
-      if ((c->is_readable || c->is_writable)) mg_tls_handshake(c);
+      //} else if (c->is_tls_hs) {
+      //  if ((c->is_readable || c->is_writable)) mg_tls_handshake(c);
     } else {
       if (c->is_readable) read_conn(c);
       if (c->is_writable) write_conn(c);
@@ -5041,7 +8689,7 @@ static char *mg_ssi(const char *path, const char *root, int depth) {
       if (intag && ch == '>' && buf[len - 1] == '-' && buf[len - 2] == '-') {
         buf[len++] = (char) (ch & 0xff);
         buf[len] = '\0';
-        if (sscanf(buf, "<!--#include file=\"%[^\"]", arg)) {
+        if (sscanf(buf, "<!--#include file=\"%[^\"]", arg) > 0) {
           char tmp[MG_PATH_MAX + MG_SSI_BUFSIZ + 10],
               *p = (char *) path + strlen(path), *data;
           while (p > path && p[-1] != MG_DIRSEP && p[-1] != '/') p--;
@@ -5053,7 +8701,7 @@ static char *mg_ssi(const char *path, const char *root, int depth) {
           } else {
             MG_ERROR(("%s: file=%s error or too deep", path, arg));
           }
-        } else if (sscanf(buf, "<!--#include virtual=\"%[^\"]", arg)) {
+        } else if (sscanf(buf, "<!--#include virtual=\"%[^\"]", arg) > 0) {
           char tmp[MG_PATH_MAX + MG_SSI_BUFSIZ + 10], *data;
           mg_snprintf(tmp, sizeof(tmp), "%s%s", root, arg);
           if (depth < MG_MAX_SSI_DEPTH &&
@@ -5121,55 +8769,36 @@ void mg_http_serve_ssi(struct mg_connection *c, const char *root,
 
 
 struct mg_str mg_str_s(const char *s) {
-  struct mg_str str = {s, s == NULL ? 0 : strlen(s)};
+  struct mg_str str = {(char *) s, s == NULL ? 0 : strlen(s)};
   return str;
 }
 
 struct mg_str mg_str_n(const char *s, size_t n) {
-  struct mg_str str = {s, n};
+  struct mg_str str = {(char *) s, n};
   return str;
 }
 
-int mg_lower(const char *s) {
-  int c = *s;
-  if (c >= 'A' && c <= 'Z') c += 'a' - 'A';
-  return c;
-}
-
-int mg_ncasecmp(const char *s1, const char *s2, size_t len) {
-  int diff = 0;
-  if (len > 0) do {
-      diff = mg_lower(s1++) - mg_lower(s2++);
-    } while (diff == 0 && s1[-1] != '\0' && --len > 0);
-  return diff;
+static int mg_tolc(char c) {
+  return (c >= 'A' && c <= 'Z') ? c + 'a' - 'A' : c;
 }
 
 int mg_casecmp(const char *s1, const char *s2) {
-  return mg_ncasecmp(s1, s2, (size_t) ~0);
-}
-
-int mg_vcmp(const struct mg_str *s1, const char *s2) {
-  size_t n2 = strlen(s2), n1 = s1->len;
-  int r = strncmp(s1->ptr, s2, (n1 < n2) ? n1 : n2);
-  if (r == 0) return (int) (n1 - n2);
-  return r;
-}
-
-int mg_vcasecmp(const struct mg_str *str1, const char *str2) {
-  size_t n2 = strlen(str2), n1 = str1->len;
-  int r = mg_ncasecmp(str1->ptr, str2, (n1 < n2) ? n1 : n2);
-  if (r == 0) return (int) (n1 - n2);
-  return r;
+  int diff = 0;
+  do {
+    int c = mg_tolc(*s1++), d = mg_tolc(*s2++);
+    diff = c - d;
+  } while (diff == 0 && s1[-1] != '\0');
+  return diff;
 }
 
 struct mg_str mg_strdup(const struct mg_str s) {
   struct mg_str r = {NULL, 0};
-  if (s.len > 0 && s.ptr != NULL) {
+  if (s.len > 0 && s.buf != NULL) {
     char *sc = (char *) calloc(1, s.len + 1);
     if (sc != NULL) {
-      memcpy(sc, s.ptr, s.len);
+      memcpy(sc, s.buf, s.len);
       sc[s.len] = '\0';
-      r.ptr = sc;
+      r.buf = sc;
       r.len = s.len;
     }
   }
@@ -5179,8 +8808,8 @@ struct mg_str mg_strdup(const struct mg_str s) {
 int mg_strcmp(const struct mg_str str1, const struct mg_str str2) {
   size_t i = 0;
   while (i < str1.len && i < str2.len) {
-    int c1 = str1.ptr[i];
-    int c2 = str2.ptr[i];
+    int c1 = str1.buf[i];
+    int c2 = str2.buf[i];
     if (c1 < c2) return -1;
     if (c1 > c2) return 1;
     i++;
@@ -5190,168 +8819,135 @@ int mg_strcmp(const struct mg_str str1, const struct mg_str str2) {
   return 0;
 }
 
-const char *mg_strstr(const struct mg_str haystack,
-                      const struct mg_str needle) {
-  size_t i;
-  if (needle.len > haystack.len) return NULL;
-  if (needle.len == 0) return haystack.ptr;
-  for (i = 0; i <= haystack.len - needle.len; i++) {
-    if (memcmp(haystack.ptr + i, needle.ptr, needle.len) == 0) {
-      return haystack.ptr + i;
-    }
+int mg_strcasecmp(const struct mg_str str1, const struct mg_str str2) {
+  size_t i = 0;
+  while (i < str1.len && i < str2.len) {
+    int c1 = mg_tolc(str1.buf[i]);
+    int c2 = mg_tolc(str2.buf[i]);
+    if (c1 < c2) return -1;
+    if (c1 > c2) return 1;
+    i++;
   }
-  return NULL;
-}
-
-static bool is_space(int c) {
-  return c == ' ' || c == '\r' || c == '\n' || c == '\t';
-}
-
-struct mg_str mg_strstrip(struct mg_str s) {
-  while (s.len > 0 && is_space((int) *s.ptr)) s.ptr++, s.len--;
-  while (s.len > 0 && is_space((int) *(s.ptr + s.len - 1))) s.len--;
-  return s;
+  if (i < str1.len) return 1;
+  if (i < str2.len) return -1;
+  return 0;
 }
 
 bool mg_match(struct mg_str s, struct mg_str p, struct mg_str *caps) {
   size_t i = 0, j = 0, ni = 0, nj = 0;
-  if (caps) caps->ptr = NULL, caps->len = 0;
+  if (caps) caps->buf = NULL, caps->len = 0;
   while (i < p.len || j < s.len) {
-    if (i < p.len && j < s.len && (p.ptr[i] == '?' || s.ptr[j] == p.ptr[i])) {
+    if (i < p.len && j < s.len &&
+        (p.buf[i] == '?' ||
+         (p.buf[i] != '*' && p.buf[i] != '#' && s.buf[j] == p.buf[i]))) {
       if (caps == NULL) {
-      } else if (p.ptr[i] == '?') {
-        caps->ptr = &s.ptr[j], caps->len = 1;     // Finalize `?` cap
-        caps++, caps->ptr = NULL, caps->len = 0;  // Init next cap
-      } else if (caps->ptr != NULL && caps->len == 0) {
-        caps->len = (size_t) (&s.ptr[j] - caps->ptr);  // Finalize current cap
-        caps++, caps->len = 0, caps->ptr = NULL;       // Init next cap
+      } else if (p.buf[i] == '?') {
+        caps->buf = &s.buf[j], caps->len = 1;     // Finalize `?` cap
+        caps++, caps->buf = NULL, caps->len = 0;  // Init next cap
+      } else if (caps->buf != NULL && caps->len == 0) {
+        caps->len = (size_t) (&s.buf[j] - caps->buf);  // Finalize current cap
+        caps++, caps->len = 0, caps->buf = NULL;       // Init next cap
       }
       i++, j++;
-    } else if (i < p.len && (p.ptr[i] == '*' || p.ptr[i] == '#')) {
-      if (caps && !caps->ptr) caps->len = 0, caps->ptr = &s.ptr[j];  // Init cap
+    } else if (i < p.len && (p.buf[i] == '*' || p.buf[i] == '#')) {
+      if (caps && !caps->buf) caps->len = 0, caps->buf = &s.buf[j];  // Init cap
       ni = i++, nj = j + 1;
-    } else if (nj > 0 && nj <= s.len && (p.ptr[ni] == '#' || s.ptr[j] != '/')) {
+    } else if (nj > 0 && nj <= s.len && (p.buf[ni] == '#' || s.buf[j] != '/')) {
       i = ni, j = nj;
-      if (caps && caps->ptr == NULL && caps->len == 0) {
+      if (caps && caps->buf == NULL && caps->len == 0) {
         caps--, caps->len = 0;  // Restart previous cap
       }
     } else {
       return false;
     }
   }
-  if (caps && caps->ptr && caps->len == 0) {
-    caps->len = (size_t) (&s.ptr[j] - caps->ptr);
+  if (caps && caps->buf && caps->len == 0) {
+    caps->len = (size_t) (&s.buf[j] - caps->buf);
   }
   return true;
 }
 
-bool mg_globmatch(const char *s1, size_t n1, const char *s2, size_t n2) {
-  return mg_match(mg_str_n(s2, n2), mg_str_n(s1, n1), NULL);
-}
-
-static size_t mg_nce(const char *s, size_t n, size_t ofs, size_t *koff,
-                     size_t *klen, size_t *voff, size_t *vlen, char delim) {
-  size_t kvlen, kl;
-  for (kvlen = 0; ofs + kvlen < n && s[ofs + kvlen] != delim;) kvlen++;
-  for (kl = 0; kl < kvlen && s[ofs + kl] != '=';) kl++;
-  if (koff != NULL) *koff = ofs;
-  if (klen != NULL) *klen = kl;
-  if (voff != NULL) *voff = kl < kvlen ? ofs + kl + 1 : 0;
-  if (vlen != NULL) *vlen = kl < kvlen ? kvlen - kl - 1 : 0;
-  ofs += kvlen + 1;
-  return ofs > n ? n : ofs;
-}
-
-bool mg_split(struct mg_str *s, struct mg_str *k, struct mg_str *v, char sep) {
-  size_t koff = 0, klen = 0, voff = 0, vlen = 0, off = 0;
-  if (s->ptr == NULL || s->len == 0) return 0;
-  off = mg_nce(s->ptr, s->len, 0, &koff, &klen, &voff, &vlen, sep);
-  if (k != NULL) *k = mg_str_n(s->ptr + koff, klen);
-  if (v != NULL) *v = mg_str_n(s->ptr + voff, vlen);
-  *s = mg_str_n(s->ptr + off, s->len - off);
-  return off > 0;
-}
-
-bool mg_commalist(struct mg_str *s, struct mg_str *k, struct mg_str *v) {
-  return mg_split(s, k, v, ',');
-}
-
-char *mg_hex(const void *buf, size_t len, char *to) {
-  const unsigned char *p = (const unsigned char *) buf;
-  const char *hex = "0123456789abcdef";
-  size_t i = 0;
-  for (; len--; p++) {
-    to[i++] = hex[p[0] >> 4];
-    to[i++] = hex[p[0] & 0x0f];
-  }
-  to[i] = '\0';
-  return to;
-}
-
-static unsigned char mg_unhex_nimble(unsigned char c) {
-  return (c >= '0' && c <= '9')   ? (unsigned char) (c - '0')
-         : (c >= 'A' && c <= 'F') ? (unsigned char) (c - '7')
-                                  : (unsigned char) (c - 'W');
-}
-
-unsigned long mg_unhexn(const char *s, size_t len) {
-  unsigned long i = 0, v = 0;
-  for (i = 0; i < len; i++) v <<= 4, v |= mg_unhex_nimble(((uint8_t *) s)[i]);
-  return v;
-}
-
-void mg_unhex(const char *buf, size_t len, unsigned char *to) {
-  size_t i;
-  for (i = 0; i < len; i += 2) {
-    to[i >> 1] = (unsigned char) mg_unhexn(&buf[i], 2);
+bool mg_span(struct mg_str s, struct mg_str *a, struct mg_str *b, char sep) {
+  if (s.len == 0 || s.buf == NULL) {
+    return false;  // Empty string, nothing to span - fail
+  } else {
+    size_t len = 0;
+    while (len < s.len && s.buf[len] != sep) len++;  // Find separator
+    if (a) *a = mg_str_n(s.buf, len);                // Init a
+    if (b) *b = mg_str_n(s.buf + len, s.len - len);  // Init b
+    if (b && len < s.len) b->buf++, b->len--;        // Skip separator
+    return true;
   }
 }
 
-uint64_t mg_tou64(struct mg_str str) {
+bool mg_str_to_num(struct mg_str str, int base, void *val, size_t val_len) {
+  size_t i = 0, ndigits = 0;
+  uint64_t max = val_len == sizeof(uint8_t)    ? 0xFF
+                 : val_len == sizeof(uint16_t) ? 0xFFFF
+                 : val_len == sizeof(uint32_t) ? 0xFFFFFFFF
+                                               : (uint64_t) ~0;
   uint64_t result = 0;
-  size_t i = 0;
-  while (i < str.len && (str.ptr[i] == ' ' || str.ptr[i] == '\t')) i++;
-  while (i < str.len && str.ptr[i] >= '0' && str.ptr[i] <= '9') {
-    result *= 10;
-    result += (unsigned) (str.ptr[i] - '0');
-    i++;
-  }
-  return result;
-}
-
-int64_t mg_to64(struct mg_str str) {
-  int64_t result = 0, neg = 1, max = 922337203685477570 /* INT64_MAX/10-10 */;
-  size_t i = 0;
-  while (i < str.len && (str.ptr[i] == ' ' || str.ptr[i] == '\t')) i++;
-  if (i < str.len && str.ptr[i] == '-') neg = -1, i++;
-  while (i < str.len && str.ptr[i] >= '0' && str.ptr[i] <= '9') {
-    if (result > max) return 0;
-    result *= 10;
-    result += (str.ptr[i] - '0');
-    i++;
-  }
-  return result * neg;
-}
-
-char *mg_remove_double_dots(char *s) {
-  char *saved = s, *p = s;
-  while (*s != '\0') {
-    *p++ = *s++;
-    if (s[-1] == '/' || s[-1] == '\\') {
-      while (s[0] != '\0') {
-        if (s[0] == '/' || s[0] == '\\') {
-          s++;
-        } else if (s[0] == '.' && s[1] == '.' &&
-                   (s[2] == '/' || s[2] == '\\')) {
-          s += 2;
-        } else {
-          break;
-        }
-      }
+  if (max == (uint64_t) ~0 && val_len != sizeof(uint64_t)) return false;
+  if (base == 0 && str.len >= 2) {
+    if (str.buf[i] == '0') {
+      i++;
+      base = str.buf[i] == 'b' ? 2 : str.buf[i] == 'x' ? 16 : 10;
+      if (base != 10) ++i;
+    } else {
+      base = 10;
     }
   }
-  *p = '\0';
-  return saved;
+  switch (base) {
+    case 2:
+      while (i < str.len && (str.buf[i] == '0' || str.buf[i] == '1')) {
+        uint64_t digit = (uint64_t) (str.buf[i] - '0');
+        if (result > max / 2) return false;  // Overflow
+        result *= 2;
+        if (result > max - digit) return false;  // Overflow
+        result += digit;
+        i++, ndigits++;
+      }
+      break;
+    case 10:
+      while (i < str.len && str.buf[i] >= '0' && str.buf[i] <= '9') {
+        uint64_t digit = (uint64_t) (str.buf[i] - '0');
+        if (result > max / 10) return false;  // Overflow
+        result *= 10;
+        if (result > max - digit) return false;  // Overflow
+        result += digit;
+        i++, ndigits++;
+      }
+      break;
+    case 16:
+      while (i < str.len) {
+        char c = str.buf[i];
+        uint64_t digit = (c >= '0' && c <= '9')   ? (uint64_t) (c - '0')
+                         : (c >= 'A' && c <= 'F') ? (uint64_t) (c - '7')
+                         : (c >= 'a' && c <= 'f') ? (uint64_t) (c - 'W')
+                                                  : (uint64_t) ~0;
+        if (digit == (uint64_t) ~0) break;
+        if (result > max / 16) return false;  // Overflow
+        result *= 16;
+        if (result > max - digit) return false;  // Overflow
+        result += digit;
+        i++, ndigits++;
+      }
+      break;
+    default:
+      return false;
+  }
+  if (ndigits == 0) return false;
+  if (i != str.len) return false;
+  if (val_len == 1) {
+    *((uint8_t *) val) = (uint8_t) result;
+  } else if (val_len == 2) {
+    *((uint16_t *) val) = (uint16_t) result;
+  } else if (val_len == 4) {
+    *((uint32_t *) val) = (uint32_t) result;
+  } else {
+    *((uint64_t *) val) = (uint64_t) result;
+  }
+  return true;
 }
 
 #ifdef MG_ENABLE_LINES
@@ -5399,11 +8995,4231 @@ void mg_timer_poll(struct mg_timer **head, uint64_t now_ms) {
 }
 
 #ifdef MG_ENABLE_LINES
+#line 1 "src/tls_aes128.c"
+#endif
+/******************************************************************************
+ *
+ * THIS SOURCE CODE IS HEREBY PLACED INTO THE PUBLIC DOMAIN FOR THE GOOD OF ALL
+ *
+ * This is a simple and straightforward implementation of the AES Rijndael
+ * 128-bit block cipher designed by Vincent Rijmen and Joan Daemen. The focus
+ * of this work was correctness & accuracy.  It is written in 'C' without any
+ * particular focus upon optimization or speed. It should be endian (memory
+ * byte order) neutral since the few places that care are handled explicitly.
+ *
+ * This implementation of Rijndael was created by Steven M. Gibson of GRC.com.
+ *
+ * It is intended for general purpose use, but was written in support of GRC's
+ * reference implementation of the SQRL (Secure Quick Reliable Login) client.
+ *
+ * See:    http://csrc.nist.gov/archive/aes/rijndael/wsdindex.html
+ *
+ * NO COPYRIGHT IS CLAIMED IN THIS WORK, HOWEVER, NEITHER IS ANY WARRANTY MADE
+ * REGARDING ITS FITNESS FOR ANY PARTICULAR PURPOSE. USE IT AT YOUR OWN RISK.
+ *
+ *******************************************************************************/
+
+/******************************************************************************/
+#define AES_DECRYPTION 1  // whether AES decryption is supported
+/******************************************************************************/
+
+#define MG_ENCRYPT 1  // specify whether we're encrypting
+#define MG_DECRYPT 0  // or decrypting
+
+
+
+
+
+#if MG_TLS == MG_TLS_BUILTIN
+/******************************************************************************
+ *  AES_INIT_KEYGEN_TABLES : MUST be called once before any AES use
+ ******************************************************************************/
+static void aes_init_keygen_tables(void);
+
+/******************************************************************************
+ *  AES_SETKEY : called to expand the key for encryption or decryption
+ ******************************************************************************/
+static int aes_setkey(aes_context *ctx,  // pointer to context
+                      int mode,          // 1 or 0 for Encrypt/Decrypt
+                      const unsigned char *key,  // AES input key
+                      unsigned int keysize);  // size in bytes (must be 16, 24, 32 for
+                                      // 128, 192 or 256-bit keys respectively)
+                                      // returns 0 for success
+
+/******************************************************************************
+ *  AES_CIPHER : called to encrypt or decrypt ONE 128-bit block of data
+ ******************************************************************************/
+static int aes_cipher(aes_context *ctx,       // pointer to context
+                      const unsigned char input[16],  // 128-bit block to en/decipher
+                      unsigned char output[16]);      // 128-bit output result block
+                                              // returns 0 for success
+
+/******************************************************************************
+ *  GCM_CONTEXT : GCM context / holds keytables, instance data, and AES ctx
+ ******************************************************************************/
+typedef struct {
+  int mode;             // cipher direction: encrypt/decrypt
+  uint64_t len;         // cipher data length processed so far
+  uint64_t add_len;     // total add data length
+  uint64_t HL[16];      // precalculated lo-half HTable
+  uint64_t HH[16];      // precalculated hi-half HTable
+  unsigned char base_ectr[16];  // first counter-mode cipher output for tag
+  unsigned char y[16];          // the current cipher-input IV|Counter value
+  unsigned char buf[16];        // buf working value
+  aes_context aes_ctx;  // cipher context used
+} gcm_context;
+
+/******************************************************************************
+ *  GCM_SETKEY : sets the GCM (and AES) keying material for use
+ ******************************************************************************/
+static int gcm_setkey(
+    gcm_context *ctx,   // caller-provided context ptr
+    const unsigned char *key,   // pointer to cipher key
+    const unsigned int keysize  // size in bytes (must be 16, 24, 32 for
+                        // 128, 192 or 256-bit keys respectively)
+);                      // returns 0 for success
+
+/******************************************************************************
+ *
+ *  GCM_CRYPT_AND_TAG
+ *
+ *  This either encrypts or decrypts the user-provided data and, either
+ *  way, generates an authentication tag of the requested length. It must be
+ *  called with a GCM context whose key has already been set with GCM_SETKEY.
+ *
+ *  The user would typically call this explicitly to ENCRYPT a buffer of data
+ *  and optional associated data, and produce its an authentication tag.
+ *
+ *  To reverse the process the user would typically call the companion
+ *  GCM_AUTH_DECRYPT function to decrypt data and verify a user-provided
+ *  authentication tag.  The GCM_AUTH_DECRYPT function calls this function
+ *  to perform its decryption and tag generation, which it then compares.
+ *
+ ******************************************************************************/
+static int gcm_crypt_and_tag(
+    gcm_context *ctx,    // gcm context with key already setup
+    int mode,            // cipher direction: MG_ENCRYPT (1) or MG_DECRYPT (0)
+    const unsigned char *iv,     // pointer to the 12-byte initialization vector
+    size_t iv_len,       // byte length if the IV. should always be 12
+    const unsigned char *add,    // pointer to the non-ciphered additional data
+    size_t add_len,      // byte length of the additional AEAD data
+    const unsigned char *input,  // pointer to the cipher data source
+    unsigned char *output,       // pointer to the cipher data destination
+    size_t length,       // byte length of the cipher data
+    unsigned char *tag,          // pointer to the tag to be generated
+    size_t tag_len);     // byte length of the tag to be generated
+
+/******************************************************************************
+ *
+ *  GCM_START
+ *
+ *  Given a user-provided GCM context, this initializes it, sets the encryption
+ *  mode, and preprocesses the initialization vector and additional AEAD data.
+ *
+ ******************************************************************************/
+static int gcm_start(
+    gcm_context *ctx,  // pointer to user-provided GCM context
+    int mode,          // MG_ENCRYPT (1) or MG_DECRYPT (0)
+    const unsigned char *iv,   // pointer to initialization vector
+    size_t iv_len,     // IV length in bytes (should == 12)
+    const unsigned char *add,  // pointer to additional AEAD data (NULL if none)
+    size_t add_len);   // length of additional AEAD data (bytes)
+
+/******************************************************************************
+ *
+ *  GCM_UPDATE
+ *
+ *  This is called once or more to process bulk plaintext or ciphertext data.
+ *  We give this some number of bytes of input and it returns the same number
+ *  of output bytes. If called multiple times (which is fine) all but the final
+ *  invocation MUST be called with length mod 16 == 0. (Only the final call can
+ *  have a partial block length of < 128 bits.)
+ *
+ ******************************************************************************/
+static int gcm_update(gcm_context *ctx,  // pointer to user-provided GCM context
+                      size_t length,     // length, in bytes, of data to process
+                      const unsigned char *input,  // pointer to source data
+                      unsigned char *output);      // pointer to destination data
+
+/******************************************************************************
+ *
+ *  GCM_FINISH
+ *
+ *  This is called once after all calls to GCM_UPDATE to finalize the GCM.
+ *  It performs the final GHASH to produce the resulting authentication TAG.
+ *
+ ******************************************************************************/
+static int gcm_finish(
+    gcm_context *ctx,  // pointer to user-provided GCM context
+    unsigned char *tag,        // ptr to tag buffer - NULL if tag_len = 0
+    size_t tag_len);   // length, in bytes, of the tag-receiving buf
+
+/******************************************************************************
+ *
+ *  GCM_ZERO_CTX
+ *
+ *  The GCM context contains both the GCM context and the AES context.
+ *  This includes keying and key-related material which is security-
+ *  sensitive, so it MUST be zeroed after use. This function does that.
+ *
+ ******************************************************************************/
+static void gcm_zero_ctx(gcm_context *ctx);
+
+/******************************************************************************
+ *
+ * THIS SOURCE CODE IS HEREBY PLACED INTO THE PUBLIC DOMAIN FOR THE GOOD OF ALL
+ *
+ * This is a simple and straightforward implementation of the AES Rijndael
+ * 128-bit block cipher designed by Vincent Rijmen and Joan Daemen. The focus
+ * of this work was correctness & accuracy.  It is written in 'C' without any
+ * particular focus upon optimization or speed. It should be endian (memory
+ * byte order) neutral since the few places that care are handled explicitly.
+ *
+ * This implementation of Rijndael was created by Steven M. Gibson of GRC.com.
+ *
+ * It is intended for general purpose use, but was written in support of GRC's
+ * reference implementation of the SQRL (Secure Quick Reliable Login) client.
+ *
+ * See:    http://csrc.nist.gov/archive/aes/rijndael/wsdindex.html
+ *
+ * NO COPYRIGHT IS CLAIMED IN THIS WORK, HOWEVER, NEITHER IS ANY WARRANTY MADE
+ * REGARDING ITS FITNESS FOR ANY PARTICULAR PURPOSE. USE IT AT YOUR OWN RISK.
+ *
+ *******************************************************************************/
+
+
+
+
+static int aes_tables_inited = 0;  // run-once flag for performing key
+                                   // expasion table generation (see below)
+/*
+ *  The following static local tables must be filled-in before the first use of
+ *  the GCM or AES ciphers. They are used for the AES key expansion/scheduling
+ *  and once built are read-only and thread safe. The "gcm_initialize" function
+ *  must be called once during system initialization to populate these arrays
+ *  for subsequent use by the AES key scheduler. If they have not been built
+ *  before attempted use, an error will be returned to the caller.
+ *
+ *  NOTE: GCM Encryption/Decryption does NOT REQUIRE AES decryption. Since
+ *  GCM uses AES in counter-mode, where the AES cipher output is XORed with
+ *  the GCM input, we ONLY NEED AES encryption.  Thus, to save space AES
+ *  decryption is typically disabled by setting AES_DECRYPTION to 0 in aes.h.
+ */
+// We always need our forward tables
+static unsigned char FSb[256];     // Forward substitution box (FSb)
+static uint32_t FT0[256];  // Forward key schedule assembly tables
+static uint32_t FT1[256];
+static uint32_t FT2[256];
+static uint32_t FT3[256];
+
+#if AES_DECRYPTION         // We ONLY need reverse for decryption
+static unsigned char RSb[256];     // Reverse substitution box (RSb)
+static uint32_t RT0[256];  // Reverse key schedule assembly tables
+static uint32_t RT1[256];
+static uint32_t RT2[256];
+static uint32_t RT3[256];
+#endif /* AES_DECRYPTION */
+
+static uint32_t RCON[10];  // AES round constants
+
+/*
+ * Platform Endianness Neutralizing Load and Store Macro definitions
+ * AES wants platform-neutral Little Endian (LE) byte ordering
+ */
+#define GET_UINT32_LE(n, b, i)                                               \
+  {                                                                          \
+    (n) = ((uint32_t) (b)[(i)]) | ((uint32_t) (b)[(i) + 1] << 8) |           \
+          ((uint32_t) (b)[(i) + 2] << 16) | ((uint32_t) (b)[(i) + 3] << 24); \
+  }
+
+#define PUT_UINT32_LE(n, b, i)          \
+  {                                     \
+    (b)[(i)] = (unsigned char) ((n));           \
+    (b)[(i) + 1] = (unsigned char) ((n) >> 8);  \
+    (b)[(i) + 2] = (unsigned char) ((n) >> 16); \
+    (b)[(i) + 3] = (unsigned char) ((n) >> 24); \
+  }
+
+/*
+ *  AES forward and reverse encryption round processing macros
+ */
+#define AES_FROUND(X0, X1, X2, X3, Y0, Y1, Y2, Y3)          \
+  {                                                         \
+    X0 = *RK++ ^ FT0[(Y0) & 0xFF] ^ FT1[(Y1 >> 8) & 0xFF] ^ \
+         FT2[(Y2 >> 16) & 0xFF] ^ FT3[(Y3 >> 24) & 0xFF];   \
+                                                            \
+    X1 = *RK++ ^ FT0[(Y1) & 0xFF] ^ FT1[(Y2 >> 8) & 0xFF] ^ \
+         FT2[(Y3 >> 16) & 0xFF] ^ FT3[(Y0 >> 24) & 0xFF];   \
+                                                            \
+    X2 = *RK++ ^ FT0[(Y2) & 0xFF] ^ FT1[(Y3 >> 8) & 0xFF] ^ \
+         FT2[(Y0 >> 16) & 0xFF] ^ FT3[(Y1 >> 24) & 0xFF];   \
+                                                            \
+    X3 = *RK++ ^ FT0[(Y3) & 0xFF] ^ FT1[(Y0 >> 8) & 0xFF] ^ \
+         FT2[(Y1 >> 16) & 0xFF] ^ FT3[(Y2 >> 24) & 0xFF];   \
+  }
+
+#define AES_RROUND(X0, X1, X2, X3, Y0, Y1, Y2, Y3)          \
+  {                                                         \
+    X0 = *RK++ ^ RT0[(Y0) & 0xFF] ^ RT1[(Y3 >> 8) & 0xFF] ^ \
+         RT2[(Y2 >> 16) & 0xFF] ^ RT3[(Y1 >> 24) & 0xFF];   \
+                                                            \
+    X1 = *RK++ ^ RT0[(Y1) & 0xFF] ^ RT1[(Y0 >> 8) & 0xFF] ^ \
+         RT2[(Y3 >> 16) & 0xFF] ^ RT3[(Y2 >> 24) & 0xFF];   \
+                                                            \
+    X2 = *RK++ ^ RT0[(Y2) & 0xFF] ^ RT1[(Y1 >> 8) & 0xFF] ^ \
+         RT2[(Y0 >> 16) & 0xFF] ^ RT3[(Y3 >> 24) & 0xFF];   \
+                                                            \
+    X3 = *RK++ ^ RT0[(Y3) & 0xFF] ^ RT1[(Y2 >> 8) & 0xFF] ^ \
+         RT2[(Y1 >> 16) & 0xFF] ^ RT3[(Y0 >> 24) & 0xFF];   \
+  }
+
+/*
+ *  These macros improve the readability of the key
+ *  generation initialization code by collapsing
+ *  repetitive common operations into logical pieces.
+ */
+#define ROTL8(x) ((x << 8) & 0xFFFFFFFF) | (x >> 24)
+#define XTIME(x) ((x << 1) ^ ((x & 0x80) ? 0x1B : 0x00))
+#define MUL(x, y) ((x && y) ? pow[(log[x] + log[y]) % 255] : 0)
+#define MIX(x, y)                     \
+  {                                   \
+    y = ((y << 1) | (y >> 7)) & 0xFF; \
+    x ^= y;                           \
+  }
+#define CPY128     \
+  {                \
+    *RK++ = *SK++; \
+    *RK++ = *SK++; \
+    *RK++ = *SK++; \
+    *RK++ = *SK++; \
+  }
+
+/******************************************************************************
+ *
+ *  AES_INIT_KEYGEN_TABLES
+ *
+ *  Fills the AES key expansion tables allocated above with their static
+ *  data. This is not "per key" data, but static system-wide read-only
+ *  table data. THIS FUNCTION IS NOT THREAD SAFE. It must be called once
+ *  at system initialization to setup the tables for all subsequent use.
+ *
+ ******************************************************************************/
+void aes_init_keygen_tables(void) {
+  int i, x, y, z;  // general purpose iteration and computation locals
+  int pow[256];
+  int log[256];
+
+  if (aes_tables_inited) return;
+
+  // fill the 'pow' and 'log' tables over GF(2^8)
+  for (i = 0, x = 1; i < 256; i++) {
+    pow[i] = x;
+    log[x] = i;
+    x = (x ^ XTIME(x)) & 0xFF;
+  }
+  // compute the round constants
+  for (i = 0, x = 1; i < 10; i++) {
+    RCON[i] = (uint32_t) x;
+    x = XTIME(x) & 0xFF;
+  }
+  // fill the forward and reverse substitution boxes
+  FSb[0x00] = 0x63;
+#if AES_DECRYPTION  // whether AES decryption is supported
+  RSb[0x63] = 0x00;
+#endif /* AES_DECRYPTION */
+
+  for (i = 1; i < 256; i++) {
+    x = y = pow[255 - log[i]];
+    MIX(x, y);
+    MIX(x, y);
+    MIX(x, y);
+    MIX(x, y);
+    FSb[i] = (unsigned char) (x ^= 0x63);
+#if AES_DECRYPTION  // whether AES decryption is supported
+    RSb[x] = (unsigned char) i;
+#endif /* AES_DECRYPTION */
+  }
+  // generate the forward and reverse key expansion tables
+  for (i = 0; i < 256; i++) {
+    x = FSb[i];
+    y = XTIME(x) & 0xFF;
+    z = (y ^ x) & 0xFF;
+
+    FT0[i] = ((uint32_t) y) ^ ((uint32_t) x << 8) ^ ((uint32_t) x << 16) ^
+             ((uint32_t) z << 24);
+
+    FT1[i] = ROTL8(FT0[i]);
+    FT2[i] = ROTL8(FT1[i]);
+    FT3[i] = ROTL8(FT2[i]);
+
+#if AES_DECRYPTION  // whether AES decryption is supported
+    x = RSb[i];
+
+    RT0[i] = ((uint32_t) MUL(0x0E, x)) ^ ((uint32_t) MUL(0x09, x) << 8) ^
+             ((uint32_t) MUL(0x0D, x) << 16) ^ ((uint32_t) MUL(0x0B, x) << 24);
+
+    RT1[i] = ROTL8(RT0[i]);
+    RT2[i] = ROTL8(RT1[i]);
+    RT3[i] = ROTL8(RT2[i]);
+#endif /* AES_DECRYPTION */
+  }
+  aes_tables_inited = 1;  // flag that the tables have been generated
+}  // to permit subsequent use of the AES cipher
+
+/******************************************************************************
+ *
+ *  AES_SET_ENCRYPTION_KEY
+ *
+ *  This is called by 'aes_setkey' when we're establishing a key for
+ *  subsequent encryption.  We give it a pointer to the encryption
+ *  context, a pointer to the key, and the key's length in bytes.
+ *  Valid lengths are: 16, 24 or 32 bytes (128, 192, 256 bits).
+ *
+ ******************************************************************************/
+static int aes_set_encryption_key(aes_context *ctx, const unsigned char *key,
+                                  unsigned int keysize) {
+  unsigned int i;                  // general purpose iteration local
+  uint32_t *RK = ctx->rk;  // initialize our RoundKey buffer pointer
+
+  for (i = 0; i < (keysize >> 2); i++) {
+    GET_UINT32_LE(RK[i], key, i << 2);
+  }
+
+  switch (ctx->rounds) {
+    case 10:
+      for (i = 0; i < 10; i++, RK += 4) {
+        RK[4] = RK[0] ^ RCON[i] ^ ((uint32_t) FSb[(RK[3] >> 8) & 0xFF]) ^
+                ((uint32_t) FSb[(RK[3] >> 16) & 0xFF] << 8) ^
+                ((uint32_t) FSb[(RK[3] >> 24) & 0xFF] << 16) ^
+                ((uint32_t) FSb[(RK[3]) & 0xFF] << 24);
+
+        RK[5] = RK[1] ^ RK[4];
+        RK[6] = RK[2] ^ RK[5];
+        RK[7] = RK[3] ^ RK[6];
+      }
+      break;
+
+    case 12:
+      for (i = 0; i < 8; i++, RK += 6) {
+        RK[6] = RK[0] ^ RCON[i] ^ ((uint32_t) FSb[(RK[5] >> 8) & 0xFF]) ^
+                ((uint32_t) FSb[(RK[5] >> 16) & 0xFF] << 8) ^
+                ((uint32_t) FSb[(RK[5] >> 24) & 0xFF] << 16) ^
+                ((uint32_t) FSb[(RK[5]) & 0xFF] << 24);
+
+        RK[7] = RK[1] ^ RK[6];
+        RK[8] = RK[2] ^ RK[7];
+        RK[9] = RK[3] ^ RK[8];
+        RK[10] = RK[4] ^ RK[9];
+        RK[11] = RK[5] ^ RK[10];
+      }
+      break;
+
+    case 14:
+      for (i = 0; i < 7; i++, RK += 8) {
+        RK[8] = RK[0] ^ RCON[i] ^ ((uint32_t) FSb[(RK[7] >> 8) & 0xFF]) ^
+                ((uint32_t) FSb[(RK[7] >> 16) & 0xFF] << 8) ^
+                ((uint32_t) FSb[(RK[7] >> 24) & 0xFF] << 16) ^
+                ((uint32_t) FSb[(RK[7]) & 0xFF] << 24);
+
+        RK[9] = RK[1] ^ RK[8];
+        RK[10] = RK[2] ^ RK[9];
+        RK[11] = RK[3] ^ RK[10];
+
+        RK[12] = RK[4] ^ ((uint32_t) FSb[(RK[11]) & 0xFF]) ^
+                 ((uint32_t) FSb[(RK[11] >> 8) & 0xFF] << 8) ^
+                 ((uint32_t) FSb[(RK[11] >> 16) & 0xFF] << 16) ^
+                 ((uint32_t) FSb[(RK[11] >> 24) & 0xFF] << 24);
+
+        RK[13] = RK[5] ^ RK[12];
+        RK[14] = RK[6] ^ RK[13];
+        RK[15] = RK[7] ^ RK[14];
+      }
+      break;
+
+    default:
+      return -1;
+  }
+  return (0);
+}
+
+#if AES_DECRYPTION  // whether AES decryption is supported
+
+/******************************************************************************
+ *
+ *  AES_SET_DECRYPTION_KEY
+ *
+ *  This is called by 'aes_setkey' when we're establishing a
+ *  key for subsequent decryption.  We give it a pointer to
+ *  the encryption context, a pointer to the key, and the key's
+ *  length in bits. Valid lengths are: 128, 192, or 256 bits.
+ *
+ ******************************************************************************/
+static int aes_set_decryption_key(aes_context *ctx, const unsigned char *key,
+                                  unsigned int keysize) {
+  int i, j;
+  aes_context cty;         // a calling aes context for set_encryption_key
+  uint32_t *RK = ctx->rk;  // initialize our RoundKey buffer pointer
+  uint32_t *SK;
+  int ret;
+
+  cty.rounds = ctx->rounds;  // initialize our local aes context
+  cty.rk = cty.buf;          // round count and key buf pointer
+
+  if ((ret = aes_set_encryption_key(&cty, key, keysize)) != 0) return (ret);
+
+  SK = cty.rk + cty.rounds * 4;
+
+  CPY128  // copy a 128-bit block from *SK to *RK
+
+      for (i = ctx->rounds - 1, SK -= 8; i > 0; i--, SK -= 8) {
+    for (j = 0; j < 4; j++, SK++) {
+      *RK++ = RT0[FSb[(*SK) & 0xFF]] ^ RT1[FSb[(*SK >> 8) & 0xFF]] ^
+              RT2[FSb[(*SK >> 16) & 0xFF]] ^ RT3[FSb[(*SK >> 24) & 0xFF]];
+    }
+  }
+  CPY128  // copy a 128-bit block from *SK to *RK
+      memset(&cty, 0, sizeof(aes_context));  // clear local aes context
+  return (0);
+}
+
+#endif /* AES_DECRYPTION */
+
+/******************************************************************************
+ *
+ *  AES_SETKEY
+ *
+ *  Invoked to establish the key schedule for subsequent encryption/decryption
+ *
+ ******************************************************************************/
+static int aes_setkey(aes_context *ctx,  // AES context provided by our caller
+                      int mode,          // ENCRYPT or DECRYPT flag
+                      const unsigned char *key,  // pointer to the key
+                      unsigned int keysize)      // key length in bytes
+{
+  // since table initialization is not thread safe, we could either add
+  // system-specific mutexes and init the AES key generation tables on
+  // demand, or ask the developer to simply call "gcm_initialize" once during
+  // application startup before threading begins. That's what we choose.
+  if (!aes_tables_inited) return (-1);  // fail the call when not inited.
+
+  ctx->mode = mode;    // capture the key type we're creating
+  ctx->rk = ctx->buf;  // initialize our round key pointer
+
+  switch (keysize)  // set the rounds count based upon the keysize
+  {
+    case 16:
+      ctx->rounds = 10;
+      break;  // 16-byte, 128-bit key
+    case 24:
+      ctx->rounds = 12;
+      break;  // 24-byte, 192-bit key
+    case 32:
+      ctx->rounds = 14;
+      break;  // 32-byte, 256-bit key
+    default:
+      return (-1);
+  }
+
+#if AES_DECRYPTION
+  if (mode == MG_DECRYPT)  // expand our key for encryption or decryption
+    return (aes_set_decryption_key(ctx, key, keysize));
+  else /* MG_ENCRYPT */
+#endif /* AES_DECRYPTION */
+    return (aes_set_encryption_key(ctx, key, keysize));
+}
+
+/******************************************************************************
+ *
+ *  AES_CIPHER
+ *
+ *  Perform AES encryption and decryption.
+ *  The AES context will have been setup with the encryption mode
+ *  and all keying information appropriate for the task.
+ *
+ ******************************************************************************/
+static int aes_cipher(aes_context *ctx, const unsigned char input[16],
+                      unsigned char output[16]) {
+  int i;
+  uint32_t *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;  // general purpose locals
+
+  RK = ctx->rk;
+
+  GET_UINT32_LE(X0, input, 0);
+  X0 ^= *RK++;  // load our 128-bit
+  GET_UINT32_LE(X1, input, 4);
+  X1 ^= *RK++;  // input buffer in a storage
+  GET_UINT32_LE(X2, input, 8);
+  X2 ^= *RK++;  // memory endian-neutral way
+  GET_UINT32_LE(X3, input, 12);
+  X3 ^= *RK++;
+
+#if AES_DECRYPTION  // whether AES decryption is supported
+
+  if (ctx->mode == MG_DECRYPT) {
+    for (i = (ctx->rounds >> 1) - 1; i > 0; i--) {
+      AES_RROUND(Y0, Y1, Y2, Y3, X0, X1, X2, X3);
+      AES_RROUND(X0, X1, X2, X3, Y0, Y1, Y2, Y3);
+    }
+
+    AES_RROUND(Y0, Y1, Y2, Y3, X0, X1, X2, X3);
+
+    X0 = *RK++ ^ ((uint32_t) RSb[(Y0) & 0xFF]) ^
+         ((uint32_t) RSb[(Y3 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) RSb[(Y2 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) RSb[(Y1 >> 24) & 0xFF] << 24);
+
+    X1 = *RK++ ^ ((uint32_t) RSb[(Y1) & 0xFF]) ^
+         ((uint32_t) RSb[(Y0 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) RSb[(Y3 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) RSb[(Y2 >> 24) & 0xFF] << 24);
+
+    X2 = *RK++ ^ ((uint32_t) RSb[(Y2) & 0xFF]) ^
+         ((uint32_t) RSb[(Y1 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) RSb[(Y0 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) RSb[(Y3 >> 24) & 0xFF] << 24);
+
+    X3 = *RK++ ^ ((uint32_t) RSb[(Y3) & 0xFF]) ^
+         ((uint32_t) RSb[(Y2 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) RSb[(Y1 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) RSb[(Y0 >> 24) & 0xFF] << 24);
+  } else /* MG_ENCRYPT */
+  {
+#endif /* AES_DECRYPTION */
+
+    for (i = (ctx->rounds >> 1) - 1; i > 0; i--) {
+      AES_FROUND(Y0, Y1, Y2, Y3, X0, X1, X2, X3);
+      AES_FROUND(X0, X1, X2, X3, Y0, Y1, Y2, Y3);
+    }
+
+    AES_FROUND(Y0, Y1, Y2, Y3, X0, X1, X2, X3);
+
+    X0 = *RK++ ^ ((uint32_t) FSb[(Y0) & 0xFF]) ^
+         ((uint32_t) FSb[(Y1 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) FSb[(Y2 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) FSb[(Y3 >> 24) & 0xFF] << 24);
+
+    X1 = *RK++ ^ ((uint32_t) FSb[(Y1) & 0xFF]) ^
+         ((uint32_t) FSb[(Y2 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) FSb[(Y3 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) FSb[(Y0 >> 24) & 0xFF] << 24);
+
+    X2 = *RK++ ^ ((uint32_t) FSb[(Y2) & 0xFF]) ^
+         ((uint32_t) FSb[(Y3 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) FSb[(Y0 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) FSb[(Y1 >> 24) & 0xFF] << 24);
+
+    X3 = *RK++ ^ ((uint32_t) FSb[(Y3) & 0xFF]) ^
+         ((uint32_t) FSb[(Y0 >> 8) & 0xFF] << 8) ^
+         ((uint32_t) FSb[(Y1 >> 16) & 0xFF] << 16) ^
+         ((uint32_t) FSb[(Y2 >> 24) & 0xFF] << 24);
+
+#if AES_DECRYPTION  // whether AES decryption is supported
+  }
+#endif /* AES_DECRYPTION */
+
+  PUT_UINT32_LE(X0, output, 0);
+  PUT_UINT32_LE(X1, output, 4);
+  PUT_UINT32_LE(X2, output, 8);
+  PUT_UINT32_LE(X3, output, 12);
+
+  return (0);
+}
+/* end of aes.c */
+/******************************************************************************
+ *
+ * THIS SOURCE CODE IS HEREBY PLACED INTO THE PUBLIC DOMAIN FOR THE GOOD OF ALL
+ *
+ * This is a simple and straightforward implementation of AES-GCM authenticated
+ * encryption. The focus of this work was correctness & accuracy. It is written
+ * in straight 'C' without any particular focus upon optimization or speed. It
+ * should be endian (memory byte order) neutral since the few places that care
+ * are handled explicitly.
+ *
+ * This implementation of AES-GCM was created by Steven M. Gibson of GRC.com.
+ *
+ * It is intended for general purpose use, but was written in support of GRC's
+ * reference implementation of the SQRL (Secure Quick Reliable Login) client.
+ *
+ * See:    http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+ *         http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/
+ *         gcm/gcm-revised-spec.pdf
+ *
+ * NO COPYRIGHT IS CLAIMED IN THIS WORK, HOWEVER, NEITHER IS ANY WARRANTY MADE
+ * REGARDING ITS FITNESS FOR ANY PARTICULAR PURPOSE. USE IT AT YOUR OWN RISK.
+ *
+ *******************************************************************************/
+
+/******************************************************************************
+ *                      ==== IMPLEMENTATION WARNING ====
+ *
+ *  This code was developed for use within SQRL's fixed environmnent. Thus, it
+ *  is somewhat less "general purpose" than it would be if it were designed as
+ *  a general purpose AES-GCM library. Specifically, it bothers with almost NO
+ *  error checking on parameter limits, buffer bounds, etc. It assumes that it
+ *  is being invoked by its author or by someone who understands the values it
+ *  expects to receive. Its behavior will be undefined otherwise.
+ *
+ *  All functions that might fail are defined to return 'ints' to indicate a
+ *  problem. Most do not do so now. But this allows for error propagation out
+ *  of internal functions if robust error checking should ever be desired.
+ *
+ ******************************************************************************/
+
+/* Calculating the "GHASH"
+ *
+ * There are many ways of calculating the so-called GHASH in software, each with
+ * a traditional size vs performance tradeoff.  The GHASH (Galois field hash) is
+ * an intriguing construction which takes two 128-bit strings (also the cipher's
+ * block size and the fundamental operation size for the system) and hashes them
+ * into a third 128-bit result.
+ *
+ * Many implementation solutions have been worked out that use large precomputed
+ * table lookups in place of more time consuming bit fiddling, and this approach
+ * can be scaled easily upward or downward as needed to change the time/space
+ * tradeoff. It's been studied extensively and there's a solid body of theory
+ * and practice.  For example, without using any lookup tables an implementation
+ * might obtain 119 cycles per byte throughput, whereas using a simple, though
+ * large, key-specific 64 kbyte 8-bit lookup table the performance jumps to 13
+ * cycles per byte.
+ *
+ * And Intel's processors have, since 2010, included an instruction which does
+ * the entire 128x128->128 bit job in just several 64x64->128 bit pieces.
+ *
+ * Since SQRL is interactive, and only processing a few 128-bit blocks, I've
+ * settled upon a relatively slower but appealing small-table compromise which
+ * folds a bunch of not only time consuming but also bit twiddling into a simple
+ * 16-entry table which is attributed to Victor Shoup's 1996 work while at
+ * Bellcore: "On Fast and Provably Secure MessageAuthentication Based on
+ * Universal Hashing."  See: http://www.shoup.net/papers/macs.pdf
+ * See, also section 4.1 of the "gcm-revised-spec" cited above.
+ */
+
+/*
+ *  This 16-entry table of pre-computed constants is used by the
+ *  GHASH multiplier to improve over a strictly table-free but
+ *  significantly slower 128x128 bit multiple within GF(2^128).
+ */
+static const uint64_t last4[16] = {
+    0x0000, 0x1c20, 0x3840, 0x2460, 0x7080, 0x6ca0, 0x48c0, 0x54e0,
+    0xe100, 0xfd20, 0xd940, 0xc560, 0x9180, 0x8da0, 0xa9c0, 0xb5e0};
+
+/*
+ * Platform Endianness Neutralizing Load and Store Macro definitions
+ * GCM wants platform-neutral Big Endian (BE) byte ordering
+ */
+#define GET_UINT32_BE(n, b, i)                                            \
+  {                                                                       \
+    (n) = ((uint32_t) (b)[(i)] << 24) | ((uint32_t) (b)[(i) + 1] << 16) | \
+          ((uint32_t) (b)[(i) + 2] << 8) | ((uint32_t) (b)[(i) + 3]);     \
+  }
+
+#define PUT_UINT32_BE(n, b, i)          \
+  {                                     \
+    (b)[(i)] = (unsigned char) ((n) >> 24);     \
+    (b)[(i) + 1] = (unsigned char) ((n) >> 16); \
+    (b)[(i) + 2] = (unsigned char) ((n) >> 8);  \
+    (b)[(i) + 3] = (unsigned char) ((n));       \
+  }
+
+/******************************************************************************
+ *
+ *  GCM_INITIALIZE
+ *
+ *  Must be called once to initialize the GCM library.
+ *
+ *  At present, this only calls the AES keygen table generator, which expands
+ *  the AES keying tables for use. This is NOT A THREAD-SAFE function, so it
+ *  MUST be called during system initialization before a multi-threading
+ *  environment is running.
+ *
+ ******************************************************************************/
+int mg_gcm_initialize(void) {
+  aes_init_keygen_tables();
+  return (0);
+}
+
+/******************************************************************************
+ *
+ *  GCM_MULT
+ *
+ *  Performs a GHASH operation on the 128-bit input vector 'x', setting
+ *  the 128-bit output vector to 'x' times H using our precomputed tables.
+ *  'x' and 'output' are seen as elements of GCM's GF(2^128) Galois field.
+ *
+ ******************************************************************************/
+static void gcm_mult(gcm_context *ctx,   // pointer to established context
+                     const unsigned char x[16],  // pointer to 128-bit input vector
+                     unsigned char output[16])   // pointer to 128-bit output vector
+{
+  int i;
+  unsigned char lo, hi, rem;
+  uint64_t zh, zl;
+
+  lo = (unsigned char) (x[15] & 0x0f);
+  hi = (unsigned char) (x[15] >> 4);
+  zh = ctx->HH[lo];
+  zl = ctx->HL[lo];
+
+  for (i = 15; i >= 0; i--) {
+    lo = (unsigned char) (x[i] & 0x0f);
+    hi = (unsigned char) (x[i] >> 4);
+
+    if (i != 15) {
+      rem = (unsigned char) (zl & 0x0f);
+      zl = (zh << 60) | (zl >> 4);
+      zh = (zh >> 4);
+      zh ^= (uint64_t) last4[rem] << 48;
+      zh ^= ctx->HH[lo];
+      zl ^= ctx->HL[lo];
+    }
+    rem = (unsigned char) (zl & 0x0f);
+    zl = (zh << 60) | (zl >> 4);
+    zh = (zh >> 4);
+    zh ^= (uint64_t) last4[rem] << 48;
+    zh ^= ctx->HH[hi];
+    zl ^= ctx->HL[hi];
+  }
+  PUT_UINT32_BE(zh >> 32, output, 0);
+  PUT_UINT32_BE(zh, output, 4);
+  PUT_UINT32_BE(zl >> 32, output, 8);
+  PUT_UINT32_BE(zl, output, 12);
+}
+
+/******************************************************************************
+ *
+ *  GCM_SETKEY
+ *
+ *  This is called to set the AES-GCM key. It initializes the AES key
+ *  and populates the gcm context's pre-calculated HTables.
+ *
+ ******************************************************************************/
+static int gcm_setkey(
+    gcm_context *ctx,    // pointer to caller-provided gcm context
+    const unsigned char *key,    // pointer to the AES encryption key
+    const unsigned int keysize)  // size in bytes (must be 16, 24, 32 for
+                         // 128, 192 or 256-bit keys respectively)
+{
+  int ret, i, j;
+  uint64_t hi, lo;
+  uint64_t vl, vh;
+  unsigned char h[16];
+
+  memset(ctx, 0, sizeof(gcm_context));  // zero caller-provided GCM context
+  memset(h, 0, 16);                     // initialize the block to encrypt
+
+  // encrypt the null 128-bit block to generate a key-based value
+  // which is then used to initialize our GHASH lookup tables
+  if ((ret = aes_setkey(&ctx->aes_ctx, MG_ENCRYPT, key, keysize)) != 0)
+    return (ret);
+  if ((ret = aes_cipher(&ctx->aes_ctx, h, h)) != 0) return (ret);
+
+  GET_UINT32_BE(hi, h, 0);  // pack h as two 64-bit ints, big-endian
+  GET_UINT32_BE(lo, h, 4);
+  vh = (uint64_t) hi << 32 | lo;
+
+  GET_UINT32_BE(hi, h, 8);
+  GET_UINT32_BE(lo, h, 12);
+  vl = (uint64_t) hi << 32 | lo;
+
+  ctx->HL[8] = vl;  // 8 = 1000 corresponds to 1 in GF(2^128)
+  ctx->HH[8] = vh;
+  ctx->HH[0] = 0;  // 0 corresponds to 0 in GF(2^128)
+  ctx->HL[0] = 0;
+
+  for (i = 4; i > 0; i >>= 1) {
+    uint32_t T = (uint32_t) (vl & 1) * 0xe1000000U;
+    vl = (vh << 63) | (vl >> 1);
+    vh = (vh >> 1) ^ ((uint64_t) T << 32);
+    ctx->HL[i] = vl;
+    ctx->HH[i] = vh;
+  }
+  for (i = 2; i < 16; i <<= 1) {
+    uint64_t *HiL = ctx->HL + i, *HiH = ctx->HH + i;
+    vh = *HiH;
+    vl = *HiL;
+    for (j = 1; j < i; j++) {
+      HiH[j] = vh ^ ctx->HH[j];
+      HiL[j] = vl ^ ctx->HL[j];
+    }
+  }
+  return (0);
+}
+
+/******************************************************************************
+ *
+ *    GCM processing occurs four phases: SETKEY, START, UPDATE and FINISH.
+ *
+ *  SETKEY:
+ *
+ *   START: Sets the Encryption/Decryption mode.
+ *          Accepts the initialization vector and additional data.
+ *
+ *  UPDATE: Encrypts or decrypts the plaintext or ciphertext.
+ *
+ *  FINISH: Performs a final GHASH to generate the authentication tag.
+ *
+ ******************************************************************************
+ *
+ *  GCM_START
+ *
+ *  Given a user-provided GCM context, this initializes it, sets the encryption
+ *  mode, and preprocesses the initialization vector and additional AEAD data.
+ *
+ ******************************************************************************/
+int gcm_start(gcm_context *ctx,  // pointer to user-provided GCM context
+              int mode,          // GCM_ENCRYPT or GCM_DECRYPT
+              const unsigned char *iv,   // pointer to initialization vector
+              size_t iv_len,     // IV length in bytes (should == 12)
+              const unsigned char *add,  // ptr to additional AEAD data (NULL if none)
+              size_t add_len)    // length of additional AEAD data (bytes)
+{
+  int ret;             // our error return if the AES encrypt fails
+  unsigned char work_buf[16];  // XOR source built from provided IV if len != 16
+  const unsigned char *p;      // general purpose array pointer
+  size_t use_len;      // byte count to process, up to 16 bytes
+  size_t i;            // local loop iterator
+
+  // since the context might be reused under the same key
+  // we zero the working buffers for this next new process
+  memset(ctx->y, 0x00, sizeof(ctx->y));
+  memset(ctx->buf, 0x00, sizeof(ctx->buf));
+  ctx->len = 0;
+  ctx->add_len = 0;
+
+  ctx->mode = mode;                // set the GCM encryption/decryption mode
+  ctx->aes_ctx.mode = MG_ENCRYPT;  // GCM *always* runs AES in ENCRYPTION mode
+
+  if (iv_len == 12) {            // GCM natively uses a 12-byte, 96-bit IV
+    memcpy(ctx->y, iv, iv_len);  // copy the IV to the top of the 'y' buff
+    ctx->y[15] = 1;              // start "counting" from 1 (not 0)
+  } else  // if we don't have a 12-byte IV, we GHASH whatever we've been given
+  {
+    memset(work_buf, 0x00, 16);               // clear the working buffer
+    PUT_UINT32_BE(iv_len * 8, work_buf, 12);  // place the IV into buffer
+
+    p = iv;
+    while (iv_len > 0) {
+      use_len = (iv_len < 16) ? iv_len : 16;
+      for (i = 0; i < use_len; i++) ctx->y[i] ^= p[i];
+      gcm_mult(ctx, ctx->y, ctx->y);
+      iv_len -= use_len;
+      p += use_len;
+    }
+    for (i = 0; i < 16; i++) ctx->y[i] ^= work_buf[i];
+    gcm_mult(ctx, ctx->y, ctx->y);
+  }
+  if ((ret = aes_cipher(&ctx->aes_ctx, ctx->y, ctx->base_ectr)) != 0)
+    return (ret);
+
+  ctx->add_len = add_len;
+  p = add;
+  while (add_len > 0) {
+    use_len = (add_len < 16) ? add_len : 16;
+    for (i = 0; i < use_len; i++) ctx->buf[i] ^= p[i];
+    gcm_mult(ctx, ctx->buf, ctx->buf);
+    add_len -= use_len;
+    p += use_len;
+  }
+  return (0);
+}
+
+/******************************************************************************
+ *
+ *  GCM_UPDATE
+ *
+ *  This is called once or more to process bulk plaintext or ciphertext data.
+ *  We give this some number of bytes of input and it returns the same number
+ *  of output bytes. If called multiple times (which is fine) all but the final
+ *  invocation MUST be called with length mod 16 == 0. (Only the final call can
+ *  have a partial block length of < 128 bits.)
+ *
+ ******************************************************************************/
+int gcm_update(gcm_context *ctx,    // pointer to user-provided GCM context
+               size_t length,       // length, in bytes, of data to process
+               const unsigned char *input,  // pointer to source data
+               unsigned char *output)       // pointer to destination data
+{
+  int ret;         // our error return if the AES encrypt fails
+  unsigned char ectr[16];  // counter-mode cipher output for XORing
+  size_t use_len;  // byte count to process, up to 16 bytes
+  size_t i;        // local loop iterator
+
+  ctx->len += length;  // bump the GCM context's running length count
+
+  while (length > 0) {
+    // clamp the length to process at 16 bytes
+    use_len = (length < 16) ? length : 16;
+
+    // increment the context's 128-bit IV||Counter 'y' vector
+    for (i = 16; i > 12; i--)
+      if (++ctx->y[i - 1] != 0) break;
+
+    // encrypt the context's 'y' vector under the established key
+    if ((ret = aes_cipher(&ctx->aes_ctx, ctx->y, ectr)) != 0) return (ret);
+
+    // encrypt or decrypt the input to the output
+    if (ctx->mode == MG_ENCRYPT) {
+      for (i = 0; i < use_len; i++) {
+        // XOR the cipher's ouptut vector (ectr) with our input
+        output[i] = (unsigned char) (ectr[i] ^ input[i]);
+        // now we mix in our data into the authentication hash.
+        // if we're ENcrypting we XOR in the post-XOR (output)
+        // results, but if we're DEcrypting we XOR in the input
+        // data
+        ctx->buf[i] ^= output[i];
+      }
+    } else {
+      for (i = 0; i < use_len; i++) {
+        // but if we're DEcrypting we XOR in the input data first,
+        // i.e. before saving to ouput data, otherwise if the input
+        // and output buffer are the same (inplace decryption) we
+        // would not get the correct auth tag
+
+        ctx->buf[i] ^= input[i];
+
+        // XOR the cipher's ouptut vector (ectr) with our input
+        output[i] = (unsigned char) (ectr[i] ^ input[i]);
+      }
+    }
+    gcm_mult(ctx, ctx->buf, ctx->buf);  // perform a GHASH operation
+
+    length -= use_len;  // drop the remaining byte count to process
+    input += use_len;   // bump our input pointer forward
+    output += use_len;  // bump our output pointer forward
+  }
+  return (0);
+}
+
+/******************************************************************************
+ *
+ *  GCM_FINISH
+ *
+ *  This is called once after all calls to GCM_UPDATE to finalize the GCM.
+ *  It performs the final GHASH to produce the resulting authentication TAG.
+ *
+ ******************************************************************************/
+int gcm_finish(gcm_context *ctx,  // pointer to user-provided GCM context
+               unsigned char *tag,        // pointer to buffer which receives the tag
+               size_t tag_len)    // length, in bytes, of the tag-receiving buf
+{
+  unsigned char work_buf[16];
+  uint64_t orig_len = ctx->len * 8;
+  uint64_t orig_add_len = ctx->add_len * 8;
+  size_t i;
+
+  if (tag_len != 0) memcpy(tag, ctx->base_ectr, tag_len);
+
+  if (orig_len || orig_add_len) {
+    memset(work_buf, 0x00, 16);
+
+    PUT_UINT32_BE((orig_add_len >> 32), work_buf, 0);
+    PUT_UINT32_BE((orig_add_len), work_buf, 4);
+    PUT_UINT32_BE((orig_len >> 32), work_buf, 8);
+    PUT_UINT32_BE((orig_len), work_buf, 12);
+
+    for (i = 0; i < 16; i++) ctx->buf[i] ^= work_buf[i];
+    gcm_mult(ctx, ctx->buf, ctx->buf);
+    for (i = 0; i < tag_len; i++) tag[i] ^= ctx->buf[i];
+  }
+  return (0);
+}
+
+/******************************************************************************
+ *
+ *  GCM_CRYPT_AND_TAG
+ *
+ *  This either encrypts or decrypts the user-provided data and, either
+ *  way, generates an authentication tag of the requested length. It must be
+ *  called with a GCM context whose key has already been set with GCM_SETKEY.
+ *
+ *  The user would typically call this explicitly to ENCRYPT a buffer of data
+ *  and optional associated data, and produce its an authentication tag.
+ *
+ *  To reverse the process the user would typically call the companion
+ *  GCM_AUTH_DECRYPT function to decrypt data and verify a user-provided
+ *  authentication tag.  The GCM_AUTH_DECRYPT function calls this function
+ *  to perform its decryption and tag generation, which it then compares.
+ *
+ ******************************************************************************/
+int gcm_crypt_and_tag(
+    gcm_context *ctx,    // gcm context with key already setup
+    int mode,            // cipher direction: GCM_ENCRYPT or GCM_DECRYPT
+    const unsigned char *iv,     // pointer to the 12-byte initialization vector
+    size_t iv_len,       // byte length if the IV. should always be 12
+    const unsigned char *add,    // pointer to the non-ciphered additional data
+    size_t add_len,      // byte length of the additional AEAD data
+    const unsigned char *input,  // pointer to the cipher data source
+    unsigned char *output,       // pointer to the cipher data destination
+    size_t length,       // byte length of the cipher data
+    unsigned char *tag,          // pointer to the tag to be generated
+    size_t tag_len)      // byte length of the tag to be generated
+{                        /*
+                            assuming that the caller has already invoked gcm_setkey to
+                            prepare the gcm context with the keying material, we simply
+                            invoke each of the three GCM sub-functions in turn...
+                         */
+  gcm_start(ctx, mode, iv, iv_len, add, add_len);
+  gcm_update(ctx, length, input, output);
+  gcm_finish(ctx, tag, tag_len);
+  return (0);
+}
+
+/******************************************************************************
+ *
+ *  GCM_ZERO_CTX
+ *
+ *  The GCM context contains both the GCM context and the AES context.
+ *  This includes keying and key-related material which is security-
+ *  sensitive, so it MUST be zeroed after use. This function does that.
+ *
+ ******************************************************************************/
+void gcm_zero_ctx(gcm_context *ctx) {
+  // zero the context originally provided to us
+  memset(ctx, 0, sizeof(gcm_context));
+}
+//
+//  aes-gcm.c
+//  Pods
+//
+//  Created by Markus Kosmal on 20/11/14.
+//
+//
+
+int mg_aes_gcm_encrypt(unsigned char *output,  //
+                       const unsigned char *input, size_t input_length,
+                       const unsigned char *key, const size_t key_len,
+                       const unsigned char *iv, const size_t iv_len,
+                       unsigned char *aead, size_t aead_len, unsigned char *tag,
+                       const size_t tag_len) {
+  int ret = 0;      // our return value
+  gcm_context ctx;  // includes the AES context structure
+
+  gcm_setkey(&ctx, key, (unsigned int) key_len);
+
+  ret = gcm_crypt_and_tag(&ctx, MG_ENCRYPT, iv, iv_len, aead, aead_len, input,
+                          output, input_length, tag, tag_len);
+
+  gcm_zero_ctx(&ctx);
+
+  return (ret);
+}
+
+int mg_aes_gcm_decrypt(unsigned char *output, const unsigned char *input,
+                       size_t input_length, const unsigned char *key,
+                       const size_t key_len, const unsigned char *iv,
+                       const size_t iv_len) {
+  int ret = 0;      // our return value
+  gcm_context ctx;  // includes the AES context structure
+
+  size_t tag_len = 0;
+  unsigned char *tag_buf = NULL;
+
+  gcm_setkey(&ctx, key, (unsigned int) key_len);
+
+  ret = gcm_crypt_and_tag(&ctx, MG_DECRYPT, iv, iv_len, NULL, 0, input, output,
+                          input_length, tag_buf, tag_len);
+
+  gcm_zero_ctx(&ctx);
+
+  return (ret);
+}
+#endif
+// End of aes128 PD
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/tls_builtin.c"
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+#if MG_TLS == MG_TLS_BUILTIN
+
+#define CHACHA20 1
+
+/* TLS 1.3 Record Content Type (RFC8446 B.1) */
+#define MG_TLS_CHANGE_CIPHER 20
+#define MG_TLS_ALERT 21
+#define MG_TLS_HANDSHAKE 22
+#define MG_TLS_APP_DATA 23
+#define MG_TLS_HEARTBEAT 24
+
+/* TLS 1.3 Handshake Message Type (RFC8446 B.3) */
+#define MG_TLS_CLIENT_HELLO 1
+#define MG_TLS_SERVER_HELLO 2
+#define MG_TLS_ENCRYPTED_EXTENSIONS 8
+#define MG_TLS_CERTIFICATE 11
+#define MG_TLS_CERTIFICATE_REQUEST 13
+#define MG_TLS_CERTIFICATE_VERIFY 15
+#define MG_TLS_FINISHED 20
+
+// handshake is re-entrant, so we need to keep track of its state state names
+// refer to RFC8446#A.1
+enum mg_tls_hs_state {
+  // Client state machine:
+  MG_TLS_STATE_CLIENT_START,          // Send ClientHello
+  MG_TLS_STATE_CLIENT_WAIT_SH,        // Wait for ServerHello
+  MG_TLS_STATE_CLIENT_WAIT_EE,        // Wait for EncryptedExtensions
+  MG_TLS_STATE_CLIENT_WAIT_CERT,      // Wait for Certificate
+  MG_TLS_STATE_CLIENT_WAIT_CV,        // Wait for CertificateVerify
+  MG_TLS_STATE_CLIENT_WAIT_FINISHED,  // Wait for Finished
+  MG_TLS_STATE_CLIENT_CONNECTED,      // Done
+
+  // Server state machine:
+  MG_TLS_STATE_SERVER_START,       // Wait for ClientHello
+  MG_TLS_STATE_SERVER_NEGOTIATED,  // Wait for Finished
+  MG_TLS_STATE_SERVER_CONNECTED    // Done
+};
+
+// encryption keys for a TLS connection
+struct tls_enc {
+  uint32_t sseq;  // server sequence number, used in encryption
+  uint32_t cseq;  // client sequence number, used in decryption
+  // keys for AES encryption or ChaCha20
+  uint8_t handshake_secret[32];
+  uint8_t server_write_key[32];
+  uint8_t server_write_iv[12];
+  uint8_t server_finished_key[32];
+  uint8_t client_write_key[32];
+  uint8_t client_write_iv[12];
+  uint8_t client_finished_key[32];
+};
+
+// per-connection TLS data
+struct tls_data {
+  enum mg_tls_hs_state state;  // keep track of connection handshake progress
+
+  struct mg_iobuf send;  // For the receive path, we're reusing c->rtls
+  size_t recv_offset;    // While c->rtls contains full records, reuse that
+  size_t recv_len;       // buffer but point at individual decrypted messages
+
+  uint8_t content_type;  // Last received record content type
+
+  mg_sha256_ctx sha256;  // incremental SHA-256 hash for TLS handshake
+
+  uint8_t random[32];      // client random from ClientHello
+  uint8_t session_id[32];  // client session ID between the handshake states
+  uint8_t x25519_cli[32];  // client X25519 key between the handshake states
+  uint8_t x25519_sec[32];  // x25519 secret between the handshake states
+
+  int skip_verification;   // perform checks on server certificate?
+  int cert_requested;      // client received a CertificateRequest?
+  struct mg_str cert_der;  // certificate in DER format
+  struct mg_str ca_der;    // CA certificate
+  uint8_t ec_key[32];      // EC private key
+  char hostname[254];      // server hostname (client extension)
+
+  int is_ec_pubkey;          // EC or RSA?
+  uint8_t pubkey[512 + 16];  // server EC (64) or RSA (512+exp) public key to
+                             // verify cert
+  size_t pubkeysz;           // size of the server public key
+  uint8_t sighash[32];       // calculated signature verification hash
+
+  struct tls_enc enc;
+};
+
+#define TLS_RECHDR_SIZE 5  // 1 byte type, 2 bytes version, 2 bytes length
+#define TLS_MSGHDR_SIZE 4  // 1 byte type, 3 bytes length
+
+#ifdef MG_TLS_SSLKEYLOGFILE
+#include <stdio.h>
+static void mg_ssl_key_log(const char *label, uint8_t client_random[32],
+                           uint8_t *secret, size_t secretsz) {
+  char *keylogfile = getenv("SSLKEYLOGFILE");
+  size_t i;
+  if (keylogfile != NULL) {
+    MG_DEBUG(("Dumping key log into %s", keylogfile));
+    FILE *f = fopen(keylogfile, "a");
+    if (f != NULL) {
+      fprintf(f, "%s ", label);
+      for (i = 0; i < 32; i++) {
+        fprintf(f, "%02x", client_random[i]);
+      }
+      fprintf(f, " ");
+      for (i = 0; i < secretsz; i++) {
+        fprintf(f, "%02x", secret[i]);
+      }
+      fprintf(f, "\n");
+      fclose(f);
+    } else {
+      MG_ERROR(("Cannot open %s", keylogfile));
+    }
+  }
+}
+#endif
+
+// for derived tls keys we need SHA256([0]*32)
+static uint8_t zeros[32] = {0};
+static uint8_t zeros_sha256_digest[32] = {
+    0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4,
+    0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b,
+    0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55};
+
+// helper to hexdump buffers inline
+static void mg_tls_hexdump(const char *msg, uint8_t *buf, size_t bufsz) {
+  MG_VERBOSE(("%s: %M", msg, mg_print_hex, bufsz, buf));
+}
+
+// helper utilities to parse ASN.1 DER
+struct mg_der_tlv {
+  uint8_t type;
+  uint32_t len;
+  uint8_t *value;
+};
+
+static int mg_der_parse(uint8_t *der, size_t dersz, struct mg_der_tlv *tlv) {
+  size_t header_len = 2;
+  uint32_t len = dersz < 2 ? 0 : der[1];
+  if (dersz < 2) return -1;  // Invalid DER
+  tlv->type = der[0];
+  if (len > 0x7F) {  // long-form length
+    uint8_t len_bytes = len & 0x7F;
+    if (dersz < (size_t) (2 + len_bytes)) return -1;
+    len = 0;
+    for (uint8_t i = 0; i < len_bytes; i++) {
+      len = (len << 8) | der[2 + i];
+    }
+    header_len += len_bytes;
+  }
+  if (dersz < header_len + len) return -1;
+  tlv->len = len;
+  tlv->value = der + header_len;
+  return (int) (header_len + len);
+}
+
+static int mg_der_next(struct mg_der_tlv *parent, struct mg_der_tlv *child) {
+  if (parent->len == 0) return 0;
+  int consumed = mg_der_parse(parent->value, parent->len, child);
+  if (consumed < 0) return -1;
+  parent->value += consumed;
+  parent->len -= (uint32_t) consumed;
+  return 1;
+}
+
+static int mg_der_find_oid(struct mg_der_tlv *tlv, const uint8_t *oid,
+                           size_t oid_len, struct mg_der_tlv *found) {
+  struct mg_der_tlv parent, child;
+  parent = *tlv;
+  while (mg_der_next(&parent, &child) > 0) {
+    if (child.type == 0x06 && child.len == oid_len &&
+        memcmp(child.value, oid, oid_len) == 0) {
+      return mg_der_next(&parent, found);
+    } else if (child.type & 0x20) {
+      struct mg_der_tlv sub_parent = child;
+      if (mg_der_find_oid(&sub_parent, oid, oid_len, found)) return 1;
+    }
+  }
+  return 0;
+}
+
+#if 0
+static void mg_der_debug(struct mg_der_tlv *tlv, int depth) {
+  MG_DEBUG(("> %.*sd=%d Type: 0x%02X, Length: %u\n", depth * 4, " ", depth,
+            tlv->type, tlv->len));
+
+  if (tlv->type & 0x20) {  // Constructed: recurse into children
+    struct mg_der_tlv child;
+    struct mg_der_tlv parent = *tlv;
+    while (mg_der_next(&parent, &child) > 0) {
+      mg_der_debug(&child, depth + 1);
+    }
+  }
+}
+#endif
+
+// parse DER into a TLV record
+static int mg_der_to_tlv(uint8_t *der, size_t dersz, struct mg_der_tlv *tlv) {
+  if (dersz < 2) {
+    return -1;
+  }
+  tlv->type = der[0];
+  tlv->len = der[1];
+  tlv->value = der + 2;
+  if (tlv->len > 0x7f) {
+    uint32_t i, n = tlv->len - 0x80;
+    tlv->len = 0;
+    for (i = 0; i < n; i++) {
+      tlv->len = (tlv->len << 8) | (der[2 + i]);
+    }
+    tlv->value = der + 2 + n;
+  }
+  if (der + dersz < tlv->value + tlv->len) {
+    return -1;
+  }
+  return 0;
+}
+
+// Did we receive a full TLS record in the c->rtls buffer?
+static bool mg_tls_got_record(struct mg_connection *c) {
+  return c->rtls.len >= (size_t) TLS_RECHDR_SIZE &&
+         c->rtls.len >=
+             (size_t) (TLS_RECHDR_SIZE + MG_LOAD_BE16(c->rtls.buf + 3));
+}
+
+// Remove a single TLS record from the recv buffer
+static void mg_tls_drop_record(struct mg_connection *c) {
+  struct mg_iobuf *rio = &c->rtls;
+  uint16_t n = MG_LOAD_BE16(rio->buf + 3) + TLS_RECHDR_SIZE;
+  mg_iobuf_del(rio, 0, n);
+}
+
+// Remove a single TLS message from decrypted buffer, remove the wrapping
+// record if it was the last message within a record
+static void mg_tls_drop_message(struct mg_connection *c) {
+  uint32_t len;
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf = &c->rtls.buf[tls->recv_offset];
+  if (tls->recv_len == 0) return;
+  len = MG_LOAD_BE24(recv_buf + 1) + TLS_MSGHDR_SIZE;
+  if (tls->recv_len < len) {
+    mg_error(c, "wrong size");
+    return;
+  }
+  mg_sha256_update(&tls->sha256, recv_buf, len);
+  tls->recv_offset += len;
+  tls->recv_len -= len;
+  if (tls->recv_len == 0) {
+    mg_tls_drop_record(c);
+  }
+}
+
+// TLS1.3 secret derivation based on the key label
+static void mg_tls_derive_secret(const char *label, uint8_t *key, size_t keysz,
+                                 uint8_t *data, size_t datasz, uint8_t *hash,
+                                 size_t hashsz) {
+  size_t labelsz = strlen(label);
+  uint8_t secret[32];
+  uint8_t packed[256] = {0, (uint8_t) hashsz, (uint8_t) labelsz};
+  // TODO: assert lengths of label, key, data and hash
+  if (labelsz > 0) memmove(packed + 3, label, labelsz);
+  packed[3 + labelsz] = (uint8_t) datasz;
+  if (datasz > 0) memmove(packed + labelsz + 4, data, datasz);
+  packed[4 + labelsz + datasz] = 1;
+
+  mg_hmac_sha256(secret, key, keysz, packed, 5 + labelsz + datasz);
+  memmove(hash, secret, hashsz);
+}
+
+// at this point we have x25519 shared secret, we can generate a set of derived
+// handshake encryption keys
+static void mg_tls_generate_handshake_keys(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+
+  mg_sha256_ctx sha256;
+  uint8_t early_secret[32];
+  uint8_t pre_extract_secret[32];
+  uint8_t hello_hash[32];
+  uint8_t server_hs_secret[32];
+  uint8_t client_hs_secret[32];
+#if CHACHA20
+  const size_t keysz = 32;
+#else
+  const size_t keysz = 16;
+#endif
+
+  mg_hmac_sha256(early_secret, NULL, 0, zeros, sizeof(zeros));
+  mg_tls_derive_secret("tls13 derived", early_secret, 32, zeros_sha256_digest,
+                       32, pre_extract_secret, 32);
+  mg_hmac_sha256(tls->enc.handshake_secret, pre_extract_secret,
+                 sizeof(pre_extract_secret), tls->x25519_sec,
+                 sizeof(tls->x25519_sec));
+  mg_tls_hexdump("hs secret", tls->enc.handshake_secret, 32);
+
+  // mg_sha256_final is not idempotent, need to copy sha256 context to calculate
+  // the digest
+  memmove(&sha256, &tls->sha256, sizeof(mg_sha256_ctx));
+  mg_sha256_final(hello_hash, &sha256);
+
+  mg_tls_hexdump("hello hash", hello_hash, 32);
+  // derive keys needed for the rest of the handshake
+  mg_tls_derive_secret("tls13 s hs traffic", tls->enc.handshake_secret, 32,
+                       hello_hash, 32, server_hs_secret, 32);
+  mg_tls_derive_secret("tls13 c hs traffic", tls->enc.handshake_secret, 32,
+                       hello_hash, 32, client_hs_secret, 32);
+
+  mg_tls_derive_secret("tls13 key", server_hs_secret, 32, NULL, 0,
+                       tls->enc.server_write_key, keysz);
+  mg_tls_derive_secret("tls13 iv", server_hs_secret, 32, NULL, 0,
+                       tls->enc.server_write_iv, 12);
+  mg_tls_derive_secret("tls13 finished", server_hs_secret, 32, NULL, 0,
+                       tls->enc.server_finished_key, 32);
+
+  mg_tls_derive_secret("tls13 key", client_hs_secret, 32, NULL, 0,
+                       tls->enc.client_write_key, keysz);
+  mg_tls_derive_secret("tls13 iv", client_hs_secret, 32, NULL, 0,
+                       tls->enc.client_write_iv, 12);
+  mg_tls_derive_secret("tls13 finished", client_hs_secret, 32, NULL, 0,
+                       tls->enc.client_finished_key, 32);
+
+  mg_tls_hexdump("s hs traffic", server_hs_secret, 32);
+  mg_tls_hexdump("s key", tls->enc.server_write_key, keysz);
+  mg_tls_hexdump("s iv", tls->enc.server_write_iv, 12);
+  mg_tls_hexdump("s finished", tls->enc.server_finished_key, 32);
+  mg_tls_hexdump("c hs traffic", client_hs_secret, 32);
+  mg_tls_hexdump("c key", tls->enc.client_write_key, keysz);
+  mg_tls_hexdump("c iv", tls->enc.client_write_iv, 12);
+  mg_tls_hexdump("c finished", tls->enc.client_finished_key, 32);
+
+#ifdef MG_TLS_SSLKEYLOGFILE
+  mg_ssl_key_log("SERVER_HANDSHAKE_TRAFFIC_SECRET", tls->random,
+                 server_hs_secret, 32);
+  mg_ssl_key_log("CLIENT_HANDSHAKE_TRAFFIC_SECRET", tls->random,
+                 client_hs_secret, 32);
+#endif
+}
+
+static void mg_tls_generate_application_keys(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  uint8_t hash[32];
+  uint8_t premaster_secret[32];
+  uint8_t master_secret[32];
+  uint8_t server_secret[32];
+  uint8_t client_secret[32];
+#if CHACHA20
+  const size_t keysz = 32;
+#else
+  const size_t keysz = 16;
+#endif
+
+  mg_sha256_ctx sha256;
+  memmove(&sha256, &tls->sha256, sizeof(mg_sha256_ctx));
+  mg_sha256_final(hash, &sha256);
+
+  mg_tls_derive_secret("tls13 derived", tls->enc.handshake_secret, 32,
+                       zeros_sha256_digest, 32, premaster_secret, 32);
+  mg_hmac_sha256(master_secret, premaster_secret, 32, zeros, 32);
+
+  mg_tls_derive_secret("tls13 s ap traffic", master_secret, 32, hash, 32,
+                       server_secret, 32);
+  mg_tls_derive_secret("tls13 key", server_secret, 32, NULL, 0,
+                       tls->enc.server_write_key, keysz);
+  mg_tls_derive_secret("tls13 iv", server_secret, 32, NULL, 0,
+                       tls->enc.server_write_iv, 12);
+  mg_tls_derive_secret("tls13 c ap traffic", master_secret, 32, hash, 32,
+                       client_secret, 32);
+  mg_tls_derive_secret("tls13 key", client_secret, 32, NULL, 0,
+                       tls->enc.client_write_key, keysz);
+  mg_tls_derive_secret("tls13 iv", client_secret, 32, NULL, 0,
+                       tls->enc.client_write_iv, 12);
+
+  mg_tls_hexdump("s ap traffic", server_secret, 32);
+  mg_tls_hexdump("s key", tls->enc.server_write_key, keysz);
+  mg_tls_hexdump("s iv", tls->enc.server_write_iv, 12);
+  mg_tls_hexdump("s finished", tls->enc.server_finished_key, 32);
+  mg_tls_hexdump("c ap traffic", client_secret, 32);
+  mg_tls_hexdump("c key", tls->enc.client_write_key, keysz);
+  mg_tls_hexdump("c iv", tls->enc.client_write_iv, 12);
+  mg_tls_hexdump("c finished", tls->enc.client_finished_key, 32);
+  tls->enc.sseq = tls->enc.cseq = 0;
+
+#ifdef MG_TLS_SSLKEYLOGFILE
+  mg_ssl_key_log("SERVER_TRAFFIC_SECRET_0", tls->random, server_secret, 32);
+  mg_ssl_key_log("CLIENT_TRAFFIC_SECRET_0", tls->random, client_secret, 32);
+#endif
+}
+
+// AES GCM encryption of the message + put encoded data into the write buffer
+static void mg_tls_encrypt(struct mg_connection *c, const uint8_t *msg,
+                           size_t msgsz, uint8_t msgtype) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *wio = &tls->send;
+  uint8_t *outmsg;
+  uint8_t *tag;
+  size_t encsz = msgsz + 16 + 1;
+  uint8_t hdr[5] = {MG_TLS_APP_DATA, 0x03, 0x03,
+                    (uint8_t) ((encsz >> 8) & 0xff), (uint8_t) (encsz & 0xff)};
+  uint8_t associated_data[5] = {MG_TLS_APP_DATA, 0x03, 0x03,
+                                (uint8_t) ((encsz >> 8) & 0xff),
+                                (uint8_t) (encsz & 0xff)};
+  uint8_t nonce[12];
+
+  uint32_t seq = c->is_client ? tls->enc.cseq : tls->enc.sseq;
+  uint8_t *key =
+      c->is_client ? tls->enc.client_write_key : tls->enc.server_write_key;
+  uint8_t *iv =
+      c->is_client ? tls->enc.client_write_iv : tls->enc.server_write_iv;
+
+#if !CHACHA20
+  mg_gcm_initialize();
+#endif
+
+  memmove(nonce, iv, sizeof(nonce));
+  nonce[8] ^= (uint8_t) ((seq >> 24) & 255U);
+  nonce[9] ^= (uint8_t) ((seq >> 16) & 255U);
+  nonce[10] ^= (uint8_t) ((seq >> 8) & 255U);
+  nonce[11] ^= (uint8_t) ((seq) & 255U);
+
+  mg_iobuf_add(wio, wio->len, hdr, sizeof(hdr));
+  mg_iobuf_resize(wio, wio->len + encsz);
+  outmsg = wio->buf + wio->len;
+  tag = wio->buf + wio->len + msgsz + 1;
+  memmove(outmsg, msg, msgsz);
+  outmsg[msgsz] = msgtype;
+#if CHACHA20
+  (void) tag;  // tag is only used in aes gcm
+  {
+    size_t maxlen = MG_IO_SIZE > 16384 ? 16384 : MG_IO_SIZE;
+    uint8_t *enc = (uint8_t *) calloc(1, maxlen + 256 + 1);
+    if (enc == NULL) {
+      mg_error(c, "TLS OOM");
+      return;
+    } else {
+      size_t n = mg_chacha20_poly1305_encrypt(enc, key, nonce, associated_data,
+                                              sizeof(associated_data), outmsg,
+                                              msgsz + 1);
+      memmove(outmsg, enc, n);
+      free(enc);
+    }
+  }
+#else
+  mg_aes_gcm_encrypt(outmsg, outmsg, msgsz + 1, key, 16, nonce, sizeof(nonce),
+                     associated_data, sizeof(associated_data), tag, 16);
+#endif
+  c->is_client ? tls->enc.cseq++ : tls->enc.sseq++;
+  wio->len += encsz;
+}
+
+// read an encrypted record, decrypt it in place
+static int mg_tls_recv_record(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *rio = &c->rtls;
+  uint16_t msgsz;
+  uint8_t *msg;
+  uint8_t nonce[12];
+  int r;
+
+  uint32_t seq = c->is_client ? tls->enc.sseq : tls->enc.cseq;
+  uint8_t *key =
+      c->is_client ? tls->enc.server_write_key : tls->enc.client_write_key;
+  uint8_t *iv =
+      c->is_client ? tls->enc.server_write_iv : tls->enc.client_write_iv;
+
+  if (tls->recv_len > 0) {
+    return 0; /* some data from previous record is still present */
+  }
+  for (;;) {
+    if (!mg_tls_got_record(c)) {
+      return MG_IO_WAIT;
+    }
+    if (rio->buf[0] == MG_TLS_APP_DATA) {
+      break;
+    } else if (rio->buf[0] ==
+               MG_TLS_CHANGE_CIPHER) {  // Skip ChangeCipher messages
+      mg_tls_drop_record(c);
+    } else if (rio->buf[0] == MG_TLS_ALERT) {  // Skip Alerts
+      MG_INFO(("TLS ALERT packet received"));
+      mg_tls_drop_record(c);
+    } else {
+      mg_error(c, "unexpected packet");
+      return -1;
+    }
+  }
+
+  msgsz = MG_LOAD_BE16(rio->buf + 3);
+  msg = rio->buf + 5;
+  if (msgsz < 16) {
+    mg_error(c, "wrong size");
+    return -1;
+  }
+
+  memmove(nonce, iv, sizeof(nonce));
+  nonce[8] ^= (uint8_t) ((seq >> 24) & 255U);
+  nonce[9] ^= (uint8_t) ((seq >> 16) & 255U);
+  nonce[10] ^= (uint8_t) ((seq >> 8) & 255U);
+  nonce[11] ^= (uint8_t) ((seq) & 255U);
+#if CHACHA20
+  {
+    uint8_t *dec = (uint8_t *) calloc(1, msgsz);
+    size_t n;
+    if (dec == NULL) {
+      mg_error(c, "TLS OOM");
+      return -1;
+    }
+    n = mg_chacha20_poly1305_decrypt(dec, key, nonce, msg, msgsz);
+    memmove(msg, dec, n);
+    free(dec);
+  }
+#else
+  mg_gcm_initialize();
+  mg_aes_gcm_decrypt(msg, msg, msgsz - 16, key, 16, nonce, sizeof(nonce));
+#endif
+
+  r = msgsz - 16 - 1;
+  tls->content_type = msg[msgsz - 16 - 1];
+  tls->recv_offset = (size_t) msg - (size_t) rio->buf;
+  tls->recv_len = (size_t) msgsz - 16 - 1;
+  c->is_client ? tls->enc.sseq++ : tls->enc.cseq++;
+  return r;
+}
+
+static void mg_tls_calc_cert_verify_hash(struct mg_connection *c,
+                                         uint8_t hash[32], int is_client) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  uint8_t server_context[34] = "TLS 1.3, server CertificateVerify";
+  uint8_t client_context[34] = "TLS 1.3, client CertificateVerify";
+  uint8_t sig_content[130];
+  mg_sha256_ctx sha256;
+
+  memset(sig_content, 0x20, 64);
+  if (is_client) {
+    memmove(sig_content + 64, client_context, sizeof(client_context));
+  } else {
+    memmove(sig_content + 64, server_context, sizeof(server_context));
+  }
+
+  memmove(&sha256, &tls->sha256, sizeof(mg_sha256_ctx));
+  mg_sha256_final(sig_content + 98, &sha256);
+
+  mg_sha256_init(&sha256);
+  mg_sha256_update(&sha256, sig_content, sizeof(sig_content));
+  mg_sha256_final(hash, &sha256);
+}
+
+// read and parse ClientHello record
+static int mg_tls_server_recv_hello(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *rio = &c->rtls;
+  uint8_t session_id_len;
+  uint16_t j;
+  uint16_t cipher_suites_len;
+  uint16_t ext_len;
+  uint8_t *ext;
+  uint16_t msgsz;
+
+  if (!mg_tls_got_record(c)) {
+    return MG_IO_WAIT;
+  }
+  if (rio->buf[0] != MG_TLS_HANDSHAKE || rio->buf[5] != MG_TLS_CLIENT_HELLO) {
+    mg_error(c, "not a client hello packet");
+    return -1;
+  }
+  msgsz = MG_LOAD_BE16(rio->buf + 3);
+  mg_sha256_update(&tls->sha256, rio->buf + 5, msgsz);
+  // store client random
+  memmove(tls->random, rio->buf + 11, sizeof(tls->random));
+  // store session_id
+  session_id_len = rio->buf[43];
+  if (session_id_len == sizeof(tls->session_id)) {
+    memmove(tls->session_id, rio->buf + 44, session_id_len);
+  } else if (session_id_len != 0) {
+    MG_INFO(("bad session id len"));
+  }
+  cipher_suites_len = MG_LOAD_BE16(rio->buf + 44 + session_id_len);
+  if (cipher_suites_len > (rio->len - 46 - session_id_len)) goto fail;
+  ext_len = MG_LOAD_BE16(rio->buf + 48 + session_id_len + cipher_suites_len);
+  ext = rio->buf + 50 + session_id_len + cipher_suites_len;
+  if (ext_len > (rio->len - 50 - session_id_len - cipher_suites_len)) goto fail;
+  for (j = 0; j < ext_len;) {
+    uint16_t k;
+    uint16_t key_exchange_len;
+    uint8_t *key_exchange;
+    uint16_t n = MG_LOAD_BE16(ext + j + 2);
+    if (MG_LOAD_BE16(ext + j) != 0x0033) {  // not a key share extension, ignore
+      j += (uint16_t) (n + 4);
+      continue;
+    }
+    key_exchange_len = MG_LOAD_BE16(ext + j + 4);
+    key_exchange = ext + j + 6;
+    if (key_exchange_len >
+        rio->len - (uint16_t) ((size_t) key_exchange - (size_t) rio->buf))
+      goto fail;
+    for (k = 0; k < key_exchange_len;) {
+      uint16_t m = MG_LOAD_BE16(key_exchange + k + 2);
+      if (m > (key_exchange_len - k - 4)) goto fail;
+      if (m == 32 && key_exchange[k] == 0x00 && key_exchange[k + 1] == 0x1d) {
+        memmove(tls->x25519_cli, key_exchange + k + 4, m);
+        mg_tls_drop_record(c);
+        return 0;
+      }
+      k += (uint16_t) (m + 4);
+    }
+    j += (uint16_t) (n + 4);
+  }
+fail:
+  mg_error(c, "bad client hello");
+  return -1;
+}
+
+#define PLACEHOLDER_8B 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X'
+#define PLACEHOLDER_16B PLACEHOLDER_8B, PLACEHOLDER_8B
+#define PLACEHOLDER_32B PLACEHOLDER_16B, PLACEHOLDER_16B
+
+// put ServerHello record into wio buffer
+static void mg_tls_server_send_hello(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *wio = &tls->send;
+
+  // clang-format off
+  uint8_t msg_server_hello[122] = {
+      // server hello, tls 1.2
+      0x02, 0x00, 0x00, 0x76, 0x03, 0x03,
+      // random (32 bytes)
+      PLACEHOLDER_32B,
+      // session ID length + session ID (32 bytes)
+      0x20, PLACEHOLDER_32B,
+#if defined(CHACHA20) && CHACHA20
+      // TLS_CHACHA20_POLY1305_SHA256 + no compression
+      0x13, 0x03, 0x00,
+#else
+      // TLS_AES_128_GCM_SHA256 + no compression
+      0x13, 0x01, 0x00,
+#endif
+      // extensions + keyshare
+      0x00, 0x2e, 0x00, 0x33, 0x00, 0x24, 0x00, 0x1d, 0x00, 0x20,
+      // x25519 keyshare
+      PLACEHOLDER_32B,
+      // supported versions (tls1.3 == 0x304)
+      0x00, 0x2b, 0x00, 0x02, 0x03, 0x04};
+  // clang-format on
+
+  // calculate keyshare
+  uint8_t x25519_pub[X25519_BYTES];
+  uint8_t x25519_prv[X25519_BYTES];
+  if (!mg_random(x25519_prv, sizeof(x25519_prv))) mg_error(c, "RNG");
+  mg_tls_x25519(x25519_pub, x25519_prv, X25519_BASE_POINT, 1);
+  mg_tls_x25519(tls->x25519_sec, x25519_prv, tls->x25519_cli, 1);
+  mg_tls_hexdump("s x25519 sec", tls->x25519_sec, sizeof(tls->x25519_sec));
+
+  // fill in the gaps: random + session ID + keyshare
+  memmove(msg_server_hello + 6, tls->random, sizeof(tls->random));
+  memmove(msg_server_hello + 39, tls->session_id, sizeof(tls->session_id));
+  memmove(msg_server_hello + 84, x25519_pub, sizeof(x25519_pub));
+
+  // server hello message
+  mg_iobuf_add(wio, wio->len, "\x16\x03\x03\x00\x7a", 5);
+  mg_iobuf_add(wio, wio->len, msg_server_hello, sizeof(msg_server_hello));
+  mg_sha256_update(&tls->sha256, msg_server_hello, sizeof(msg_server_hello));
+
+  // change cipher message
+  mg_iobuf_add(wio, wio->len, "\x14\x03\x03\x00\x01\x01", 6);
+}
+
+static void mg_tls_server_send_ext(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  // server extensions
+  uint8_t ext[6] = {0x08, 0, 0, 2, 0, 0};
+  mg_sha256_update(&tls->sha256, ext, sizeof(ext));
+  mg_tls_encrypt(c, ext, sizeof(ext), MG_TLS_HANDSHAKE);
+}
+
+static void mg_tls_server_send_cert(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  int send_ca = !c->is_client && tls->ca_der.len > 0;
+  // server DER certificate + CA (optional)
+  size_t n = tls->cert_der.len + (send_ca ? tls->ca_der.len + 5 : 0);
+  uint8_t *cert = (uint8_t *) calloc(1, 13 + n);
+  if (cert == NULL) {
+    mg_error(c, "tls cert oom");
+    return;
+  }
+  cert[0] = 0x0b;  // handshake header
+  MG_STORE_BE24(cert + 1, n + 9);
+  cert[4] = 0;                                 // request context
+  MG_STORE_BE24(cert + 5, n + 5);              // 3 bytes: cert (s) length
+  MG_STORE_BE24(cert + 8, tls->cert_der.len);  // 3 bytes: first cert len
+  // bytes 11+ are certificate in DER format
+  memmove(cert + 11, tls->cert_der.buf, tls->cert_der.len);
+  MG_STORE_BE16(cert + 11 + tls->cert_der.len,
+                0);  // certificate extensions (none)
+  if (send_ca) {
+    size_t offset = 13 + tls->cert_der.len;
+    MG_STORE_BE24(cert + offset, tls->ca_der.len);  // 3 bytes: CA cert length
+    memmove(cert + offset + 3, tls->ca_der.buf,
+            tls->ca_der.len);         // CA cert data
+    MG_STORE_BE16(cert + 11 + n, 0);  // certificate extensions (none)
+  }
+  mg_sha256_update(&tls->sha256, cert, 13 + n);
+  mg_tls_encrypt(c, cert, 13 + n, MG_TLS_HANDSHAKE);
+  free(cert);
+}
+
+// type adapter between uECC hash context and our sha256 implementation
+typedef struct SHA256_HashContext {
+  MG_UECC_HashContext uECC;
+  mg_sha256_ctx ctx;
+} SHA256_HashContext;
+
+static void init_SHA256(const MG_UECC_HashContext *base) {
+  SHA256_HashContext *c = (SHA256_HashContext *) base;
+  mg_sha256_init(&c->ctx);
+}
+
+static void update_SHA256(const MG_UECC_HashContext *base,
+                          const uint8_t *message, unsigned message_size) {
+  SHA256_HashContext *c = (SHA256_HashContext *) base;
+  mg_sha256_update(&c->ctx, message, message_size);
+}
+static void finish_SHA256(const MG_UECC_HashContext *base,
+                          uint8_t *hash_result) {
+  SHA256_HashContext *c = (SHA256_HashContext *) base;
+  mg_sha256_final(hash_result, &c->ctx);
+}
+
+static void mg_tls_send_cert_verify(struct mg_connection *c, int is_client) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  // server certificate verify packet
+  uint8_t verify[82] = {0x0f, 0x00, 0x00, 0x00, 0x04, 0x03, 0x00, 0x00};
+  size_t sigsz, verifysz = 0;
+  uint8_t hash[32] = {0}, tmp[2 * 32 + 64] = {0};
+  struct SHA256_HashContext ctx = {
+      {&init_SHA256, &update_SHA256, &finish_SHA256, 64, 32, tmp},
+      {{0}, 0, 0, {0}}};
+  int neg1, neg2;
+  uint8_t sig[64] = {0};
+
+  mg_tls_calc_cert_verify_hash(c, (uint8_t *) hash, is_client);
+
+  mg_uecc_sign_deterministic(tls->ec_key, hash, sizeof(hash), &ctx.uECC, sig,
+                             mg_uecc_secp256r1());
+
+  neg1 = !!(sig[0] & 0x80);
+  neg2 = !!(sig[32] & 0x80);
+  verify[8] = 0x30;  // ASN.1 SEQUENCE
+  verify[9] = (uint8_t) (68 + neg1 + neg2);
+  verify[10] = 0x02;  // ASN.1 INTEGER
+  verify[11] = (uint8_t) (32 + neg1);
+  memmove(verify + 12 + neg1, sig, 32);
+  verify[12 + 32 + neg1] = 0x02;  // ASN.1 INTEGER
+  verify[13 + 32 + neg1] = (uint8_t) (32 + neg2);
+  memmove(verify + 14 + 32 + neg1 + neg2, sig + 32, 32);
+
+  sigsz = (size_t) (70 + neg1 + neg2);
+  verifysz = 8U + sigsz;
+  verify[3] = (uint8_t) (sigsz + 4);
+  verify[7] = (uint8_t) sigsz;
+
+  mg_sha256_update(&tls->sha256, verify, verifysz);
+  mg_tls_encrypt(c, verify, verifysz, MG_TLS_HANDSHAKE);
+}
+
+static void mg_tls_server_send_finish(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *wio = &tls->send;
+  mg_sha256_ctx sha256;
+  uint8_t hash[32];
+  uint8_t finish[36] = {0x14, 0, 0, 32};
+  memmove(&sha256, &tls->sha256, sizeof(mg_sha256_ctx));
+  mg_sha256_final(hash, &sha256);
+  mg_hmac_sha256(finish + 4, tls->enc.server_finished_key, 32, hash, 32);
+  mg_tls_encrypt(c, finish, sizeof(finish), MG_TLS_HANDSHAKE);
+  mg_io_send(c, wio->buf, wio->len);
+  wio->len = 0;
+
+  mg_sha256_update(&tls->sha256, finish, sizeof(finish));
+}
+
+static int mg_tls_server_recv_finish(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf;
+  // we have to backup sha256 value to restore it later, since Finished record
+  // is exceptional and is not supposed to be added to the rolling hash
+  // calculation.
+  mg_sha256_ctx sha256 = tls->sha256;
+  if (mg_tls_recv_record(c) < 0) {
+    return -1;
+  }
+  recv_buf = &c->rtls.buf[tls->recv_offset];
+  if (recv_buf[0] != MG_TLS_FINISHED) {
+    mg_error(c, "expected Finish but got msg 0x%02x", recv_buf[0]);
+    return -1;
+  }
+  mg_tls_drop_message(c);
+
+  // restore hash
+  tls->sha256 = sha256;
+  return 0;
+}
+
+static void mg_tls_client_send_hello(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *wio = &tls->send;
+
+  uint8_t x25519_pub[X25519_BYTES];
+
+  // signature algorithms we actually support:
+  // rsa_pkcs1_sha256, rsa_pss_rsae_sha256 and ecdsa_secp256r1_sha256
+  uint8_t secp256r1_sig_algs[12] = {
+      0x00, 0x0d, 0x00, 0x08, 0x00, 0x06, 0x04, 0x03, 0x08, 0x04, 0x04, 0x01,
+  };
+  // all popular signature algorithms (if we don't care about verification)
+  uint8_t all_sig_algs[34] = {
+      0x00, 0x0d, 0x00, 0x1e, 0x00, 0x1c, 0x04, 0x03, 0x05, 0x03, 0x06, 0x03,
+      0x08, 0x07, 0x08, 0x08, 0x08, 0x09, 0x08, 0x0a, 0x08, 0x0b, 0x08, 0x04,
+      0x08, 0x05, 0x08, 0x06, 0x04, 0x01, 0x05, 0x01, 0x06, 0x01};
+  uint8_t server_name_ext[9] = {0x00, 0x00, 0x00, 0xfe, 0x00,
+                                0xfe, 0x00, 0x00, 0xfe};
+
+  // clang-format off
+  uint8_t msg_client_hello[145] = {
+      // TLS Client Hello header reported as TLS1.2 (5)
+      0x16, 0x03, 0x03, 0x00, 0xfe,
+      // client hello, tls 1.2 (6)
+      0x01, 0x00, 0x00, 0x8c, 0x03, 0x03,
+      // random (32 bytes)
+      PLACEHOLDER_32B,
+      // session ID length + session ID (32 bytes)
+      0x20, PLACEHOLDER_32B, 0x00,
+      0x02,  // size = 2 bytes
+#if defined(CHACHA20) && CHACHA20
+      // TLS_CHACHA20_POLY1305_SHA256
+      0x13, 0x03,
+#else
+      // TLS_AES_128_GCM_SHA256
+      0x13, 0x01,
+#endif
+      // no compression
+      0x01, 0x00,
+      // extensions + keyshare
+      0x00, 0xfe,
+      // x25519 keyshare
+      0x00, 0x33, 0x00, 0x26, 0x00, 0x24, 0x00, 0x1d, 0x00, 0x20,
+      PLACEHOLDER_32B,
+      // supported groups (x25519)
+      0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d,
+      // supported versions (tls1.3 == 0x304)
+      0x00, 0x2b, 0x00, 0x03, 0x02, 0x03, 0x04,
+      // session ticket (none)
+      0x00, 0x23, 0x00, 0x00, // 144 bytes till here
+	};
+  // clang-format on
+  const char *hostname = tls->hostname;
+  size_t hostnamesz = strlen(tls->hostname);
+  size_t hostname_extsz = hostnamesz ? hostnamesz + 9 : 0;
+  uint8_t *sig_alg = tls->skip_verification ? all_sig_algs : secp256r1_sig_algs;
+  size_t sig_alg_sz = tls->skip_verification ? sizeof(all_sig_algs)
+                                             : sizeof(secp256r1_sig_algs);
+
+  // patch ClientHello with correct hostname ext length (if any)
+  MG_STORE_BE16(msg_client_hello + 3,
+                hostname_extsz + 183 - 9 - 34 + sig_alg_sz);
+  MG_STORE_BE16(msg_client_hello + 7,
+                hostname_extsz + 179 - 9 - 34 + sig_alg_sz);
+  MG_STORE_BE16(msg_client_hello + 82,
+                hostname_extsz + 104 - 9 - 34 + sig_alg_sz);
+
+  if (hostnamesz > 0) {
+    MG_STORE_BE16(server_name_ext + 2, hostnamesz + 5);
+    MG_STORE_BE16(server_name_ext + 4, hostnamesz + 3);
+    MG_STORE_BE16(server_name_ext + 7, hostnamesz);
+  }
+
+  // calculate keyshare
+  if (!mg_random(tls->x25519_cli, sizeof(tls->x25519_cli))) mg_error(c, "RNG");
+  mg_tls_x25519(x25519_pub, tls->x25519_cli, X25519_BASE_POINT, 1);
+
+  // fill in the gaps: random + session ID + keyshare
+  if (!mg_random(tls->session_id, sizeof(tls->session_id))) mg_error(c, "RNG");
+  if (!mg_random(tls->random, sizeof(tls->random))) mg_error(c, "RNG");
+  memmove(msg_client_hello + 11, tls->random, sizeof(tls->random));
+  memmove(msg_client_hello + 44, tls->session_id, sizeof(tls->session_id));
+  memmove(msg_client_hello + 94, x25519_pub, sizeof(x25519_pub));
+
+  // client hello message
+  mg_iobuf_add(wio, wio->len, msg_client_hello, sizeof(msg_client_hello));
+  mg_sha256_update(&tls->sha256, msg_client_hello + 5,
+                   sizeof(msg_client_hello) - 5);
+  mg_iobuf_add(wio, wio->len, sig_alg, sig_alg_sz);
+  mg_sha256_update(&tls->sha256, sig_alg, sig_alg_sz);
+  if (hostnamesz > 0) {
+    mg_iobuf_add(wio, wio->len, server_name_ext, sizeof(server_name_ext));
+    mg_iobuf_add(wio, wio->len, hostname, hostnamesz);
+    mg_sha256_update(&tls->sha256, server_name_ext, sizeof(server_name_ext));
+    mg_sha256_update(&tls->sha256, (uint8_t *) hostname, hostnamesz);
+  }
+
+  // change cipher message
+  mg_iobuf_add(wio, wio->len, (const char *) "\x14\x03\x03\x00\x01\x01", 6);
+  mg_io_send(c, wio->buf, wio->len);
+  wio->len = 0;
+}
+
+static int mg_tls_client_recv_hello(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *rio = &c->rtls;
+  uint16_t msgsz;
+  uint8_t *ext;
+  uint16_t ext_len;
+  int j;
+
+  if (!mg_tls_got_record(c)) {
+    return MG_IO_WAIT;
+  }
+  if (rio->buf[0] != MG_TLS_HANDSHAKE || rio->buf[5] != MG_TLS_SERVER_HELLO) {
+    if (rio->buf[0] == MG_TLS_ALERT && rio->len >= 7) {
+      mg_error(c, "tls alert %d", rio->buf[6]);
+      return -1;
+    }
+    MG_INFO(("got packet type 0x%02x/0x%02x", rio->buf[0], rio->buf[5]));
+    mg_error(c, "not a server hello packet");
+    return -1;
+  }
+
+  msgsz = MG_LOAD_BE16(rio->buf + 3);
+  mg_sha256_update(&tls->sha256, rio->buf + 5, msgsz);
+
+  ext_len = MG_LOAD_BE16(rio->buf + 5 + 39 + 32 + 3);
+  ext = rio->buf + 5 + 39 + 32 + 3 + 2;
+  if (ext_len > (rio->len - (5 + 39 + 32 + 3 + 2))) goto fail;
+
+  for (j = 0; j < ext_len;) {
+    uint16_t ext_type = MG_LOAD_BE16(ext + j);
+    uint16_t ext_len2 = MG_LOAD_BE16(ext + j + 2);
+    uint16_t group;
+    uint8_t *key_exchange;
+    uint16_t key_exchange_len;
+    if (ext_len2 > (ext_len - j - 4)) goto fail;
+    if (ext_type != 0x0033) {  // not a key share extension, ignore
+      j += (uint16_t) (ext_len2 + 4);
+      continue;
+    }
+    group = MG_LOAD_BE16(ext + j + 4);
+    if (group != 0x001d) {
+      mg_error(c, "bad key exchange group");
+      return -1;
+    }
+    key_exchange_len = MG_LOAD_BE16(ext + j + 6);
+    key_exchange = ext + j + 8;
+    if (key_exchange_len != 32) {
+      mg_error(c, "bad key exchange length");
+      return -1;
+    }
+    mg_tls_x25519(tls->x25519_sec, tls->x25519_cli, key_exchange, 1);
+    mg_tls_hexdump("c x25519 sec", tls->x25519_sec, 32);
+    mg_tls_drop_record(c);
+    /* generate handshake keys */
+    mg_tls_generate_handshake_keys(c);
+    return 0;
+  }
+fail:
+  mg_error(c, "bad server hello");
+  return -1;
+}
+
+static int mg_tls_client_recv_ext(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf;
+  if (mg_tls_recv_record(c) < 0) {
+    return -1;
+  }
+  recv_buf = &c->rtls.buf[tls->recv_offset];
+  if (recv_buf[0] != MG_TLS_ENCRYPTED_EXTENSIONS) {
+    mg_error(c, "expected server extensions but got msg 0x%02x", recv_buf[0]);
+    return -1;
+  }
+  mg_tls_drop_message(c);
+  return 0;
+}
+
+struct mg_tls_cert {
+  int is_ec_pubkey;
+  struct mg_str sn;
+  struct mg_str pubkey;
+  struct mg_str sig;    // signature
+  uint8_t tbshash[48];  // 32b for sha256/secp256, 48b for sha384/secp384
+  size_t tbshashsz;     // actual TBS hash size
+};
+
+static void mg_der_debug_cert_name(const char *name, struct mg_der_tlv *tlv) {
+  struct mg_der_tlv v;
+  struct mg_str cn, c, o, ou;
+  cn = c = o = ou = mg_str("");
+  if (mg_der_find_oid(tlv, (uint8_t *) "\x55\x04\x03", 3, &v))
+    cn = mg_str_n((const char *) v.value, v.len);
+  if (mg_der_find_oid(tlv, (uint8_t *) "\x55\x04\x06", 3, &v))
+    c = mg_str_n((const char *) v.value, v.len);
+  if (mg_der_find_oid(tlv, (uint8_t *) "\x55\x04\x0a", 3, &v))
+    o = mg_str_n((const char *) v.value, v.len);
+  if (mg_der_find_oid(tlv, (uint8_t *) "\x55\x04\x0b", 3, &v))
+    ou = mg_str_n((const char *) v.value, v.len);
+  MG_VERBOSE(("%s: CN=%.*s, C=%.*s, O=%.*s, OU=%.*s", name, cn.len, cn.buf,
+              c.len, c.buf, o.len, o.buf, ou.len, ou.buf));
+}
+
+static int mg_tls_parse_cert_der(void *buf, size_t dersz,
+                                 struct mg_tls_cert *cert) {
+  uint8_t *tbs, *der = (uint8_t *) buf;
+  size_t tbssz;
+  struct mg_der_tlv root, tbs_cert, field, algo;  // pubkey, signature;
+  struct mg_der_tlv pki, pki_algo, pki_key, pki_curve, raw_sig;
+
+  // Parse outermost SEQUENCE
+  if (mg_der_parse(der, dersz, &root) <= 0 || root.type != 0x30) return -1;
+
+  // Parse TBSCertificate SEQUENCE
+  tbs = root.value;
+  if (mg_der_next(&root, &tbs_cert) <= 0 || tbs_cert.type != 0x30) return -1;
+  tbssz = (size_t) (tbs_cert.value + tbs_cert.len - tbs);
+
+  // Parse Version (optional field)
+  if (mg_der_next(&tbs_cert, &field) <= 0) return -1;
+  if (field.type == 0xa0) {  // v3
+    if (mg_der_parse(field.value, field.len, &field) <= 0 || field.len != 1 ||
+        field.value[0] != 2)
+      return -1;
+    if (mg_der_next(&tbs_cert, &field) <= 0) return -1;
+  }
+
+  // Parse Serial Number
+  if (field.type != 2) return -1;
+  cert->sn = mg_str_n((char *) field.value, field.len);
+  MG_VERBOSE(("cert s/n: %M", mg_print_hex, cert->sn.len, cert->sn.buf));
+
+  // Parse signature algorithm (first occurrence)
+  if (mg_der_next(&tbs_cert, &field) <= 0 || field.type != 0x30) return -1;
+  if (mg_der_next(&field, &algo) <= 0 || algo.type != 0x06) return -1;
+
+  MG_VERBOSE(("sig algo (oid): %M", mg_print_hex, algo.len, algo.value));
+  // Signature algorithm OID mapping
+  if (memcmp(algo.value, "\x2A\x86\x48\xCE\x3D\x04\x03\x02", algo.len) == 0) {
+    MG_VERBOSE(("sig algo: ECDSA with SHA256"));
+    mg_sha256(cert->tbshash, tbs, tbssz);
+    cert->tbshashsz = 32;
+  } else if (memcmp(algo.value, "\x2A\x86\x48\x86\xF7\x0D\x01\x01\x0B",
+                    algo.len) == 0) {
+    MG_VERBOSE(("sig algo: RSA with SHA256"));
+    mg_sha256(cert->tbshash, tbs, tbssz);
+    cert->tbshashsz = 32;
+  } else if (memcmp(algo.value, "\x2A\x86\x48\xCE\x3D\x04\x03\x03", algo.len) ==
+             0) {
+    MG_VERBOSE(("sig algo: ECDSA with SHA384"));
+    mg_sha384(cert->tbshash, tbs, tbssz);
+    cert->tbshashsz = 48;
+  } else if (memcmp(algo.value, "\x2A\x86\x48\x86\xF7\x0D\x01\x01\x0C",
+                    algo.len) == 0) {
+    MG_VERBOSE(("sig algo: RSA with SHA384"));
+    mg_sha384(cert->tbshash, tbs, tbssz);
+    cert->tbshashsz = 48;
+  } else {
+    MG_ERROR(
+        ("sig algo: unsupported OID: %M", mg_print_hex, algo.len, algo.value));
+    return -1;
+  }
+  MG_VERBOSE(("tbs hash: %M", mg_print_hex, cert->tbshashsz, cert->tbshash));
+
+  // issuer
+  if (mg_der_next(&tbs_cert, &field) <= 0 || field.type != 0x30) return -1;
+  mg_der_debug_cert_name("issuer", &field);
+
+  // validity dates (before/after)
+  if (mg_der_next(&tbs_cert, &field) <= 0 || field.type != 0x30) return -1;
+  if (1) {
+    struct mg_der_tlv before, after;
+    mg_der_next(&field, &before);
+    mg_der_next(&field, &after);
+    if (memcmp(after.value, "250101000000Z", after.len) < 0) {
+      MG_ERROR(("invalid validity dates: before=%M after=%M", mg_print_hex,
+                before.len, before.value, mg_print_hex, after.len,
+                after.value));
+      return -1;
+    }
+  }
+
+  // subject
+  if (mg_der_next(&tbs_cert, &field) <= 0 || field.type != 0x30) return -1;
+  mg_der_debug_cert_name("subject", &field);
+
+  // subject public key info
+  if (mg_der_next(&tbs_cert, &field) <= 0 || field.type != 0x30) return -1;
+
+  if (mg_der_next(&field, &pki) <= 0 || pki.type != 0x30) return -1;
+  if (mg_der_next(&pki, &pki_algo) <= 0 || pki_algo.type != 0x06) return -1;
+
+  // public key algorithm
+  MG_VERBOSE(("pk algo (oid): %M", mg_print_hex, pki_algo.len, pki_algo.value));
+  if (memcmp(pki_algo.value, "\x2A\x86\x48\xCE\x3D\x03\x01\x07",
+             pki_algo.len) == 0) {
+    cert->is_ec_pubkey = 1;
+    MG_VERBOSE(("pk algo: ECDSA secp256r1"));
+  } else if (memcmp(pki_algo.value, "\x2A\x86\x48\xCE\x3D\x03\x01\x08",
+                    pki_algo.len) == 0) {
+    cert->is_ec_pubkey = 1;
+    MG_VERBOSE(("pk algo: ECDSA secp384r1"));
+  } else if (memcmp(pki_algo.value, "\x2A\x86\x48\xCE\x3D\x02\x01",
+                    pki_algo.len) == 0) {
+    cert->is_ec_pubkey = 1;
+    MG_VERBOSE(("pk algo: EC public key"));
+  } else if (memcmp(pki_algo.value, "\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01",
+                    pki_algo.len) == 0) {
+    cert->is_ec_pubkey = 0;
+    MG_VERBOSE(("pk algo: RSA"));
+  } else {
+    MG_ERROR(("unsupported pk algo: %M", mg_print_hex, pki_algo.len,
+              pki_algo.value));
+    return -1;
+  }
+
+  // Parse public key
+  if (cert->is_ec_pubkey) {
+    if (mg_der_next(&pki, &pki_curve) <= 0 || pki_curve.type != 0x06) return -1;
+  }
+  if (mg_der_next(&field, &pki_key) <= 0 || pki_key.type != 0x03) return -1;
+
+  if (cert->is_ec_pubkey) {  // Skip leading 0x00 and 0x04 (=uncompressed)
+    cert->pubkey = mg_str_n((char *) pki_key.value + 2, pki_key.len - 2);
+  } else {  // Skip leading 0x00 byte
+    cert->pubkey = mg_str_n((char *) pki_key.value + 1, pki_key.len - 1);
+  }
+
+  // Parse signature
+  if (mg_der_next(&root, &field) <= 0 || field.type != 0x30) return -1;
+  if (mg_der_next(&root, &raw_sig) <= 0 || raw_sig.type != 0x03) return -1;
+  if (raw_sig.len < 1 || raw_sig.value[0] != 0x00) return -1;
+
+  cert->sig = mg_str_n((char *) raw_sig.value + 1, raw_sig.len - 1);
+  MG_VERBOSE(("sig: %M", mg_print_hex, cert->sig.len, cert->sig.buf));
+
+  return 0;
+}
+
+static int mg_tls_verify_cert_san(const uint8_t *der, size_t dersz,
+                                  const char *server_name) {
+  struct mg_der_tlv root, field, name;
+  if (mg_der_parse((uint8_t *) der, dersz, &root) < 0 ||
+      mg_der_find_oid(&root, (uint8_t *) "\x55\x1d\x11", 3, &field) < 0) {
+    MG_ERROR(("failed to parse certificate to extract SAN"));
+    return -1;
+  }
+  if (mg_der_parse(field.value, field.len, &field) < 0) {
+    MG_ERROR(
+        ("certificate subject alternative names is not a constructed object"));
+    return -1;
+  }
+  while (mg_der_next(&field, &name) > 0) {
+    if (mg_match(mg_str(server_name),
+                 mg_str_n((const char *) name.value, name.len), NULL)) {
+      // Found SAN that matches the host name
+      return 1;
+    }
+  }
+  return -1;
+}
+
+static int mg_tls_verify_cert_signature(const struct mg_tls_cert *cert,
+                                        const struct mg_tls_cert *issuer) {
+  if (issuer->is_ec_pubkey) {
+    uint8_t sig[128];
+    struct mg_der_tlv seq = {0, 0, 0}, a = {0, 0, 0}, b = {0, 0, 0};
+    mg_der_parse((uint8_t *) cert->sig.buf, cert->sig.len, &seq);
+    mg_der_next(&seq, &a);
+    mg_der_next(&seq, &b);
+    if (a.len == 0 || b.len == 0) {
+      MG_ERROR(("cert verification error"));
+      return 0;
+    }
+    if (issuer->pubkey.len == 64) {
+      const uint32_t N = 32;
+      if (a.len > N) a.value += (a.len - N), a.len = N;
+      if (b.len > N) b.value += (b.len - N), b.len = N;
+      memmove(sig, a.value, N);
+      memmove(sig + N, b.value, N);
+      return mg_uecc_verify((uint8_t *) issuer->pubkey.buf, cert->tbshash,
+                            (unsigned) cert->tbshashsz, sig,
+                            mg_uecc_secp256r1());
+    } else if (issuer->pubkey.len == 96) {
+      MG_DEBUG(("ignore secp386 for now"));
+      return 1;
+    } else {
+      MG_ERROR(("unsupported public key length: %d", issuer->pubkey.len));
+      return 0;
+    }
+  } else {
+    int r;
+    uint8_t sig2[256];  // 2048 bits
+    struct mg_der_tlv seq, modulus, exponent;
+    if (mg_der_parse((uint8_t *) issuer->pubkey.buf, issuer->pubkey.len,
+                     &seq) <= 0 ||
+        mg_der_next(&seq, &modulus) <= 0 || modulus.type != 2 ||
+        mg_der_next(&seq, &exponent) <= 0 || exponent.type != 2) {
+      return -1;
+    }
+    mg_rsa_mod_pow(modulus.value, modulus.len, exponent.value, exponent.len,
+                   (uint8_t *) cert->sig.buf, cert->sig.len, sig2,
+                   sizeof(sig2));
+
+    r = memcmp(sig2 + sizeof(sig2) - cert->tbshashsz, cert->tbshash,
+               cert->tbshashsz);
+    return r == 0;
+  }
+}
+
+static int mg_tls_client_recv_cert(struct mg_connection *c) {
+  int subj_match = 0;
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf;
+  (void) subj_match;
+
+  if (mg_tls_recv_record(c) < 0) {
+    return -1;
+  }
+
+  recv_buf = &c->rtls.buf[tls->recv_offset];
+
+  if (recv_buf[0] == MG_TLS_CERTIFICATE_REQUEST) {
+    MG_VERBOSE(("got certificate request"));
+    mg_tls_drop_message(c);
+    tls->cert_requested = 1;
+    return -1;
+  }
+
+  if (recv_buf[0] != MG_TLS_CERTIFICATE) {
+    mg_error(c, "expected server certificate but got msg 0x%02x", recv_buf[0]);
+    return -1;
+  }
+
+  if (tls->recv_len < 11) {
+    mg_error(c, "certificate list too short");
+    return -1;
+  }
+
+  uint32_t full_cert_chain_len = MG_LOAD_BE24(recv_buf + 1);
+  uint32_t cert_chain_len = MG_LOAD_BE24(recv_buf + 5);
+  if (cert_chain_len != full_cert_chain_len - 4) {
+    MG_ERROR(("full chain length: %d, chain length: %d", full_cert_chain_len,
+              cert_chain_len));
+    mg_error(c, "certificate chain length mismatch");
+    return -1;
+  }
+
+  // Normally, there are 2-3 certs in a chain
+  struct mg_tls_cert certs[8];
+  int certnum = 0;
+  uint8_t *p = recv_buf + 8;
+  //uint8_t *endp = recv_buf + tls->recv_len;
+  uint8_t *endp = recv_buf + cert_chain_len;
+
+  int found_ca = 0;
+  struct mg_tls_cert ca;
+
+  memset(certs, 0, sizeof(certs));
+  memset(&ca, 0, sizeof(ca));
+
+  if (tls->ca_der.len > 0) {
+    if (mg_tls_parse_cert_der(tls->ca_der.buf, tls->ca_der.len, &ca) < 0) {
+      mg_error(c, "failed to parse CA certificate");
+      return -1;
+    }
+    MG_VERBOSE(("CA serial: %M", mg_print_hex, ca.sn.len, ca.sn.buf));
+  }
+
+  while (p < endp) {
+    struct mg_tls_cert *ci = &certs[certnum++];
+    uint32_t certsz = MG_LOAD_BE24(p);
+    uint8_t *cert = p + 3;
+    uint16_t certext = MG_LOAD_BE16(cert + certsz);
+    if (certext != 0) {
+      mg_error(c, "certificate extensions are not supported");
+      return -1;
+    }
+    p = cert + certsz + 2;
+
+    if (mg_tls_parse_cert_der(cert, certsz, ci) < 0) {
+      mg_error(c, "failed to parse certificate");
+      return -1;
+    }
+
+    if (ci == certs) {
+      // First certificate in the chain is peer cert, check SAN and store
+      // public key for further CertVerify step
+      if (mg_tls_verify_cert_san(cert, certsz, tls->hostname) <= 0) {
+        mg_error(c, "failed to verify hostname");
+        return -1;
+      }
+      memmove(tls->pubkey, ci->pubkey.buf, ci->pubkey.len);
+      tls->pubkeysz = ci->pubkey.len;
+    } else {
+      if (!mg_tls_verify_cert_signature(ci - 1, ci)) {
+        mg_error(c, "failed to verify certificate chain");
+        return -1;
+      }
+    }
+
+    if (ca.pubkey.len == ci->pubkey.len &&
+        memcmp(ca.pubkey.buf, ci->pubkey.buf, ca.pubkey.len) == 0) {
+      found_ca = 1;
+      break;
+    }
+
+    if (certnum == sizeof(certs) / sizeof(certs[0]) - 1) {
+      mg_error(c, "too many certificates in the chain");
+      return -1;
+    }
+  }
+
+  if (!found_ca && tls->ca_der.len > 0) {
+    if (certnum < 1 ||
+        !mg_tls_verify_cert_signature(&certs[certnum - 1], &ca)) {
+      mg_error(c, "failed to verify CA");
+      return -1;
+    } else {
+      MG_VERBOSE(
+          ("CA was not in the chain, but verification with builtin CA passed"));
+    }
+  }
+
+  mg_tls_drop_message(c);
+  mg_tls_calc_cert_verify_hash(c, tls->sighash, 0);
+  return 0;
+}
+
+static int mg_tls_client_recv_cert_verify(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf;
+  if (mg_tls_recv_record(c) < 0) {
+    return -1;
+  }
+  recv_buf = &c->rtls.buf[tls->recv_offset];
+  if (recv_buf[0] != MG_TLS_CERTIFICATE_VERIFY) {
+    mg_error(c, "expected server certificate verify but got msg 0x%02x",
+             recv_buf[0]);
+    return -1;
+  }
+  if (tls->recv_len < 8) {
+    mg_error(c, "server certificate verify is too short: %d bytes",
+             tls->recv_len);
+    return -1;
+  }
+
+  // Ignore CertificateVerify is strict checks are not required
+  if (tls->skip_verification) {
+    mg_tls_drop_message(c);
+    return 0;
+  }
+
+  uint16_t sigalg = MG_LOAD_BE16(recv_buf + 4);
+  uint16_t siglen = MG_LOAD_BE16(recv_buf + 6);
+  uint8_t *sigbuf = recv_buf + 8;
+  if (siglen > tls->recv_len - 8) {
+    mg_error(c, "invalid certverify signature length: %d, expected %d", siglen,
+             tls->recv_len - 8);
+    return -1;
+  }
+  MG_VERBOSE(("certificate verification, algo=%04x, siglen=%d", sigalg, siglen));
+
+  if (sigalg == 0x0804) {  // rsa_pss_rsae_sha256
+    uint8_t sig2[512];     // 2048 or 4096 bits
+    struct mg_der_tlv seq, modulus, exponent;
+
+    if (mg_der_parse(tls->pubkey, tls->pubkeysz, &seq) <= 0 ||
+        mg_der_next(&seq, &modulus) <= 0 || modulus.type != 2 ||
+        mg_der_next(&seq, &exponent) <= 0 || exponent.type != 2) {
+      mg_error(c, "invalid public key");
+      return -1;
+    }
+
+    mg_rsa_mod_pow(modulus.value, modulus.len, exponent.value, exponent.len,
+                   sigbuf, siglen, sig2, sizeof(sig2));
+
+    if (sig2[sizeof(sig2) - 1] != 0xbc) {
+      mg_error(c, "failed to verify RSA certificate (certverify)");
+      return -1;
+    }
+    MG_DEBUG(("certificate verification successful (RSA)"));
+  } else if (sigalg == 0x0403) {  // ecdsa_secp256r1_sha256
+    // Extract certificate signature and verify it using pubkey and sighash
+    uint8_t sig[64];
+    struct mg_der_tlv seq, r, s;
+    if (mg_der_to_tlv(sigbuf, siglen, &seq) < 0) {
+      mg_error(c, "verification message is not an ASN.1 DER sequence");
+      return -1;
+    }
+    if (mg_der_to_tlv(seq.value, seq.len, &r) < 0) {
+      mg_error(c, "missing first part of the signature");
+      return -1;
+    }
+    if (mg_der_to_tlv(r.value + r.len, seq.len - r.len, &s) < 0) {
+      mg_error(c, "missing second part of the signature");
+      return -1;
+    }
+    // Integers may be padded with zeroes
+    if (r.len > 32) r.value = r.value + (r.len - 32), r.len = 32;
+    if (s.len > 32) s.value = s.value + (s.len - 32), s.len = 32;
+
+    memmove(sig, r.value, r.len);
+    memmove(sig + 32, s.value, s.len);
+
+    if (mg_uecc_verify(tls->pubkey, tls->sighash, sizeof(tls->sighash), sig,
+                       mg_uecc_secp256r1()) != 1) {
+      mg_error(c, "failed to verify EC certificate (certverify)");
+      return -1;
+    }
+    MG_DEBUG(("certificate verification successful (EC)"));
+  } else {
+    // From
+    // https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml:
+    //   0805 = rsa_pss_rsae_sha384
+    //   0806 = rsa_pss_rsae_sha512
+    //   0807 = ed25519
+    //   0808 = ed448
+    //   0809 = rsa_pss_pss_sha256
+    //   080A = rsa_pss_pss_sha384
+    //   080B = rsa_pss_pss_sha512
+    MG_ERROR(("unsupported certverify signature scheme: %x of %d bytes", sigalg,
+              siglen));
+    return -1;
+  }
+  mg_tls_drop_message(c);
+  return 0;
+}
+
+static int mg_tls_client_recv_finish(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf;
+  if (mg_tls_recv_record(c) < 0) {
+    return -1;
+  }
+  recv_buf = &c->rtls.buf[tls->recv_offset];
+  if (recv_buf[0] != MG_TLS_FINISHED) {
+    mg_error(c, "expected server finished but got msg 0x%02x", recv_buf[0]);
+    return -1;
+  }
+  mg_tls_drop_message(c);
+  return 0;
+}
+
+static void mg_tls_client_send_finish(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  struct mg_iobuf *wio = &tls->send;
+  mg_sha256_ctx sha256;
+  uint8_t hash[32];
+  uint8_t finish[36] = {0x14, 0, 0, 32};
+  memmove(&sha256, &tls->sha256, sizeof(mg_sha256_ctx));
+  mg_sha256_final(hash, &sha256);
+  mg_hmac_sha256(finish + 4, tls->enc.client_finished_key, 32, hash, 32);
+  mg_tls_encrypt(c, finish, sizeof(finish), MG_TLS_HANDSHAKE);
+  mg_io_send(c, wio->buf, wio->len);
+  wio->len = 0;
+}
+
+static void mg_tls_client_handshake(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  switch (tls->state) {
+    case MG_TLS_STATE_CLIENT_START:
+      mg_tls_client_send_hello(c);
+      tls->state = MG_TLS_STATE_CLIENT_WAIT_SH;
+      // Fallthrough
+    case MG_TLS_STATE_CLIENT_WAIT_SH:
+      if (mg_tls_client_recv_hello(c) < 0) {
+        break;
+      }
+      tls->state = MG_TLS_STATE_CLIENT_WAIT_EE;
+      // Fallthrough
+    case MG_TLS_STATE_CLIENT_WAIT_EE:
+      if (mg_tls_client_recv_ext(c) < 0) {
+        break;
+      }
+      tls->state = MG_TLS_STATE_CLIENT_WAIT_CERT;
+      // Fallthrough
+    case MG_TLS_STATE_CLIENT_WAIT_CERT:
+      if (mg_tls_client_recv_cert(c) < 0) {
+        break;
+      }
+      tls->state = MG_TLS_STATE_CLIENT_WAIT_CV;
+      // Fallthrough
+    case MG_TLS_STATE_CLIENT_WAIT_CV:
+      if (mg_tls_client_recv_cert_verify(c) < 0) {
+        break;
+      }
+      tls->state = MG_TLS_STATE_CLIENT_WAIT_FINISHED;
+      // Fallthrough
+    case MG_TLS_STATE_CLIENT_WAIT_FINISHED:
+      if (mg_tls_client_recv_finish(c) < 0) {
+        break;
+      }
+      if (tls->cert_requested) {
+        /* for mTLS we should generate application keys at this point
+         * but then restore handshake keys and continue with
+         * the rest of the handshake */
+        struct tls_enc app_keys;
+        struct tls_enc hs_keys = tls->enc;
+        mg_tls_generate_application_keys(c);
+        app_keys = tls->enc;
+        tls->enc = hs_keys;
+        mg_tls_server_send_cert(c);
+        mg_tls_send_cert_verify(c, 1);
+        mg_tls_client_send_finish(c);
+        tls->enc = app_keys;
+      } else {
+        mg_tls_client_send_finish(c);
+        mg_tls_generate_application_keys(c);
+      }
+      tls->state = MG_TLS_STATE_CLIENT_CONNECTED;
+      c->is_tls_hs = 0;
+      mg_call(c, MG_EV_TLS_HS, NULL);
+      break;
+    default: mg_error(c, "unexpected client state: %d", tls->state); break;
+  }
+}
+
+static void mg_tls_server_handshake(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  switch (tls->state) {
+    case MG_TLS_STATE_SERVER_START:
+      if (mg_tls_server_recv_hello(c) < 0) {
+        return;
+      }
+      mg_tls_server_send_hello(c);
+      mg_tls_generate_handshake_keys(c);
+      mg_tls_server_send_ext(c);
+      mg_tls_server_send_cert(c);
+      mg_tls_send_cert_verify(c, 0);
+      mg_tls_server_send_finish(c);
+      tls->state = MG_TLS_STATE_SERVER_NEGOTIATED;
+      // fallthrough
+    case MG_TLS_STATE_SERVER_NEGOTIATED:
+      if (mg_tls_server_recv_finish(c) < 0) {
+        return;
+      }
+      mg_tls_generate_application_keys(c);
+      tls->state = MG_TLS_STATE_SERVER_CONNECTED;
+      c->is_tls_hs = 0;
+      return;
+    default: mg_error(c, "unexpected server state: %d", tls->state); break;
+  }
+}
+
+void mg_tls_handshake(struct mg_connection *c) {
+  if (c->is_client) {
+    mg_tls_client_handshake(c);
+  } else {
+    mg_tls_server_handshake(c);
+  }
+}
+
+static int mg_parse_pem(const struct mg_str pem, const struct mg_str label,
+                        struct mg_str *der) {
+  size_t n = 0, m = 0;
+  char *s;
+  const char *c;
+  struct mg_str caps[6];  // number of wildcards + 1
+  if (!mg_match(pem, mg_str("#-----BEGIN #-----#-----END #-----#"), caps)) {
+    *der = mg_strdup(pem);
+    return 0;
+  }
+  if (mg_strcmp(caps[1], label) != 0 || mg_strcmp(caps[3], label) != 0) {
+    return -1;  // bad label
+  }
+  if ((s = (char *) calloc(1, caps[2].len)) == NULL) {
+    return -1;
+  }
+
+  for (c = caps[2].buf; c < caps[2].buf + caps[2].len; c++) {
+    if (*c == ' ' || *c == '\n' || *c == '\r' || *c == '\t') {
+      continue;
+    }
+    s[n++] = *c;
+  }
+  m = mg_base64_decode(s, n, s, n);
+  if (m == 0) {
+    free(s);
+    return -1;
+  }
+  der->buf = s;
+  der->len = m;
+  return 0;
+}
+
+void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
+  struct mg_str key;
+  struct tls_data *tls = (struct tls_data *) calloc(1, sizeof(struct tls_data));
+  if (tls == NULL) {
+    mg_error(c, "tls oom");
+    return;
+  }
+
+  tls->state =
+      c->is_client ? MG_TLS_STATE_CLIENT_START : MG_TLS_STATE_SERVER_START;
+
+  tls->skip_verification = opts->skip_verification;
+  // tls->send.align = MG_IO_SIZE;
+
+  c->tls = tls;
+  c->is_tls = c->is_tls_hs = 1;
+  mg_sha256_init(&tls->sha256);
+
+  // save hostname (client extension)
+  if (opts->name.len > 0) {
+    if (opts->name.len >= sizeof(tls->hostname) - 1) {
+      mg_error(c, "hostname too long");
+      return;
+    }
+    strncpy((char *) tls->hostname, opts->name.buf, sizeof(tls->hostname) - 1);
+    tls->hostname[opts->name.len] = 0;
+  }
+  // server CA certificate, store serial number
+  if (opts->ca.len > 0) {
+    if (mg_parse_pem(opts->ca, mg_str_s("CERTIFICATE"), &tls->ca_der) < 0) {
+      MG_ERROR(("Failed to load certificate"));
+      return;
+    }
+  }
+
+  if (opts->cert.buf == NULL) {
+    MG_VERBOSE(("No certificate provided"));
+    return;
+  }
+
+  // parse PEM or DER certificate
+  if (mg_parse_pem(opts->cert, mg_str_s("CERTIFICATE"), &tls->cert_der) < 0) {
+    MG_ERROR(("Failed to load certificate"));
+    return;
+  }
+
+  // parse PEM or DER EC key
+  if (opts->key.buf == NULL) {
+    mg_error(c, "Certificate provided without a private key");
+    return;
+  }
+
+  if (mg_parse_pem(opts->key, mg_str_s("EC PRIVATE KEY"), &key) == 0) {
+    if (key.len < 39) {
+      MG_ERROR(("EC private key too short"));
+      return;
+    }
+    // expect ASN.1 SEQUENCE=[INTEGER=1, BITSTRING of 32 bytes, ...]
+    // 30 nn 02 01 01 04 20 [key] ...
+    if (key.buf[0] != 0x30 || (key.buf[1] & 0x80) != 0) {
+      MG_ERROR(("EC private key: ASN.1 bad sequence"));
+      return;
+    }
+    if (memcmp(key.buf + 2, "\x02\x01\x01\x04\x20", 5) != 0) {
+      MG_ERROR(("EC private key: ASN.1 bad data"));
+    }
+    memmove(tls->ec_key, key.buf + 7, 32);
+    free((void *) key.buf);
+  } else if (mg_parse_pem(opts->key, mg_str_s("PRIVATE KEY"), &key) == 0) {
+    mg_error(c, "PKCS8 private key format is not supported");
+  } else {
+    mg_error(c, "Expected EC PRIVATE KEY or PRIVATE KEY");
+  }
+}
+
+void mg_tls_free(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  if (tls != NULL) {
+    mg_iobuf_free(&tls->send);
+    free((void *) tls->cert_der.buf);
+    free((void *) tls->ca_der.buf);
+  }
+  free(c->tls);
+  c->tls = NULL;
+}
+
+long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  long n = MG_IO_WAIT;
+  if (len > MG_IO_SIZE) len = MG_IO_SIZE;
+  if (len > 16384) len = 16384;
+  mg_tls_encrypt(c, (const uint8_t *) buf, len, MG_TLS_APP_DATA);
+  while (tls->send.len > 0 &&
+         (n = mg_io_send(c, tls->send.buf, tls->send.len)) > 0) {
+    mg_iobuf_del(&tls->send, 0, (size_t) n);
+  }
+  if (n == MG_IO_ERR || n == MG_IO_WAIT) return n;
+  return (long) len;
+}
+
+long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
+  int r = 0;
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  unsigned char *recv_buf;
+  size_t minlen;
+
+  r = mg_tls_recv_record(c);
+  if (r < 0) {
+    return r;
+  }
+  recv_buf = &c->rtls.buf[tls->recv_offset];
+
+  if (tls->content_type != MG_TLS_APP_DATA) {
+    tls->recv_len = 0;
+    mg_tls_drop_record(c);
+    return MG_IO_WAIT;
+  }
+  minlen = len < tls->recv_len ? len : tls->recv_len;
+  memmove(buf, recv_buf, minlen);
+  tls->recv_offset += minlen;
+  tls->recv_len -= minlen;
+  if (tls->recv_len == 0) {
+    mg_tls_drop_record(c);
+  }
+  return (long) minlen;
+}
+
+size_t mg_tls_pending(struct mg_connection *c) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  return tls != NULL ? tls->recv_len : 0;
+}
+
+void mg_tls_ctx_init(struct mg_mgr *mgr) {
+  (void) mgr;
+}
+
+void mg_tls_ctx_free(struct mg_mgr *mgr) {
+  (void) mgr;
+}
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/tls_chacha20.c"
+#endif
+// portable8439 v1.0.1
+// Source: https://github.com/DavyLandman/portable8439
+// Licensed under CC0-1.0
+// Contains poly1305-donna e6ad6e091d30d7f4ec2d4f978be1fcfcbce72781 (Public
+// Domain)
+
+
+
+
+#if MG_TLS == MG_TLS_BUILTIN
+// ******* BEGIN: chacha-portable/chacha-portable.h ********
+
+#if !defined(__cplusplus) && !defined(_MSC_VER) && \
+    (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+#error "C99 or newer required"
+#endif
+
+#define CHACHA20_KEY_SIZE (32)
+#define CHACHA20_NONCE_SIZE (12)
+
+#if defined(_MSC_VER) || defined(__cplusplus)
+// add restrict support
+#if (defined(_MSC_VER) && _MSC_VER >= 1900) || defined(__clang__) || \
+    defined(__GNUC__)
+#define restrict __restrict
+#else
+#define restrict
+#endif
+#endif
+
+// xor data with a ChaCha20 keystream as per RFC8439
+static PORTABLE_8439_DECL void chacha20_xor_stream(
+    uint8_t *restrict dest, const uint8_t *restrict source, size_t length,
+    const uint8_t key[CHACHA20_KEY_SIZE],
+    const uint8_t nonce[CHACHA20_NONCE_SIZE], uint32_t counter);
+
+static PORTABLE_8439_DECL void rfc8439_keygen(
+    uint8_t poly_key[32], const uint8_t key[CHACHA20_KEY_SIZE],
+    const uint8_t nonce[CHACHA20_NONCE_SIZE]);
+
+// ******* END:   chacha-portable/chacha-portable.h ********
+// ******* BEGIN: poly1305-donna/poly1305-donna.h ********
+
+#include <stddef.h>
+
+typedef struct poly1305_context {
+  size_t aligner;
+  unsigned char opaque[136];
+} poly1305_context;
+
+static PORTABLE_8439_DECL void poly1305_init(poly1305_context *ctx,
+                                             const unsigned char key[32]);
+static PORTABLE_8439_DECL void poly1305_update(poly1305_context *ctx,
+                                               const unsigned char *m,
+                                               size_t bytes);
+static PORTABLE_8439_DECL void poly1305_finish(poly1305_context *ctx,
+                                               unsigned char mac[16]);
+
+// ******* END:   poly1305-donna/poly1305-donna.h ********
+// ******* BEGIN: chacha-portable.c ********
+
+#include <assert.h>
+#include <string.h>
+
+// this is a fresh implementation of chacha20, based on the description in
+// rfc8349 it's such a nice compact algorithm that it is easy to do. In
+// relationship to other c implementation this implementation:
+//  - pure c99
+//  - big & little endian support
+//  - safe for architectures that don't support unaligned reads
+//
+// Next to this, we try to be fast as possible without resorting inline
+// assembly.
+
+// based on https://sourceforge.net/p/predef/wiki/Endianness/
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define __HAVE_LITTLE_ENDIAN 1
+#elif defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) ||                 \
+    defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) || \
+    defined(__MIPSEL) || defined(__MIPSEL__) || defined(__XTENSA_EL__) || \
+    defined(__AVR__) || defined(LITTLE_ENDIAN)
+#define __HAVE_LITTLE_ENDIAN 1
+#endif
+
+#ifndef TEST_SLOW_PATH
+#if defined(__HAVE_LITTLE_ENDIAN)
+#define FAST_PATH
+#endif
+#endif
+
+#define CHACHA20_STATE_WORDS (16)
+#define CHACHA20_BLOCK_SIZE (CHACHA20_STATE_WORDS * sizeof(uint32_t))
+
+#ifdef FAST_PATH
+#define store_32_le(target, source) memcpy(&(target), source, sizeof(uint32_t))
+#else
+#define store_32_le(target, source)                                 \
+  target = (uint32_t) (source)[0] | ((uint32_t) (source)[1]) << 8 | \
+           ((uint32_t) (source)[2]) << 16 | ((uint32_t) (source)[3]) << 24
+#endif
+
+static void initialize_state(uint32_t state[CHACHA20_STATE_WORDS],
+                             const uint8_t key[CHACHA20_KEY_SIZE],
+                             const uint8_t nonce[CHACHA20_NONCE_SIZE],
+                             uint32_t counter) {
+#if 0
+#ifdef static_assert
+  static_assert(sizeof(uint32_t) == 4,
+                "We don't support systems that do not conform to standard of "
+                "uint32_t being exact 32bit wide");
+#endif
+#endif
+  state[0] = 0x61707865;
+  state[1] = 0x3320646e;
+  state[2] = 0x79622d32;
+  state[3] = 0x6b206574;
+  store_32_le(state[4], key);
+  store_32_le(state[5], key + 4);
+  store_32_le(state[6], key + 8);
+  store_32_le(state[7], key + 12);
+  store_32_le(state[8], key + 16);
+  store_32_le(state[9], key + 20);
+  store_32_le(state[10], key + 24);
+  store_32_le(state[11], key + 28);
+  state[12] = counter;
+  store_32_le(state[13], nonce);
+  store_32_le(state[14], nonce + 4);
+  store_32_le(state[15], nonce + 8);
+}
+
+#define increment_counter(state) (state)[12]++
+
+// source: http://blog.regehr.org/archives/1063
+#define rotl32a(x, n) ((x) << (n)) | ((x) >> (32 - (n)))
+
+#define Qround(a, b, c, d) \
+  a += b;                  \
+  d ^= a;                  \
+  d = rotl32a(d, 16);      \
+  c += d;                  \
+  b ^= c;                  \
+  b = rotl32a(b, 12);      \
+  a += b;                  \
+  d ^= a;                  \
+  d = rotl32a(d, 8);       \
+  c += d;                  \
+  b ^= c;                  \
+  b = rotl32a(b, 7);
+
+#define TIMES16(x)                                                          \
+  x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) \
+      x(14) x(15)
+
+static void core_block(const uint32_t *restrict start,
+                       uint32_t *restrict output) {
+  int i;
+// instead of working on the output array,
+// we let the compiler allocate 16 local variables on the stack
+#define __LV(i) uint32_t __t##i = start[i];
+  TIMES16(__LV)
+
+#define __Q(a, b, c, d) Qround(__t##a, __t##b, __t##c, __t##d)
+
+  for (i = 0; i < 10; i++) {
+    __Q(0, 4, 8, 12);
+    __Q(1, 5, 9, 13);
+    __Q(2, 6, 10, 14);
+    __Q(3, 7, 11, 15);
+    __Q(0, 5, 10, 15);
+    __Q(1, 6, 11, 12);
+    __Q(2, 7, 8, 13);
+    __Q(3, 4, 9, 14);
+  }
+
+#define __FIN(i) output[i] = start[i] + __t##i;
+  TIMES16(__FIN)
+}
+
+#define U8(x) ((uint8_t) ((x) &0xFF))
+
+#ifdef FAST_PATH
+#define xor32_le(dst, src, pad)            \
+  uint32_t __value;                        \
+  memcpy(&__value, src, sizeof(uint32_t)); \
+  __value ^= *(pad);                       \
+  memcpy(dst, &__value, sizeof(uint32_t));
+#else
+#define xor32_le(dst, src, pad)           \
+  (dst)[0] = (src)[0] ^ U8(*(pad));       \
+  (dst)[1] = (src)[1] ^ U8(*(pad) >> 8);  \
+  (dst)[2] = (src)[2] ^ U8(*(pad) >> 16); \
+  (dst)[3] = (src)[3] ^ U8(*(pad) >> 24);
+#endif
+
+#define index8_32(a, ix) ((a) + ((ix) * sizeof(uint32_t)))
+
+#define xor32_blocks(dest, source, pad, words)                    \
+  for (i = 0; i < words; i++) {                                   \
+    xor32_le(index8_32(dest, i), index8_32(source, i), (pad) + i) \
+  }
+
+static void xor_block(uint8_t *restrict dest, const uint8_t *restrict source,
+                      const uint32_t *restrict pad, unsigned int chunk_size) {
+  unsigned int i, full_blocks = chunk_size / (unsigned int) sizeof(uint32_t);
+  // have to be carefull, we are going back from uint32 to uint8, so endianness
+  // matters again
+  xor32_blocks(dest, source, pad, full_blocks)
+
+      dest += full_blocks * sizeof(uint32_t);
+  source += full_blocks * sizeof(uint32_t);
+  pad += full_blocks;
+
+  switch (chunk_size % sizeof(uint32_t)) {
+    case 1:
+      dest[0] = source[0] ^ U8(*pad);
+      break;
+    case 2:
+      dest[0] = source[0] ^ U8(*pad);
+      dest[1] = source[1] ^ U8(*pad >> 8);
+      break;
+    case 3:
+      dest[0] = source[0] ^ U8(*pad);
+      dest[1] = source[1] ^ U8(*pad >> 8);
+      dest[2] = source[2] ^ U8(*pad >> 16);
+      break;
+  }
+}
+
+static void chacha20_xor_stream(uint8_t *restrict dest,
+                                const uint8_t *restrict source, size_t length,
+                                const uint8_t key[CHACHA20_KEY_SIZE],
+                                const uint8_t nonce[CHACHA20_NONCE_SIZE],
+                                uint32_t counter) {
+  uint32_t state[CHACHA20_STATE_WORDS];
+  uint32_t pad[CHACHA20_STATE_WORDS];
+  size_t i, b, last_block, full_blocks = length / CHACHA20_BLOCK_SIZE;
+  initialize_state(state, key, nonce, counter);
+  for (b = 0; b < full_blocks; b++) {
+    core_block(state, pad);
+    increment_counter(state);
+    xor32_blocks(dest, source, pad, CHACHA20_STATE_WORDS) dest +=
+        CHACHA20_BLOCK_SIZE;
+    source += CHACHA20_BLOCK_SIZE;
+  }
+  last_block = length % CHACHA20_BLOCK_SIZE;
+  if (last_block > 0) {
+    core_block(state, pad);
+    xor_block(dest, source, pad, (unsigned int) last_block);
+  }
+}
+
+#ifdef FAST_PATH
+#define serialize(poly_key, result) memcpy(poly_key, result, 32)
+#else
+#define store32_le(target, source)   \
+  (target)[0] = U8(*(source));       \
+  (target)[1] = U8(*(source) >> 8);  \
+  (target)[2] = U8(*(source) >> 16); \
+  (target)[3] = U8(*(source) >> 24);
+
+#define serialize(poly_key, result)                 \
+  for (i = 0; i < 32 / sizeof(uint32_t); i++) {     \
+    store32_le(index8_32(poly_key, i), result + i); \
+  }
+#endif
+
+static void rfc8439_keygen(uint8_t poly_key[32],
+                           const uint8_t key[CHACHA20_KEY_SIZE],
+                           const uint8_t nonce[CHACHA20_NONCE_SIZE]) {
+  uint32_t state[CHACHA20_STATE_WORDS];
+  uint32_t result[CHACHA20_STATE_WORDS];
+  size_t i;
+  initialize_state(state, key, nonce, 0);
+  core_block(state, result);
+  serialize(poly_key, result);
+  (void) i;
+}
+// ******* END: chacha-portable.c ********
+// ******* BEGIN: poly1305-donna.c ********
+
+/* auto detect between 32bit / 64bit */
+#if /* uint128 available on 64bit system*/                              \
+    (defined(__SIZEOF_INT128__) &&                                      \
+     defined(__LP64__))                       /* MSVC 64bit compiler */ \
+    || (defined(_MSC_VER) && defined(_M_X64)) /* gcc >= 4.4 64bit */    \
+    || (defined(__GNUC__) && defined(__LP64__) &&                       \
+        ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))))
+#define __GUESS64
+#else
+#define __GUESS32
+#endif
+
+#if defined(POLY1305_8BIT)
+/*
+        poly1305 implementation using 8 bit * 8 bit = 16 bit multiplication and
+32 bit addition
+
+        based on the public domain reference version in supercop by djb
+static */
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#define POLY1305_NOINLINE
+#elif defined(_MSC_VER)
+#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 51*sizeof(unsigned char) */
+typedef struct poly1305_state_internal_t {
+  unsigned char buffer[poly1305_block_size];
+  size_t leftover;
+  unsigned char h[17];
+  unsigned char r[17];
+  unsigned char pad[17];
+  unsigned char final;
+} poly1305_state_internal_t;
+
+static void poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  size_t i;
+
+  st->leftover = 0;
+
+  /* h = 0 */
+  for (i = 0; i < 17; i++) st->h[i] = 0;
+
+  /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+  st->r[0] = key[0] & 0xff;
+  st->r[1] = key[1] & 0xff;
+  st->r[2] = key[2] & 0xff;
+  st->r[3] = key[3] & 0x0f;
+  st->r[4] = key[4] & 0xfc;
+  st->r[5] = key[5] & 0xff;
+  st->r[6] = key[6] & 0xff;
+  st->r[7] = key[7] & 0x0f;
+  st->r[8] = key[8] & 0xfc;
+  st->r[9] = key[9] & 0xff;
+  st->r[10] = key[10] & 0xff;
+  st->r[11] = key[11] & 0x0f;
+  st->r[12] = key[12] & 0xfc;
+  st->r[13] = key[13] & 0xff;
+  st->r[14] = key[14] & 0xff;
+  st->r[15] = key[15] & 0x0f;
+  st->r[16] = 0;
+
+  /* save pad for later */
+  for (i = 0; i < 16; i++) st->pad[i] = key[i + 16];
+  st->pad[16] = 0;
+
+  st->final = 0;
+}
+
+static void poly1305_add(unsigned char h[17], const unsigned char c[17]) {
+  unsigned short u;
+  unsigned int i;
+  for (u = 0, i = 0; i < 17; i++) {
+    u += (unsigned short) h[i] + (unsigned short) c[i];
+    h[i] = (unsigned char) u & 0xff;
+    u >>= 8;
+  }
+}
+
+static void poly1305_squeeze(unsigned char h[17], unsigned long hr[17]) {
+  unsigned long u;
+  unsigned int i;
+  u = 0;
+  for (i = 0; i < 16; i++) {
+    u += hr[i];
+    h[i] = (unsigned char) u & 0xff;
+    u >>= 8;
+  }
+  u += hr[16];
+  h[16] = (unsigned char) u & 0x03;
+  u >>= 2;
+  u += (u << 2); /* u *= 5; */
+  for (i = 0; i < 16; i++) {
+    u += h[i];
+    h[i] = (unsigned char) u & 0xff;
+    u >>= 8;
+  }
+  h[16] += (unsigned char) u;
+}
+
+static void poly1305_freeze(unsigned char h[17]) {
+  const unsigned char minusp[17] = {0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0xfc};
+  unsigned char horig[17], negative;
+  unsigned int i;
+
+  /* compute h + -p */
+  for (i = 0; i < 17; i++) horig[i] = h[i];
+  poly1305_add(h, minusp);
+
+  /* select h if h < p, or h + -p if h >= p */
+  negative = -(h[16] >> 7);
+  for (i = 0; i < 17; i++) h[i] ^= negative & (horig[i] ^ h[i]);
+}
+
+static void poly1305_blocks(poly1305_state_internal_t *st,
+                            const unsigned char *m, size_t bytes) {
+  const unsigned char hibit = st->final ^ 1; /* 1 << 128 */
+
+  while (bytes >= poly1305_block_size) {
+    unsigned long hr[17], u;
+    unsigned char c[17];
+    unsigned int i, j;
+
+    /* h += m */
+    for (i = 0; i < 16; i++) c[i] = m[i];
+    c[16] = hibit;
+    poly1305_add(st->h, c);
+
+    /* h *= r */
+    for (i = 0; i < 17; i++) {
+      u = 0;
+      for (j = 0; j <= i; j++) {
+        u += (unsigned short) st->h[j] * st->r[i - j];
+      }
+      for (j = i + 1; j < 17; j++) {
+        unsigned long v = (unsigned short) st->h[j] * st->r[i + 17 - j];
+        v = ((v << 8) + (v << 6)); /* v *= (5 << 6); */
+        u += v;
+      }
+      hr[i] = u;
+    }
+
+    /* (partial) h %= p */
+    poly1305_squeeze(st->h, hr);
+
+    m += poly1305_block_size;
+    bytes -= poly1305_block_size;
+  }
+}
+
+static POLY1305_NOINLINE void poly1305_finish(poly1305_context *ctx,
+                                              unsigned char mac[16]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  size_t i;
+
+  /* process the remaining block */
+  if (st->leftover) {
+    size_t i = st->leftover;
+    st->buffer[i++] = 1;
+    for (; i < poly1305_block_size; i++) st->buffer[i] = 0;
+    st->final = 1;
+    poly1305_blocks(st, st->buffer, poly1305_block_size);
+  }
+
+  /* fully reduce h */
+  poly1305_freeze(st->h);
+
+  /* h = (h + pad) % (1 << 128) */
+  poly1305_add(st->h, st->pad);
+  for (i = 0; i < 16; i++) mac[i] = st->h[i];
+
+  /* zero out the state */
+  for (i = 0; i < 17; i++) st->h[i] = 0;
+  for (i = 0; i < 17; i++) st->r[i] = 0;
+  for (i = 0; i < 17; i++) st->pad[i] = 0;
+}
+#elif defined(POLY1305_16BIT)
+/*
+        poly1305 implementation using 16 bit * 16 bit = 32 bit multiplication
+and 32 bit addition static */
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#define POLY1305_NOINLINE
+#elif defined(_MSC_VER)
+#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 18*sizeof(unsigned short) */
+typedef struct poly1305_state_internal_t {
+  unsigned char buffer[poly1305_block_size];
+  size_t leftover;
+  unsigned short r[10];
+  unsigned short h[10];
+  unsigned short pad[8];
+  unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret two 8 bit unsigned integers as a 16 bit unsigned integer in little
+ * endian */
+static unsigned short U8TO16(const unsigned char *p) {
+  return (((unsigned short) (p[0] & 0xff)) |
+          ((unsigned short) (p[1] & 0xff) << 8));
+}
+
+/* store a 16 bit unsigned integer as two 8 bit unsigned integers in little
+ * endian */
+static void U16TO8(unsigned char *p, unsigned short v) {
+  p[0] = (v) &0xff;
+  p[1] = (v >> 8) & 0xff;
+}
+
+static void poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  unsigned short t0, t1, t2, t3, t4, t5, t6, t7;
+  size_t i;
+
+  /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+  t0 = U8TO16(&key[0]);
+  st->r[0] = (t0) &0x1fff;
+  t1 = U8TO16(&key[2]);
+  st->r[1] = ((t0 >> 13) | (t1 << 3)) & 0x1fff;
+  t2 = U8TO16(&key[4]);
+  st->r[2] = ((t1 >> 10) | (t2 << 6)) & 0x1f03;
+  t3 = U8TO16(&key[6]);
+  st->r[3] = ((t2 >> 7) | (t3 << 9)) & 0x1fff;
+  t4 = U8TO16(&key[8]);
+  st->r[4] = ((t3 >> 4) | (t4 << 12)) & 0x00ff;
+  st->r[5] = ((t4 >> 1)) & 0x1ffe;
+  t5 = U8TO16(&key[10]);
+  st->r[6] = ((t4 >> 14) | (t5 << 2)) & 0x1fff;
+  t6 = U8TO16(&key[12]);
+  st->r[7] = ((t5 >> 11) | (t6 << 5)) & 0x1f81;
+  t7 = U8TO16(&key[14]);
+  st->r[8] = ((t6 >> 8) | (t7 << 8)) & 0x1fff;
+  st->r[9] = ((t7 >> 5)) & 0x007f;
+
+  /* h = 0 */
+  for (i = 0; i < 10; i++) st->h[i] = 0;
+
+  /* save pad for later */
+  for (i = 0; i < 8; i++) st->pad[i] = U8TO16(&key[16 + (2 * i)]);
+
+  st->leftover = 0;
+  st->final = 0;
+}
+
+static void poly1305_blocks(poly1305_state_internal_t *st,
+                            const unsigned char *m, size_t bytes) {
+  const unsigned short hibit = (st->final) ? 0 : (1 << 11); /* 1 << 128 */
+  unsigned short t0, t1, t2, t3, t4, t5, t6, t7;
+  unsigned long d[10];
+  unsigned long c;
+
+  while (bytes >= poly1305_block_size) {
+    size_t i, j;
+
+    /* h += m[i] */
+    t0 = U8TO16(&m[0]);
+    st->h[0] += (t0) &0x1fff;
+    t1 = U8TO16(&m[2]);
+    st->h[1] += ((t0 >> 13) | (t1 << 3)) & 0x1fff;
+    t2 = U8TO16(&m[4]);
+    st->h[2] += ((t1 >> 10) | (t2 << 6)) & 0x1fff;
+    t3 = U8TO16(&m[6]);
+    st->h[3] += ((t2 >> 7) | (t3 << 9)) & 0x1fff;
+    t4 = U8TO16(&m[8]);
+    st->h[4] += ((t3 >> 4) | (t4 << 12)) & 0x1fff;
+    st->h[5] += ((t4 >> 1)) & 0x1fff;
+    t5 = U8TO16(&m[10]);
+    st->h[6] += ((t4 >> 14) | (t5 << 2)) & 0x1fff;
+    t6 = U8TO16(&m[12]);
+    st->h[7] += ((t5 >> 11) | (t6 << 5)) & 0x1fff;
+    t7 = U8TO16(&m[14]);
+    st->h[8] += ((t6 >> 8) | (t7 << 8)) & 0x1fff;
+    st->h[9] += ((t7 >> 5)) | hibit;
+
+    /* h *= r, (partial) h %= p */
+    for (i = 0, c = 0; i < 10; i++) {
+      d[i] = c;
+      for (j = 0; j < 10; j++) {
+        d[i] += (unsigned long) st->h[j] *
+                ((j <= i) ? st->r[i - j] : (5 * st->r[i + 10 - j]));
+        /* Sum(h[i] * r[i] * 5) will overflow slightly above 6 products with an
+         * unclamped r, so carry at 5 */
+        if (j == 4) {
+          c = (d[i] >> 13);
+          d[i] &= 0x1fff;
+        }
+      }
+      c += (d[i] >> 13);
+      d[i] &= 0x1fff;
+    }
+    c = ((c << 2) + c); /* c *= 5 */
+    c += d[0];
+    d[0] = ((unsigned short) c & 0x1fff);
+    c = (c >> 13);
+    d[1] += c;
+
+    for (i = 0; i < 10; i++) st->h[i] = (unsigned short) d[i];
+
+    m += poly1305_block_size;
+    bytes -= poly1305_block_size;
+  }
+}
+
+static POLY1305_NOINLINE void poly1305_finish(poly1305_context *ctx,
+                                              unsigned char mac[16]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  unsigned short c;
+  unsigned short g[10];
+  unsigned short mask;
+  unsigned long f;
+  size_t i;
+
+  /* process the remaining block */
+  if (st->leftover) {
+    size_t i = st->leftover;
+    st->buffer[i++] = 1;
+    for (; i < poly1305_block_size; i++) st->buffer[i] = 0;
+    st->final = 1;
+    poly1305_blocks(st, st->buffer, poly1305_block_size);
+  }
+
+  /* fully carry h */
+  c = st->h[1] >> 13;
+  st->h[1] &= 0x1fff;
+  for (i = 2; i < 10; i++) {
+    st->h[i] += c;
+    c = st->h[i] >> 13;
+    st->h[i] &= 0x1fff;
+  }
+  st->h[0] += (c * 5);
+  c = st->h[0] >> 13;
+  st->h[0] &= 0x1fff;
+  st->h[1] += c;
+  c = st->h[1] >> 13;
+  st->h[1] &= 0x1fff;
+  st->h[2] += c;
+
+  /* compute h + -p */
+  g[0] = st->h[0] + 5;
+  c = g[0] >> 13;
+  g[0] &= 0x1fff;
+  for (i = 1; i < 10; i++) {
+    g[i] = st->h[i] + c;
+    c = g[i] >> 13;
+    g[i] &= 0x1fff;
+  }
+
+  /* select h if h < p, or h + -p if h >= p */
+  mask = (c ^ 1) - 1;
+  for (i = 0; i < 10; i++) g[i] &= mask;
+  mask = ~mask;
+  for (i = 0; i < 10; i++) st->h[i] = (st->h[i] & mask) | g[i];
+
+  /* h = h % (2^128) */
+  st->h[0] = ((st->h[0]) | (st->h[1] << 13)) & 0xffff;
+  st->h[1] = ((st->h[1] >> 3) | (st->h[2] << 10)) & 0xffff;
+  st->h[2] = ((st->h[2] >> 6) | (st->h[3] << 7)) & 0xffff;
+  st->h[3] = ((st->h[3] >> 9) | (st->h[4] << 4)) & 0xffff;
+  st->h[4] = ((st->h[4] >> 12) | (st->h[5] << 1) | (st->h[6] << 14)) & 0xffff;
+  st->h[5] = ((st->h[6] >> 2) | (st->h[7] << 11)) & 0xffff;
+  st->h[6] = ((st->h[7] >> 5) | (st->h[8] << 8)) & 0xffff;
+  st->h[7] = ((st->h[8] >> 8) | (st->h[9] << 5)) & 0xffff;
+
+  /* mac = (h + pad) % (2^128) */
+  f = (unsigned long) st->h[0] + st->pad[0];
+  st->h[0] = (unsigned short) f;
+  for (i = 1; i < 8; i++) {
+    f = (unsigned long) st->h[i] + st->pad[i] + (f >> 16);
+    st->h[i] = (unsigned short) f;
+  }
+
+  for (i = 0; i < 8; i++) U16TO8(mac + (i * 2), st->h[i]);
+
+  /* zero out the state */
+  for (i = 0; i < 10; i++) st->h[i] = 0;
+  for (i = 0; i < 10; i++) st->r[i] = 0;
+  for (i = 0; i < 8; i++) st->pad[i] = 0;
+}
+#elif defined(POLY1305_32BIT) || \
+    (!defined(POLY1305_64BIT) && defined(__GUESS32))
+/*
+        poly1305 implementation using 32 bit * 32 bit = 64 bit multiplication
+and 64 bit addition static */
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#define POLY1305_NOINLINE
+#elif defined(_MSC_VER)
+#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 14*sizeof(unsigned long) */
+typedef struct poly1305_state_internal_t {
+  unsigned long r[5];
+  unsigned long h[5];
+  unsigned long pad[4];
+  size_t leftover;
+  unsigned char buffer[poly1305_block_size];
+  unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret four 8 bit unsigned integers as a 32 bit unsigned integer in little
+ * endian */
+static unsigned long U8TO32(const unsigned char *p) {
+  return (((unsigned long) (p[0] & 0xff)) |
+          ((unsigned long) (p[1] & 0xff) << 8) |
+          ((unsigned long) (p[2] & 0xff) << 16) |
+          ((unsigned long) (p[3] & 0xff) << 24));
+}
+
+/* store a 32 bit unsigned integer as four 8 bit unsigned integers in little
+ * endian */
+static void U32TO8(unsigned char *p, unsigned long v) {
+  p[0] = (unsigned char) ((v) &0xff);
+  p[1] = (unsigned char) ((v >> 8) & 0xff);
+  p[2] = (unsigned char) ((v >> 16) & 0xff);
+  p[3] = (unsigned char) ((v >> 24) & 0xff);
+}
+
+static void poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+
+  /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+  st->r[0] = (U8TO32(&key[0])) & 0x3ffffff;
+  st->r[1] = (U8TO32(&key[3]) >> 2) & 0x3ffff03;
+  st->r[2] = (U8TO32(&key[6]) >> 4) & 0x3ffc0ff;
+  st->r[3] = (U8TO32(&key[9]) >> 6) & 0x3f03fff;
+  st->r[4] = (U8TO32(&key[12]) >> 8) & 0x00fffff;
+
+  /* h = 0 */
+  st->h[0] = 0;
+  st->h[1] = 0;
+  st->h[2] = 0;
+  st->h[3] = 0;
+  st->h[4] = 0;
+
+  /* save pad for later */
+  st->pad[0] = U8TO32(&key[16]);
+  st->pad[1] = U8TO32(&key[20]);
+  st->pad[2] = U8TO32(&key[24]);
+  st->pad[3] = U8TO32(&key[28]);
+
+  st->leftover = 0;
+  st->final = 0;
+}
+
+static void poly1305_blocks(poly1305_state_internal_t *st,
+                            const unsigned char *m, size_t bytes) {
+  const unsigned long hibit = (st->final) ? 0 : (1UL << 24); /* 1 << 128 */
+  unsigned long r0, r1, r2, r3, r4;
+  unsigned long s1, s2, s3, s4;
+  unsigned long h0, h1, h2, h3, h4;
+  uint64_t d0, d1, d2, d3, d4;
+  unsigned long c;
+
+  r0 = st->r[0];
+  r1 = st->r[1];
+  r2 = st->r[2];
+  r3 = st->r[3];
+  r4 = st->r[4];
+
+  s1 = r1 * 5;
+  s2 = r2 * 5;
+  s3 = r3 * 5;
+  s4 = r4 * 5;
+
+  h0 = st->h[0];
+  h1 = st->h[1];
+  h2 = st->h[2];
+  h3 = st->h[3];
+  h4 = st->h[4];
+
+  while (bytes >= poly1305_block_size) {
+    /* h += m[i] */
+    h0 += (U8TO32(m + 0)) & 0x3ffffff;
+    h1 += (U8TO32(m + 3) >> 2) & 0x3ffffff;
+    h2 += (U8TO32(m + 6) >> 4) & 0x3ffffff;
+    h3 += (U8TO32(m + 9) >> 6) & 0x3ffffff;
+    h4 += (U8TO32(m + 12) >> 8) | hibit;
+
+    /* h *= r */
+    d0 = ((uint64_t) h0 * r0) + ((uint64_t) h1 * s4) + ((uint64_t) h2 * s3) +
+         ((uint64_t) h3 * s2) + ((uint64_t) h4 * s1);
+    d1 = ((uint64_t) h0 * r1) + ((uint64_t) h1 * r0) + ((uint64_t) h2 * s4) +
+         ((uint64_t) h3 * s3) + ((uint64_t) h4 * s2);
+    d2 = ((uint64_t) h0 * r2) + ((uint64_t) h1 * r1) + ((uint64_t) h2 * r0) +
+         ((uint64_t) h3 * s4) + ((uint64_t) h4 * s3);
+    d3 = ((uint64_t) h0 * r3) + ((uint64_t) h1 * r2) + ((uint64_t) h2 * r1) +
+         ((uint64_t) h3 * r0) + ((uint64_t) h4 * s4);
+    d4 = ((uint64_t) h0 * r4) + ((uint64_t) h1 * r3) + ((uint64_t) h2 * r2) +
+         ((uint64_t) h3 * r1) + ((uint64_t) h4 * r0);
+
+    /* (partial) h %= p */
+    c = (unsigned long) (d0 >> 26);
+    h0 = (unsigned long) d0 & 0x3ffffff;
+    d1 += c;
+    c = (unsigned long) (d1 >> 26);
+    h1 = (unsigned long) d1 & 0x3ffffff;
+    d2 += c;
+    c = (unsigned long) (d2 >> 26);
+    h2 = (unsigned long) d2 & 0x3ffffff;
+    d3 += c;
+    c = (unsigned long) (d3 >> 26);
+    h3 = (unsigned long) d3 & 0x3ffffff;
+    d4 += c;
+    c = (unsigned long) (d4 >> 26);
+    h4 = (unsigned long) d4 & 0x3ffffff;
+    h0 += c * 5;
+    c = (h0 >> 26);
+    h0 = h0 & 0x3ffffff;
+    h1 += c;
+
+    m += poly1305_block_size;
+    bytes -= poly1305_block_size;
+  }
+
+  st->h[0] = h0;
+  st->h[1] = h1;
+  st->h[2] = h2;
+  st->h[3] = h3;
+  st->h[4] = h4;
+}
+
+static POLY1305_NOINLINE void poly1305_finish(poly1305_context *ctx,
+                                              unsigned char mac[16]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  unsigned long h0, h1, h2, h3, h4, c;
+  unsigned long g0, g1, g2, g3, g4;
+  uint64_t f;
+  unsigned long mask;
+
+  /* process the remaining block */
+  if (st->leftover) {
+    size_t i = st->leftover;
+    st->buffer[i++] = 1;
+    for (; i < poly1305_block_size; i++) st->buffer[i] = 0;
+    st->final = 1;
+    poly1305_blocks(st, st->buffer, poly1305_block_size);
+  }
+
+  /* fully carry h */
+  h0 = st->h[0];
+  h1 = st->h[1];
+  h2 = st->h[2];
+  h3 = st->h[3];
+  h4 = st->h[4];
+
+  c = h1 >> 26;
+  h1 = h1 & 0x3ffffff;
+  h2 += c;
+  c = h2 >> 26;
+  h2 = h2 & 0x3ffffff;
+  h3 += c;
+  c = h3 >> 26;
+  h3 = h3 & 0x3ffffff;
+  h4 += c;
+  c = h4 >> 26;
+  h4 = h4 & 0x3ffffff;
+  h0 += c * 5;
+  c = h0 >> 26;
+  h0 = h0 & 0x3ffffff;
+  h1 += c;
+
+  /* compute h + -p */
+  g0 = h0 + 5;
+  c = g0 >> 26;
+  g0 &= 0x3ffffff;
+  g1 = h1 + c;
+  c = g1 >> 26;
+  g1 &= 0x3ffffff;
+  g2 = h2 + c;
+  c = g2 >> 26;
+  g2 &= 0x3ffffff;
+  g3 = h3 + c;
+  c = g3 >> 26;
+  g3 &= 0x3ffffff;
+  g4 = h4 + c - (1UL << 26);
+
+  /* select h if h < p, or h + -p if h >= p */
+  mask = (g4 >> ((sizeof(unsigned long) * 8) - 1)) - 1;
+  g0 &= mask;
+  g1 &= mask;
+  g2 &= mask;
+  g3 &= mask;
+  g4 &= mask;
+  mask = ~mask;
+  h0 = (h0 & mask) | g0;
+  h1 = (h1 & mask) | g1;
+  h2 = (h2 & mask) | g2;
+  h3 = (h3 & mask) | g3;
+  h4 = (h4 & mask) | g4;
+
+  /* h = h % (2^128) */
+  h0 = ((h0) | (h1 << 26)) & 0xffffffff;
+  h1 = ((h1 >> 6) | (h2 << 20)) & 0xffffffff;
+  h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
+  h3 = ((h3 >> 18) | (h4 << 8)) & 0xffffffff;
+
+  /* mac = (h + pad) % (2^128) */
+  f = (uint64_t) h0 + st->pad[0];
+  h0 = (unsigned long) f;
+  f = (uint64_t) h1 + st->pad[1] + (f >> 32);
+  h1 = (unsigned long) f;
+  f = (uint64_t) h2 + st->pad[2] + (f >> 32);
+  h2 = (unsigned long) f;
+  f = (uint64_t) h3 + st->pad[3] + (f >> 32);
+  h3 = (unsigned long) f;
+
+  U32TO8(mac + 0, h0);
+  U32TO8(mac + 4, h1);
+  U32TO8(mac + 8, h2);
+  U32TO8(mac + 12, h3);
+
+  /* zero out the state */
+  st->h[0] = 0;
+  st->h[1] = 0;
+  st->h[2] = 0;
+  st->h[3] = 0;
+  st->h[4] = 0;
+  st->r[0] = 0;
+  st->r[1] = 0;
+  st->r[2] = 0;
+  st->r[3] = 0;
+  st->r[4] = 0;
+  st->pad[0] = 0;
+  st->pad[1] = 0;
+  st->pad[2] = 0;
+  st->pad[3] = 0;
+}
+
+#else
+/*
+        poly1305 implementation using 64 bit * 64 bit = 128 bit multiplication
+and 128 bit addition static */
+
+#if defined(_MSC_VER)
+
+typedef struct uint128_t {
+  uint64_t lo;
+  uint64_t hi;
+} uint128_t;
+
+#define MUL128(out, x, y) out.lo = _umul128((x), (y), &out.hi)
+#define ADD(out, in)                \
+  {                                 \
+    uint64_t t = out.lo;            \
+    out.lo += in.lo;                \
+    out.hi += (out.lo < t) + in.hi; \
+  }
+#define ADDLO(out, in)      \
+  {                         \
+    uint64_t t = out.lo;    \
+    out.lo += in;           \
+    out.hi += (out.lo < t); \
+  }
+#define SHR(in, shift) (__shiftright128(in.lo, in.hi, (shift)))
+#define LO(in) (in.lo)
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#define POLY1305_NOINLINE
+#else
+#define POLY1305_NOINLINE __declspec(noinline)
+#endif
+#elif defined(__GNUC__)
+#if defined(__SIZEOF_INT128__)
+// Get rid of GCC warning "ISO C does not support '__int128' types"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+typedef unsigned __int128 uint128_t;
+#pragma GCC diagnostic pop
+#else
+typedef unsigned uint128_t __attribute__((mode(TI)));
+#endif
+
+#define MUL128(out, x, y) out = ((uint128_t) x * y)
+#define ADD(out, in) out += in
+#define ADDLO(out, in) out += in
+#define SHR(in, shift) (uint64_t)(in >> (shift))
+#define LO(in) (uint64_t)(in)
+
+#define POLY1305_NOINLINE __attribute__((noinline))
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 8*sizeof(uint64_t) */
+typedef struct poly1305_state_internal_t {
+  uint64_t r[3];
+  uint64_t h[3];
+  uint64_t pad[2];
+  size_t leftover;
+  unsigned char buffer[poly1305_block_size];
+  unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret eight 8 bit unsigned integers as a 64 bit unsigned integer in
+ * little endian */
+static uint64_t U8TO64(const unsigned char *p) {
+  return (((uint64_t) (p[0] & 0xff)) | ((uint64_t) (p[1] & 0xff) << 8) |
+          ((uint64_t) (p[2] & 0xff) << 16) | ((uint64_t) (p[3] & 0xff) << 24) |
+          ((uint64_t) (p[4] & 0xff) << 32) | ((uint64_t) (p[5] & 0xff) << 40) |
+          ((uint64_t) (p[6] & 0xff) << 48) | ((uint64_t) (p[7] & 0xff) << 56));
+}
+
+/* store a 64 bit unsigned integer as eight 8 bit unsigned integers in little
+ * endian */
+static void U64TO8(unsigned char *p, uint64_t v) {
+  p[0] = (unsigned char) ((v) &0xff);
+  p[1] = (unsigned char) ((v >> 8) & 0xff);
+  p[2] = (unsigned char) ((v >> 16) & 0xff);
+  p[3] = (unsigned char) ((v >> 24) & 0xff);
+  p[4] = (unsigned char) ((v >> 32) & 0xff);
+  p[5] = (unsigned char) ((v >> 40) & 0xff);
+  p[6] = (unsigned char) ((v >> 48) & 0xff);
+  p[7] = (unsigned char) ((v >> 56) & 0xff);
+}
+
+static void poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  uint64_t t0, t1;
+
+  /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+  t0 = U8TO64(&key[0]);
+  t1 = U8TO64(&key[8]);
+
+  st->r[0] = (t0) &0xffc0fffffff;
+  st->r[1] = ((t0 >> 44) | (t1 << 20)) & 0xfffffc0ffff;
+  st->r[2] = ((t1 >> 24)) & 0x00ffffffc0f;
+
+  /* h = 0 */
+  st->h[0] = 0;
+  st->h[1] = 0;
+  st->h[2] = 0;
+
+  /* save pad for later */
+  st->pad[0] = U8TO64(&key[16]);
+  st->pad[1] = U8TO64(&key[24]);
+
+  st->leftover = 0;
+  st->final = 0;
+}
+
+static void poly1305_blocks(poly1305_state_internal_t *st,
+                            const unsigned char *m, size_t bytes) {
+  const uint64_t hibit = (st->final) ? 0 : ((uint64_t) 1 << 40); /* 1 << 128 */
+  uint64_t r0, r1, r2;
+  uint64_t s1, s2;
+  uint64_t h0, h1, h2;
+  uint64_t c;
+  uint128_t d0, d1, d2, d;
+
+  r0 = st->r[0];
+  r1 = st->r[1];
+  r2 = st->r[2];
+
+  h0 = st->h[0];
+  h1 = st->h[1];
+  h2 = st->h[2];
+
+  s1 = r1 * (5 << 2);
+  s2 = r2 * (5 << 2);
+
+  while (bytes >= poly1305_block_size) {
+    uint64_t t0, t1;
+
+    /* h += m[i] */
+    t0 = U8TO64(&m[0]);
+    t1 = U8TO64(&m[8]);
+
+    h0 += ((t0) &0xfffffffffff);
+    h1 += (((t0 >> 44) | (t1 << 20)) & 0xfffffffffff);
+    h2 += (((t1 >> 24)) & 0x3ffffffffff) | hibit;
+
+    /* h *= r */
+    MUL128(d0, h0, r0);
+    MUL128(d, h1, s2);
+    ADD(d0, d);
+    MUL128(d, h2, s1);
+    ADD(d0, d);
+    MUL128(d1, h0, r1);
+    MUL128(d, h1, r0);
+    ADD(d1, d);
+    MUL128(d, h2, s2);
+    ADD(d1, d);
+    MUL128(d2, h0, r2);
+    MUL128(d, h1, r1);
+    ADD(d2, d);
+    MUL128(d, h2, r0);
+    ADD(d2, d);
+
+    /* (partial) h %= p */
+    c = SHR(d0, 44);
+    h0 = LO(d0) & 0xfffffffffff;
+    ADDLO(d1, c);
+    c = SHR(d1, 44);
+    h1 = LO(d1) & 0xfffffffffff;
+    ADDLO(d2, c);
+    c = SHR(d2, 42);
+    h2 = LO(d2) & 0x3ffffffffff;
+    h0 += c * 5;
+    c = (h0 >> 44);
+    h0 = h0 & 0xfffffffffff;
+    h1 += c;
+
+    m += poly1305_block_size;
+    bytes -= poly1305_block_size;
+  }
+
+  st->h[0] = h0;
+  st->h[1] = h1;
+  st->h[2] = h2;
+}
+
+static POLY1305_NOINLINE void poly1305_finish(poly1305_context *ctx,
+                                              unsigned char mac[16]) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  uint64_t h0, h1, h2, c;
+  uint64_t g0, g1, g2;
+  uint64_t t0, t1;
+
+  /* process the remaining block */
+  if (st->leftover) {
+    size_t i = st->leftover;
+    st->buffer[i] = 1;
+    for (i = i + 1; i < poly1305_block_size; i++) st->buffer[i] = 0;
+    st->final = 1;
+    poly1305_blocks(st, st->buffer, poly1305_block_size);
+  }
+
+  /* fully carry h */
+  h0 = st->h[0];
+  h1 = st->h[1];
+  h2 = st->h[2];
+
+  c = (h1 >> 44);
+  h1 &= 0xfffffffffff;
+  h2 += c;
+  c = (h2 >> 42);
+  h2 &= 0x3ffffffffff;
+  h0 += c * 5;
+  c = (h0 >> 44);
+  h0 &= 0xfffffffffff;
+  h1 += c;
+  c = (h1 >> 44);
+  h1 &= 0xfffffffffff;
+  h2 += c;
+  c = (h2 >> 42);
+  h2 &= 0x3ffffffffff;
+  h0 += c * 5;
+  c = (h0 >> 44);
+  h0 &= 0xfffffffffff;
+  h1 += c;
+
+  /* compute h + -p */
+  g0 = h0 + 5;
+  c = (g0 >> 44);
+  g0 &= 0xfffffffffff;
+  g1 = h1 + c;
+  c = (g1 >> 44);
+  g1 &= 0xfffffffffff;
+  g2 = h2 + c - ((uint64_t) 1 << 42);
+
+  /* select h if h < p, or h + -p if h >= p */
+  c = (g2 >> ((sizeof(uint64_t) * 8) - 1)) - 1;
+  g0 &= c;
+  g1 &= c;
+  g2 &= c;
+  c = ~c;
+  h0 = (h0 & c) | g0;
+  h1 = (h1 & c) | g1;
+  h2 = (h2 & c) | g2;
+
+  /* h = (h + pad) */
+  t0 = st->pad[0];
+  t1 = st->pad[1];
+
+  h0 += ((t0) &0xfffffffffff);
+  c = (h0 >> 44);
+  h0 &= 0xfffffffffff;
+  h1 += (((t0 >> 44) | (t1 << 20)) & 0xfffffffffff) + c;
+  c = (h1 >> 44);
+  h1 &= 0xfffffffffff;
+  h2 += (((t1 >> 24)) & 0x3ffffffffff) + c;
+  h2 &= 0x3ffffffffff;
+
+  /* mac = h % (2^128) */
+  h0 = ((h0) | (h1 << 44));
+  h1 = ((h1 >> 20) | (h2 << 24));
+
+  U64TO8(&mac[0], h0);
+  U64TO8(&mac[8], h1);
+
+  /* zero out the state */
+  st->h[0] = 0;
+  st->h[1] = 0;
+  st->h[2] = 0;
+  st->r[0] = 0;
+  st->r[1] = 0;
+  st->r[2] = 0;
+  st->pad[0] = 0;
+  st->pad[1] = 0;
+}
+
+#endif
+
+static void poly1305_update(poly1305_context *ctx, const unsigned char *m,
+                            size_t bytes) {
+  poly1305_state_internal_t *st = (poly1305_state_internal_t *) ctx;
+  size_t i;
+
+  /* handle leftover */
+  if (st->leftover) {
+    size_t want = (poly1305_block_size - st->leftover);
+    if (want > bytes) want = bytes;
+    for (i = 0; i < want; i++) st->buffer[st->leftover + i] = m[i];
+    bytes -= want;
+    m += want;
+    st->leftover += want;
+    if (st->leftover < poly1305_block_size) return;
+    poly1305_blocks(st, st->buffer, poly1305_block_size);
+    st->leftover = 0;
+  }
+
+  /* process full blocks */
+  if (bytes >= poly1305_block_size) {
+    size_t want = (bytes & (size_t) ~(poly1305_block_size - 1));
+    poly1305_blocks(st, m, want);
+    m += want;
+    bytes -= want;
+  }
+
+  /* store leftover */
+  if (bytes) {
+    for (i = 0; i < bytes; i++) st->buffer[st->leftover + i] = m[i];
+    st->leftover += bytes;
+  }
+}
+
+// ******* END: poly1305-donna.c ********
+// ******* BEGIN: portable8439.c ********
+
+#define __CHACHA20_BLOCK_SIZE (64)
+#define __POLY1305_KEY_SIZE (32)
+
+static PORTABLE_8439_DECL uint8_t __ZEROES[16] = {0};
+static PORTABLE_8439_DECL void pad_if_needed(poly1305_context *ctx,
+                                             size_t size) {
+  size_t padding = size % 16;
+  if (padding != 0) {
+    poly1305_update(ctx, __ZEROES, 16 - padding);
+  }
+}
+
+#define __u8(v) ((uint8_t) ((v) &0xFF))
+
+// TODO: make this depending on the unaligned/native read size possible
+static PORTABLE_8439_DECL void write_64bit_int(poly1305_context *ctx,
+                                               uint64_t value) {
+  uint8_t result[8];
+  result[0] = __u8(value);
+  result[1] = __u8(value >> 8);
+  result[2] = __u8(value >> 16);
+  result[3] = __u8(value >> 24);
+  result[4] = __u8(value >> 32);
+  result[5] = __u8(value >> 40);
+  result[6] = __u8(value >> 48);
+  result[7] = __u8(value >> 56);
+  poly1305_update(ctx, result, 8);
+}
+
+static PORTABLE_8439_DECL void poly1305_calculate_mac(
+    uint8_t *mac, const uint8_t *cipher_text, size_t cipher_text_size,
+    const uint8_t key[RFC_8439_KEY_SIZE],
+    const uint8_t nonce[RFC_8439_NONCE_SIZE], const uint8_t *ad,
+    size_t ad_size) {
+  // init poly key (section 2.6)
+  uint8_t poly_key[__POLY1305_KEY_SIZE] = {0};
+  poly1305_context poly_ctx;
+  rfc8439_keygen(poly_key, key, nonce);
+  // start poly1305 mac
+  poly1305_init(&poly_ctx, poly_key);
+
+  if (ad != NULL && ad_size > 0) {
+    // write AD if present
+    poly1305_update(&poly_ctx, ad, ad_size);
+    pad_if_needed(&poly_ctx, ad_size);
+  }
+
+  // now write the cipher text
+  poly1305_update(&poly_ctx, cipher_text, cipher_text_size);
+  pad_if_needed(&poly_ctx, cipher_text_size);
+
+  // write sizes
+  write_64bit_int(&poly_ctx, ad_size);
+  write_64bit_int(&poly_ctx, cipher_text_size);
+
+  // calculate MAC
+  poly1305_finish(&poly_ctx, mac);
+}
+
+#define MG_PM(p) ((size_t) (p))
+
+// pointers overlap if the smaller either ahead of the end,
+// or its end is before the start of the other
+//
+// s_size should be smaller or equal to b_size
+#define MG_OVERLAPPING(s, s_size, b, b_size) \
+  (MG_PM(s) < MG_PM((b) + (b_size))) && (MG_PM(b) < MG_PM((s) + (s_size)))
+
+PORTABLE_8439_DECL size_t mg_chacha20_poly1305_encrypt(
+    uint8_t *restrict cipher_text, const uint8_t key[RFC_8439_KEY_SIZE],
+    const uint8_t nonce[RFC_8439_NONCE_SIZE], const uint8_t *restrict ad,
+    size_t ad_size, const uint8_t *restrict plain_text,
+    size_t plain_text_size) {
+  size_t new_size = plain_text_size + RFC_8439_TAG_SIZE;
+  if (MG_OVERLAPPING(plain_text, plain_text_size, cipher_text, new_size)) {
+    return (size_t) -1;
+  }
+  chacha20_xor_stream(cipher_text, plain_text, plain_text_size, key, nonce, 1);
+  poly1305_calculate_mac(cipher_text + plain_text_size, cipher_text,
+                         plain_text_size, key, nonce, ad, ad_size);
+  return new_size;
+}
+
+PORTABLE_8439_DECL size_t mg_chacha20_poly1305_decrypt(
+    uint8_t *restrict plain_text, const uint8_t key[RFC_8439_KEY_SIZE],
+    const uint8_t nonce[RFC_8439_NONCE_SIZE],
+    const uint8_t *restrict cipher_text, size_t cipher_text_size) {
+  // first we calculate the mac and see if it lines up, only then do we decrypt
+  size_t actual_size = cipher_text_size - RFC_8439_TAG_SIZE;
+  if (MG_OVERLAPPING(plain_text, actual_size, cipher_text, cipher_text_size)) {
+    return (size_t) -1;
+  }
+
+  chacha20_xor_stream(plain_text, cipher_text, actual_size, key, nonce, 1);
+  return actual_size;
+}
+// ******* END:   portable8439.c ********
+#endif  // MG_TLS == MG_TLS_BUILTIN
+
+#ifdef MG_ENABLE_LINES
 #line 1 "src/tls_dummy.c"
 #endif
 
 
-#if !MG_ENABLE_MBEDTLS && !MG_ENABLE_OPENSSL && !MG_ENABLE_CUSTOM_TLS
+#if MG_TLS == MG_TLS_NONE
 void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   (void) opts;
   mg_error(c, "TLS is not enabled");
@@ -5424,6 +13240,12 @@ size_t mg_tls_pending(struct mg_connection *c) {
   (void) c;
   return 0;
 }
+void mg_tls_ctx_init(struct mg_mgr *mgr) {
+  (void) mgr;
+}
+void mg_tls_ctx_free(struct mg_mgr *mgr) {
+  (void) mgr;
+}
 #endif
 
 #ifdef MG_ENABLE_LINES
@@ -5432,24 +13254,54 @@ size_t mg_tls_pending(struct mg_connection *c) {
 
 
 
-
-#if MG_ENABLE_MBEDTLS
+#if MG_TLS == MG_TLS_MBED
 
 #if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000
-#define MGRNG , rng_get, NULL
+#define MG_MBEDTLS_RNG_GET , mg_mbed_rng, NULL
 #else
-#define MGRNG
+#define MG_MBEDTLS_RNG_GET
 #endif
+
+static int mg_mbed_rng(void *ctx, unsigned char *buf, size_t len) {
+  mg_random(buf, len);
+  (void) ctx;
+  return 0;
+}
+
+static bool mg_load_cert(struct mg_str str, mbedtls_x509_crt *p) {
+  int rc;
+  if (str.buf == NULL || str.buf[0] == '\0' || str.buf[0] == '*') return true;
+  if (str.buf[0] == '-') str.len++;  // PEM, include trailing NUL
+  if ((rc = mbedtls_x509_crt_parse(p, (uint8_t *) str.buf, str.len)) != 0) {
+    MG_ERROR(("cert err %#x", -rc));
+    return false;
+  }
+  return true;
+}
+
+static bool mg_load_key(struct mg_str str, mbedtls_pk_context *p) {
+  int rc;
+  if (str.buf == NULL || str.buf[0] == '\0' || str.buf[0] == '*') return true;
+  if (str.buf[0] == '-') str.len++;  // PEM, include trailing NUL
+  if ((rc = mbedtls_pk_parse_key(p, (uint8_t *) str.buf, str.len, NULL,
+                                 0 MG_MBEDTLS_RNG_GET)) != 0) {
+    MG_ERROR(("key err %#x", -rc));
+    return false;
+  }
+  return true;
+}
 
 void mg_tls_free(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   if (tls != NULL) {
-    free(tls->cafile);
     mbedtls_ssl_free(&tls->ssl);
     mbedtls_pk_free(&tls->pk);
     mbedtls_x509_crt_free(&tls->ca);
     mbedtls_x509_crt_free(&tls->cert);
     mbedtls_ssl_config_free(&tls->conf);
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+    mbedtls_ssl_ticket_free(&tls->ticket);
+#endif
     free(tls);
     c->tls = NULL;
   }
@@ -5489,35 +13341,13 @@ void mg_tls_handshake(struct mg_connection *c) {
   }
 }
 
-static int mbed_rng(void *ctx, unsigned char *buf, size_t len) {
-  mg_random(buf, len);
-  (void) ctx;
-  return 0;
-}
-
 static void debug_cb(void *c, int lev, const char *s, int n, const char *s2) {
   n = (int) strlen(s2) - 1;
   MG_INFO(("%lu %d %.*s", ((struct mg_connection *) c)->id, lev, n, s2));
   (void) s;
 }
 
-#if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000
-static int rng_get(void *p_rng, unsigned char *buf, size_t len) {
-  (void) p_rng;
-  mg_random(buf, len);
-  return 0;
-}
-#endif
-
-static struct mg_str mg_loadfile(struct mg_fs *fs, const char *path) {
-  size_t n = 0;
-  if (path[0] == '-') return mg_str(path);
-  char *p = mg_file_read(fs, path, &n);
-  return mg_str_n(p, n);
-}
-
 void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
-  struct mg_fs *fs = opts->fs == NULL ? &mg_fs_posix : opts->fs;
   struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(*tls));
   int rc = 0;
   c->tls = tls;
@@ -5525,7 +13355,13 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
     mg_error(c, "TLS OOM");
     goto fail;
   }
+  if (c->is_listening) goto fail;
   MG_DEBUG(("%lu Setting TLS", c->id));
+  MG_PROF_ADD(c, "mbedtls_init_start");
+#if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000 && \
+    defined(MBEDTLS_PSA_CRYPTO_C)
+  psa_crypto_init();  // https://github.com/Mbed-TLS/mbedtls/issues/9072#issuecomment-2084845711
+#endif
   mbedtls_ssl_init(&tls->ssl);
   mbedtls_ssl_config_init(&tls->conf);
   mbedtls_x509_crt_init(&tls->ca);
@@ -5542,68 +13378,45 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
     mg_error(c, "tls defaults %#x", -rc);
     goto fail;
   }
-  mbedtls_ssl_conf_rng(&tls->conf, mbed_rng, c);
-  if (opts->ca == NULL || strcmp(opts->ca, "*") == 0) {
+  mbedtls_ssl_conf_rng(&tls->conf, mg_mbed_rng, c);
+
+  if (opts->ca.len == 0 || mg_strcmp(opts->ca, mg_str("*")) == 0) {
+    // NOTE: MBEDTLS_SSL_VERIFY_NONE is not supported for TLS1.3 on client side
+    // See https://github.com/Mbed-TLS/mbedtls/issues/7075
     mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_NONE);
-  } else if (opts->ca != NULL && opts->ca[0] != '\0') {
-#if defined(MBEDTLS_X509_CA_CHAIN_ON_DISK)
-    tls->cafile = strdup(opts->ca);
-    rc = mbedtls_ssl_conf_ca_chain_file(&tls->conf, tls->cafile, NULL);
-    if (rc != 0) {
-      mg_error(c, "parse on-disk chain(%s) err %#x", tls->cafile, -rc);
-      goto fail;
-    }
-#else
-    struct mg_str s = mg_loadfile(fs, opts->ca);
-    rc = mbedtls_x509_crt_parse(&tls->ca, (uint8_t *) s.ptr, s.len + 1);
-    if (opts->ca[0] != '-') free((char *) s.ptr);
-    if (rc != 0) {
-      mg_error(c, "parse(%s) err %#x", opts->ca, -rc);
-      goto fail;
-    }
+  } else {
+    if (mg_load_cert(opts->ca, &tls->ca) == false) goto fail;
     mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->ca, NULL);
-#endif
-    if (opts->srvname.len > 0) {
-      char *x = mg_mprintf("%.*s", (int) opts->srvname.len, opts->srvname.ptr);
-      mbedtls_ssl_set_hostname(&tls->ssl, x);
-      free(x);
+    if (c->is_client && opts->name.buf != NULL && opts->name.buf[0] != '\0') {
+      char *host = mg_mprintf("%.*s", opts->name.len, opts->name.buf);
+      mbedtls_ssl_set_hostname(&tls->ssl, host);
+      MG_DEBUG(("%lu hostname verification: %s", c->id, host));
+      free(host);
     }
     mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
   }
-  if (opts->cert != NULL && opts->cert[0] != '\0') {
-    struct mg_str s = mg_loadfile(fs, opts->cert);
-    const char *key = opts->certkey == NULL ? opts->cert : opts->certkey;
-    rc = mbedtls_x509_crt_parse(&tls->cert, (uint8_t *) s.ptr, s.len + 1);
-    if (opts->cert[0] != '-') free((char *) s.ptr);
-    if (rc != 0) {
-      mg_error(c, "parse(%s) err %#x", opts->cert, -rc);
-      goto fail;
-    }
-    s = mg_loadfile(fs, key);
-    rc = mbedtls_pk_parse_key(&tls->pk, (uint8_t *) s.ptr, s.len + 1, NULL,
-                              0 MGRNG);
-    if (key[0] != '-') free((char *) s.ptr);
-    if (rc != 0) {
-      mg_error(c, "tls key(%s) %#x", key, -rc);
-      goto fail;
-    }
-    rc = mbedtls_ssl_conf_own_cert(&tls->conf, &tls->cert, &tls->pk);
-    if (rc != 0) {
-      mg_error(c, "own cert %#x", -rc);
-      goto fail;
-    }
+  if (!mg_load_cert(opts->cert, &tls->cert)) goto fail;
+  if (!mg_load_key(opts->key, &tls->pk)) goto fail;
+  if (tls->cert.version &&
+      (rc = mbedtls_ssl_conf_own_cert(&tls->conf, &tls->cert, &tls->pk)) != 0) {
+    mg_error(c, "own cert %#x", -rc);
+    goto fail;
   }
+
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+  mbedtls_ssl_conf_session_tickets_cb(
+      &tls->conf, mbedtls_ssl_ticket_write, mbedtls_ssl_ticket_parse,
+      &((struct mg_tls_ctx *) c->mgr->tls_ctx)->tickets);
+#endif
+
   if ((rc = mbedtls_ssl_setup(&tls->ssl, &tls->conf)) != 0) {
     mg_error(c, "setup err %#x", -rc);
     goto fail;
   }
-  c->tls = tls;
   c->is_tls = 1;
   c->is_tls_hs = 1;
   mbedtls_ssl_set_bio(&tls->ssl, c, mg_net_send, mg_net_recv, 0);
-  if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
-    mg_tls_handshake(c);
-  }
+  MG_PROF_ADD(c, "mbedtls_init_end");
   return;
 fail:
   mg_tls_free(c);
@@ -5619,6 +13432,11 @@ long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   long n = mbedtls_ssl_read(&tls->ssl, (unsigned char *) buf, len);
   if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE)
     return MG_IO_WAIT;
+#if defined(MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+  if (n == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+    return MG_IO_WAIT;
+  }
+#endif
   if (n <= 0) return MG_IO_ERR;
   return n;
 }
@@ -5631,6 +13449,35 @@ long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
   if (n <= 0) return MG_IO_ERR;
   return n;
 }
+
+void mg_tls_ctx_init(struct mg_mgr *mgr) {
+  struct mg_tls_ctx *ctx = (struct mg_tls_ctx *) calloc(1, sizeof(*ctx));
+  if (ctx == NULL) {
+    MG_ERROR(("TLS context init OOM"));
+  } else {
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+    int rc;
+    mbedtls_ssl_ticket_init(&ctx->tickets);
+    if ((rc = mbedtls_ssl_ticket_setup(&ctx->tickets, mg_mbed_rng, NULL,
+                                       MBEDTLS_CIPHER_AES_128_GCM, 86400)) !=
+        0) {
+      MG_ERROR((" mbedtls_ssl_ticket_setup %#x", -rc));
+    }
+#endif
+    mgr->tls_ctx = ctx;
+  }
+}
+
+void mg_tls_ctx_free(struct mg_mgr *mgr) {
+  struct mg_tls_ctx *ctx = (struct mg_tls_ctx *) mgr->tls_ctx;
+  if (ctx != NULL) {
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+    mbedtls_ssl_ticket_free(&ctx->tickets);
+#endif
+    free(ctx);
+    mgr->tls_ctx = NULL;
+  }
+}
 #endif
 
 #ifdef MG_ENABLE_LINES
@@ -5639,8 +13486,15 @@ long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
 
 
 
-#if MG_ENABLE_OPENSSL
-static int mg_tls_err(struct mg_tls *tls, int res) {
+#if MG_TLS == MG_TLS_OPENSSL || MG_TLS == MG_TLS_WOLFSSL
+
+static int tls_err_cb(const char *s, size_t len, void *c) {
+  int n = (int) len - 1;
+  MG_ERROR(("%lu %.*s", ((struct mg_connection *) c)->id, n, s));
+  return 0;  // undocumented
+}
+
+static int mg_tls_err(struct mg_connection *c, struct mg_tls *tls, int res) {
   int err = SSL_get_error(tls->ssl, res);
   // We've just fetched the last error from the queue.
   // Now we need to clear the error queue. If we do not, then the following
@@ -5651,19 +13505,110 @@ static int mg_tls_err(struct mg_tls *tls, int res) {
   //    Thus a single errored connection can close all the rest, unrelated ones.
   // Clearing the error keeps the shared SSL_CTX in an OK state.
 
-  if (err != 0) ERR_print_errors_fp(stderr);
+  if (err != 0) ERR_print_errors_cb(tls_err_cb, c);
   ERR_clear_error();
   if (err == SSL_ERROR_WANT_READ) return 0;
   if (err == SSL_ERROR_WANT_WRITE) return 0;
   return err;
 }
 
+static STACK_OF(X509_INFO) * load_ca_certs(struct mg_str ca) {
+  BIO *bio = BIO_new_mem_buf(ca.buf, (int) ca.len);
+  STACK_OF(X509_INFO) *certs =
+      bio ? PEM_X509_INFO_read_bio(bio, NULL, NULL, NULL) : NULL;
+  if (bio) BIO_free(bio);
+  return certs;
+}
+
+static bool add_ca_certs(SSL_CTX *ctx, STACK_OF(X509_INFO) * certs) {
+  int i;
+  X509_STORE *cert_store = SSL_CTX_get_cert_store(ctx);
+  for (i = 0; i < sk_X509_INFO_num(certs); i++) {
+    X509_INFO *cert_info = sk_X509_INFO_value(certs, i);
+    if (cert_info->x509 && !X509_STORE_add_cert(cert_store, cert_info->x509))
+      return false;
+  }
+  return true;
+}
+
+static EVP_PKEY *load_key(struct mg_str s) {
+  BIO *bio = BIO_new_mem_buf(s.buf, (int) (long) s.len);
+  EVP_PKEY *key = bio ? PEM_read_bio_PrivateKey(bio, NULL, 0, NULL) : NULL;
+  if (bio) BIO_free(bio);
+  return key;
+}
+
+static X509 *load_cert(struct mg_str s) {
+  BIO *bio = BIO_new_mem_buf(s.buf, (int) (long) s.len);
+  X509 *cert = bio == NULL ? NULL
+               : s.buf[0] == '-'
+                   ? PEM_read_bio_X509(bio, NULL, NULL, NULL)  // PEM
+                   : d2i_X509_bio(bio, NULL);                  // DER
+  if (bio) BIO_free(bio);
+  return cert;
+}
+
+static long mg_bio_ctrl(BIO *b, int cmd, long larg, void *pargs) {
+  long ret = 0;
+  if (cmd == BIO_CTRL_PUSH) ret = 1;
+  if (cmd == BIO_CTRL_POP) ret = 1;
+  if (cmd == BIO_CTRL_FLUSH) ret = 1;
+#if MG_TLS == MG_TLS_OPENSSL
+  if (cmd == BIO_C_SET_NBIO) ret = 1;
+#endif
+  // MG_DEBUG(("%d -> %ld", cmd, ret));
+  (void) b, (void) cmd, (void) larg, (void) pargs;
+  return ret;
+}
+
+static int mg_bio_read(BIO *bio, char *buf, int len) {
+  struct mg_connection *c = (struct mg_connection *) BIO_get_data(bio);
+  long res = mg_io_recv(c, buf, (size_t) len);
+  // MG_DEBUG(("%p %d %ld", buf, len, res));
+  len = res > 0 ? (int) res : -1;
+  if (res == MG_IO_WAIT) BIO_set_retry_read(bio);
+  return len;
+}
+
+static int mg_bio_write(BIO *bio, const char *buf, int len) {
+  struct mg_connection *c = (struct mg_connection *) BIO_get_data(bio);
+  long res = mg_io_send(c, buf, (size_t) len);
+  // MG_DEBUG(("%p %d %ld", buf, len, res));
+  len = res > 0 ? (int) res : -1;
+  if (res == MG_IO_WAIT) BIO_set_retry_write(bio);
+  return len;
+}
+
+#ifdef MG_TLS_SSLKEYLOGFILE
+static void ssl_keylog_cb(const SSL *ssl, const char *line) {
+  char *keylogfile = getenv("SSLKEYLOGFILE");
+  if (keylogfile == NULL) {
+    return;
+  }
+  FILE *f = fopen(keylogfile, "a");
+  fprintf(f, "%s\n", line);
+  fflush(f);
+  fclose(f);
+}
+#endif
+
+void mg_tls_free(struct mg_connection *c) {
+  struct mg_tls *tls = (struct mg_tls *) c->tls;
+  if (tls == NULL) return;
+  SSL_free(tls->ssl);
+  SSL_CTX_free(tls->ctx);
+  BIO_meth_free(tls->bm);
+  free(tls);
+  c->tls = NULL;
+}
+
 void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(*tls));
   const char *id = "mongoose";
   static unsigned char s_initialised = 0;
+  BIO *bio = NULL;
   int rc;
-
+  c->tls = tls;
   if (tls == NULL) {
     mg_error(c, "TLS OOM");
     goto fail;
@@ -5673,12 +13618,16 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
     SSL_library_init();
     s_initialised++;
   }
-  MG_DEBUG(("%lu Setting TLS, CA: %s, cert: %s, key: %s", c->id,
-            opts->ca == NULL ? "null" : opts->ca,
-            opts->cert == NULL ? "null" : opts->cert,
-            opts->certkey == NULL ? "null" : opts->certkey));
-  tls->ctx = c->is_client ? SSL_CTX_new(SSLv23_client_method())
-                          : SSL_CTX_new(SSLv23_server_method());
+  MG_DEBUG(("%lu Setting TLS", c->id));
+  tls->ctx = c->is_client ? SSL_CTX_new(TLS_client_method())
+                          : SSL_CTX_new(TLS_server_method());
+  if (tls->ctx == NULL) {
+    mg_error(c, "SSL_CTX_new");
+    goto fail;
+  }
+#ifdef MG_TLS_SSLKEYLOGFILE
+  SSL_CTX_set_keylog_callback(tls->ctx, ssl_keylog_cb);
+#endif
   if ((tls->ssl = SSL_new(tls->ctx)) == NULL) {
     mg_error(c, "SSL_new");
     goto fail;
@@ -5697,80 +13646,91 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   SSL_set_options(tls->ssl, SSL_OP_CIPHER_SERVER_PREFERENCE);
 #endif
 
-  if (opts->ca != NULL && opts->ca[0] != '\0') {
+#if MG_TLS == MG_TLS_WOLFSSL && !defined(OPENSSL_COMPATIBLE_DEFAULTS)
+  if (opts->ca.len == 0 || mg_strcmp(opts->ca, mg_str("*")) == 0) {
+    // Older versions require that either the CA is loaded or SSL_VERIFY_NONE
+    // explicitly set
+    SSL_set_verify(tls->ssl, SSL_VERIFY_NONE, NULL);
+  }
+#endif
+  if (opts->ca.buf != NULL && opts->ca.buf[0] != '\0') {
     SSL_set_verify(tls->ssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                    NULL);
-    if ((rc = SSL_CTX_load_verify_locations(tls->ctx, opts->ca, NULL)) != 1) {
-      mg_error(c, "load('%s') %d err %d", opts->ca, rc, mg_tls_err(tls, rc));
+    STACK_OF(X509_INFO) *certs = load_ca_certs(opts->ca);
+    rc = add_ca_certs(tls->ctx, certs);
+    sk_X509_INFO_pop_free(certs, X509_INFO_free);
+    if (!rc) {
+      mg_error(c, "CA err");
       goto fail;
     }
   }
-  if (opts->cert != NULL && opts->cert[0] != '\0') {
-    const char *key = opts->certkey;
-    if (key == NULL) key = opts->cert;
-    if ((rc = SSL_use_certificate_file(tls->ssl, opts->cert, 1)) != 1) {
-      mg_error(c, "Invalid SSL cert, err %d", mg_tls_err(tls, rc));
+  if (opts->cert.buf != NULL && opts->cert.buf[0] != '\0') {
+    X509 *cert = load_cert(opts->cert);
+    rc = cert == NULL ? 0 : SSL_use_certificate(tls->ssl, cert);
+    X509_free(cert);
+    if (cert == NULL || rc != 1) {
+      mg_error(c, "CERT err %d", mg_tls_err(c, tls, rc));
       goto fail;
-    } else if ((rc = SSL_use_PrivateKey_file(tls->ssl, key, 1)) != 1) {
-      mg_error(c, "Invalid SSL key, err %d", mg_tls_err(tls, rc));
-      goto fail;
-#if OPENSSL_VERSION_NUMBER > 0x10100000L
-    } else if ((rc = SSL_use_certificate_chain_file(tls->ssl, opts->cert)) !=
-               1) {
-      mg_error(c, "Invalid chain, err %d", mg_tls_err(tls, rc));
-      goto fail;
-#endif
-    } else {
-      SSL_set_mode(tls->ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
-#if OPENSSL_VERSION_NUMBER > 0x10002000L
-      SSL_set_ecdh_auto(tls->ssl, 1);
-#endif
     }
   }
-  if (opts->ciphers != NULL) SSL_set_cipher_list(tls->ssl, opts->ciphers);
+  if (opts->key.buf != NULL && opts->key.buf[0] != '\0') {
+    EVP_PKEY *key = load_key(opts->key);
+    rc = key == NULL ? 0 : SSL_use_PrivateKey(tls->ssl, key);
+    EVP_PKEY_free(key);
+    if (key == NULL || rc != 1) {
+      mg_error(c, "KEY err %d", mg_tls_err(c, tls, rc));
+      goto fail;
+    }
+  }
+
+  SSL_set_mode(tls->ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+#if MG_TLS == MG_TLS_OPENSSL && OPENSSL_VERSION_NUMBER > 0x10002000L
+  (void) SSL_set_ecdh_auto(tls->ssl, 1);
+#endif
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-  if (opts->srvname.len > 0) {
-    char *s = mg_mprintf("%.*s", (int) opts->srvname.len, opts->srvname.ptr);
+  if (opts->name.len > 0) {
+    char *s = mg_mprintf("%.*s", (int) opts->name.len, opts->name.buf);
+#if MG_TLS != MG_TLS_WOLFSSL || LIBWOLFSSL_VERSION_HEX >= 0x05005002
     SSL_set1_host(tls->ssl, s);
+#else
+    X509_VERIFY_PARAM_set1_host(SSL_get0_param(tls->ssl), s, 0);
+#endif
     SSL_set_tlsext_host_name(tls->ssl, s);
     free(s);
   }
 #endif
-  c->tls = tls;
+#if MG_TLS == MG_TLS_WOLFSSL
+  tls->bm = BIO_meth_new(0, "bio_mg");
+#else
+  tls->bm = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK, "bio_mg");
+#endif
+  BIO_meth_set_write(tls->bm, mg_bio_write);
+  BIO_meth_set_read(tls->bm, mg_bio_read);
+  BIO_meth_set_ctrl(tls->bm, mg_bio_ctrl);
+
+  bio = BIO_new(tls->bm);
+  BIO_set_data(bio, c);
+  SSL_set_bio(tls->ssl, bio, bio);
+
   c->is_tls = 1;
   c->is_tls_hs = 1;
-  if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
-    mg_tls_handshake(c);
-  }
   MG_DEBUG(("%lu SSL %s OK", c->id, c->is_accepted ? "accept" : "client"));
   return;
 fail:
-  c->is_closing = 1;
-  free(tls);
+  mg_tls_free(c);
 }
 
 void mg_tls_handshake(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
-  int rc;
-  SSL_set_fd(tls->ssl, (int) (size_t) c->fd);
-  rc = c->is_client ? SSL_connect(tls->ssl) : SSL_accept(tls->ssl);
+  int rc = c->is_client ? SSL_connect(tls->ssl) : SSL_accept(tls->ssl);
   if (rc == 1) {
     MG_DEBUG(("%lu success", c->id));
     c->is_tls_hs = 0;
     mg_call(c, MG_EV_TLS_HS, NULL);
   } else {
-    int code = mg_tls_err(tls, rc);
+    int code = mg_tls_err(c, tls, rc);
     if (code != 0) mg_error(c, "tls hs: rc %d, err %d", rc, code);
   }
-}
-
-void mg_tls_free(struct mg_connection *c) {
-  struct mg_tls *tls = (struct mg_tls *) c->tls;
-  if (tls == NULL) return;
-  SSL_free(tls->ssl);
-  SSL_CTX_free(tls->ctx);
-  free(tls);
-  c->tls = NULL;
 }
 
 size_t mg_tls_pending(struct mg_connection *c) {
@@ -5781,7 +13741,7 @@ size_t mg_tls_pending(struct mg_connection *c) {
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int n = SSL_read(tls->ssl, buf, (int) len);
-  if (n < 0 && mg_tls_err(tls, n) == 0) return MG_IO_WAIT;
+  if (n < 0 && mg_tls_err(c, tls, n) == 0) return MG_IO_WAIT;
   if (n <= 0) return MG_IO_ERR;
   return n;
 }
@@ -5789,11 +13749,5092 @@ long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
 long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int n = SSL_write(tls->ssl, buf, (int) len);
-  if (n < 0 && mg_tls_err(tls, n) == 0) return MG_IO_WAIT;
+  if (n < 0 && mg_tls_err(c, tls, n) == 0) return MG_IO_WAIT;
   if (n <= 0) return MG_IO_ERR;
   return n;
 }
+
+void mg_tls_ctx_init(struct mg_mgr *mgr) {
+  (void) mgr;
+}
+
+void mg_tls_ctx_free(struct mg_mgr *mgr) {
+  (void) mgr;
+}
 #endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/tls_rsa.c"
+#endif
+
+
+#if defined(MG_TLS) && MG_TLS == MG_TLS_BUILTIN
+
+#define NS_INTERNAL static
+typedef struct _bigint bigint; /**< An alias for _bigint */
+
+/*
+ * Copyright (c) 2007, Cameron Rich
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of the axTLS project nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Maintain a number of precomputed variables when doing reduction */
+#define BIGINT_M_OFFSET 0 /**< Normal modulo offset. */
+#define BIGINT_P_OFFSET 1 /**< p modulo offset. */
+#define BIGINT_Q_OFFSET 2 /**< q module offset. */
+#define BIGINT_NUM_MODS 3 /**< The number of modulus constants used. */
+
+/* Architecture specific functions for big ints */
+#if defined(CONFIG_INTEGER_8BIT)
+#define COMP_RADIX 256U     /**< Max component + 1 */
+#define COMP_MAX 0xFFFFU    /**< (Max dbl comp -1) */
+#define COMP_BIT_SIZE 8     /**< Number of bits in a component. */
+#define COMP_BYTE_SIZE 1    /**< Number of bytes in a component. */
+#define COMP_NUM_NIBBLES 2  /**< Used For diagnostics only. */
+typedef uint8_t comp;       /**< A single precision component. */
+typedef uint16_t long_comp; /**< A double precision component. */
+typedef int16_t slong_comp; /**< A signed double precision component. */
+#elif defined(CONFIG_INTEGER_16BIT)
+#define COMP_RADIX 65536U    /**< Max component + 1 */
+#define COMP_MAX 0xFFFFFFFFU /**< (Max dbl comp -1) */
+#define COMP_BIT_SIZE 16     /**< Number of bits in a component. */
+#define COMP_BYTE_SIZE 2     /**< Number of bytes in a component. */
+#define COMP_NUM_NIBBLES 4   /**< Used For diagnostics only. */
+typedef uint16_t comp;            /**< A single precision component. */
+typedef uint32_t long_comp;       /**< A double precision component. */
+typedef int32_t slong_comp;       /**< A signed double precision component. */
+#else                        /* regular 32 bit */
+#ifdef WIN32
+#define COMP_RADIX 4294967296i64
+#define COMP_MAX 0xFFFFFFFFFFFFFFFFui64
+#else
+#define COMP_RADIX 4294967296       /**< Max component + 1 */
+#define COMP_MAX 0xFFFFFFFFFFFFFFFF /**< (Max dbl comp -1) */
+#endif
+#define COMP_BIT_SIZE 32   /**< Number of bits in a component. */
+#define COMP_BYTE_SIZE 4   /**< Number of bytes in a component. */
+#define COMP_NUM_NIBBLES 8 /**< Used For diagnostics only. */
+typedef uint32_t comp;      /**< A single precision component. */
+typedef uint64_t long_comp; /**< A double precision component. */
+typedef int64_t slong_comp; /**< A signed double precision component. */
+#endif
+
+/**
+ * @struct  _bigint
+ * @brief A big integer basic object
+ */
+struct _bigint {
+  struct _bigint *next; /**< The next bigint in the cache. */
+  short size;           /**< The number of components in this bigint. */
+  short max_comps;      /**< The heapsize allocated for this bigint */
+  int refs;             /**< An internal reference count. */
+  comp *comps;          /**< A ptr to the actual component data */
+};
+
+/**
+ * Maintains the state of the cache, and a number of variables used in
+ * reduction.
+ */
+struct _BI_CTX /**< A big integer "session" context. */
+    {
+  bigint *active_list;             /**< Bigints currently used. */
+  bigint *free_list;               /**< Bigints not used. */
+  bigint *bi_radix;                /**< The radix used. */
+  bigint *bi_mod[BIGINT_NUM_MODS]; /**< modulus */
+
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+  bigint *bi_RR_mod_m[BIGINT_NUM_MODS]; /**< R^2 mod m */
+  bigint *bi_R_mod_m[BIGINT_NUM_MODS];  /**< R mod m */
+  comp N0_dash[BIGINT_NUM_MODS];
+#elif defined(CONFIG_BIGINT_BARRETT)
+  bigint *bi_mu[BIGINT_NUM_MODS]; /**< Storage for mu */
+#endif
+  bigint *bi_normalised_mod[BIGINT_NUM_MODS]; /**< Normalised mod storage. */
+  bigint **g;                                 /**< Used by sliding-window. */
+  int window;       /**< The size of the sliding window */
+  int active_count; /**< Number of active bigints. */
+  int free_count;   /**< Number of free bigints. */
+
+#ifdef CONFIG_BIGINT_MONTGOMERY
+  uint8_t use_classical; /**< Use classical reduction. */
+#endif
+  uint8_t mod_offset; /**< The mod offset we are using */
+};
+typedef struct _BI_CTX BI_CTX;
+
+#if !defined(MAX)
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b)  ((a) < (b) ? (a) : (b))
+#endif
+
+#define PERMANENT 0x7FFF55AA /**< A magic number for permanents. */
+
+/*
+ * Copyright (c) 2007, Cameron Rich
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of the axTLS project nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+NS_INTERNAL BI_CTX *bi_initialize(void);
+//NS_INTERNAL void bi_terminate(BI_CTX *ctx);
+NS_INTERNAL void bi_permanent(bigint *bi);
+NS_INTERNAL void bi_depermanent(bigint *bi);
+//NS_INTERNAL void bi_clear_cache(BI_CTX *ctx);
+NS_INTERNAL void bi_free(BI_CTX *ctx, bigint *bi);
+NS_INTERNAL bigint *bi_copy(bigint *bi);
+NS_INTERNAL bigint *bi_clone(BI_CTX *ctx, const bigint *bi);
+NS_INTERNAL void bi_export(BI_CTX *ctx, bigint *bi, uint8_t *data, int size);
+NS_INTERNAL bigint *bi_import(BI_CTX *ctx, const uint8_t *data, int len);
+NS_INTERNAL bigint *int_to_bi(BI_CTX *ctx, comp i);
+
+/* the functions that actually do something interesting */
+NS_INTERNAL bigint *bi_add(BI_CTX *ctx, bigint *bia, bigint *bib);
+NS_INTERNAL bigint *bi_subtract(BI_CTX *ctx, bigint *bia, bigint *bib,
+                                int *is_negative);
+NS_INTERNAL bigint *bi_divide(BI_CTX *ctx, bigint *bia, bigint *bim,
+                              int is_mod);
+NS_INTERNAL bigint *bi_multiply(BI_CTX *ctx, bigint *bia, bigint *bib);
+NS_INTERNAL bigint *bi_mod_power(BI_CTX *ctx, bigint *bi, bigint *biexp);
+#if 0
+NS_INTERNAL bigint *bi_mod_power2(BI_CTX *ctx, bigint *bi,
+			bigint *bim, bigint *biexp);
+#endif
+NS_INTERNAL int bi_compare(bigint *bia, bigint *bib);
+NS_INTERNAL void bi_set_mod(BI_CTX *ctx, bigint *bim, int mod_offset);
+//NS_INTERNAL void bi_free_mod(BI_CTX *ctx, int mod_offset);
+
+#ifdef CONFIG_SSL_FULL_MODE
+NS_INTERNAL void bi_print(const char *label, bigint *bi);
+NS_INTERNAL bigint *bi_str_import(BI_CTX *ctx, const char *data);
+#endif
+
+/**
+ * @def bi_mod
+ * Find the residue of B. bi_set_mod() must be called before hand.
+ */
+#define bi_mod(A, B) bi_divide(A, B, ctx->bi_mod[ctx->mod_offset], 1)
+
+/**
+ * bi_residue() is technically the same as bi_mod(), but it uses the
+ * appropriate reduction technique (which is bi_mod() when doing classical
+ * reduction).
+ */
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+#define bi_residue(A, B) bi_mont(A, B)
+NS_INTERNAL bigint *bi_mont(BI_CTX *ctx, bigint *bixy);
+#elif defined(CONFIG_BIGINT_BARRETT)
+#define bi_residue(A, B) bi_barrett(A, B)
+NS_INTERNAL bigint *bi_barrett(BI_CTX *ctx, bigint *bi);
+#else /* if defined(CONFIG_BIGINT_CLASSICAL) */
+#define bi_residue(A, B) bi_mod(A, B)
+#endif
+
+#ifdef CONFIG_BIGINT_SQUARE
+NS_INTERNAL bigint *bi_square(BI_CTX *ctx, bigint *bi);
+#else
+#define bi_square(A, B) bi_multiply(A, bi_copy(B), B)
+#endif
+
+//NS_INTERNAL bigint *bi_crt(BI_CTX *ctx, bigint *bi, bigint *dP, bigint *dQ,
+//                           bigint *p, bigint *q, bigint *qInv);
+
+/*
+ * Copyright (c) 2007, Cameron Rich
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of the axTLS project nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @defgroup bigint_api Big Integer API
+ * @brief The bigint implementation as used by the axTLS project.
+ *
+ * The bigint library is for RSA encryption/decryption as well as signing.
+ * This code tries to minimise use of malloc/free by maintaining a small
+ * cache. A bigint context may maintain state by being made "permanent".
+ * It be be later released with a bi_depermanent() and bi_free() call.
+ *
+ * It supports the following reduction techniques:
+ * - Classical
+ * - Barrett
+ * - Montgomery
+ *
+ * It also implements the following:
+ * - Karatsuba multiplication
+ * - Squaring
+ * - Sliding window exponentiation
+ * - Chinese Remainder Theorem (implemented in rsa.c).
+ *
+ * All the algorithms used are pretty standard, and designed for different
+ * data bus sizes. Negative numbers are not dealt with at all, so a subtraction
+ * may need to be tested for negativity.
+ *
+ * This library steals some ideas from Jef Poskanzer
+ * <http://cs.marlboro.edu/term/cs-fall02/algorithms/crypto/RSA/bigint>
+ * and GMP <http://www.swox.com/gmp>. It gets most of its implementation
+ * detail from "The Handbook of Applied Cryptography"
+ * <http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf>
+ * @{
+ */
+
+#define V1 v->comps[v->size - 1]                     /**< v1 for division */
+#define V2 v->comps[v->size - 2]                     /**< v2 for division */
+#define U(j) tmp_u->comps[tmp_u->size - j - 1]       /**< uj for division */
+#define Q(j) quotient->comps[quotient->size - j - 1] /**< qj for division */
+
+static bigint *bi_int_multiply(BI_CTX *ctx, bigint *bi, comp i);
+static bigint *bi_int_divide(BI_CTX *ctx, bigint *biR, comp denom);
+static bigint *alloc(BI_CTX *ctx, int size);
+static bigint *trim(bigint *bi);
+static void more_comps(bigint *bi, int n);
+#if defined(CONFIG_BIGINT_KARATSUBA) || defined(CONFIG_BIGINT_BARRETT) || \
+    defined(CONFIG_BIGINT_MONTGOMERY)
+static bigint *comp_right_shift(bigint *biR, int num_shifts);
+static bigint *comp_left_shift(bigint *biR, int num_shifts);
+#endif
+
+#ifdef CONFIG_BIGINT_CHECK_ON
+static void check(const bigint *bi);
+#else
+#define check(A) /**< disappears in normal production mode */
+#endif
+
+/**
+ * @brief Start a new bigint context.
+ * @return A bigint context.
+ */
+NS_INTERNAL BI_CTX *bi_initialize(void) {
+  /* calloc() sets everything to zero */
+  BI_CTX *ctx = (BI_CTX *) calloc(1, sizeof(BI_CTX));
+
+  /* the radix */
+  ctx->bi_radix = alloc(ctx, 2);
+  ctx->bi_radix->comps[0] = 0;
+  ctx->bi_radix->comps[1] = 1;
+  bi_permanent(ctx->bi_radix);
+  return ctx;
+}
+
+#if 0
+/**
+ * @brief Close the bigint context and free any resources.
+ *
+ * Free up any used memory - a check is done if all objects were not
+ * properly freed.
+ * @param ctx [in]   The bigint session context.
+ */
+NS_INTERNAL void bi_terminate(BI_CTX *ctx) {
+  bi_depermanent(ctx->bi_radix);
+  bi_free(ctx, ctx->bi_radix);
+
+  if (ctx->active_count != 0) {
+#ifdef CONFIG_SSL_FULL_MODE
+    printf("bi_terminate: there were %d un-freed bigints\n", ctx->active_count);
+#endif
+    abort();
+  }
+
+  bi_clear_cache(ctx);
+  free(ctx);
+}
+
+/**
+ *@brief Clear the memory cache.
+ */
+NS_INTERNAL void bi_clear_cache(BI_CTX *ctx) {
+  bigint *p, *pn;
+
+  if (ctx->free_list == NULL) return;
+
+  for (p = ctx->free_list; p != NULL; p = pn) {
+    pn = p->next;
+    free(p->comps);
+    free(p);
+  }
+
+  ctx->free_count = 0;
+  ctx->free_list = NULL;
+}
+#endif
+
+/**
+ * @brief Increment the number of references to this object.
+ * It does not do a full copy.
+ * @param bi [in]   The bigint to copy.
+ * @return A reference to the same bigint.
+ */
+NS_INTERNAL bigint *bi_copy(bigint *bi) {
+  check(bi);
+  if (bi->refs != PERMANENT) bi->refs++;
+  return bi;
+}
+
+/**
+ * @brief Simply make a bigint object "unfreeable" if bi_free() is called on it.
+ *
+ * For this object to be freed, bi_depermanent() must be called.
+ * @param bi [in]   The bigint to be made permanent.
+ */
+NS_INTERNAL void bi_permanent(bigint *bi) {
+  check(bi);
+  if (bi->refs != 1) {
+#ifdef CONFIG_SSL_FULL_MODE
+    printf("bi_permanent: refs was not 1\n");
+#endif
+    abort();
+  }
+
+  bi->refs = PERMANENT;
+}
+
+/**
+ * @brief Take a permanent object and make it eligible for freedom.
+ * @param bi [in]   The bigint to be made back to temporary.
+ */
+NS_INTERNAL void bi_depermanent(bigint *bi) {
+  check(bi);
+  if (bi->refs != PERMANENT) {
+#ifdef CONFIG_SSL_FULL_MODE
+    printf("bi_depermanent: bigint was not permanent\n");
+#endif
+    abort();
+  }
+
+  bi->refs = 1;
+}
+
+/**
+ * @brief Free a bigint object so it can be used again.
+ *
+ * The memory itself it not actually freed, just tagged as being available
+ * @param ctx [in]   The bigint session context.
+ * @param bi [in]    The bigint to be freed.
+ */
+NS_INTERNAL void bi_free(BI_CTX *ctx, bigint *bi) {
+  check(bi);
+  if (bi->refs == PERMANENT) {
+    return;
+  }
+
+  if (--bi->refs > 0) {
+    return;
+  }
+
+  bi->next = ctx->free_list;
+  ctx->free_list = bi;
+  ctx->free_count++;
+
+  if (--ctx->active_count < 0) {
+#ifdef CONFIG_SSL_FULL_MODE
+    printf(
+        "bi_free: active_count went negative "
+        "- double-freed bigint?\n");
+#endif
+    abort();
+  }
+}
+
+/**
+ * @brief Convert an (unsigned) integer into a bigint.
+ * @param ctx [in]   The bigint session context.
+ * @param i [in]     The (unsigned) integer to be converted.
+ *
+ */
+NS_INTERNAL bigint *int_to_bi(BI_CTX *ctx, comp i) {
+  bigint *biR = alloc(ctx, 1);
+  biR->comps[0] = i;
+  return biR;
+}
+
+/**
+ * @brief Do a full copy of the bigint object.
+ * @param ctx [in]   The bigint session context.
+ * @param bi  [in]   The bigint object to be copied.
+ */
+NS_INTERNAL bigint *bi_clone(BI_CTX *ctx, const bigint *bi) {
+  bigint *biR = alloc(ctx, bi->size);
+  check(bi);
+  memcpy(biR->comps, bi->comps, (size_t) bi->size * COMP_BYTE_SIZE);
+  return biR;
+}
+
+/**
+ * @brief Perform an addition operation between two bigints.
+ * @param ctx [in]  The bigint session context.
+ * @param bia [in]  A bigint.
+ * @param bib [in]  Another bigint.
+ * @return The result of the addition.
+ */
+NS_INTERNAL bigint *bi_add(BI_CTX *ctx, bigint *bia, bigint *bib) {
+  int n;
+  comp carry = 0;
+  comp *pa, *pb;
+
+  check(bia);
+  check(bib);
+
+  n = MAX(bia->size, bib->size);
+  more_comps(bia, n + 1);
+  more_comps(bib, n);
+  pa = bia->comps;
+  pb = bib->comps;
+
+  do {
+    comp sl, rl, cy1;
+    sl = *pa + *pb++;
+    rl = sl + carry;
+    cy1 = sl < *pa;
+    carry = cy1 | (rl < sl);
+    *pa++ = rl;
+  } while (--n != 0);
+
+  *pa = carry; /* do overflow */
+  bi_free(ctx, bib);
+  return trim(bia);
+}
+
+/**
+ * @brief Perform a subtraction operation between two bigints.
+ * @param ctx [in]  The bigint session context.
+ * @param bia [in]  A bigint.
+ * @param bib [in]  Another bigint.
+ * @param is_negative [out] If defined, indicates that the result was negative.
+ * is_negative may be null.
+ * @return The result of the subtraction. The result is always positive.
+ */
+NS_INTERNAL bigint *bi_subtract(BI_CTX *ctx, bigint *bia, bigint *bib,
+                                int *is_negative) {
+  int n = bia->size;
+  comp *pa, *pb, carry = 0;
+
+  check(bia);
+  check(bib);
+
+  more_comps(bib, n);
+  pa = bia->comps;
+  pb = bib->comps;
+
+  do {
+    comp sl, rl, cy1;
+    sl = *pa - *pb++;
+    rl = sl - carry;
+    cy1 = sl > *pa;
+    carry = cy1 | (rl > sl);
+    *pa++ = rl;
+  } while (--n != 0);
+
+  if (is_negative) /* indicate a negative result */
+  {
+    *is_negative = (int) carry;
+  }
+
+  bi_free(ctx, trim(bib)); /* put bib back to the way it was */
+  return trim(bia);
+}
+
+/**
+ * Perform a multiply between a bigint an an (unsigned) integer
+ */
+static bigint *bi_int_multiply(BI_CTX *ctx, bigint *bia, comp b) {
+  int j = 0, n = bia->size;
+  bigint *biR = alloc(ctx, n + 1);
+  comp carry = 0;
+  comp *r = biR->comps;
+  comp *a = bia->comps;
+
+  check(bia);
+
+  /* clear things to start with */
+  memset(r, 0, (size_t) ((n + 1) * COMP_BYTE_SIZE));
+
+  do {
+    long_comp tmp = *r + (long_comp) a[j] * b + carry;
+    *r++ = (comp) tmp; /* downsize */
+    carry = (comp)(tmp >> COMP_BIT_SIZE);
+  } while (++j < n);
+
+  *r = carry;
+  bi_free(ctx, bia);
+  return trim(biR);
+}
+
+/**
+ * @brief Does both division and modulo calculations.
+ *
+ * Used extensively when doing classical reduction.
+ * @param ctx [in]  The bigint session context.
+ * @param u [in]    A bigint which is the numerator.
+ * @param v [in]    Either the denominator or the modulus depending on the mode.
+ * @param is_mod [n] Determines if this is a normal division (0) or a reduction
+ * (1).
+ * @return  The result of the division/reduction.
+ */
+NS_INTERNAL bigint *bi_divide(BI_CTX *ctx, bigint *u, bigint *v, int is_mod) {
+  int n = v->size, m = u->size - n;
+  int j = 0, orig_u_size = u->size;
+  uint8_t mod_offset = ctx->mod_offset;
+  comp d;
+  bigint *quotient, *tmp_u;
+  comp q_dash;
+
+  check(u);
+  check(v);
+
+  /* if doing reduction and we are < mod, then return mod */
+  if (is_mod && bi_compare(v, u) > 0) {
+    bi_free(ctx, v);
+    return u;
+  }
+
+  quotient = alloc(ctx, m + 1);
+  tmp_u = alloc(ctx, n + 1);
+  v = trim(v); /* make sure we have no leading 0's */
+  d = (comp)((long_comp) COMP_RADIX / (V1 + 1));
+
+  /* clear things to start with */
+  memset(quotient->comps, 0, (size_t) ((quotient->size) * COMP_BYTE_SIZE));
+
+  /* normalise */
+  if (d > 1) {
+    u = bi_int_multiply(ctx, u, d);
+
+    if (is_mod) {
+      v = ctx->bi_normalised_mod[mod_offset];
+    } else {
+      v = bi_int_multiply(ctx, v, d);
+    }
+  }
+
+  if (orig_u_size == u->size) /* new digit position u0 */
+  {
+    more_comps(u, orig_u_size + 1);
+  }
+
+  do {
+    /* get a temporary short version of u */
+    memcpy(tmp_u->comps, &u->comps[u->size - n - 1 - j],
+           (size_t) (n + 1) * COMP_BYTE_SIZE);
+
+    /* calculate q' */
+    if (U(0) == V1) {
+      q_dash = COMP_RADIX - 1;
+    } else {
+      q_dash = (comp)(((long_comp) U(0) * COMP_RADIX + U(1)) / V1);
+
+      if (v->size > 1 && V2) {
+        /* we are implementing the following:
+        if (V2*q_dash > (((U(0)*COMP_RADIX + U(1) -
+                q_dash*V1)*COMP_RADIX) + U(2))) ... */
+        comp inner = (comp)((long_comp) COMP_RADIX * U(0) + U(1) -
+                            (long_comp) q_dash * V1);
+        if ((long_comp) V2 * q_dash > (long_comp) inner * COMP_RADIX + U(2)) {
+          q_dash--;
+        }
+      }
+    }
+
+    /* multiply and subtract */
+    if (q_dash) {
+      int is_negative;
+      tmp_u = bi_subtract(ctx, tmp_u, bi_int_multiply(ctx, bi_copy(v), q_dash),
+                          &is_negative);
+      more_comps(tmp_u, n + 1);
+
+      Q(j) = q_dash;
+
+      /* add back */
+      if (is_negative) {
+        Q(j)--;
+        tmp_u = bi_add(ctx, tmp_u, bi_copy(v));
+
+        /* lop off the carry */
+        tmp_u->size--;
+        v->size--;
+      }
+    } else {
+      Q(j) = 0;
+    }
+
+    /* copy back to u */
+    memcpy(&u->comps[u->size - n - 1 - j], tmp_u->comps,
+           (size_t) (n + 1) * COMP_BYTE_SIZE);
+  } while (++j <= m);
+
+  bi_free(ctx, tmp_u);
+  bi_free(ctx, v);
+
+  if (is_mod) /* get the remainder */
+  {
+    bi_free(ctx, quotient);
+    return bi_int_divide(ctx, trim(u), d);
+  } else /* get the quotient */
+  {
+    bi_free(ctx, u);
+    return trim(quotient);
+  }
+}
+
+/*
+ * Perform an integer divide on a bigint.
+ */
+static bigint *bi_int_divide(BI_CTX *ctx, bigint *biR, comp denom) {
+  int i = biR->size - 1;
+  long_comp r = 0;
+
+  (void) ctx;
+  check(biR);
+
+  do {
+    r = (r << COMP_BIT_SIZE) + biR->comps[i];
+    biR->comps[i] = (comp)(r / denom);
+    r %= denom;
+  } while (--i >= 0);
+
+  return trim(biR);
+}
+
+#ifdef CONFIG_BIGINT_MONTGOMERY
+/**
+ * There is a need for the value of integer N' such that B^-1(B-1)-N^-1N'=1,
+ * where B^-1(B-1) mod N=1. Actually, only the least significant part of
+ * N' is needed, hence the definition N0'=N' mod b. We reproduce below the
+ * simple algorithm from an article by Dusse and Kaliski to efficiently
+ * find N0' from N0 and b */
+static comp modular_inverse(bigint *bim) {
+  int i;
+  comp t = 1;
+  comp two_2_i_minus_1 = 2; /* 2^(i-1) */
+  long_comp two_2_i = 4;    /* 2^i */
+  comp N = bim->comps[0];
+
+  for (i = 2; i <= COMP_BIT_SIZE; i++) {
+    if ((long_comp) N * t % two_2_i >= two_2_i_minus_1) {
+      t += two_2_i_minus_1;
+    }
+
+    two_2_i_minus_1 <<= 1;
+    two_2_i <<= 1;
+  }
+
+  return (comp)(COMP_RADIX - t);
+}
+#endif
+
+#if defined(CONFIG_BIGINT_KARATSUBA) || defined(CONFIG_BIGINT_BARRETT) || \
+    defined(CONFIG_BIGINT_MONTGOMERY)
+/**
+ * Take each component and shift down (in terms of components)
+ */
+static bigint *comp_right_shift(bigint *biR, int num_shifts) {
+  int i = biR->size - num_shifts;
+  comp *x = biR->comps;
+  comp *y = &biR->comps[num_shifts];
+
+  check(biR);
+
+  if (i <= 0) /* have we completely right shifted? */
+  {
+    biR->comps[0] = 0; /* return 0 */
+    biR->size = 1;
+    return biR;
+  }
+
+  do {
+    *x++ = *y++;
+  } while (--i > 0);
+
+  biR->size -= num_shifts;
+  return biR;
+}
+
+/**
+ * Take each component and shift it up (in terms of components)
+ */
+static bigint *comp_left_shift(bigint *biR, int num_shifts) {
+  int i = biR->size - 1;
+  comp *x, *y;
+
+  check(biR);
+
+  if (num_shifts <= 0) {
+    return biR;
+  }
+
+  more_comps(biR, biR->size + num_shifts);
+
+  x = &biR->comps[i + num_shifts];
+  y = &biR->comps[i];
+
+  do {
+    *x-- = *y--;
+  } while (i--);
+
+  memset(biR->comps, 0, (size_t) (num_shifts * COMP_BYTE_SIZE)); /* zero LS comps */
+  return biR;
+}
+#endif
+
+/**
+ * @brief Allow a binary sequence to be imported as a bigint.
+ * @param ctx [in]  The bigint session context.
+ * @param data [in] The data to be converted.
+ * @param size [in] The number of bytes of data.
+ * @return A bigint representing this data.
+ */
+NS_INTERNAL bigint *bi_import(BI_CTX *ctx, const uint8_t *data, int size) {
+  bigint *biR = alloc(ctx, (size + COMP_BYTE_SIZE - 1) / COMP_BYTE_SIZE);
+  int i, j = 0, offset = 0;
+
+  memset(biR->comps, 0, (size_t) (biR->size * COMP_BYTE_SIZE));
+
+  for (i = size - 1; i >= 0; i--) {
+    biR->comps[offset] += (comp) data[i] << (j * 8);
+
+    if (++j == COMP_BYTE_SIZE) {
+      j = 0;
+      offset++;
+    }
+  }
+
+  return trim(biR);
+}
+
+#ifdef CONFIG_SSL_FULL_MODE
+/**
+ * @brief The testharness uses this code to import text hex-streams and
+ * convert them into bigints.
+ * @param ctx [in]  The bigint session context.
+ * @param data [in] A string consisting of hex characters. The characters must
+ * be in upper case.
+ * @return A bigint representing this data.
+ */
+NS_INTERNAL bigint *bi_str_import(BI_CTX *ctx, const char *data) {
+  int size = strlen(data);
+  bigint *biR = alloc(ctx, (size + COMP_NUM_NIBBLES - 1) / COMP_NUM_NIBBLES);
+  int i, j = 0, offset = 0;
+  memset(biR->comps, 0, (size_t) (biR->size * COMP_BYTE_SIZE));
+
+  for (i = size - 1; i >= 0; i--) {
+    int num = (data[i] <= '9') ? (data[i] - '0') : (data[i] - 'A' + 10);
+    biR->comps[offset] += num << (j * 4);
+
+    if (++j == COMP_NUM_NIBBLES) {
+      j = 0;
+      offset++;
+    }
+  }
+
+  return biR;
+}
+
+NS_INTERNAL void bi_print(const char *label, bigint *x) {
+  int i, j;
+
+  if (x == NULL) {
+    printf("%s: (null)\n", label);
+    return;
+  }
+
+  printf("%s: (size %d)\n", label, x->size);
+  for (i = x->size - 1; i >= 0; i--) {
+    for (j = COMP_NUM_NIBBLES - 1; j >= 0; j--) {
+      comp mask = 0x0f << (j * 4);
+      comp num = (x->comps[i] & mask) >> (j * 4);
+      putc((num <= 9) ? (num + '0') : (num + 'A' - 10), stdout);
+    }
+  }
+
+  printf("\n");
+}
+#endif
+
+/**
+ * @brief Take a bigint and convert it into a byte sequence.
+ *
+ * This is useful after a decrypt operation.
+ * @param ctx [in]  The bigint session context.
+ * @param x [in]  The bigint to be converted.
+ * @param data [out] The converted data as a byte stream.
+ * @param size [in] The maximum size of the byte stream. Unused bytes will be
+ * zeroed.
+ */
+NS_INTERNAL void bi_export(BI_CTX *ctx, bigint *x, uint8_t *data, int size) {
+  int i, j, k = size - 1;
+
+  check(x);
+  memset(data, 0, (size_t) size); /* ensure all leading 0's are cleared */
+
+  for (i = 0; i < x->size; i++) {
+    for (j = 0; j < COMP_BYTE_SIZE; j++) {
+      comp mask = (comp) 0xff << (j * 8);
+      int num = (int) (x->comps[i] & mask) >> (j * 8);
+      data[k--] = (uint8_t) num;
+
+      if (k < 0) {
+        goto buf_done;
+      }
+    }
+  }
+buf_done:
+
+  bi_free(ctx, x);
+}
+
+/**
+ * @brief Pre-calculate some of the expensive steps in reduction.
+ *
+ * This function should only be called once (normally when a session starts).
+ * When the session is over, bi_free_mod() should be called. bi_mod_power()
+ * relies on this function being called.
+ * @param ctx [in]  The bigint session context.
+ * @param bim [in]  The bigint modulus that will be used.
+ * @param mod_offset [in] There are three moduluii that can be stored - the
+ * standard modulus, and its two primes p and q. This offset refers to which
+ * modulus we are referring to.
+ * @see bi_free_mod(), bi_mod_power().
+ */
+NS_INTERNAL void bi_set_mod(BI_CTX *ctx, bigint *bim, int mod_offset) {
+  int k = bim->size;
+  comp d = (comp)((long_comp) COMP_RADIX / (bim->comps[k - 1] + 1));
+#ifdef CONFIG_BIGINT_MONTGOMERY
+  bigint *R, *R2;
+#endif
+
+  ctx->bi_mod[mod_offset] = bim;
+  bi_permanent(ctx->bi_mod[mod_offset]);
+  ctx->bi_normalised_mod[mod_offset] = bi_int_multiply(ctx, bim, d);
+  bi_permanent(ctx->bi_normalised_mod[mod_offset]);
+
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+  /* set montgomery variables */
+  R = comp_left_shift(bi_clone(ctx, ctx->bi_radix), k - 1);      /* R */
+  R2 = comp_left_shift(bi_clone(ctx, ctx->bi_radix), k * 2 - 1); /* R^2 */
+  ctx->bi_RR_mod_m[mod_offset] = bi_mod(ctx, R2);                /* R^2 mod m */
+  ctx->bi_R_mod_m[mod_offset] = bi_mod(ctx, R);                  /* R mod m */
+
+  bi_permanent(ctx->bi_RR_mod_m[mod_offset]);
+  bi_permanent(ctx->bi_R_mod_m[mod_offset]);
+
+  ctx->N0_dash[mod_offset] = modular_inverse(ctx->bi_mod[mod_offset]);
+
+#elif defined(CONFIG_BIGINT_BARRETT)
+  ctx->bi_mu[mod_offset] =
+      bi_divide(ctx, comp_left_shift(bi_clone(ctx, ctx->bi_radix), k * 2 - 1),
+                ctx->bi_mod[mod_offset], 0);
+  bi_permanent(ctx->bi_mu[mod_offset]);
+#endif
+}
+
+#if 0
+/**
+ * @brief Used when cleaning various bigints at the end of a session.
+ * @param ctx [in]  The bigint session context.
+ * @param mod_offset [in] The offset to use.
+ * @see bi_set_mod().
+ */
+void bi_free_mod(BI_CTX *ctx, int mod_offset) {
+  bi_depermanent(ctx->bi_mod[mod_offset]);
+  bi_free(ctx, ctx->bi_mod[mod_offset]);
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+  bi_depermanent(ctx->bi_RR_mod_m[mod_offset]);
+  bi_depermanent(ctx->bi_R_mod_m[mod_offset]);
+  bi_free(ctx, ctx->bi_RR_mod_m[mod_offset]);
+  bi_free(ctx, ctx->bi_R_mod_m[mod_offset]);
+#elif defined(CONFIG_BIGINT_BARRETT)
+  bi_depermanent(ctx->bi_mu[mod_offset]);
+  bi_free(ctx, ctx->bi_mu[mod_offset]);
+#endif
+  bi_depermanent(ctx->bi_normalised_mod[mod_offset]);
+  bi_free(ctx, ctx->bi_normalised_mod[mod_offset]);
+}
+#endif
+
+/**
+ * Perform a standard multiplication between two bigints.
+ *
+ * Barrett reduction has no need for some parts of the product, so ignore bits
+ * of the multiply. This routine gives Barrett its big performance
+ * improvements over Classical/Montgomery reduction methods.
+ */
+static bigint *regular_multiply(BI_CTX *ctx, bigint *bia, bigint *bib,
+                                int inner_partial, int outer_partial) {
+  int i = 0, j;
+  int n = bia->size;
+  int t = bib->size;
+  bigint *biR = alloc(ctx, n + t);
+  comp *sr = biR->comps;
+  comp *sa = bia->comps;
+  comp *sb = bib->comps;
+
+  check(bia);
+  check(bib);
+
+  /* clear things to start with */
+  memset(biR->comps, 0, (size_t) ((n + t) * COMP_BYTE_SIZE));
+
+  do {
+    long_comp tmp;
+    comp carry = 0;
+    int r_index = i;
+    j = 0;
+
+    if (outer_partial && outer_partial - i > 0 && outer_partial < n) {
+      r_index = outer_partial - 1;
+      j = outer_partial - i - 1;
+    }
+
+    do {
+      if (inner_partial && r_index >= inner_partial) {
+        break;
+      }
+
+      tmp = sr[r_index] + ((long_comp) sa[j]) * sb[i] + carry;
+      sr[r_index++] = (comp) tmp; /* downsize */
+      carry = (comp) (tmp >> COMP_BIT_SIZE);
+    } while (++j < n);
+
+    sr[r_index] = carry;
+  } while (++i < t);
+
+  bi_free(ctx, bia);
+  bi_free(ctx, bib);
+  return trim(biR);
+}
+
+#ifdef CONFIG_BIGINT_KARATSUBA
+/*
+ * Karatsuba improves on regular multiplication due to only 3 multiplications
+ * being done instead of 4. The additional additions/subtractions are O(N)
+ * rather than O(N^2) and so for big numbers it saves on a few operations
+ */
+static bigint *karatsuba(BI_CTX *ctx, bigint *bia, bigint *bib, int is_square) {
+  bigint *x0, *x1;
+  bigint *p0, *p1, *p2;
+  int m;
+
+  if (is_square) {
+    m = (bia->size + 1) / 2;
+  } else {
+    m = (MAX(bia->size, bib->size) + 1) / 2;
+  }
+
+  x0 = bi_clone(ctx, bia);
+  x0->size = m;
+  x1 = bi_clone(ctx, bia);
+  comp_right_shift(x1, m);
+  bi_free(ctx, bia);
+
+  /* work out the 3 partial products */
+  if (is_square) {
+    p0 = bi_square(ctx, bi_copy(x0));
+    p2 = bi_square(ctx, bi_copy(x1));
+    p1 = bi_square(ctx, bi_add(ctx, x0, x1));
+  } else /* normal multiply */
+  {
+    bigint *y0, *y1;
+    y0 = bi_clone(ctx, bib);
+    y0->size = m;
+    y1 = bi_clone(ctx, bib);
+    comp_right_shift(y1, m);
+    bi_free(ctx, bib);
+
+    p0 = bi_multiply(ctx, bi_copy(x0), bi_copy(y0));
+    p2 = bi_multiply(ctx, bi_copy(x1), bi_copy(y1));
+    p1 = bi_multiply(ctx, bi_add(ctx, x0, x1), bi_add(ctx, y0, y1));
+  }
+
+  p1 = bi_subtract(ctx, bi_subtract(ctx, p1, bi_copy(p2), NULL), bi_copy(p0),
+                   NULL);
+
+  comp_left_shift(p1, m);
+  comp_left_shift(p2, 2 * m);
+  return bi_add(ctx, p1, bi_add(ctx, p0, p2));
+}
+#endif
+
+/**
+ * @brief Perform a multiplication operation between two bigints.
+ * @param ctx [in]  The bigint session context.
+ * @param bia [in]  A bigint.
+ * @param bib [in]  Another bigint.
+ * @return The result of the multiplication.
+ */
+NS_INTERNAL bigint *bi_multiply(BI_CTX *ctx, bigint *bia, bigint *bib) {
+  check(bia);
+  check(bib);
+
+#ifdef CONFIG_BIGINT_KARATSUBA
+  if (MIN(bia->size, bib->size) < MUL_KARATSUBA_THRESH) {
+    return regular_multiply(ctx, bia, bib, 0, 0);
+  }
+
+  return karatsuba(ctx, bia, bib, 0);
+#else
+  return regular_multiply(ctx, bia, bib, 0, 0);
+#endif
+}
+
+#ifdef CONFIG_BIGINT_SQUARE
+/*
+ * Perform the actual square operion. It takes into account overflow.
+ */
+static bigint *regular_square(BI_CTX *ctx, bigint *bi) {
+  int t = bi->size;
+  int i = 0, j;
+  bigint *biR = alloc(ctx, t * 2 + 1);
+  comp *w = biR->comps;
+  comp *x = bi->comps;
+  long_comp carry;
+  memset(w, 0, biR->size * COMP_BYTE_SIZE);
+
+  do {
+    long_comp tmp = w[2 * i] + (long_comp) x[i] * x[i];
+    w[2 * i] = (comp) tmp;
+    carry = tmp >> COMP_BIT_SIZE;
+
+    for (j = i + 1; j < t; j++) {
+      uint8_t c = 0;
+      long_comp xx = (long_comp) x[i] * x[j];
+      if ((COMP_MAX - xx) < xx) c = 1;
+
+      tmp = (xx << 1);
+
+      if ((COMP_MAX - tmp) < w[i + j]) c = 1;
+
+      tmp += w[i + j];
+
+      if ((COMP_MAX - tmp) < carry) c = 1;
+
+      tmp += carry;
+      w[i + j] = (comp) tmp;
+      carry = tmp >> COMP_BIT_SIZE;
+
+      if (c) carry += COMP_RADIX;
+    }
+
+    tmp = w[i + t] + carry;
+    w[i + t] = (comp) tmp;
+    w[i + t + 1] = tmp >> COMP_BIT_SIZE;
+  } while (++i < t);
+
+  bi_free(ctx, bi);
+  return trim(biR);
+}
+
+/**
+ * @brief Perform a square operation on a bigint.
+ * @param ctx [in]  The bigint session context.
+ * @param bia [in]  A bigint.
+ * @return The result of the multiplication.
+ */
+NS_INTERNAL bigint *bi_square(BI_CTX *ctx, bigint *bia) {
+  check(bia);
+
+#ifdef CONFIG_BIGINT_KARATSUBA
+  if (bia->size < SQU_KARATSUBA_THRESH) {
+    return regular_square(ctx, bia);
+  }
+
+  return karatsuba(ctx, bia, NULL, 1);
+#else
+  return regular_square(ctx, bia);
+#endif
+}
+#endif
+
+/**
+ * @brief Compare two bigints.
+ * @param bia [in]  A bigint.
+ * @param bib [in]  Another bigint.
+ * @return -1 if smaller, 1 if larger and 0 if equal.
+ */
+NS_INTERNAL int bi_compare(bigint *bia, bigint *bib) {
+  int r, i;
+
+  check(bia);
+  check(bib);
+
+  if (bia->size > bib->size)
+    r = 1;
+  else if (bia->size < bib->size)
+    r = -1;
+  else {
+    comp *a = bia->comps;
+    comp *b = bib->comps;
+
+    /* Same number of components.  Compare starting from the high end
+     * and working down. */
+    r = 0;
+    i = bia->size - 1;
+
+    do {
+      if (a[i] > b[i]) {
+        r = 1;
+        break;
+      } else if (a[i] < b[i]) {
+        r = -1;
+        break;
+      }
+    } while (--i >= 0);
+  }
+
+  return r;
+}
+
+/*
+ * Allocate and zero more components.  Does not consume bi.
+ */
+static void more_comps(bigint *bi, int n) {
+  if (n > bi->max_comps) {
+    int max = MAX(bi->max_comps * 2, n);
+    void *p = calloc(1, (size_t) max * COMP_BYTE_SIZE);
+    if (p != NULL && bi->size > 0) memcpy(p, bi->comps, (size_t) bi->max_comps * COMP_BYTE_SIZE);
+    free(bi->comps);
+    bi->max_comps = (short) max;
+    bi->comps = (comp *) p;
+  }
+
+  if (n > bi->size) {
+    memset(&bi->comps[bi->size], 0, (size_t) (n - bi->size) * COMP_BYTE_SIZE);
+  }
+
+  bi->size = (short) n;
+}
+
+/*
+ * Make a new empty bigint. It may just use an old one if one is available.
+ * Otherwise get one off the heap.
+ */
+static bigint *alloc(BI_CTX *ctx, int size) {
+  bigint *biR;
+
+  /* Can we recycle an old bigint? */
+  if (ctx->free_list != NULL) {
+    biR = ctx->free_list;
+    ctx->free_list = biR->next;
+    ctx->free_count--;
+
+    if (biR->refs != 0) {
+#ifdef CONFIG_SSL_FULL_MODE
+      printf("alloc: refs was not 0\n");
+#endif
+      abort(); /* create a stack trace from a core dump */
+    }
+
+    more_comps(biR, size);
+  } else {
+    /* No free bigints available - create a new one. */
+    biR = (bigint *) calloc(1, sizeof(bigint));
+    biR->comps = (comp *) calloc(1, (size_t) size * COMP_BYTE_SIZE);
+    biR->max_comps = (short) size; /* give some space to spare */
+  }
+
+  biR->size = (short) size;
+  biR->refs = 1;
+  biR->next = NULL;
+  ctx->active_count++;
+  return biR;
+}
+
+/*
+ * Work out the highest '1' bit in an exponent. Used when doing sliding-window
+ * exponentiation.
+ */
+static int find_max_exp_index(bigint *biexp) {
+  int i = COMP_BIT_SIZE - 1;
+  comp shift = COMP_RADIX / 2;
+  comp test = biexp->comps[biexp->size - 1]; /* assume no leading zeroes */
+
+  check(biexp);
+
+  do {
+    if (test & shift) {
+      return i + (biexp->size - 1) * COMP_BIT_SIZE;
+    }
+
+    shift >>= 1;
+  } while (i-- != 0);
+
+  return -1; /* error - must have been a leading 0 */
+}
+
+/*
+ * Is a particular bit is an exponent 1 or 0? Used when doing sliding-window
+ * exponentiation.
+ */
+static int exp_bit_is_one(bigint *biexp, int offset) {
+  comp test = biexp->comps[offset / COMP_BIT_SIZE];
+  int num_shifts = offset % COMP_BIT_SIZE;
+  comp shift = 1;
+  int i;
+
+  check(biexp);
+
+  for (i = 0; i < num_shifts; i++) {
+    shift <<= 1;
+  }
+
+  return (test & shift) != 0;
+}
+
+#ifdef CONFIG_BIGINT_CHECK_ON
+/*
+ * Perform a sanity check on bi.
+ */
+static void check(const bigint *bi) {
+  if (bi->refs <= 0) {
+    printf("check: zero or negative refs in bigint\n");
+    abort();
+  }
+
+  if (bi->next != NULL) {
+    printf(
+        "check: attempt to use a bigint from "
+        "the free list\n");
+    abort();
+  }
+}
+#endif
+
+/*
+ * Delete any leading 0's (and allow for 0).
+ */
+static bigint *trim(bigint *bi) {
+  check(bi);
+
+  while (bi->comps[bi->size - 1] == 0 && bi->size > 1) {
+    bi->size--;
+  }
+
+  return bi;
+}
+
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+/**
+ * @brief Perform a single montgomery reduction.
+ * @param ctx [in]  The bigint session context.
+ * @param bixy [in]  A bigint.
+ * @return The result of the montgomery reduction.
+ */
+NS_INTERNAL bigint *bi_mont(BI_CTX *ctx, bigint *bixy) {
+  int i = 0, n;
+  uint8_t mod_offset = ctx->mod_offset;
+  bigint *bim = ctx->bi_mod[mod_offset];
+  comp mod_inv = ctx->N0_dash[mod_offset];
+
+  check(bixy);
+
+  if (ctx->use_classical) /* just use classical instead */
+  {
+    return bi_mod(ctx, bixy);
+  }
+
+  n = bim->size;
+
+  do {
+    bixy = bi_add(ctx, bixy,
+                  comp_left_shift(
+                      bi_int_multiply(ctx, bim, bixy->comps[i] * mod_inv), i));
+  } while (++i < n);
+
+  comp_right_shift(bixy, n);
+
+  if (bi_compare(bixy, bim) >= 0) {
+    bixy = bi_subtract(ctx, bixy, bim, NULL);
+  }
+
+  return bixy;
+}
+
+#elif defined(CONFIG_BIGINT_BARRETT)
+/*
+ * Stomp on the most significant components to give the illusion of a "mod base
+ * radix" operation
+ */
+static bigint *comp_mod(bigint *bi, int mod) {
+  check(bi);
+
+  if (bi->size > mod) {
+    bi->size = mod;
+  }
+
+  return bi;
+}
+
+/**
+ * @brief Perform a single Barrett reduction.
+ * @param ctx [in]  The bigint session context.
+ * @param bi [in]  A bigint.
+ * @return The result of the Barrett reduction.
+ */
+NS_INTERNAL bigint *bi_barrett(BI_CTX *ctx, bigint *bi) {
+  bigint *q1, *q2, *q3, *r1, *r2, *r;
+  uint8_t mod_offset = ctx->mod_offset;
+  bigint *bim = ctx->bi_mod[mod_offset];
+  int k = bim->size;
+
+  check(bi);
+  check(bim);
+
+  /* use Classical method instead  - Barrett cannot help here */
+  if (bi->size > k * 2) {
+    return bi_mod(ctx, bi);
+  }
+
+  q1 = comp_right_shift(bi_clone(ctx, bi), k - 1);
+
+  /* do outer partial multiply */
+  q2 = regular_multiply(ctx, q1, ctx->bi_mu[mod_offset], 0, k - 1);
+  q3 = comp_right_shift(q2, k + 1);
+  r1 = comp_mod(bi, k + 1);
+
+  /* do inner partial multiply */
+  r2 = comp_mod(regular_multiply(ctx, q3, bim, k + 1, 0), k + 1);
+  r = bi_subtract(ctx, r1, r2, NULL);
+
+  /* if (r >= m) r = r - m; */
+  if (bi_compare(r, bim) >= 0) {
+    r = bi_subtract(ctx, r, bim, NULL);
+  }
+
+  return r;
+}
+#endif /* CONFIG_BIGINT_BARRETT */
+
+#ifdef CONFIG_BIGINT_SLIDING_WINDOW
+/*
+ * Work out g1, g3, g5, g7... etc for the sliding-window algorithm
+ */
+static void precompute_slide_window(BI_CTX *ctx, int window, bigint *g1) {
+  int k = 1, i;
+  bigint *g2;
+
+  for (i = 0; i < window - 1; i++) /* compute 2^(window-1) */
+  {
+    k <<= 1;
+  }
+
+  ctx->g = (bigint **) calloc(1, k * sizeof(bigint *));
+  ctx->g[0] = bi_clone(ctx, g1);
+  bi_permanent(ctx->g[0]);
+  g2 = bi_residue(ctx, bi_square(ctx, ctx->g[0])); /* g^2 */
+
+  for (i = 1; i < k; i++) {
+    ctx->g[i] = bi_residue(ctx, bi_multiply(ctx, ctx->g[i - 1], bi_copy(g2)));
+    bi_permanent(ctx->g[i]);
+  }
+
+  bi_free(ctx, g2);
+  ctx->window = k;
+}
+#endif
+
+/**
+ * @brief Perform a modular exponentiation.
+ *
+ * This function requires bi_set_mod() to have been called previously. This is
+ * one of the optimisations used for performance.
+ * @param ctx [in]  The bigint session context.
+ * @param bi  [in]  The bigint on which to perform the mod power operation.
+ * @param biexp [in] The bigint exponent.
+ * @return The result of the mod exponentiation operation
+ * @see bi_set_mod().
+ */
+NS_INTERNAL bigint *bi_mod_power(BI_CTX *ctx, bigint *bi, bigint *biexp) {
+  int i = find_max_exp_index(biexp), j, window_size = 1;
+  bigint *biR = int_to_bi(ctx, 1);
+
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+  uint8_t mod_offset = ctx->mod_offset;
+  if (!ctx->use_classical) {
+    /* preconvert */
+    bi = bi_mont(ctx,
+                 bi_multiply(ctx, bi, ctx->bi_RR_mod_m[mod_offset])); /* x' */
+    bi_free(ctx, biR);
+    biR = ctx->bi_R_mod_m[mod_offset]; /* A */
+  }
+#endif
+
+  check(bi);
+  check(biexp);
+
+#ifdef CONFIG_BIGINT_SLIDING_WINDOW
+  for (j = i; j > 32; j /= 5) /* work out an optimum size */
+    window_size++;
+
+  /* work out the slide constants */
+  precompute_slide_window(ctx, window_size, bi);
+#else /* just one constant */
+  ctx->g = (bigint **) calloc(1, sizeof(bigint *));
+  ctx->g[0] = bi_clone(ctx, bi);
+  ctx->window = 1;
+  bi_permanent(ctx->g[0]);
+#endif
+
+  /* if sliding-window is off, then only one bit will be done at a time and
+   * will reduce to standard left-to-right exponentiation */
+  do {
+    if (exp_bit_is_one(biexp, i)) {
+      int l = i - window_size + 1;
+      int part_exp = 0;
+
+      if (l < 0) /* LSB of exponent will always be 1 */
+        l = 0;
+      else {
+        while (exp_bit_is_one(biexp, l) == 0) l++; /* go back up */
+      }
+
+      /* build up the section of the exponent */
+      for (j = i; j >= l; j--) {
+        biR = bi_residue(ctx, bi_square(ctx, biR));
+        if (exp_bit_is_one(biexp, j)) part_exp++;
+
+        if (j != l) part_exp <<= 1;
+      }
+
+      part_exp = (part_exp - 1) / 2; /* adjust for array */
+      biR = bi_residue(ctx, bi_multiply(ctx, biR, ctx->g[part_exp]));
+      i = l - 1;
+    } else /* square it */
+    {
+      biR = bi_residue(ctx, bi_square(ctx, biR));
+      i--;
+    }
+  } while (i >= 0);
+
+  /* cleanup */
+  for (i = 0; i < ctx->window; i++) {
+    bi_depermanent(ctx->g[i]);
+    bi_free(ctx, ctx->g[i]);
+  }
+
+  free(ctx->g);
+  bi_free(ctx, bi);
+  bi_free(ctx, biexp);
+#if defined CONFIG_BIGINT_MONTGOMERY
+  return ctx->use_classical ? biR : bi_mont(ctx, biR); /* convert back */
+#else /* CONFIG_BIGINT_CLASSICAL or CONFIG_BIGINT_BARRETT */
+  return biR;
+#endif
+}
+
+#if 0
+/**
+ * @brief Use the Chinese Remainder Theorem to quickly perform RSA decrypts.
+ *
+ * @param ctx [in]  The bigint session context.
+ * @param bi  [in]  The bigint to perform the exp/mod.
+ * @param dP [in] CRT's dP bigint
+ * @param dQ [in] CRT's dQ bigint
+ * @param p [in] CRT's p bigint
+ * @param q [in] CRT's q bigint
+ * @param qInv [in] CRT's qInv bigint
+ * @return The result of the CRT operation
+ */
+NS_INTERNAL bigint *bi_crt(BI_CTX *ctx, bigint *bi, bigint *dP, bigint *dQ,
+                           bigint *p, bigint *q, bigint *qInv) {
+  bigint *m1, *m2, *h;
+
+/* Montgomery has a condition the 0 < x, y < m and these products violate
+ * that condition. So disable Montgomery when using CRT */
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+  ctx->use_classical = 1;
+#endif
+  ctx->mod_offset = BIGINT_P_OFFSET;
+  m1 = bi_mod_power(ctx, bi_copy(bi), dP);
+
+  ctx->mod_offset = BIGINT_Q_OFFSET;
+  m2 = bi_mod_power(ctx, bi, dQ);
+
+  h = bi_subtract(ctx, bi_add(ctx, m1, p), bi_copy(m2), NULL);
+  h = bi_multiply(ctx, h, qInv);
+  ctx->mod_offset = BIGINT_P_OFFSET;
+  h = bi_residue(ctx, h);
+#if defined(CONFIG_BIGINT_MONTGOMERY)
+  ctx->use_classical = 0; /* reset for any further operation */
+#endif
+  return bi_add(ctx, m2, bi_multiply(ctx, q, h));
+}
+#endif
+
+int mg_rsa_mod_pow(const uint8_t *mod, size_t modsz, const uint8_t *exp, size_t expsz, const uint8_t *msg, size_t msgsz, uint8_t *out, size_t outsz) {
+	BI_CTX *bi_ctx = bi_initialize();
+	bigint *n = bi_import(bi_ctx, mod, (int) modsz);
+	bigint *e = bi_import(bi_ctx, exp, (int) expsz);
+	bigint *h = bi_import(bi_ctx, msg, (int) msgsz);
+	bi_set_mod(bi_ctx, n, 0);
+	bigint *m1 = bi_mod_power(bi_ctx, h, e);
+	bi_export(bi_ctx, m1, out, (int) outsz);
+	bi_free(bi_ctx, n);
+	bi_free(bi_ctx, e);
+	bi_free(bi_ctx, h);
+	bi_free(bi_ctx, m1);
+	return 0;
+}
+
+#endif /* MG_TLS == MG_TLS_BUILTIN */
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/tls_uecc.c"
+#endif
+/* Copyright 2014, Kenneth MacKay. Licensed under the BSD 2-clause license. */
+
+
+
+
+#if MG_TLS == MG_TLS_BUILTIN
+
+#ifndef MG_UECC_RNG_MAX_TRIES
+#define MG_UECC_RNG_MAX_TRIES 64
+#endif
+
+#if MG_UECC_ENABLE_VLI_API
+#define MG_UECC_VLI_API
+#else
+#define MG_UECC_VLI_API static
+#endif
+
+#if (MG_UECC_PLATFORM == mg_uecc_avr) || (MG_UECC_PLATFORM == mg_uecc_arm) || \
+    (MG_UECC_PLATFORM == mg_uecc_arm_thumb) ||                                \
+    (MG_UECC_PLATFORM == mg_uecc_arm_thumb2)
+#define MG_UECC_CONCATX(a, ...) a##__VA_ARGS__
+#define MG_UECC_CONCAT(a, ...) MG_UECC_CONCATX(a, __VA_ARGS__)
+
+#define STRX(a) #a
+#define STR(a) STRX(a)
+
+#define EVAL(...) EVAL1(EVAL1(EVAL1(EVAL1(__VA_ARGS__))))
+#define EVAL1(...) EVAL2(EVAL2(EVAL2(EVAL2(__VA_ARGS__))))
+#define EVAL2(...) EVAL3(EVAL3(EVAL3(EVAL3(__VA_ARGS__))))
+#define EVAL3(...) EVAL4(EVAL4(EVAL4(EVAL4(__VA_ARGS__))))
+#define EVAL4(...) __VA_ARGS__
+
+#define DEC_1 0
+#define DEC_2 1
+#define DEC_3 2
+#define DEC_4 3
+#define DEC_5 4
+#define DEC_6 5
+#define DEC_7 6
+#define DEC_8 7
+#define DEC_9 8
+#define DEC_10 9
+#define DEC_11 10
+#define DEC_12 11
+#define DEC_13 12
+#define DEC_14 13
+#define DEC_15 14
+#define DEC_16 15
+#define DEC_17 16
+#define DEC_18 17
+#define DEC_19 18
+#define DEC_20 19
+#define DEC_21 20
+#define DEC_22 21
+#define DEC_23 22
+#define DEC_24 23
+#define DEC_25 24
+#define DEC_26 25
+#define DEC_27 26
+#define DEC_28 27
+#define DEC_29 28
+#define DEC_30 29
+#define DEC_31 30
+#define DEC_32 31
+
+#define DEC(N) MG_UECC_CONCAT(DEC_, N)
+
+#define SECOND_ARG(_, val, ...) val
+#define SOME_CHECK_0 ~, 0
+#define GET_SECOND_ARG(...) SECOND_ARG(__VA_ARGS__, SOME, )
+#define SOME_OR_0(N) GET_SECOND_ARG(MG_UECC_CONCAT(SOME_CHECK_, N))
+
+#define MG_UECC_EMPTY(...)
+#define DEFER(...) __VA_ARGS__ MG_UECC_EMPTY()
+
+#define REPEAT_NAME_0() REPEAT_0
+#define REPEAT_NAME_SOME() REPEAT_SOME
+#define REPEAT_0(...)
+#define REPEAT_SOME(N, stuff) \
+  DEFER(MG_UECC_CONCAT(REPEAT_NAME_, SOME_OR_0(DEC(N))))()(DEC(N), stuff) stuff
+#define REPEAT(N, stuff) EVAL(REPEAT_SOME(N, stuff))
+
+#define REPEATM_NAME_0() REPEATM_0
+#define REPEATM_NAME_SOME() REPEATM_SOME
+#define REPEATM_0(...)
+#define REPEATM_SOME(N, macro) \
+  macro(N) DEFER(MG_UECC_CONCAT(REPEATM_NAME_, SOME_OR_0(DEC(N))))()(DEC(N), macro)
+#define REPEATM(N, macro) EVAL(REPEATM_SOME(N, macro))
+#endif
+
+// 
+
+#if (MG_UECC_WORD_SIZE == 1)
+#if MG_UECC_SUPPORTS_secp160r1
+#define MG_UECC_MAX_WORDS 21 /* Due to the size of curve_n. */
+#endif
+#if MG_UECC_SUPPORTS_secp192r1
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 24
+#endif
+#if MG_UECC_SUPPORTS_secp224r1
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 28
+#endif
+#if (MG_UECC_SUPPORTS_secp256r1 || MG_UECC_SUPPORTS_secp256k1)
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 32
+#endif
+#elif (MG_UECC_WORD_SIZE == 4)
+#if MG_UECC_SUPPORTS_secp160r1
+#define MG_UECC_MAX_WORDS 6 /* Due to the size of curve_n. */
+#endif
+#if MG_UECC_SUPPORTS_secp192r1
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 6
+#endif
+#if MG_UECC_SUPPORTS_secp224r1
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 7
+#endif
+#if (MG_UECC_SUPPORTS_secp256r1 || MG_UECC_SUPPORTS_secp256k1)
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 8
+#endif
+#elif (MG_UECC_WORD_SIZE == 8)
+#if MG_UECC_SUPPORTS_secp160r1
+#define MG_UECC_MAX_WORDS 3
+#endif
+#if MG_UECC_SUPPORTS_secp192r1
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 3
+#endif
+#if MG_UECC_SUPPORTS_secp224r1
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 4
+#endif
+#if (MG_UECC_SUPPORTS_secp256r1 || MG_UECC_SUPPORTS_secp256k1)
+#undef MG_UECC_MAX_WORDS
+#define MG_UECC_MAX_WORDS 4
+#endif
+#endif /* MG_UECC_WORD_SIZE */
+
+#define BITS_TO_WORDS(num_bits)                                \
+  ((wordcount_t) ((num_bits + ((MG_UECC_WORD_SIZE * 8) - 1)) / \
+                  (MG_UECC_WORD_SIZE * 8)))
+#define BITS_TO_BYTES(num_bits) ((num_bits + 7) / 8)
+
+struct MG_UECC_Curve_t {
+  wordcount_t num_words;
+  wordcount_t num_bytes;
+  bitcount_t num_n_bits;
+  mg_uecc_word_t p[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t n[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t G[MG_UECC_MAX_WORDS * 2];
+  mg_uecc_word_t b[MG_UECC_MAX_WORDS];
+  void (*double_jacobian)(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                          mg_uecc_word_t *Z1, MG_UECC_Curve curve);
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+  void (*mod_sqrt)(mg_uecc_word_t *a, MG_UECC_Curve curve);
+#endif
+  void (*x_side)(mg_uecc_word_t *result, const mg_uecc_word_t *x,
+                 MG_UECC_Curve curve);
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+  void (*mmod_fast)(mg_uecc_word_t *result, mg_uecc_word_t *product);
+#endif
+};
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+static void bcopy(uint8_t *dst, const uint8_t *src, unsigned num_bytes) {
+  while (0 != num_bytes) {
+    num_bytes--;
+    dst[num_bytes] = src[num_bytes];
+  }
+}
+#endif
+
+static cmpresult_t mg_uecc_vli_cmp_unsafe(const mg_uecc_word_t *left,
+                                          const mg_uecc_word_t *right,
+                                          wordcount_t num_words);
+
+#if (MG_UECC_PLATFORM == mg_uecc_arm ||       \
+     MG_UECC_PLATFORM == mg_uecc_arm_thumb || \
+     MG_UECC_PLATFORM == mg_uecc_arm_thumb2)
+
+#endif
+
+#if (MG_UECC_PLATFORM == mg_uecc_avr)
+
+#endif
+
+#ifndef asm_clear
+#define asm_clear 0
+#endif
+#ifndef asm_set
+#define asm_set 0
+#endif
+#ifndef asm_add
+#define asm_add 0
+#endif
+#ifndef asm_sub
+#define asm_sub 0
+#endif
+#ifndef asm_mult
+#define asm_mult 0
+#endif
+#ifndef asm_rshift1
+#define asm_rshift1 0
+#endif
+#ifndef asm_mmod_fast_secp256r1
+#define asm_mmod_fast_secp256r1 0
+#endif
+
+#if defined(default_RNG_defined) && default_RNG_defined
+static MG_UECC_RNG_Function g_rng_function = &default_RNG;
+#else
+static MG_UECC_RNG_Function g_rng_function = 0;
+#endif
+
+void mg_uecc_set_rng(MG_UECC_RNG_Function rng_function) {
+  g_rng_function = rng_function;
+}
+
+MG_UECC_RNG_Function mg_uecc_get_rng(void) {
+  return g_rng_function;
+}
+
+int mg_uecc_curve_private_key_size(MG_UECC_Curve curve) {
+  return BITS_TO_BYTES(curve->num_n_bits);
+}
+
+int mg_uecc_curve_public_key_size(MG_UECC_Curve curve) {
+  return 2 * curve->num_bytes;
+}
+
+#if !asm_clear
+MG_UECC_VLI_API void mg_uecc_vli_clear(mg_uecc_word_t *vli,
+                                       wordcount_t num_words) {
+  wordcount_t i;
+  for (i = 0; i < num_words; ++i) {
+    vli[i] = 0;
+  }
+}
+#endif /* !asm_clear */
+
+/* Constant-time comparison to zero - secure way to compare long integers */
+/* Returns 1 if vli == 0, 0 otherwise. */
+MG_UECC_VLI_API mg_uecc_word_t mg_uecc_vli_isZero(const mg_uecc_word_t *vli,
+                                                  wordcount_t num_words) {
+  mg_uecc_word_t bits = 0;
+  wordcount_t i;
+  for (i = 0; i < num_words; ++i) {
+    bits |= vli[i];
+  }
+  return (bits == 0);
+}
+
+/* Returns nonzero if bit 'bit' of vli is set. */
+MG_UECC_VLI_API mg_uecc_word_t mg_uecc_vli_testBit(const mg_uecc_word_t *vli,
+                                                   bitcount_t bit) {
+  return (vli[bit >> MG_UECC_WORD_BITS_SHIFT] &
+          ((mg_uecc_word_t) 1 << (bit & MG_UECC_WORD_BITS_MASK)));
+}
+
+/* Counts the number of words in vli. */
+static wordcount_t vli_numDigits(const mg_uecc_word_t *vli,
+                                 const wordcount_t max_words) {
+  wordcount_t i;
+  /* Search from the end until we find a non-zero digit.
+     We do it in reverse because we expect that most digits will be nonzero. */
+  for (i = max_words - 1; i >= 0 && vli[i] == 0; --i) {
+  }
+
+  return (i + 1);
+}
+
+/* Counts the number of bits required to represent vli. */
+MG_UECC_VLI_API bitcount_t mg_uecc_vli_numBits(const mg_uecc_word_t *vli,
+                                               const wordcount_t max_words) {
+  mg_uecc_word_t i;
+  mg_uecc_word_t digit;
+
+  wordcount_t num_digits = vli_numDigits(vli, max_words);
+  if (num_digits == 0) {
+    return 0;
+  }
+
+  digit = vli[num_digits - 1];
+  for (i = 0; digit; ++i) {
+    digit >>= 1;
+  }
+
+  return (((bitcount_t) ((num_digits - 1) << MG_UECC_WORD_BITS_SHIFT)) +
+          (bitcount_t) i);
+}
+
+/* Sets dest = src. */
+#if !asm_set
+MG_UECC_VLI_API void mg_uecc_vli_set(mg_uecc_word_t *dest,
+                                     const mg_uecc_word_t *src,
+                                     wordcount_t num_words) {
+  wordcount_t i;
+  for (i = 0; i < num_words; ++i) {
+    dest[i] = src[i];
+  }
+}
+#endif /* !asm_set */
+
+/* Returns sign of left - right. */
+static cmpresult_t mg_uecc_vli_cmp_unsafe(const mg_uecc_word_t *left,
+                                          const mg_uecc_word_t *right,
+                                          wordcount_t num_words) {
+  wordcount_t i;
+  for (i = num_words - 1; i >= 0; --i) {
+    if (left[i] > right[i]) {
+      return 1;
+    } else if (left[i] < right[i]) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+/* Constant-time comparison function - secure way to compare long integers */
+/* Returns one if left == right, zero otherwise. */
+MG_UECC_VLI_API mg_uecc_word_t mg_uecc_vli_equal(const mg_uecc_word_t *left,
+                                                 const mg_uecc_word_t *right,
+                                                 wordcount_t num_words) {
+  mg_uecc_word_t diff = 0;
+  wordcount_t i;
+  for (i = num_words - 1; i >= 0; --i) {
+    diff |= (left[i] ^ right[i]);
+  }
+  return (diff == 0);
+}
+
+MG_UECC_VLI_API mg_uecc_word_t mg_uecc_vli_sub(mg_uecc_word_t *result,
+                                               const mg_uecc_word_t *left,
+                                               const mg_uecc_word_t *right,
+                                               wordcount_t num_words);
+
+/* Returns sign of left - right, in constant time. */
+MG_UECC_VLI_API cmpresult_t mg_uecc_vli_cmp(const mg_uecc_word_t *left,
+                                            const mg_uecc_word_t *right,
+                                            wordcount_t num_words) {
+  mg_uecc_word_t tmp[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t neg = !!mg_uecc_vli_sub(tmp, left, right, num_words);
+  mg_uecc_word_t equal = mg_uecc_vli_isZero(tmp, num_words);
+  return (cmpresult_t) (!equal - 2 * neg);
+}
+
+/* Computes vli = vli >> 1. */
+#if !asm_rshift1
+MG_UECC_VLI_API void mg_uecc_vli_rshift1(mg_uecc_word_t *vli,
+                                         wordcount_t num_words) {
+  mg_uecc_word_t *end = vli;
+  mg_uecc_word_t carry = 0;
+
+  vli += num_words;
+  while (vli-- > end) {
+    mg_uecc_word_t temp = *vli;
+    *vli = (temp >> 1) | carry;
+    carry = temp << (MG_UECC_WORD_BITS - 1);
+  }
+}
+#endif /* !asm_rshift1 */
+
+/* Computes result = left + right, returning carry. Can modify in place. */
+#if !asm_add
+MG_UECC_VLI_API mg_uecc_word_t mg_uecc_vli_add(mg_uecc_word_t *result,
+                                               const mg_uecc_word_t *left,
+                                               const mg_uecc_word_t *right,
+                                               wordcount_t num_words) {
+  mg_uecc_word_t carry = 0;
+  wordcount_t i;
+  for (i = 0; i < num_words; ++i) {
+    mg_uecc_word_t sum = left[i] + right[i] + carry;
+    if (sum != left[i]) {
+      carry = (sum < left[i]);
+    }
+    result[i] = sum;
+  }
+  return carry;
+}
+#endif /* !asm_add */
+
+/* Computes result = left - right, returning borrow. Can modify in place. */
+#if !asm_sub
+MG_UECC_VLI_API mg_uecc_word_t mg_uecc_vli_sub(mg_uecc_word_t *result,
+                                               const mg_uecc_word_t *left,
+                                               const mg_uecc_word_t *right,
+                                               wordcount_t num_words) {
+  mg_uecc_word_t borrow = 0;
+  wordcount_t i;
+  for (i = 0; i < num_words; ++i) {
+    mg_uecc_word_t diff = left[i] - right[i] - borrow;
+    if (diff != left[i]) {
+      borrow = (diff > left[i]);
+    }
+    result[i] = diff;
+  }
+  return borrow;
+}
+#endif /* !asm_sub */
+
+#if !asm_mult || (MG_UECC_SQUARE_FUNC && !asm_square) ||               \
+    (MG_UECC_SUPPORTS_secp256k1 && (MG_UECC_OPTIMIZATION_LEVEL > 0) && \
+     ((MG_UECC_WORD_SIZE == 1) || (MG_UECC_WORD_SIZE == 8)))
+static void muladd(mg_uecc_word_t a, mg_uecc_word_t b, mg_uecc_word_t *r0,
+                   mg_uecc_word_t *r1, mg_uecc_word_t *r2) {
+#if MG_UECC_WORD_SIZE == 8
+  uint64_t a0 = a & 0xffffffff;
+  uint64_t a1 = a >> 32;
+  uint64_t b0 = b & 0xffffffff;
+  uint64_t b1 = b >> 32;
+
+  uint64_t i0 = a0 * b0;
+  uint64_t i1 = a0 * b1;
+  uint64_t i2 = a1 * b0;
+  uint64_t i3 = a1 * b1;
+
+  uint64_t p0, p1;
+
+  i2 += (i0 >> 32);
+  i2 += i1;
+  if (i2 < i1) { /* overflow */
+    i3 += 0x100000000;
+  }
+
+  p0 = (i0 & 0xffffffff) | (i2 << 32);
+  p1 = i3 + (i2 >> 32);
+
+  *r0 += p0;
+  *r1 += (p1 + (*r0 < p0));
+  *r2 += ((*r1 < p1) || (*r1 == p1 && *r0 < p0));
+#else
+  mg_uecc_dword_t p = (mg_uecc_dword_t) a * b;
+  mg_uecc_dword_t r01 = ((mg_uecc_dword_t) (*r1) << MG_UECC_WORD_BITS) | *r0;
+  r01 += p;
+  *r2 += (r01 < p);
+  *r1 = (mg_uecc_word_t) (r01 >> MG_UECC_WORD_BITS);
+  *r0 = (mg_uecc_word_t) r01;
+#endif
+}
+#endif /* muladd needed */
+
+#if !asm_mult
+MG_UECC_VLI_API void mg_uecc_vli_mult(mg_uecc_word_t *result,
+                                      const mg_uecc_word_t *left,
+                                      const mg_uecc_word_t *right,
+                                      wordcount_t num_words) {
+  mg_uecc_word_t r0 = 0;
+  mg_uecc_word_t r1 = 0;
+  mg_uecc_word_t r2 = 0;
+  wordcount_t i, k;
+
+  /* Compute each digit of result in sequence, maintaining the carries. */
+  for (k = 0; k < num_words; ++k) {
+    for (i = 0; i <= k; ++i) {
+      muladd(left[i], right[k - i], &r0, &r1, &r2);
+    }
+    result[k] = r0;
+    r0 = r1;
+    r1 = r2;
+    r2 = 0;
+  }
+  for (k = num_words; k < num_words * 2 - 1; ++k) {
+    for (i = (wordcount_t) ((k + 1) - num_words); i < num_words; ++i) {
+      muladd(left[i], right[k - i], &r0, &r1, &r2);
+    }
+    result[k] = r0;
+    r0 = r1;
+    r1 = r2;
+    r2 = 0;
+  }
+  result[num_words * 2 - 1] = r0;
+}
+#endif /* !asm_mult */
+
+#if MG_UECC_SQUARE_FUNC
+
+#if !asm_square
+static void mul2add(mg_uecc_word_t a, mg_uecc_word_t b, mg_uecc_word_t *r0,
+                    mg_uecc_word_t *r1, mg_uecc_word_t *r2) {
+#if MG_UECC_WORD_SIZE == 8
+  uint64_t a0 = a & 0xffffffffull;
+  uint64_t a1 = a >> 32;
+  uint64_t b0 = b & 0xffffffffull;
+  uint64_t b1 = b >> 32;
+
+  uint64_t i0 = a0 * b0;
+  uint64_t i1 = a0 * b1;
+  uint64_t i2 = a1 * b0;
+  uint64_t i3 = a1 * b1;
+
+  uint64_t p0, p1;
+
+  i2 += (i0 >> 32);
+  i2 += i1;
+  if (i2 < i1) { /* overflow */
+    i3 += 0x100000000ull;
+  }
+
+  p0 = (i0 & 0xffffffffull) | (i2 << 32);
+  p1 = i3 + (i2 >> 32);
+
+  *r2 += (p1 >> 63);
+  p1 = (p1 << 1) | (p0 >> 63);
+  p0 <<= 1;
+
+  *r0 += p0;
+  *r1 += (p1 + (*r0 < p0));
+  *r2 += ((*r1 < p1) || (*r1 == p1 && *r0 < p0));
+#else
+  mg_uecc_dword_t p = (mg_uecc_dword_t) a * b;
+  mg_uecc_dword_t r01 = ((mg_uecc_dword_t) (*r1) << MG_UECC_WORD_BITS) | *r0;
+  *r2 += (p >> (MG_UECC_WORD_BITS * 2 - 1));
+  p *= 2;
+  r01 += p;
+  *r2 += (r01 < p);
+  *r1 = r01 >> MG_UECC_WORD_BITS;
+  *r0 = (mg_uecc_word_t) r01;
+#endif
+}
+
+MG_UECC_VLI_API void mg_uecc_vli_square(mg_uecc_word_t *result,
+                                        const mg_uecc_word_t *left,
+                                        wordcount_t num_words) {
+  mg_uecc_word_t r0 = 0;
+  mg_uecc_word_t r1 = 0;
+  mg_uecc_word_t r2 = 0;
+
+  wordcount_t i, k;
+
+  for (k = 0; k < num_words * 2 - 1; ++k) {
+    mg_uecc_word_t min = (k < num_words ? 0 : (k + 1) - num_words);
+    for (i = min; i <= k && i <= k - i; ++i) {
+      if (i < k - i) {
+        mul2add(left[i], left[k - i], &r0, &r1, &r2);
+      } else {
+        muladd(left[i], left[k - i], &r0, &r1, &r2);
+      }
+    }
+    result[k] = r0;
+    r0 = r1;
+    r1 = r2;
+    r2 = 0;
+  }
+
+  result[num_words * 2 - 1] = r0;
+}
+#endif /* !asm_square */
+
+#else /* MG_UECC_SQUARE_FUNC */
+
+#if MG_UECC_ENABLE_VLI_API
+MG_UECC_VLI_API void mg_uecc_vli_square(mg_uecc_word_t *result,
+                                        const mg_uecc_word_t *left,
+                                        wordcount_t num_words) {
+  mg_uecc_vli_mult(result, left, left, num_words);
+}
+#endif /* MG_UECC_ENABLE_VLI_API */
+
+#endif /* MG_UECC_SQUARE_FUNC */
+
+/* Computes result = (left + right) % mod.
+   Assumes that left < mod and right < mod, and that result does not overlap
+   mod. */
+MG_UECC_VLI_API void mg_uecc_vli_modAdd(mg_uecc_word_t *result,
+                                        const mg_uecc_word_t *left,
+                                        const mg_uecc_word_t *right,
+                                        const mg_uecc_word_t *mod,
+                                        wordcount_t num_words) {
+  mg_uecc_word_t carry = mg_uecc_vli_add(result, left, right, num_words);
+  if (carry || mg_uecc_vli_cmp_unsafe(mod, result, num_words) != 1) {
+    /* result > mod (result = mod + remainder), so subtract mod to get
+     * remainder. */
+    mg_uecc_vli_sub(result, result, mod, num_words);
+  }
+}
+
+/* Computes result = (left - right) % mod.
+   Assumes that left < mod and right < mod, and that result does not overlap
+   mod. */
+MG_UECC_VLI_API void mg_uecc_vli_modSub(mg_uecc_word_t *result,
+                                        const mg_uecc_word_t *left,
+                                        const mg_uecc_word_t *right,
+                                        const mg_uecc_word_t *mod,
+                                        wordcount_t num_words) {
+  mg_uecc_word_t l_borrow = mg_uecc_vli_sub(result, left, right, num_words);
+  if (l_borrow) {
+    /* In this case, result == -diff == (max int) - diff. Since -x % d == d - x,
+       we can get the correct result from result + mod (with overflow). */
+    mg_uecc_vli_add(result, result, mod, num_words);
+  }
+}
+
+/* Computes result = product % mod, where product is 2N words long. */
+/* Currently only designed to work for curve_p or curve_n. */
+MG_UECC_VLI_API void mg_uecc_vli_mmod(mg_uecc_word_t *result,
+                                      mg_uecc_word_t *product,
+                                      const mg_uecc_word_t *mod,
+                                      wordcount_t num_words) {
+  mg_uecc_word_t mod_multiple[2 * MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tmp[2 * MG_UECC_MAX_WORDS];
+  mg_uecc_word_t *v[2] = {tmp, product};
+  mg_uecc_word_t index;
+
+  /* Shift mod so its highest set bit is at the maximum position. */
+  bitcount_t shift = (bitcount_t) ((num_words * 2 * MG_UECC_WORD_BITS) -
+                                   mg_uecc_vli_numBits(mod, num_words));
+  wordcount_t word_shift = (wordcount_t) (shift / MG_UECC_WORD_BITS);
+  wordcount_t bit_shift = (wordcount_t) (shift % MG_UECC_WORD_BITS);
+  mg_uecc_word_t carry = 0;
+  mg_uecc_vli_clear(mod_multiple, word_shift);
+  if (bit_shift > 0) {
+    for (index = 0; index < (mg_uecc_word_t) num_words; ++index) {
+      mod_multiple[(mg_uecc_word_t) word_shift + index] =
+          (mg_uecc_word_t) (mod[index] << bit_shift) | carry;
+      carry = mod[index] >> (MG_UECC_WORD_BITS - bit_shift);
+    }
+  } else {
+    mg_uecc_vli_set(mod_multiple + word_shift, mod, num_words);
+  }
+
+  for (index = 1; shift >= 0; --shift) {
+    mg_uecc_word_t borrow = 0;
+    wordcount_t i;
+    for (i = 0; i < num_words * 2; ++i) {
+      mg_uecc_word_t diff = v[index][i] - mod_multiple[i] - borrow;
+      if (diff != v[index][i]) {
+        borrow = (diff > v[index][i]);
+      }
+      v[1 - index][i] = diff;
+    }
+    index = !(index ^ borrow); /* Swap the index if there was no borrow */
+    mg_uecc_vli_rshift1(mod_multiple, num_words);
+    mod_multiple[num_words - 1] |= mod_multiple[num_words]
+                                   << (MG_UECC_WORD_BITS - 1);
+    mg_uecc_vli_rshift1(mod_multiple + num_words, num_words);
+  }
+  mg_uecc_vli_set(result, v[index], num_words);
+}
+
+/* Computes result = (left * right) % mod. */
+MG_UECC_VLI_API void mg_uecc_vli_modMult(mg_uecc_word_t *result,
+                                         const mg_uecc_word_t *left,
+                                         const mg_uecc_word_t *right,
+                                         const mg_uecc_word_t *mod,
+                                         wordcount_t num_words) {
+  mg_uecc_word_t product[2 * MG_UECC_MAX_WORDS];
+  mg_uecc_vli_mult(product, left, right, num_words);
+  mg_uecc_vli_mmod(result, product, mod, num_words);
+}
+
+MG_UECC_VLI_API void mg_uecc_vli_modMult_fast(mg_uecc_word_t *result,
+                                              const mg_uecc_word_t *left,
+                                              const mg_uecc_word_t *right,
+                                              MG_UECC_Curve curve) {
+  mg_uecc_word_t product[2 * MG_UECC_MAX_WORDS];
+  mg_uecc_vli_mult(product, left, right, curve->num_words);
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+  curve->mmod_fast(result, product);
+#else
+  mg_uecc_vli_mmod(result, product, curve->p, curve->num_words);
+#endif
+}
+
+#if MG_UECC_SQUARE_FUNC
+
+#if MG_UECC_ENABLE_VLI_API
+/* Computes result = left^2 % mod. */
+MG_UECC_VLI_API void mg_uecc_vli_modSquare(mg_uecc_word_t *result,
+                                           const mg_uecc_word_t *left,
+                                           const mg_uecc_word_t *mod,
+                                           wordcount_t num_words) {
+  mg_uecc_word_t product[2 * MG_UECC_MAX_WORDS];
+  mg_uecc_vli_square(product, left, num_words);
+  mg_uecc_vli_mmod(result, product, mod, num_words);
+}
+#endif /* MG_UECC_ENABLE_VLI_API */
+
+MG_UECC_VLI_API void mg_uecc_vli_modSquare_fast(mg_uecc_word_t *result,
+                                                const mg_uecc_word_t *left,
+                                                MG_UECC_Curve curve) {
+  mg_uecc_word_t product[2 * MG_UECC_MAX_WORDS];
+  mg_uecc_vli_square(product, left, curve->num_words);
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+  curve->mmod_fast(result, product);
+#else
+  mg_uecc_vli_mmod(result, product, curve->p, curve->num_words);
+#endif
+}
+
+#else /* MG_UECC_SQUARE_FUNC */
+
+#if MG_UECC_ENABLE_VLI_API
+MG_UECC_VLI_API void mg_uecc_vli_modSquare(mg_uecc_word_t *result,
+                                           const mg_uecc_word_t *left,
+                                           const mg_uecc_word_t *mod,
+                                           wordcount_t num_words) {
+  mg_uecc_vli_modMult(result, left, left, mod, num_words);
+}
+#endif /* MG_UECC_ENABLE_VLI_API */
+
+MG_UECC_VLI_API void mg_uecc_vli_modSquare_fast(mg_uecc_word_t *result,
+                                                const mg_uecc_word_t *left,
+                                                MG_UECC_Curve curve) {
+  mg_uecc_vli_modMult_fast(result, left, left, curve);
+}
+
+#endif /* MG_UECC_SQUARE_FUNC */
+
+#define EVEN(vli) (!(vli[0] & 1))
+static void vli_modInv_update(mg_uecc_word_t *uv, const mg_uecc_word_t *mod,
+                              wordcount_t num_words) {
+  mg_uecc_word_t carry = 0;
+  if (!EVEN(uv)) {
+    carry = mg_uecc_vli_add(uv, uv, mod, num_words);
+  }
+  mg_uecc_vli_rshift1(uv, num_words);
+  if (carry) {
+    uv[num_words - 1] |= HIGH_BIT_SET;
+  }
+}
+
+/* Computes result = (1 / input) % mod. All VLIs are the same size.
+   See "From Euclid's GCD to Montgomery Multiplication to the Great Divide" */
+MG_UECC_VLI_API void mg_uecc_vli_modInv(mg_uecc_word_t *result,
+                                        const mg_uecc_word_t *input,
+                                        const mg_uecc_word_t *mod,
+                                        wordcount_t num_words) {
+  mg_uecc_word_t a[MG_UECC_MAX_WORDS], b[MG_UECC_MAX_WORDS],
+      u[MG_UECC_MAX_WORDS], v[MG_UECC_MAX_WORDS];
+  cmpresult_t cmpResult;
+
+  if (mg_uecc_vli_isZero(input, num_words)) {
+    mg_uecc_vli_clear(result, num_words);
+    return;
+  }
+
+  mg_uecc_vli_set(a, input, num_words);
+  mg_uecc_vli_set(b, mod, num_words);
+  mg_uecc_vli_clear(u, num_words);
+  u[0] = 1;
+  mg_uecc_vli_clear(v, num_words);
+  while ((cmpResult = mg_uecc_vli_cmp_unsafe(a, b, num_words)) != 0) {
+    if (EVEN(a)) {
+      mg_uecc_vli_rshift1(a, num_words);
+      vli_modInv_update(u, mod, num_words);
+    } else if (EVEN(b)) {
+      mg_uecc_vli_rshift1(b, num_words);
+      vli_modInv_update(v, mod, num_words);
+    } else if (cmpResult > 0) {
+      mg_uecc_vli_sub(a, a, b, num_words);
+      mg_uecc_vli_rshift1(a, num_words);
+      if (mg_uecc_vli_cmp_unsafe(u, v, num_words) < 0) {
+        mg_uecc_vli_add(u, u, mod, num_words);
+      }
+      mg_uecc_vli_sub(u, u, v, num_words);
+      vli_modInv_update(u, mod, num_words);
+    } else {
+      mg_uecc_vli_sub(b, b, a, num_words);
+      mg_uecc_vli_rshift1(b, num_words);
+      if (mg_uecc_vli_cmp_unsafe(v, u, num_words) < 0) {
+        mg_uecc_vli_add(v, v, mod, num_words);
+      }
+      mg_uecc_vli_sub(v, v, u, num_words);
+      vli_modInv_update(v, mod, num_words);
+    }
+  }
+  mg_uecc_vli_set(result, u, num_words);
+}
+
+/* ------ Point operations ------ */
+
+/* Copyright 2015, Kenneth MacKay. Licensed under the BSD 2-clause license. */
+
+#ifndef _UECC_CURVE_SPECIFIC_H_
+#define _UECC_CURVE_SPECIFIC_H_
+
+#define num_bytes_secp160r1 20
+#define num_bytes_secp192r1 24
+#define num_bytes_secp224r1 28
+#define num_bytes_secp256r1 32
+#define num_bytes_secp256k1 32
+
+#if (MG_UECC_WORD_SIZE == 1)
+
+#define num_words_secp160r1 20
+#define num_words_secp192r1 24
+#define num_words_secp224r1 28
+#define num_words_secp256r1 32
+#define num_words_secp256k1 32
+
+#define BYTES_TO_WORDS_8(a, b, c, d, e, f, g, h) \
+  0x##a, 0x##b, 0x##c, 0x##d, 0x##e, 0x##f, 0x##g, 0x##h
+#define BYTES_TO_WORDS_4(a, b, c, d) 0x##a, 0x##b, 0x##c, 0x##d
+
+#elif (MG_UECC_WORD_SIZE == 4)
+
+#define num_words_secp160r1 5
+#define num_words_secp192r1 6
+#define num_words_secp224r1 7
+#define num_words_secp256r1 8
+#define num_words_secp256k1 8
+
+#define BYTES_TO_WORDS_8(a, b, c, d, e, f, g, h) 0x##d##c##b##a, 0x##h##g##f##e
+#define BYTES_TO_WORDS_4(a, b, c, d) 0x##d##c##b##a
+
+#elif (MG_UECC_WORD_SIZE == 8)
+
+#define num_words_secp160r1 3
+#define num_words_secp192r1 3
+#define num_words_secp224r1 4
+#define num_words_secp256r1 4
+#define num_words_secp256k1 4
+
+#define BYTES_TO_WORDS_8(a, b, c, d, e, f, g, h) 0x##h##g##f##e##d##c##b##a##U
+#define BYTES_TO_WORDS_4(a, b, c, d) 0x##d##c##b##a##U
+
+#endif /* MG_UECC_WORD_SIZE */
+
+#if MG_UECC_SUPPORTS_secp160r1 || MG_UECC_SUPPORTS_secp192r1 || \
+    MG_UECC_SUPPORTS_secp224r1 || MG_UECC_SUPPORTS_secp256r1
+static void double_jacobian_default(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                                    mg_uecc_word_t *Z1, MG_UECC_Curve curve) {
+  /* t1 = X, t2 = Y, t3 = Z */
+  mg_uecc_word_t t4[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t t5[MG_UECC_MAX_WORDS];
+  wordcount_t num_words = curve->num_words;
+
+  if (mg_uecc_vli_isZero(Z1, num_words)) {
+    return;
+  }
+
+  mg_uecc_vli_modSquare_fast(t4, Y1, curve);   /* t4 = y1^2 */
+  mg_uecc_vli_modMult_fast(t5, X1, t4, curve); /* t5 = x1*y1^2 = A */
+  mg_uecc_vli_modSquare_fast(t4, t4, curve);   /* t4 = y1^4 */
+  mg_uecc_vli_modMult_fast(Y1, Y1, Z1, curve); /* t2 = y1*z1 = z3 */
+  mg_uecc_vli_modSquare_fast(Z1, Z1, curve);   /* t3 = z1^2 */
+
+  mg_uecc_vli_modAdd(X1, X1, Z1, curve->p, num_words); /* t1 = x1 + z1^2 */
+  mg_uecc_vli_modAdd(Z1, Z1, Z1, curve->p, num_words); /* t3 = 2*z1^2 */
+  mg_uecc_vli_modSub(Z1, X1, Z1, curve->p, num_words); /* t3 = x1 - z1^2 */
+  mg_uecc_vli_modMult_fast(X1, X1, Z1, curve);         /* t1 = x1^2 - z1^4 */
+
+  mg_uecc_vli_modAdd(Z1, X1, X1, curve->p,
+                     num_words); /* t3 = 2*(x1^2 - z1^4) */
+  mg_uecc_vli_modAdd(X1, X1, Z1, curve->p,
+                     num_words); /* t1 = 3*(x1^2 - z1^4) */
+  if (mg_uecc_vli_testBit(X1, 0)) {
+    mg_uecc_word_t l_carry = mg_uecc_vli_add(X1, X1, curve->p, num_words);
+    mg_uecc_vli_rshift1(X1, num_words);
+    X1[num_words - 1] |= l_carry << (MG_UECC_WORD_BITS - 1);
+  } else {
+    mg_uecc_vli_rshift1(X1, num_words);
+  }
+  /* t1 = 3/2*(x1^2 - z1^4) = B */
+
+  mg_uecc_vli_modSquare_fast(Z1, X1, curve);           /* t3 = B^2 */
+  mg_uecc_vli_modSub(Z1, Z1, t5, curve->p, num_words); /* t3 = B^2 - A */
+  mg_uecc_vli_modSub(Z1, Z1, t5, curve->p, num_words); /* t3 = B^2 - 2A = x3 */
+  mg_uecc_vli_modSub(t5, t5, Z1, curve->p, num_words); /* t5 = A - x3 */
+  mg_uecc_vli_modMult_fast(X1, X1, t5, curve);         /* t1 = B * (A - x3) */
+  mg_uecc_vli_modSub(t4, X1, t4, curve->p,
+                     num_words); /* t4 = B * (A - x3) - y1^4 = y3 */
+
+  mg_uecc_vli_set(X1, Z1, num_words);
+  mg_uecc_vli_set(Z1, Y1, num_words);
+  mg_uecc_vli_set(Y1, t4, num_words);
+}
+
+/* Computes result = x^3 + ax + b. result must not overlap x. */
+static void x_side_default(mg_uecc_word_t *result, const mg_uecc_word_t *x,
+                           MG_UECC_Curve curve) {
+  mg_uecc_word_t _3[MG_UECC_MAX_WORDS] = {3}; /* -a = 3 */
+  wordcount_t num_words = curve->num_words;
+
+  mg_uecc_vli_modSquare_fast(result, x, curve);                /* r = x^2 */
+  mg_uecc_vli_modSub(result, result, _3, curve->p, num_words); /* r = x^2 - 3 */
+  mg_uecc_vli_modMult_fast(result, result, x, curve); /* r = x^3 - 3x */
+  mg_uecc_vli_modAdd(result, result, curve->b, curve->p,
+                     num_words); /* r = x^3 - 3x + b */
+}
+#endif /* MG_UECC_SUPPORTS_secp... */
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+#if MG_UECC_SUPPORTS_secp160r1 || MG_UECC_SUPPORTS_secp192r1 || \
+    MG_UECC_SUPPORTS_secp256r1 || MG_UECC_SUPPORTS_secp256k1
+/* Compute a = sqrt(a) (mod curve_p). */
+static void mod_sqrt_default(mg_uecc_word_t *a, MG_UECC_Curve curve) {
+  bitcount_t i;
+  mg_uecc_word_t p1[MG_UECC_MAX_WORDS] = {1};
+  mg_uecc_word_t l_result[MG_UECC_MAX_WORDS] = {1};
+  wordcount_t num_words = curve->num_words;
+
+  /* When curve->p == 3 (mod 4), we can compute
+     sqrt(a) = a^((curve->p + 1) / 4) (mod curve->p). */
+  mg_uecc_vli_add(p1, curve->p, p1, num_words); /* p1 = curve_p + 1 */
+  for (i = mg_uecc_vli_numBits(p1, num_words) - 1; i > 1; --i) {
+    mg_uecc_vli_modSquare_fast(l_result, l_result, curve);
+    if (mg_uecc_vli_testBit(p1, i)) {
+      mg_uecc_vli_modMult_fast(l_result, l_result, a, curve);
+    }
+  }
+  mg_uecc_vli_set(a, l_result, num_words);
+}
+#endif /* MG_UECC_SUPPORTS_secp... */
+#endif /* MG_UECC_SUPPORT_COMPRESSED_POINT */
+
+#if MG_UECC_SUPPORTS_secp160r1
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+static void vli_mmod_fast_secp160r1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product);
+#endif
+
+static const struct MG_UECC_Curve_t curve_secp160r1 = {
+    num_words_secp160r1,
+    num_bytes_secp160r1,
+    161, /* num_n_bits */
+    {BYTES_TO_WORDS_8(FF, FF, FF, 7F, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_4(FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(57, 22, 75, CA, D3, AE, 27, F9),
+     BYTES_TO_WORDS_8(C8, F4, 01, 00, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, 01, 00, 00, 00)},
+    {BYTES_TO_WORDS_8(82, FC, CB, 13, B9, 8B, C3, 68),
+     BYTES_TO_WORDS_8(89, 69, 64, 46, 28, 73, F5, 8E),
+     BYTES_TO_WORDS_4(68, B5, 96, 4A),
+
+     BYTES_TO_WORDS_8(32, FB, C5, 7A, 37, 51, 23, 04),
+     BYTES_TO_WORDS_8(12, C9, DC, 59, 7D, 94, 68, 31),
+     BYTES_TO_WORDS_4(55, 28, A6, 23)},
+    {BYTES_TO_WORDS_8(45, FA, 65, C5, AD, D4, D4, 81),
+     BYTES_TO_WORDS_8(9F, F8, AC, 65, 8B, 7A, BD, 54),
+     BYTES_TO_WORDS_4(FC, BE, 97, 1C)},
+    &double_jacobian_default,
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+    &mod_sqrt_default,
+#endif
+    &x_side_default,
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+    &vli_mmod_fast_secp160r1
+#endif
+};
+
+MG_UECC_Curve mg_uecc_secp160r1(void) {
+  return &curve_secp160r1;
+}
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0 && !asm_mmod_fast_secp160r1)
+/* Computes result = product % curve_p
+    see http://www.isys.uni-klu.ac.at/PDF/2001-0126-MT.pdf page 354
+
+    Note that this only works if log2(omega) < log2(p) / 2 */
+static void omega_mult_secp160r1(mg_uecc_word_t *result,
+                                 const mg_uecc_word_t *right);
+#if MG_UECC_WORD_SIZE == 8
+static void vli_mmod_fast_secp160r1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product) {
+  mg_uecc_word_t tmp[2 * num_words_secp160r1];
+  mg_uecc_word_t copy;
+
+  mg_uecc_vli_clear(tmp, num_words_secp160r1);
+  mg_uecc_vli_clear(tmp + num_words_secp160r1, num_words_secp160r1);
+
+  omega_mult_secp160r1(tmp,
+                       product + num_words_secp160r1 - 1); /* (Rq, q) = q * c */
+
+  product[num_words_secp160r1 - 1] &= 0xffffffff;
+  copy = tmp[num_words_secp160r1 - 1];
+  tmp[num_words_secp160r1 - 1] &= 0xffffffff;
+  mg_uecc_vli_add(result, product, tmp,
+                  num_words_secp160r1); /* (C, r) = r + q */
+  mg_uecc_vli_clear(product, num_words_secp160r1);
+  tmp[num_words_secp160r1 - 1] = copy;
+  omega_mult_secp160r1(product, tmp + num_words_secp160r1 - 1); /* Rq*c */
+  mg_uecc_vli_add(result, result, product,
+                  num_words_secp160r1); /* (C1, r) = r + Rq*c */
+
+  while (mg_uecc_vli_cmp_unsafe(result, curve_secp160r1.p,
+                                num_words_secp160r1) > 0) {
+    mg_uecc_vli_sub(result, result, curve_secp160r1.p, num_words_secp160r1);
+  }
+}
+
+static void omega_mult_secp160r1(uint64_t *result, const uint64_t *right) {
+  uint32_t carry;
+  unsigned i;
+
+  /* Multiply by (2^31 + 1). */
+  carry = 0;
+  for (i = 0; i < num_words_secp160r1; ++i) {
+    uint64_t tmp = (right[i] >> 32) | (right[i + 1] << 32);
+    result[i] = (tmp << 31) + tmp + carry;
+    carry = (tmp >> 33) + (result[i] < tmp || (carry && result[i] == tmp));
+  }
+  result[i] = carry;
+}
+#else
+static void vli_mmod_fast_secp160r1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product) {
+  mg_uecc_word_t tmp[2 * num_words_secp160r1];
+  mg_uecc_word_t carry;
+
+  mg_uecc_vli_clear(tmp, num_words_secp160r1);
+  mg_uecc_vli_clear(tmp + num_words_secp160r1, num_words_secp160r1);
+
+  omega_mult_secp160r1(tmp,
+                       product + num_words_secp160r1); /* (Rq, q) = q * c */
+
+  carry = mg_uecc_vli_add(result, product, tmp,
+                          num_words_secp160r1); /* (C, r) = r + q */
+  mg_uecc_vli_clear(product, num_words_secp160r1);
+  omega_mult_secp160r1(product, tmp + num_words_secp160r1); /* Rq*c */
+  carry += mg_uecc_vli_add(result, result, product,
+                           num_words_secp160r1); /* (C1, r) = r + Rq*c */
+
+  while (carry > 0) {
+    --carry;
+    mg_uecc_vli_sub(result, result, curve_secp160r1.p, num_words_secp160r1);
+  }
+  if (mg_uecc_vli_cmp_unsafe(result, curve_secp160r1.p, num_words_secp160r1) >
+      0) {
+    mg_uecc_vli_sub(result, result, curve_secp160r1.p, num_words_secp160r1);
+  }
+}
+#endif
+
+#if MG_UECC_WORD_SIZE == 1
+static void omega_mult_secp160r1(uint8_t *result, const uint8_t *right) {
+  uint8_t carry;
+  uint8_t i;
+
+  /* Multiply by (2^31 + 1). */
+  mg_uecc_vli_set(result + 4, right, num_words_secp160r1); /* 2^32 */
+  mg_uecc_vli_rshift1(result + 4, num_words_secp160r1);    /* 2^31 */
+  result[3] = right[0] << 7; /* get last bit from shift */
+
+  carry = mg_uecc_vli_add(result, result, right,
+                          num_words_secp160r1); /* 2^31 + 1 */
+  for (i = num_words_secp160r1; carry; ++i) {
+    uint16_t sum = (uint16_t) result[i] + carry;
+    result[i] = (uint8_t) sum;
+    carry = sum >> 8;
+  }
+}
+#elif MG_UECC_WORD_SIZE == 4
+static void omega_mult_secp160r1(uint32_t *result, const uint32_t *right) {
+  uint32_t carry;
+  unsigned i;
+
+  /* Multiply by (2^31 + 1). */
+  mg_uecc_vli_set(result + 1, right, num_words_secp160r1); /* 2^32 */
+  mg_uecc_vli_rshift1(result + 1, num_words_secp160r1);    /* 2^31 */
+  result[0] = right[0] << 31; /* get last bit from shift */
+
+  carry = mg_uecc_vli_add(result, result, right,
+                          num_words_secp160r1); /* 2^31 + 1 */
+  for (i = num_words_secp160r1; carry; ++i) {
+    uint64_t sum = (uint64_t) result[i] + carry;
+    result[i] = (uint32_t) sum;
+    carry = sum >> 32;
+  }
+}
+#endif /* MG_UECC_WORD_SIZE */
+#endif /* (MG_UECC_OPTIMIZATION_LEVEL > 0 && !asm_mmod_fast_secp160r1) */
+
+#endif /* MG_UECC_SUPPORTS_secp160r1 */
+
+#if MG_UECC_SUPPORTS_secp192r1
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+static void vli_mmod_fast_secp192r1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product);
+#endif
+
+static const struct MG_UECC_Curve_t curve_secp192r1 = {
+    num_words_secp192r1,
+    num_bytes_secp192r1,
+    192, /* num_n_bits */
+    {BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FE, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(31, 28, D2, B4, B1, C9, 6B, 14),
+     BYTES_TO_WORDS_8(36, F8, DE, 99, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(12, 10, FF, 82, FD, 0A, FF, F4),
+     BYTES_TO_WORDS_8(00, 88, A1, 43, EB, 20, BF, 7C),
+     BYTES_TO_WORDS_8(F6, 90, 30, B0, 0E, A8, 8D, 18),
+
+     BYTES_TO_WORDS_8(11, 48, 79, 1E, A1, 77, F9, 73),
+     BYTES_TO_WORDS_8(D5, CD, 24, 6B, ED, 11, 10, 63),
+     BYTES_TO_WORDS_8(78, DA, C8, FF, 95, 2B, 19, 07)},
+    {BYTES_TO_WORDS_8(B1, B9, 46, C1, EC, DE, B8, FE),
+     BYTES_TO_WORDS_8(49, 30, 24, 72, AB, E9, A7, 0F),
+     BYTES_TO_WORDS_8(E7, 80, 9C, E5, 19, 05, 21, 64)},
+    &double_jacobian_default,
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+    &mod_sqrt_default,
+#endif
+    &x_side_default,
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+    &vli_mmod_fast_secp192r1
+#endif
+};
+
+MG_UECC_Curve mg_uecc_secp192r1(void) {
+  return &curve_secp192r1;
+}
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+/* Computes result = product % curve_p.
+   See algorithm 5 and 6 from http://www.isys.uni-klu.ac.at/PDF/2001-0126-MT.pdf
+ */
+#if MG_UECC_WORD_SIZE == 1
+static void vli_mmod_fast_secp192r1(uint8_t *result, uint8_t *product) {
+  uint8_t tmp[num_words_secp192r1];
+  uint8_t carry;
+
+  mg_uecc_vli_set(result, product, num_words_secp192r1);
+
+  mg_uecc_vli_set(tmp, &product[24], num_words_secp192r1);
+  carry = mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  tmp[0] = tmp[1] = tmp[2] = tmp[3] = tmp[4] = tmp[5] = tmp[6] = tmp[7] = 0;
+  tmp[8] = product[24];
+  tmp[9] = product[25];
+  tmp[10] = product[26];
+  tmp[11] = product[27];
+  tmp[12] = product[28];
+  tmp[13] = product[29];
+  tmp[14] = product[30];
+  tmp[15] = product[31];
+  tmp[16] = product[32];
+  tmp[17] = product[33];
+  tmp[18] = product[34];
+  tmp[19] = product[35];
+  tmp[20] = product[36];
+  tmp[21] = product[37];
+  tmp[22] = product[38];
+  tmp[23] = product[39];
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  tmp[0] = tmp[8] = product[40];
+  tmp[1] = tmp[9] = product[41];
+  tmp[2] = tmp[10] = product[42];
+  tmp[3] = tmp[11] = product[43];
+  tmp[4] = tmp[12] = product[44];
+  tmp[5] = tmp[13] = product[45];
+  tmp[6] = tmp[14] = product[46];
+  tmp[7] = tmp[15] = product[47];
+  tmp[16] = tmp[17] = tmp[18] = tmp[19] = tmp[20] = tmp[21] = tmp[22] =
+      tmp[23] = 0;
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  while (carry || mg_uecc_vli_cmp_unsafe(curve_secp192r1.p, result,
+                                         num_words_secp192r1) != 1) {
+    carry -=
+        mg_uecc_vli_sub(result, result, curve_secp192r1.p, num_words_secp192r1);
+  }
+}
+#elif MG_UECC_WORD_SIZE == 4
+static void vli_mmod_fast_secp192r1(uint32_t *result, uint32_t *product) {
+  uint32_t tmp[num_words_secp192r1];
+  int carry;
+
+  mg_uecc_vli_set(result, product, num_words_secp192r1);
+
+  mg_uecc_vli_set(tmp, &product[6], num_words_secp192r1);
+  carry = mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  tmp[0] = tmp[1] = 0;
+  tmp[2] = product[6];
+  tmp[3] = product[7];
+  tmp[4] = product[8];
+  tmp[5] = product[9];
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  tmp[0] = tmp[2] = product[10];
+  tmp[1] = tmp[3] = product[11];
+  tmp[4] = tmp[5] = 0;
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  while (carry || mg_uecc_vli_cmp_unsafe(curve_secp192r1.p, result,
+                                         num_words_secp192r1) != 1) {
+    carry -=
+        mg_uecc_vli_sub(result, result, curve_secp192r1.p, num_words_secp192r1);
+  }
+}
+#else
+static void vli_mmod_fast_secp192r1(uint64_t *result, uint64_t *product) {
+  uint64_t tmp[num_words_secp192r1];
+  int carry;
+
+  mg_uecc_vli_set(result, product, num_words_secp192r1);
+
+  mg_uecc_vli_set(tmp, &product[3], num_words_secp192r1);
+  carry = (int) mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  tmp[0] = 0;
+  tmp[1] = product[3];
+  tmp[2] = product[4];
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  tmp[0] = tmp[1] = product[5];
+  tmp[2] = 0;
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp192r1);
+
+  while (carry || mg_uecc_vli_cmp_unsafe(curve_secp192r1.p, result,
+                                         num_words_secp192r1) != 1) {
+    carry -=
+        mg_uecc_vli_sub(result, result, curve_secp192r1.p, num_words_secp192r1);
+  }
+}
+#endif /* MG_UECC_WORD_SIZE */
+#endif /* (MG_UECC_OPTIMIZATION_LEVEL > 0) */
+
+#endif /* MG_UECC_SUPPORTS_secp192r1 */
+
+#if MG_UECC_SUPPORTS_secp224r1
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+static void mod_sqrt_secp224r1(mg_uecc_word_t *a, MG_UECC_Curve curve);
+#endif
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+static void vli_mmod_fast_secp224r1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product);
+#endif
+
+static const struct MG_UECC_Curve_t curve_secp224r1 = {
+    num_words_secp224r1,
+    num_bytes_secp224r1,
+    224, /* num_n_bits */
+    {BYTES_TO_WORDS_8(01, 00, 00, 00, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_4(FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(3D, 2A, 5C, 5C, 45, 29, DD, 13),
+     BYTES_TO_WORDS_8(3E, F0, B8, E0, A2, 16, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_4(FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(21, 1D, 5C, 11, D6, 80, 32, 34),
+     BYTES_TO_WORDS_8(22, 11, C2, 56, D3, C1, 03, 4A),
+     BYTES_TO_WORDS_8(B9, 90, 13, 32, 7F, BF, B4, 6B),
+     BYTES_TO_WORDS_4(BD, 0C, 0E, B7),
+
+     BYTES_TO_WORDS_8(34, 7E, 00, 85, 99, 81, D5, 44),
+     BYTES_TO_WORDS_8(64, 47, 07, 5A, A0, 75, 43, CD),
+     BYTES_TO_WORDS_8(E6, DF, 22, 4C, FB, 23, F7, B5),
+     BYTES_TO_WORDS_4(88, 63, 37, BD)},
+    {BYTES_TO_WORDS_8(B4, FF, 55, 23, 43, 39, 0B, 27),
+     BYTES_TO_WORDS_8(BA, D8, BF, D7, B7, B0, 44, 50),
+     BYTES_TO_WORDS_8(56, 32, 41, F5, AB, B3, 04, 0C),
+     BYTES_TO_WORDS_4(85, 0A, 05, B4)},
+    &double_jacobian_default,
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+    &mod_sqrt_secp224r1,
+#endif
+    &x_side_default,
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+    &vli_mmod_fast_secp224r1
+#endif
+};
+
+MG_UECC_Curve mg_uecc_secp224r1(void) {
+  return &curve_secp224r1;
+}
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+/* Routine 3.2.4 RS;  from http://www.nsa.gov/ia/_files/nist-routines.pdf */
+static void mod_sqrt_secp224r1_rs(mg_uecc_word_t *d1, mg_uecc_word_t *e1,
+                                  mg_uecc_word_t *f1, const mg_uecc_word_t *d0,
+                                  const mg_uecc_word_t *e0,
+                                  const mg_uecc_word_t *f0) {
+  mg_uecc_word_t t[num_words_secp224r1];
+
+  mg_uecc_vli_modSquare_fast(t, d0, &curve_secp224r1);    /* t <-- d0 ^ 2 */
+  mg_uecc_vli_modMult_fast(e1, d0, e0, &curve_secp224r1); /* e1 <-- d0 * e0 */
+  mg_uecc_vli_modAdd(d1, t, f0, curve_secp224r1.p,
+                     num_words_secp224r1); /* d1 <-- t  + f0 */
+  mg_uecc_vli_modAdd(e1, e1, e1, curve_secp224r1.p,
+                     num_words_secp224r1);               /* e1 <-- e1 + e1 */
+  mg_uecc_vli_modMult_fast(f1, t, f0, &curve_secp224r1); /* f1 <-- t  * f0 */
+  mg_uecc_vli_modAdd(f1, f1, f1, curve_secp224r1.p,
+                     num_words_secp224r1); /* f1 <-- f1 + f1 */
+  mg_uecc_vli_modAdd(f1, f1, f1, curve_secp224r1.p,
+                     num_words_secp224r1); /* f1 <-- f1 + f1 */
+}
+
+/* Routine 3.2.5 RSS;  from http://www.nsa.gov/ia/_files/nist-routines.pdf */
+static void mod_sqrt_secp224r1_rss(mg_uecc_word_t *d1, mg_uecc_word_t *e1,
+                                   mg_uecc_word_t *f1, const mg_uecc_word_t *d0,
+                                   const mg_uecc_word_t *e0,
+                                   const mg_uecc_word_t *f0,
+                                   const bitcount_t j) {
+  bitcount_t i;
+
+  mg_uecc_vli_set(d1, d0, num_words_secp224r1); /* d1 <-- d0 */
+  mg_uecc_vli_set(e1, e0, num_words_secp224r1); /* e1 <-- e0 */
+  mg_uecc_vli_set(f1, f0, num_words_secp224r1); /* f1 <-- f0 */
+  for (i = 1; i <= j; i++) {
+    mod_sqrt_secp224r1_rs(d1, e1, f1, d1, e1, f1); /* RS (d1,e1,f1,d1,e1,f1) */
+  }
+}
+
+/* Routine 3.2.6 RM;  from http://www.nsa.gov/ia/_files/nist-routines.pdf */
+static void mod_sqrt_secp224r1_rm(mg_uecc_word_t *d2, mg_uecc_word_t *e2,
+                                  mg_uecc_word_t *f2, const mg_uecc_word_t *c,
+                                  const mg_uecc_word_t *d0,
+                                  const mg_uecc_word_t *e0,
+                                  const mg_uecc_word_t *d1,
+                                  const mg_uecc_word_t *e1) {
+  mg_uecc_word_t t1[num_words_secp224r1];
+  mg_uecc_word_t t2[num_words_secp224r1];
+
+  mg_uecc_vli_modMult_fast(t1, e0, e1, &curve_secp224r1); /* t1 <-- e0 * e1 */
+  mg_uecc_vli_modMult_fast(t1, t1, c, &curve_secp224r1);  /* t1 <-- t1 * c */
+  /* t1 <-- p  - t1 */
+  mg_uecc_vli_modSub(t1, curve_secp224r1.p, t1, curve_secp224r1.p,
+                     num_words_secp224r1);
+  mg_uecc_vli_modMult_fast(t2, d0, d1, &curve_secp224r1); /* t2 <-- d0 * d1 */
+  mg_uecc_vli_modAdd(t2, t2, t1, curve_secp224r1.p,
+                     num_words_secp224r1);                /* t2 <-- t2 + t1 */
+  mg_uecc_vli_modMult_fast(t1, d0, e1, &curve_secp224r1); /* t1 <-- d0 * e1 */
+  mg_uecc_vli_modMult_fast(e2, d1, e0, &curve_secp224r1); /* e2 <-- d1 * e0 */
+  mg_uecc_vli_modAdd(e2, e2, t1, curve_secp224r1.p,
+                     num_words_secp224r1);               /* e2 <-- e2 + t1 */
+  mg_uecc_vli_modSquare_fast(f2, e2, &curve_secp224r1);  /* f2 <-- e2^2 */
+  mg_uecc_vli_modMult_fast(f2, f2, c, &curve_secp224r1); /* f2 <-- f2 * c */
+  /* f2 <-- p  - f2 */
+  mg_uecc_vli_modSub(f2, curve_secp224r1.p, f2, curve_secp224r1.p,
+                     num_words_secp224r1);
+  mg_uecc_vli_set(d2, t2, num_words_secp224r1); /* d2 <-- t2 */
+}
+
+/* Routine 3.2.7 RP;  from http://www.nsa.gov/ia/_files/nist-routines.pdf */
+static void mod_sqrt_secp224r1_rp(mg_uecc_word_t *d1, mg_uecc_word_t *e1,
+                                  mg_uecc_word_t *f1, const mg_uecc_word_t *c,
+                                  const mg_uecc_word_t *r) {
+  wordcount_t i;
+  wordcount_t pow2i = 1;
+  mg_uecc_word_t d0[num_words_secp224r1];
+  mg_uecc_word_t e0[num_words_secp224r1] = {1}; /* e0 <-- 1 */
+  mg_uecc_word_t f0[num_words_secp224r1];
+
+  mg_uecc_vli_set(d0, r, num_words_secp224r1); /* d0 <-- r */
+  /* f0 <-- p  - c */
+  mg_uecc_vli_modSub(f0, curve_secp224r1.p, c, curve_secp224r1.p,
+                     num_words_secp224r1);
+  for (i = 0; i <= 6; i++) {
+    mod_sqrt_secp224r1_rss(d1, e1, f1, d0, e0, f0,
+                           pow2i); /* RSS (d1,e1,f1,d0,e0,f0,2^i) */
+    mod_sqrt_secp224r1_rm(d1, e1, f1, c, d1, e1, d0,
+                          e0); /* RM (d1,e1,f1,c,d1,e1,d0,e0) */
+    mg_uecc_vli_set(d0, d1, num_words_secp224r1); /* d0 <-- d1 */
+    mg_uecc_vli_set(e0, e1, num_words_secp224r1); /* e0 <-- e1 */
+    mg_uecc_vli_set(f0, f1, num_words_secp224r1); /* f0 <-- f1 */
+    pow2i *= 2;
+  }
+}
+
+/* Compute a = sqrt(a) (mod curve_p). */
+/* Routine 3.2.8 mp_mod_sqrt_224; from
+ * http://www.nsa.gov/ia/_files/nist-routines.pdf */
+static void mod_sqrt_secp224r1(mg_uecc_word_t *a, MG_UECC_Curve curve) {
+  (void) curve;
+  bitcount_t i;
+  mg_uecc_word_t e1[num_words_secp224r1];
+  mg_uecc_word_t f1[num_words_secp224r1];
+  mg_uecc_word_t d0[num_words_secp224r1];
+  mg_uecc_word_t e0[num_words_secp224r1];
+  mg_uecc_word_t f0[num_words_secp224r1];
+  mg_uecc_word_t d1[num_words_secp224r1];
+
+  /* s = a; using constant instead of random value */
+  mod_sqrt_secp224r1_rp(d0, e0, f0, a, a); /* RP (d0, e0, f0, c, s) */
+  mod_sqrt_secp224r1_rs(d1, e1, f1, d0, e0,
+                        f0); /* RS (d1, e1, f1, d0, e0, f0) */
+  for (i = 1; i <= 95; i++) {
+    mg_uecc_vli_set(d0, d1, num_words_secp224r1); /* d0 <-- d1 */
+    mg_uecc_vli_set(e0, e1, num_words_secp224r1); /* e0 <-- e1 */
+    mg_uecc_vli_set(f0, f1, num_words_secp224r1); /* f0 <-- f1 */
+    mod_sqrt_secp224r1_rs(d1, e1, f1, d0, e0,
+                          f0); /* RS (d1, e1, f1, d0, e0, f0) */
+    if (mg_uecc_vli_isZero(d1, num_words_secp224r1)) { /* if d1 == 0 */
+      break;
+    }
+  }
+  mg_uecc_vli_modInv(f1, e0, curve_secp224r1.p,
+                     num_words_secp224r1);               /* f1 <-- 1 / e0 */
+  mg_uecc_vli_modMult_fast(a, d0, f1, &curve_secp224r1); /* a  <-- d0 / e0 */
+}
+#endif /* MG_UECC_SUPPORT_COMPRESSED_POINT */
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+/* Computes result = product % curve_p
+   from http://www.nsa.gov/ia/_files/nist-routines.pdf */
+#if MG_UECC_WORD_SIZE == 1
+static void vli_mmod_fast_secp224r1(uint8_t *result, uint8_t *product) {
+  uint8_t tmp[num_words_secp224r1];
+  int8_t carry;
+
+  /* t */
+  mg_uecc_vli_set(result, product, num_words_secp224r1);
+
+  /* s1 */
+  tmp[0] = tmp[1] = tmp[2] = tmp[3] = 0;
+  tmp[4] = tmp[5] = tmp[6] = tmp[7] = 0;
+  tmp[8] = tmp[9] = tmp[10] = tmp[11] = 0;
+  tmp[12] = product[28];
+  tmp[13] = product[29];
+  tmp[14] = product[30];
+  tmp[15] = product[31];
+  tmp[16] = product[32];
+  tmp[17] = product[33];
+  tmp[18] = product[34];
+  tmp[19] = product[35];
+  tmp[20] = product[36];
+  tmp[21] = product[37];
+  tmp[22] = product[38];
+  tmp[23] = product[39];
+  tmp[24] = product[40];
+  tmp[25] = product[41];
+  tmp[26] = product[42];
+  tmp[27] = product[43];
+  carry = mg_uecc_vli_add(result, result, tmp, num_words_secp224r1);
+
+  /* s2 */
+  tmp[12] = product[44];
+  tmp[13] = product[45];
+  tmp[14] = product[46];
+  tmp[15] = product[47];
+  tmp[16] = product[48];
+  tmp[17] = product[49];
+  tmp[18] = product[50];
+  tmp[19] = product[51];
+  tmp[20] = product[52];
+  tmp[21] = product[53];
+  tmp[22] = product[54];
+  tmp[23] = product[55];
+  tmp[24] = tmp[25] = tmp[26] = tmp[27] = 0;
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp224r1);
+
+  /* d1 */
+  tmp[0] = product[28];
+  tmp[1] = product[29];
+  tmp[2] = product[30];
+  tmp[3] = product[31];
+  tmp[4] = product[32];
+  tmp[5] = product[33];
+  tmp[6] = product[34];
+  tmp[7] = product[35];
+  tmp[8] = product[36];
+  tmp[9] = product[37];
+  tmp[10] = product[38];
+  tmp[11] = product[39];
+  tmp[12] = product[40];
+  tmp[13] = product[41];
+  tmp[14] = product[42];
+  tmp[15] = product[43];
+  tmp[16] = product[44];
+  tmp[17] = product[45];
+  tmp[18] = product[46];
+  tmp[19] = product[47];
+  tmp[20] = product[48];
+  tmp[21] = product[49];
+  tmp[22] = product[50];
+  tmp[23] = product[51];
+  tmp[24] = product[52];
+  tmp[25] = product[53];
+  tmp[26] = product[54];
+  tmp[27] = product[55];
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp224r1);
+
+  /* d2 */
+  tmp[0] = product[44];
+  tmp[1] = product[45];
+  tmp[2] = product[46];
+  tmp[3] = product[47];
+  tmp[4] = product[48];
+  tmp[5] = product[49];
+  tmp[6] = product[50];
+  tmp[7] = product[51];
+  tmp[8] = product[52];
+  tmp[9] = product[53];
+  tmp[10] = product[54];
+  tmp[11] = product[55];
+  tmp[12] = tmp[13] = tmp[14] = tmp[15] = 0;
+  tmp[16] = tmp[17] = tmp[18] = tmp[19] = 0;
+  tmp[20] = tmp[21] = tmp[22] = tmp[23] = 0;
+  tmp[24] = tmp[25] = tmp[26] = tmp[27] = 0;
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp224r1);
+
+  if (carry < 0) {
+    do {
+      carry += mg_uecc_vli_add(result, result, curve_secp224r1.p,
+                               num_words_secp224r1);
+    } while (carry < 0);
+  } else {
+    while (carry || mg_uecc_vli_cmp_unsafe(curve_secp224r1.p, result,
+                                           num_words_secp224r1) != 1) {
+      carry -= mg_uecc_vli_sub(result, result, curve_secp224r1.p,
+                               num_words_secp224r1);
+    }
+  }
+}
+#elif MG_UECC_WORD_SIZE == 4
+static void vli_mmod_fast_secp224r1(uint32_t *result, uint32_t *product) {
+  uint32_t tmp[num_words_secp224r1];
+  int carry;
+
+  /* t */
+  mg_uecc_vli_set(result, product, num_words_secp224r1);
+
+  /* s1 */
+  tmp[0] = tmp[1] = tmp[2] = 0;
+  tmp[3] = product[7];
+  tmp[4] = product[8];
+  tmp[5] = product[9];
+  tmp[6] = product[10];
+  carry = mg_uecc_vli_add(result, result, tmp, num_words_secp224r1);
+
+  /* s2 */
+  tmp[3] = product[11];
+  tmp[4] = product[12];
+  tmp[5] = product[13];
+  tmp[6] = 0;
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp224r1);
+
+  /* d1 */
+  tmp[0] = product[7];
+  tmp[1] = product[8];
+  tmp[2] = product[9];
+  tmp[3] = product[10];
+  tmp[4] = product[11];
+  tmp[5] = product[12];
+  tmp[6] = product[13];
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp224r1);
+
+  /* d2 */
+  tmp[0] = product[11];
+  tmp[1] = product[12];
+  tmp[2] = product[13];
+  tmp[3] = tmp[4] = tmp[5] = tmp[6] = 0;
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp224r1);
+
+  if (carry < 0) {
+    do {
+      carry += mg_uecc_vli_add(result, result, curve_secp224r1.p,
+                               num_words_secp224r1);
+    } while (carry < 0);
+  } else {
+    while (carry || mg_uecc_vli_cmp_unsafe(curve_secp224r1.p, result,
+                                           num_words_secp224r1) != 1) {
+      carry -= mg_uecc_vli_sub(result, result, curve_secp224r1.p,
+                               num_words_secp224r1);
+    }
+  }
+}
+#else
+static void vli_mmod_fast_secp224r1(uint64_t *result, uint64_t *product) {
+  uint64_t tmp[num_words_secp224r1];
+  int carry = 0;
+
+  /* t */
+  mg_uecc_vli_set(result, product, num_words_secp224r1);
+  result[num_words_secp224r1 - 1] &= 0xffffffff;
+
+  /* s1 */
+  tmp[0] = 0;
+  tmp[1] = product[3] & 0xffffffff00000000ull;
+  tmp[2] = product[4];
+  tmp[3] = product[5] & 0xffffffff;
+  mg_uecc_vli_add(result, result, tmp, num_words_secp224r1);
+
+  /* s2 */
+  tmp[1] = product[5] & 0xffffffff00000000ull;
+  tmp[2] = product[6];
+  tmp[3] = 0;
+  mg_uecc_vli_add(result, result, tmp, num_words_secp224r1);
+
+  /* d1 */
+  tmp[0] = (product[3] >> 32) | (product[4] << 32);
+  tmp[1] = (product[4] >> 32) | (product[5] << 32);
+  tmp[2] = (product[5] >> 32) | (product[6] << 32);
+  tmp[3] = product[6] >> 32;
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp224r1);
+
+  /* d2 */
+  tmp[0] = (product[5] >> 32) | (product[6] << 32);
+  tmp[1] = product[6] >> 32;
+  tmp[2] = tmp[3] = 0;
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp224r1);
+
+  if (carry < 0) {
+    do {
+      carry += mg_uecc_vli_add(result, result, curve_secp224r1.p,
+                               num_words_secp224r1);
+    } while (carry < 0);
+  } else {
+    while (mg_uecc_vli_cmp_unsafe(curve_secp224r1.p, result,
+                                  num_words_secp224r1) != 1) {
+      mg_uecc_vli_sub(result, result, curve_secp224r1.p, num_words_secp224r1);
+    }
+  }
+}
+#endif /* MG_UECC_WORD_SIZE */
+#endif /* (MG_UECC_OPTIMIZATION_LEVEL > 0) */
+
+#endif /* MG_UECC_SUPPORTS_secp224r1 */
+
+#if MG_UECC_SUPPORTS_secp256r1
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+static void vli_mmod_fast_secp256r1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product);
+#endif
+
+static const struct MG_UECC_Curve_t curve_secp256r1 = {
+    num_words_secp256r1,
+    num_bytes_secp256r1,
+    256, /* num_n_bits */
+    {BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(01, 00, 00, 00, FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(51, 25, 63, FC, C2, CA, B9, F3),
+     BYTES_TO_WORDS_8(84, 9E, 17, A7, AD, FA, E6, BC),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(96, C2, 98, D8, 45, 39, A1, F4),
+     BYTES_TO_WORDS_8(A0, 33, EB, 2D, 81, 7D, 03, 77),
+     BYTES_TO_WORDS_8(F2, 40, A4, 63, E5, E6, BC, F8),
+     BYTES_TO_WORDS_8(47, 42, 2C, E1, F2, D1, 17, 6B),
+
+     BYTES_TO_WORDS_8(F5, 51, BF, 37, 68, 40, B6, CB),
+     BYTES_TO_WORDS_8(CE, 5E, 31, 6B, 57, 33, CE, 2B),
+     BYTES_TO_WORDS_8(16, 9E, 0F, 7C, 4A, EB, E7, 8E),
+     BYTES_TO_WORDS_8(9B, 7F, 1A, FE, E2, 42, E3, 4F)},
+    {BYTES_TO_WORDS_8(4B, 60, D2, 27, 3E, 3C, CE, 3B),
+     BYTES_TO_WORDS_8(F6, B0, 53, CC, B0, 06, 1D, 65),
+     BYTES_TO_WORDS_8(BC, 86, 98, 76, 55, BD, EB, B3),
+     BYTES_TO_WORDS_8(E7, 93, 3A, AA, D8, 35, C6, 5A)},
+    &double_jacobian_default,
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+    &mod_sqrt_default,
+#endif
+    &x_side_default,
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+    &vli_mmod_fast_secp256r1
+#endif
+};
+
+MG_UECC_Curve mg_uecc_secp256r1(void) {
+  return &curve_secp256r1;
+}
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0 && !asm_mmod_fast_secp256r1)
+/* Computes result = product % curve_p
+   from http://www.nsa.gov/ia/_files/nist-routines.pdf */
+#if MG_UECC_WORD_SIZE == 1
+static void vli_mmod_fast_secp256r1(uint8_t *result, uint8_t *product) {
+  uint8_t tmp[num_words_secp256r1];
+  int8_t carry;
+
+  /* t */
+  mg_uecc_vli_set(result, product, num_words_secp256r1);
+
+  /* s1 */
+  tmp[0] = tmp[1] = tmp[2] = tmp[3] = 0;
+  tmp[4] = tmp[5] = tmp[6] = tmp[7] = 0;
+  tmp[8] = tmp[9] = tmp[10] = tmp[11] = 0;
+  tmp[12] = product[44];
+  tmp[13] = product[45];
+  tmp[14] = product[46];
+  tmp[15] = product[47];
+  tmp[16] = product[48];
+  tmp[17] = product[49];
+  tmp[18] = product[50];
+  tmp[19] = product[51];
+  tmp[20] = product[52];
+  tmp[21] = product[53];
+  tmp[22] = product[54];
+  tmp[23] = product[55];
+  tmp[24] = product[56];
+  tmp[25] = product[57];
+  tmp[26] = product[58];
+  tmp[27] = product[59];
+  tmp[28] = product[60];
+  tmp[29] = product[61];
+  tmp[30] = product[62];
+  tmp[31] = product[63];
+  carry = mg_uecc_vli_add(tmp, tmp, tmp, num_words_secp256r1);
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s2 */
+  tmp[12] = product[48];
+  tmp[13] = product[49];
+  tmp[14] = product[50];
+  tmp[15] = product[51];
+  tmp[16] = product[52];
+  tmp[17] = product[53];
+  tmp[18] = product[54];
+  tmp[19] = product[55];
+  tmp[20] = product[56];
+  tmp[21] = product[57];
+  tmp[22] = product[58];
+  tmp[23] = product[59];
+  tmp[24] = product[60];
+  tmp[25] = product[61];
+  tmp[26] = product[62];
+  tmp[27] = product[63];
+  tmp[28] = tmp[29] = tmp[30] = tmp[31] = 0;
+  carry += mg_uecc_vli_add(tmp, tmp, tmp, num_words_secp256r1);
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s3 */
+  tmp[0] = product[32];
+  tmp[1] = product[33];
+  tmp[2] = product[34];
+  tmp[3] = product[35];
+  tmp[4] = product[36];
+  tmp[5] = product[37];
+  tmp[6] = product[38];
+  tmp[7] = product[39];
+  tmp[8] = product[40];
+  tmp[9] = product[41];
+  tmp[10] = product[42];
+  tmp[11] = product[43];
+  tmp[12] = tmp[13] = tmp[14] = tmp[15] = 0;
+  tmp[16] = tmp[17] = tmp[18] = tmp[19] = 0;
+  tmp[20] = tmp[21] = tmp[22] = tmp[23] = 0;
+  tmp[24] = product[56];
+  tmp[25] = product[57];
+  tmp[26] = product[58];
+  tmp[27] = product[59];
+  tmp[28] = product[60];
+  tmp[29] = product[61];
+  tmp[30] = product[62];
+  tmp[31] = product[63];
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s4 */
+  tmp[0] = product[36];
+  tmp[1] = product[37];
+  tmp[2] = product[38];
+  tmp[3] = product[39];
+  tmp[4] = product[40];
+  tmp[5] = product[41];
+  tmp[6] = product[42];
+  tmp[7] = product[43];
+  tmp[8] = product[44];
+  tmp[9] = product[45];
+  tmp[10] = product[46];
+  tmp[11] = product[47];
+  tmp[12] = product[52];
+  tmp[13] = product[53];
+  tmp[14] = product[54];
+  tmp[15] = product[55];
+  tmp[16] = product[56];
+  tmp[17] = product[57];
+  tmp[18] = product[58];
+  tmp[19] = product[59];
+  tmp[20] = product[60];
+  tmp[21] = product[61];
+  tmp[22] = product[62];
+  tmp[23] = product[63];
+  tmp[24] = product[52];
+  tmp[25] = product[53];
+  tmp[26] = product[54];
+  tmp[27] = product[55];
+  tmp[28] = product[32];
+  tmp[29] = product[33];
+  tmp[30] = product[34];
+  tmp[31] = product[35];
+  carry += mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* d1 */
+  tmp[0] = product[44];
+  tmp[1] = product[45];
+  tmp[2] = product[46];
+  tmp[3] = product[47];
+  tmp[4] = product[48];
+  tmp[5] = product[49];
+  tmp[6] = product[50];
+  tmp[7] = product[51];
+  tmp[8] = product[52];
+  tmp[9] = product[53];
+  tmp[10] = product[54];
+  tmp[11] = product[55];
+  tmp[12] = tmp[13] = tmp[14] = tmp[15] = 0;
+  tmp[16] = tmp[17] = tmp[18] = tmp[19] = 0;
+  tmp[20] = tmp[21] = tmp[22] = tmp[23] = 0;
+  tmp[24] = product[32];
+  tmp[25] = product[33];
+  tmp[26] = product[34];
+  tmp[27] = product[35];
+  tmp[28] = product[40];
+  tmp[29] = product[41];
+  tmp[30] = product[42];
+  tmp[31] = product[43];
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d2 */
+  tmp[0] = product[48];
+  tmp[1] = product[49];
+  tmp[2] = product[50];
+  tmp[3] = product[51];
+  tmp[4] = product[52];
+  tmp[5] = product[53];
+  tmp[6] = product[54];
+  tmp[7] = product[55];
+  tmp[8] = product[56];
+  tmp[9] = product[57];
+  tmp[10] = product[58];
+  tmp[11] = product[59];
+  tmp[12] = product[60];
+  tmp[13] = product[61];
+  tmp[14] = product[62];
+  tmp[15] = product[63];
+  tmp[16] = tmp[17] = tmp[18] = tmp[19] = 0;
+  tmp[20] = tmp[21] = tmp[22] = tmp[23] = 0;
+  tmp[24] = product[36];
+  tmp[25] = product[37];
+  tmp[26] = product[38];
+  tmp[27] = product[39];
+  tmp[28] = product[44];
+  tmp[29] = product[45];
+  tmp[30] = product[46];
+  tmp[31] = product[47];
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d3 */
+  tmp[0] = product[52];
+  tmp[1] = product[53];
+  tmp[2] = product[54];
+  tmp[3] = product[55];
+  tmp[4] = product[56];
+  tmp[5] = product[57];
+  tmp[6] = product[58];
+  tmp[7] = product[59];
+  tmp[8] = product[60];
+  tmp[9] = product[61];
+  tmp[10] = product[62];
+  tmp[11] = product[63];
+  tmp[12] = product[32];
+  tmp[13] = product[33];
+  tmp[14] = product[34];
+  tmp[15] = product[35];
+  tmp[16] = product[36];
+  tmp[17] = product[37];
+  tmp[18] = product[38];
+  tmp[19] = product[39];
+  tmp[20] = product[40];
+  tmp[21] = product[41];
+  tmp[22] = product[42];
+  tmp[23] = product[43];
+  tmp[24] = tmp[25] = tmp[26] = tmp[27] = 0;
+  tmp[28] = product[48];
+  tmp[29] = product[49];
+  tmp[30] = product[50];
+  tmp[31] = product[51];
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d4 */
+  tmp[0] = product[56];
+  tmp[1] = product[57];
+  tmp[2] = product[58];
+  tmp[3] = product[59];
+  tmp[4] = product[60];
+  tmp[5] = product[61];
+  tmp[6] = product[62];
+  tmp[7] = product[63];
+  tmp[8] = tmp[9] = tmp[10] = tmp[11] = 0;
+  tmp[12] = product[36];
+  tmp[13] = product[37];
+  tmp[14] = product[38];
+  tmp[15] = product[39];
+  tmp[16] = product[40];
+  tmp[17] = product[41];
+  tmp[18] = product[42];
+  tmp[19] = product[43];
+  tmp[20] = product[44];
+  tmp[21] = product[45];
+  tmp[22] = product[46];
+  tmp[23] = product[47];
+  tmp[24] = tmp[25] = tmp[26] = tmp[27] = 0;
+  tmp[28] = product[52];
+  tmp[29] = product[53];
+  tmp[30] = product[54];
+  tmp[31] = product[55];
+  carry -= mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  if (carry < 0) {
+    do {
+      carry += mg_uecc_vli_add(result, result, curve_secp256r1.p,
+                               num_words_secp256r1);
+    } while (carry < 0);
+  } else {
+    while (carry || mg_uecc_vli_cmp_unsafe(curve_secp256r1.p, result,
+                                           num_words_secp256r1) != 1) {
+      carry -= mg_uecc_vli_sub(result, result, curve_secp256r1.p,
+                               num_words_secp256r1);
+    }
+  }
+}
+#elif MG_UECC_WORD_SIZE == 4
+static void vli_mmod_fast_secp256r1(uint32_t *result, uint32_t *product) {
+  uint32_t tmp[num_words_secp256r1];
+  int carry;
+
+  /* t */
+  mg_uecc_vli_set(result, product, num_words_secp256r1);
+
+  /* s1 */
+  tmp[0] = tmp[1] = tmp[2] = 0;
+  tmp[3] = product[11];
+  tmp[4] = product[12];
+  tmp[5] = product[13];
+  tmp[6] = product[14];
+  tmp[7] = product[15];
+  carry = (int) mg_uecc_vli_add(tmp, tmp, tmp, num_words_secp256r1);
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s2 */
+  tmp[3] = product[12];
+  tmp[4] = product[13];
+  tmp[5] = product[14];
+  tmp[6] = product[15];
+  tmp[7] = 0;
+  carry += (int) mg_uecc_vli_add(tmp, tmp, tmp, num_words_secp256r1);
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s3 */
+  tmp[0] = product[8];
+  tmp[1] = product[9];
+  tmp[2] = product[10];
+  tmp[3] = tmp[4] = tmp[5] = 0;
+  tmp[6] = product[14];
+  tmp[7] = product[15];
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s4 */
+  tmp[0] = product[9];
+  tmp[1] = product[10];
+  tmp[2] = product[11];
+  tmp[3] = product[13];
+  tmp[4] = product[14];
+  tmp[5] = product[15];
+  tmp[6] = product[13];
+  tmp[7] = product[8];
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* d1 */
+  tmp[0] = product[11];
+  tmp[1] = product[12];
+  tmp[2] = product[13];
+  tmp[3] = tmp[4] = tmp[5] = 0;
+  tmp[6] = product[8];
+  tmp[7] = product[10];
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d2 */
+  tmp[0] = product[12];
+  tmp[1] = product[13];
+  tmp[2] = product[14];
+  tmp[3] = product[15];
+  tmp[4] = tmp[5] = 0;
+  tmp[6] = product[9];
+  tmp[7] = product[11];
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d3 */
+  tmp[0] = product[13];
+  tmp[1] = product[14];
+  tmp[2] = product[15];
+  tmp[3] = product[8];
+  tmp[4] = product[9];
+  tmp[5] = product[10];
+  tmp[6] = 0;
+  tmp[7] = product[12];
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d4 */
+  tmp[0] = product[14];
+  tmp[1] = product[15];
+  tmp[2] = 0;
+  tmp[3] = product[9];
+  tmp[4] = product[10];
+  tmp[5] = product[11];
+  tmp[6] = 0;
+  tmp[7] = product[13];
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  if (carry < 0) {
+    do {
+      carry += (int) mg_uecc_vli_add(result, result, curve_secp256r1.p,
+                                     num_words_secp256r1);
+    } while (carry < 0);
+  } else {
+    while (carry || mg_uecc_vli_cmp_unsafe(curve_secp256r1.p, result,
+                                           num_words_secp256r1) != 1) {
+      carry -= (int) mg_uecc_vli_sub(result, result, curve_secp256r1.p,
+                                     num_words_secp256r1);
+    }
+  }
+}
+#else
+static void vli_mmod_fast_secp256r1(uint64_t *result, uint64_t *product) {
+  uint64_t tmp[num_words_secp256r1];
+  int carry;
+
+  /* t */
+  mg_uecc_vli_set(result, product, num_words_secp256r1);
+
+  /* s1 */
+  tmp[0] = 0;
+  tmp[1] = product[5] & 0xffffffff00000000U;
+  tmp[2] = product[6];
+  tmp[3] = product[7];
+  carry = (int) mg_uecc_vli_add(tmp, tmp, tmp, num_words_secp256r1);
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s2 */
+  tmp[1] = product[6] << 32;
+  tmp[2] = (product[6] >> 32) | (product[7] << 32);
+  tmp[3] = product[7] >> 32;
+  carry += (int) mg_uecc_vli_add(tmp, tmp, tmp, num_words_secp256r1);
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s3 */
+  tmp[0] = product[4];
+  tmp[1] = product[5] & 0xffffffff;
+  tmp[2] = 0;
+  tmp[3] = product[7];
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* s4 */
+  tmp[0] = (product[4] >> 32) | (product[5] << 32);
+  tmp[1] = (product[5] >> 32) | (product[6] & 0xffffffff00000000U);
+  tmp[2] = product[7];
+  tmp[3] = (product[6] >> 32) | (product[4] << 32);
+  carry += (int) mg_uecc_vli_add(result, result, tmp, num_words_secp256r1);
+
+  /* d1 */
+  tmp[0] = (product[5] >> 32) | (product[6] << 32);
+  tmp[1] = (product[6] >> 32);
+  tmp[2] = 0;
+  tmp[3] = (product[4] & 0xffffffff) | (product[5] << 32);
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d2 */
+  tmp[0] = product[6];
+  tmp[1] = product[7];
+  tmp[2] = 0;
+  tmp[3] = (product[4] >> 32) | (product[5] & 0xffffffff00000000);
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d3 */
+  tmp[0] = (product[6] >> 32) | (product[7] << 32);
+  tmp[1] = (product[7] >> 32) | (product[4] << 32);
+  tmp[2] = (product[4] >> 32) | (product[5] << 32);
+  tmp[3] = (product[6] << 32);
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  /* d4 */
+  tmp[0] = product[7];
+  tmp[1] = product[4] & 0xffffffff00000000U;
+  tmp[2] = product[5];
+  tmp[3] = product[6] & 0xffffffff00000000U;
+  carry -= (int) mg_uecc_vli_sub(result, result, tmp, num_words_secp256r1);
+
+  if (carry < 0) {
+    do {
+      carry += (int) mg_uecc_vli_add(result, result, curve_secp256r1.p,
+                                     num_words_secp256r1);
+    } while (carry < 0);
+  } else {
+    while (carry || mg_uecc_vli_cmp_unsafe(curve_secp256r1.p, result,
+                                           num_words_secp256r1) != 1) {
+      carry -= (int) mg_uecc_vli_sub(result, result, curve_secp256r1.p,
+                                     num_words_secp256r1);
+    }
+  }
+}
+#endif /* MG_UECC_WORD_SIZE */
+#endif /* (MG_UECC_OPTIMIZATION_LEVEL > 0 && !asm_mmod_fast_secp256r1) */
+
+#endif /* MG_UECC_SUPPORTS_secp256r1 */
+
+#if MG_UECC_SUPPORTS_secp256k1
+
+static void double_jacobian_secp256k1(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                                      mg_uecc_word_t *Z1, MG_UECC_Curve curve);
+static void x_side_secp256k1(mg_uecc_word_t *result, const mg_uecc_word_t *x,
+                             MG_UECC_Curve curve);
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+static void vli_mmod_fast_secp256k1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product);
+#endif
+
+static const struct MG_UECC_Curve_t curve_secp256k1 = {
+    num_words_secp256k1,
+    num_bytes_secp256k1,
+    256, /* num_n_bits */
+    {BYTES_TO_WORDS_8(2F, FC, FF, FF, FE, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(41, 41, 36, D0, 8C, 5E, D2, BF),
+     BYTES_TO_WORDS_8(3B, A0, 48, AF, E6, DC, AE, BA),
+     BYTES_TO_WORDS_8(FE, FF, FF, FF, FF, FF, FF, FF),
+     BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF)},
+    {BYTES_TO_WORDS_8(98, 17, F8, 16, 5B, 81, F2, 59),
+     BYTES_TO_WORDS_8(D9, 28, CE, 2D, DB, FC, 9B, 02),
+     BYTES_TO_WORDS_8(07, 0B, 87, CE, 95, 62, A0, 55),
+     BYTES_TO_WORDS_8(AC, BB, DC, F9, 7E, 66, BE, 79),
+
+     BYTES_TO_WORDS_8(B8, D4, 10, FB, 8F, D0, 47, 9C),
+     BYTES_TO_WORDS_8(19, 54, 85, A6, 48, B4, 17, FD),
+     BYTES_TO_WORDS_8(A8, 08, 11, 0E, FC, FB, A4, 5D),
+     BYTES_TO_WORDS_8(65, C4, A3, 26, 77, DA, 3A, 48)},
+    {BYTES_TO_WORDS_8(07, 00, 00, 00, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, 00, 00, 00, 00),
+     BYTES_TO_WORDS_8(00, 00, 00, 00, 00, 00, 00, 00)},
+    &double_jacobian_secp256k1,
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+    &mod_sqrt_default,
+#endif
+    &x_side_secp256k1,
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+    &vli_mmod_fast_secp256k1
+#endif
+};
+
+MG_UECC_Curve mg_uecc_secp256k1(void) {
+  return &curve_secp256k1;
+}
+
+/* Double in place */
+static void double_jacobian_secp256k1(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                                      mg_uecc_word_t *Z1, MG_UECC_Curve curve) {
+  /* t1 = X, t2 = Y, t3 = Z */
+  mg_uecc_word_t t4[num_words_secp256k1];
+  mg_uecc_word_t t5[num_words_secp256k1];
+
+  if (mg_uecc_vli_isZero(Z1, num_words_secp256k1)) {
+    return;
+  }
+
+  mg_uecc_vli_modSquare_fast(t5, Y1, curve);   /* t5 = y1^2 */
+  mg_uecc_vli_modMult_fast(t4, X1, t5, curve); /* t4 = x1*y1^2 = A */
+  mg_uecc_vli_modSquare_fast(X1, X1, curve);   /* t1 = x1^2 */
+  mg_uecc_vli_modSquare_fast(t5, t5, curve);   /* t5 = y1^4 */
+  mg_uecc_vli_modMult_fast(Z1, Y1, Z1, curve); /* t3 = y1*z1 = z3 */
+
+  mg_uecc_vli_modAdd(Y1, X1, X1, curve->p,
+                     num_words_secp256k1); /* t2 = 2*x1^2 */
+  mg_uecc_vli_modAdd(Y1, Y1, X1, curve->p,
+                     num_words_secp256k1); /* t2 = 3*x1^2 */
+  if (mg_uecc_vli_testBit(Y1, 0)) {
+    mg_uecc_word_t carry =
+        mg_uecc_vli_add(Y1, Y1, curve->p, num_words_secp256k1);
+    mg_uecc_vli_rshift1(Y1, num_words_secp256k1);
+    Y1[num_words_secp256k1 - 1] |= carry << (MG_UECC_WORD_BITS - 1);
+  } else {
+    mg_uecc_vli_rshift1(Y1, num_words_secp256k1);
+  }
+  /* t2 = 3/2*(x1^2) = B */
+
+  mg_uecc_vli_modSquare_fast(X1, Y1, curve); /* t1 = B^2 */
+  mg_uecc_vli_modSub(X1, X1, t4, curve->p,
+                     num_words_secp256k1); /* t1 = B^2 - A */
+  mg_uecc_vli_modSub(X1, X1, t4, curve->p,
+                     num_words_secp256k1); /* t1 = B^2 - 2A = x3 */
+
+  mg_uecc_vli_modSub(t4, t4, X1, curve->p,
+                     num_words_secp256k1);     /* t4 = A - x3 */
+  mg_uecc_vli_modMult_fast(Y1, Y1, t4, curve); /* t2 = B * (A - x3) */
+  mg_uecc_vli_modSub(Y1, Y1, t5, curve->p,
+                     num_words_secp256k1); /* t2 = B * (A - x3) - y1^4 = y3 */
+}
+
+/* Computes result = x^3 + b. result must not overlap x. */
+static void x_side_secp256k1(mg_uecc_word_t *result, const mg_uecc_word_t *x,
+                             MG_UECC_Curve curve) {
+  mg_uecc_vli_modSquare_fast(result, x, curve);       /* r = x^2 */
+  mg_uecc_vli_modMult_fast(result, result, x, curve); /* r = x^3 */
+  mg_uecc_vli_modAdd(result, result, curve->b, curve->p,
+                     num_words_secp256k1); /* r = x^3 + b */
+}
+
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0 && !asm_mmod_fast_secp256k1)
+static void omega_mult_secp256k1(mg_uecc_word_t *result,
+                                 const mg_uecc_word_t *right);
+static void vli_mmod_fast_secp256k1(mg_uecc_word_t *result,
+                                    mg_uecc_word_t *product) {
+  mg_uecc_word_t tmp[2 * num_words_secp256k1];
+  mg_uecc_word_t carry;
+
+  mg_uecc_vli_clear(tmp, num_words_secp256k1);
+  mg_uecc_vli_clear(tmp + num_words_secp256k1, num_words_secp256k1);
+
+  omega_mult_secp256k1(tmp,
+                       product + num_words_secp256k1); /* (Rq, q) = q * c */
+
+  carry = mg_uecc_vli_add(result, product, tmp,
+                          num_words_secp256k1); /* (C, r) = r + q       */
+  mg_uecc_vli_clear(product, num_words_secp256k1);
+  omega_mult_secp256k1(product, tmp + num_words_secp256k1); /* Rq*c */
+  carry += mg_uecc_vli_add(result, result, product,
+                           num_words_secp256k1); /* (C1, r) = r + Rq*c */
+
+  while (carry > 0) {
+    --carry;
+    mg_uecc_vli_sub(result, result, curve_secp256k1.p, num_words_secp256k1);
+  }
+  if (mg_uecc_vli_cmp_unsafe(result, curve_secp256k1.p, num_words_secp256k1) >
+      0) {
+    mg_uecc_vli_sub(result, result, curve_secp256k1.p, num_words_secp256k1);
+  }
+}
+
+#if MG_UECC_WORD_SIZE == 1
+static void omega_mult_secp256k1(uint8_t *result, const uint8_t *right) {
+  /* Multiply by (2^32 + 2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1). */
+  mg_uecc_word_t r0 = 0;
+  mg_uecc_word_t r1 = 0;
+  mg_uecc_word_t r2 = 0;
+  wordcount_t k;
+
+  /* Multiply by (2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1). */
+  muladd(0xD1, right[0], &r0, &r1, &r2);
+  result[0] = r0;
+  r0 = r1;
+  r1 = r2;
+  /* r2 is still 0 */
+
+  for (k = 1; k < num_words_secp256k1; ++k) {
+    muladd(0x03, right[k - 1], &r0, &r1, &r2);
+    muladd(0xD1, right[k], &r0, &r1, &r2);
+    result[k] = r0;
+    r0 = r1;
+    r1 = r2;
+    r2 = 0;
+  }
+  muladd(0x03, right[num_words_secp256k1 - 1], &r0, &r1, &r2);
+  result[num_words_secp256k1] = r0;
+  result[num_words_secp256k1 + 1] = r1;
+  /* add the 2^32 multiple */
+  result[4 + num_words_secp256k1] =
+      mg_uecc_vli_add(result + 4, result + 4, right, num_words_secp256k1);
+}
+#elif MG_UECC_WORD_SIZE == 4
+static void omega_mult_secp256k1(uint32_t *result, const uint32_t *right) {
+  /* Multiply by (2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1). */
+  uint32_t carry = 0;
+  wordcount_t k;
+
+  for (k = 0; k < num_words_secp256k1; ++k) {
+    uint64_t p = (uint64_t) 0x3D1 * right[k] + carry;
+    result[k] = (uint32_t) p;
+    carry = p >> 32;
+  }
+  result[num_words_secp256k1] = carry;
+  /* add the 2^32 multiple */
+  result[1 + num_words_secp256k1] =
+      mg_uecc_vli_add(result + 1, result + 1, right, num_words_secp256k1);
+}
+#else
+static void omega_mult_secp256k1(uint64_t *result, const uint64_t *right) {
+  mg_uecc_word_t r0 = 0;
+  mg_uecc_word_t r1 = 0;
+  mg_uecc_word_t r2 = 0;
+  wordcount_t k;
+
+  /* Multiply by (2^32 + 2^9 + 2^8 + 2^7 + 2^6 + 2^4 + 1). */
+  for (k = 0; k < num_words_secp256k1; ++k) {
+    muladd(0x1000003D1ull, right[k], &r0, &r1, &r2);
+    result[k] = r0;
+    r0 = r1;
+    r1 = r2;
+    r2 = 0;
+  }
+  result[num_words_secp256k1] = r0;
+}
+#endif /* MG_UECC_WORD_SIZE */
+#endif /* (MG_UECC_OPTIMIZATION_LEVEL > 0 &&  && !asm_mmod_fast_secp256k1) */
+
+#endif /* MG_UECC_SUPPORTS_secp256k1 */
+
+#endif /* _UECC_CURVE_SPECIFIC_H_ */
+
+/* Returns 1 if 'point' is the point at infinity, 0 otherwise. */
+#define EccPoint_isZero(point, curve) \
+  mg_uecc_vli_isZero((point), (wordcount_t) ((curve)->num_words * 2))
+
+/* Point multiplication algorithm using Montgomery's ladder with co-Z
+coordinates. From http://eprint.iacr.org/2011/338.pdf
+*/
+
+/* Modify (x1, y1) => (x1 * z^2, y1 * z^3) */
+static void apply_z(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                    const mg_uecc_word_t *const Z, MG_UECC_Curve curve) {
+  mg_uecc_word_t t1[MG_UECC_MAX_WORDS];
+
+  mg_uecc_vli_modSquare_fast(t1, Z, curve);    /* z^2 */
+  mg_uecc_vli_modMult_fast(X1, X1, t1, curve); /* x1 * z^2 */
+  mg_uecc_vli_modMult_fast(t1, t1, Z, curve);  /* z^3 */
+  mg_uecc_vli_modMult_fast(Y1, Y1, t1, curve); /* y1 * z^3 */
+}
+
+/* P = (x1, y1) => 2P, (x2, y2) => P' */
+static void XYcZ_initial_double(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                                mg_uecc_word_t *X2, mg_uecc_word_t *Y2,
+                                const mg_uecc_word_t *const initial_Z,
+                                MG_UECC_Curve curve) {
+  mg_uecc_word_t z[MG_UECC_MAX_WORDS];
+  wordcount_t num_words = curve->num_words;
+  if (initial_Z) {
+    mg_uecc_vli_set(z, initial_Z, num_words);
+  } else {
+    mg_uecc_vli_clear(z, num_words);
+    z[0] = 1;
+  }
+
+  mg_uecc_vli_set(X2, X1, num_words);
+  mg_uecc_vli_set(Y2, Y1, num_words);
+
+  apply_z(X1, Y1, z, curve);
+  curve->double_jacobian(X1, Y1, z, curve);
+  apply_z(X2, Y2, z, curve);
+}
+
+/* Input P = (x1, y1, Z), Q = (x2, y2, Z)
+   Output P' = (x1', y1', Z3), P + Q = (x3, y3, Z3)
+   or P => P', Q => P + Q
+*/
+static void XYcZ_add(mg_uecc_word_t *X1, mg_uecc_word_t *Y1, mg_uecc_word_t *X2,
+                     mg_uecc_word_t *Y2, MG_UECC_Curve curve) {
+  /* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
+  mg_uecc_word_t t5[MG_UECC_MAX_WORDS] = {0};
+  wordcount_t num_words = curve->num_words;
+
+  mg_uecc_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
+  mg_uecc_vli_modSquare_fast(t5, t5, curve);   /* t5 = (x2 - x1)^2 = A */
+  mg_uecc_vli_modMult_fast(X1, X1, t5, curve); /* t1 = x1*A = B */
+  mg_uecc_vli_modMult_fast(X2, X2, t5, curve); /* t3 = x2*A = C */
+  mg_uecc_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
+  mg_uecc_vli_modSquare_fast(t5, Y2, curve); /* t5 = (y2 - y1)^2 = D */
+
+  mg_uecc_vli_modSub(t5, t5, X1, curve->p, num_words); /* t5 = D - B */
+  mg_uecc_vli_modSub(t5, t5, X2, curve->p, num_words); /* t5 = D - B - C = x3 */
+  mg_uecc_vli_modSub(X2, X2, X1, curve->p, num_words); /* t3 = C - B */
+  mg_uecc_vli_modMult_fast(Y1, Y1, X2, curve);         /* t2 = y1*(C - B) */
+  mg_uecc_vli_modSub(X2, X1, t5, curve->p, num_words); /* t3 = B - x3 */
+  mg_uecc_vli_modMult_fast(Y2, Y2, X2, curve); /* t4 = (y2 - y1)*(B - x3) */
+  mg_uecc_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y3 */
+
+  mg_uecc_vli_set(X2, t5, num_words);
+}
+
+/* Input P = (x1, y1, Z), Q = (x2, y2, Z)
+   Output P + Q = (x3, y3, Z3), P - Q = (x3', y3', Z3)
+   or P => P - Q, Q => P + Q
+*/
+static void XYcZ_addC(mg_uecc_word_t *X1, mg_uecc_word_t *Y1,
+                      mg_uecc_word_t *X2, mg_uecc_word_t *Y2,
+                      MG_UECC_Curve curve) {
+  /* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
+  mg_uecc_word_t t5[MG_UECC_MAX_WORDS] = {0};
+  mg_uecc_word_t t6[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t t7[MG_UECC_MAX_WORDS];
+  wordcount_t num_words = curve->num_words;
+
+  mg_uecc_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
+  mg_uecc_vli_modSquare_fast(t5, t5, curve);   /* t5 = (x2 - x1)^2 = A */
+  mg_uecc_vli_modMult_fast(X1, X1, t5, curve); /* t1 = x1*A = B */
+  mg_uecc_vli_modMult_fast(X2, X2, t5, curve); /* t3 = x2*A = C */
+  mg_uecc_vli_modAdd(t5, Y2, Y1, curve->p, num_words); /* t5 = y2 + y1 */
+  mg_uecc_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
+
+  mg_uecc_vli_modSub(t6, X2, X1, curve->p, num_words); /* t6 = C - B */
+  mg_uecc_vli_modMult_fast(Y1, Y1, t6, curve); /* t2 = y1 * (C - B) = E */
+  mg_uecc_vli_modAdd(t6, X1, X2, curve->p, num_words); /* t6 = B + C */
+  mg_uecc_vli_modSquare_fast(X2, Y2, curve); /* t3 = (y2 - y1)^2 = D */
+  mg_uecc_vli_modSub(X2, X2, t6, curve->p,
+                     num_words); /* t3 = D - (B + C) = x3 */
+
+  mg_uecc_vli_modSub(t7, X1, X2, curve->p, num_words); /* t7 = B - x3 */
+  mg_uecc_vli_modMult_fast(Y2, Y2, t7, curve); /* t4 = (y2 - y1)*(B - x3) */
+  mg_uecc_vli_modSub(Y2, Y2, Y1, curve->p,
+                     num_words); /* t4 = (y2 - y1)*(B - x3) - E = y3 */
+
+  mg_uecc_vli_modSquare_fast(t7, t5, curve); /* t7 = (y2 + y1)^2 = F */
+  mg_uecc_vli_modSub(t7, t7, t6, curve->p,
+                     num_words); /* t7 = F - (B + C) = x3' */
+  mg_uecc_vli_modSub(t6, t7, X1, curve->p, num_words); /* t6 = x3' - B */
+  mg_uecc_vli_modMult_fast(t6, t6, t5, curve); /* t6 = (y2+y1)*(x3' - B) */
+  mg_uecc_vli_modSub(Y1, t6, Y1, curve->p,
+                     num_words); /* t2 = (y2+y1)*(x3' - B) - E = y3' */
+
+  mg_uecc_vli_set(X1, t7, num_words);
+}
+
+/* result may overlap point. */
+static void EccPoint_mult(mg_uecc_word_t *result, const mg_uecc_word_t *point,
+                          const mg_uecc_word_t *scalar,
+                          const mg_uecc_word_t *initial_Z, bitcount_t num_bits,
+                          MG_UECC_Curve curve) {
+  /* R0 and R1 */
+  mg_uecc_word_t Rx[2][MG_UECC_MAX_WORDS];
+  mg_uecc_word_t Ry[2][MG_UECC_MAX_WORDS];
+  mg_uecc_word_t z[MG_UECC_MAX_WORDS];
+  bitcount_t i;
+  mg_uecc_word_t nb;
+  wordcount_t num_words = curve->num_words;
+
+  mg_uecc_vli_set(Rx[1], point, num_words);
+  mg_uecc_vli_set(Ry[1], point + num_words, num_words);
+
+  XYcZ_initial_double(Rx[1], Ry[1], Rx[0], Ry[0], initial_Z, curve);
+
+  for (i = num_bits - 2; i > 0; --i) {
+    nb = !mg_uecc_vli_testBit(scalar, i);
+    XYcZ_addC(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], curve);
+    XYcZ_add(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], curve);
+  }
+
+  nb = !mg_uecc_vli_testBit(scalar, 0);
+  XYcZ_addC(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], curve);
+
+  /* Find final 1/Z value. */
+  mg_uecc_vli_modSub(z, Rx[1], Rx[0], curve->p, num_words); /* X1 - X0 */
+  mg_uecc_vli_modMult_fast(z, z, Ry[1 - nb], curve);        /* Yb * (X1 - X0) */
+  mg_uecc_vli_modMult_fast(z, z, point, curve);  /* xP * Yb * (X1 - X0) */
+  mg_uecc_vli_modInv(z, z, curve->p, num_words); /* 1 / (xP * Yb * (X1 - X0)) */
+  /* yP / (xP * Yb * (X1 - X0)) */
+  mg_uecc_vli_modMult_fast(z, z, point + num_words, curve);
+  mg_uecc_vli_modMult_fast(z, z, Rx[1 - nb],
+                           curve); /* Xb * yP / (xP * Yb * (X1 - X0)) */
+  /* End 1/Z calculation */
+
+  XYcZ_add(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], curve);
+  apply_z(Rx[0], Ry[0], z, curve);
+
+  mg_uecc_vli_set(result, Rx[0], num_words);
+  mg_uecc_vli_set(result + num_words, Ry[0], num_words);
+}
+
+static mg_uecc_word_t regularize_k(const mg_uecc_word_t *const k,
+                                   mg_uecc_word_t *k0, mg_uecc_word_t *k1,
+                                   MG_UECC_Curve curve) {
+  wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+  bitcount_t num_n_bits = curve->num_n_bits;
+  mg_uecc_word_t carry =
+      mg_uecc_vli_add(k0, k, curve->n, num_n_words) ||
+      (num_n_bits < ((bitcount_t) num_n_words * MG_UECC_WORD_SIZE * 8) &&
+       mg_uecc_vli_testBit(k0, num_n_bits));
+  mg_uecc_vli_add(k1, k0, curve->n, num_n_words);
+  return carry;
+}
+
+/* Generates a random integer in the range 0 < random < top.
+   Both random and top have num_words words. */
+MG_UECC_VLI_API int mg_uecc_generate_random_int(mg_uecc_word_t *random,
+                                                const mg_uecc_word_t *top,
+                                                wordcount_t num_words) {
+  mg_uecc_word_t mask = (mg_uecc_word_t) -1;
+  mg_uecc_word_t tries;
+  bitcount_t num_bits = mg_uecc_vli_numBits(top, num_words);
+
+  if (!g_rng_function) {
+    return 0;
+  }
+
+  for (tries = 0; tries < MG_UECC_RNG_MAX_TRIES; ++tries) {
+    if (!g_rng_function((uint8_t *) random,
+                        (unsigned int) (num_words * MG_UECC_WORD_SIZE))) {
+      return 0;
+    }
+    random[num_words - 1] &=
+        mask >> ((bitcount_t) (num_words * MG_UECC_WORD_SIZE * 8 - num_bits));
+    if (!mg_uecc_vli_isZero(random, num_words) &&
+        mg_uecc_vli_cmp(top, random, num_words) == 1) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static mg_uecc_word_t EccPoint_compute_public_key(mg_uecc_word_t *result,
+                                                  mg_uecc_word_t *private_key,
+                                                  MG_UECC_Curve curve) {
+  mg_uecc_word_t tmp1[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tmp2[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t *p2[2] = {tmp1, tmp2};
+  mg_uecc_word_t *initial_Z = 0;
+  mg_uecc_word_t carry;
+
+  /* Regularize the bitcount for the private key so that attackers cannot use a
+     side channel attack to learn the number of leading zeros. */
+  carry = regularize_k(private_key, tmp1, tmp2, curve);
+
+  /* If an RNG function was specified, try to get a random initial Z value to
+     improve protection against side-channel attacks. */
+  if (g_rng_function) {
+    if (!mg_uecc_generate_random_int(p2[carry], curve->p, curve->num_words)) {
+      return 0;
+    }
+    initial_Z = p2[carry];
+  }
+  EccPoint_mult(result, curve->G, p2[!carry], initial_Z,
+                (bitcount_t) (curve->num_n_bits + 1), curve);
+
+  if (EccPoint_isZero(result, curve)) {
+    return 0;
+  }
+  return 1;
+}
+
+#if MG_UECC_WORD_SIZE == 1
+
+MG_UECC_VLI_API void mg_uecc_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
+                                               const uint8_t *native) {
+  wordcount_t i;
+  for (i = 0; i < num_bytes; ++i) {
+    bytes[i] = native[(num_bytes - 1) - i];
+  }
+}
+
+MG_UECC_VLI_API void mg_uecc_vli_bytesToNative(uint8_t *native,
+                                               const uint8_t *bytes,
+                                               int num_bytes) {
+  mg_uecc_vli_nativeToBytes(native, num_bytes, bytes);
+}
+
+#else
+
+MG_UECC_VLI_API void mg_uecc_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
+                                               const mg_uecc_word_t *native) {
+  int i;
+  for (i = 0; i < num_bytes; ++i) {
+    unsigned b = (unsigned) (num_bytes - 1 - i);
+    bytes[i] = (uint8_t) (native[b / MG_UECC_WORD_SIZE] >>
+                          (8 * (b % MG_UECC_WORD_SIZE)));
+  }
+}
+
+MG_UECC_VLI_API void mg_uecc_vli_bytesToNative(mg_uecc_word_t *native,
+                                               const uint8_t *bytes,
+                                               int num_bytes) {
+  int i;
+  mg_uecc_vli_clear(native,
+                    (wordcount_t) ((num_bytes + (MG_UECC_WORD_SIZE - 1)) /
+                                   MG_UECC_WORD_SIZE));
+  for (i = 0; i < num_bytes; ++i) {
+    unsigned b = (unsigned) (num_bytes - 1 - i);
+    native[b / MG_UECC_WORD_SIZE] |= (mg_uecc_word_t) bytes[i]
+                                     << (8 * (b % MG_UECC_WORD_SIZE));
+  }
+}
+
+#endif /* MG_UECC_WORD_SIZE */
+
+int mg_uecc_make_key(uint8_t *public_key, uint8_t *private_key,
+                     MG_UECC_Curve curve) {
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  mg_uecc_word_t *_private = (mg_uecc_word_t *) private_key;
+  mg_uecc_word_t *_public = (mg_uecc_word_t *) public_key;
+#else
+  mg_uecc_word_t _private[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t _public[MG_UECC_MAX_WORDS * 2];
+#endif
+  mg_uecc_word_t tries;
+
+  for (tries = 0; tries < MG_UECC_RNG_MAX_TRIES; ++tries) {
+    if (!mg_uecc_generate_random_int(_private, curve->n,
+                                     BITS_TO_WORDS(curve->num_n_bits))) {
+      return 0;
+    }
+
+    if (EccPoint_compute_public_key(_public, _private, curve)) {
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN == 0
+      mg_uecc_vli_nativeToBytes(private_key, BITS_TO_BYTES(curve->num_n_bits),
+                                _private);
+      mg_uecc_vli_nativeToBytes(public_key, curve->num_bytes, _public);
+      mg_uecc_vli_nativeToBytes(public_key + curve->num_bytes, curve->num_bytes,
+                                _public + curve->num_words);
+#endif
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int mg_uecc_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
+                          uint8_t *secret, MG_UECC_Curve curve) {
+  mg_uecc_word_t _public[MG_UECC_MAX_WORDS * 2];
+  mg_uecc_word_t _private[MG_UECC_MAX_WORDS];
+
+  mg_uecc_word_t tmp[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t *p2[2] = {_private, tmp};
+  mg_uecc_word_t *initial_Z = 0;
+  mg_uecc_word_t carry;
+  wordcount_t num_words = curve->num_words;
+  wordcount_t num_bytes = curve->num_bytes;
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy((uint8_t *) _private, private_key, num_bytes);
+  bcopy((uint8_t *) _public, public_key, num_bytes * 2);
+#else
+  mg_uecc_vli_bytesToNative(_private, private_key,
+                            BITS_TO_BYTES(curve->num_n_bits));
+  mg_uecc_vli_bytesToNative(_public, public_key, num_bytes);
+  mg_uecc_vli_bytesToNative(_public + num_words, public_key + num_bytes,
+                            num_bytes);
+#endif
+
+  /* Regularize the bitcount for the private key so that attackers cannot use a
+     side channel attack to learn the number of leading zeros. */
+  carry = regularize_k(_private, _private, tmp, curve);
+
+  /* If an RNG function was specified, try to get a random initial Z value to
+     improve protection against side-channel attacks. */
+  if (g_rng_function) {
+    if (!mg_uecc_generate_random_int(p2[carry], curve->p, num_words)) {
+      return 0;
+    }
+    initial_Z = p2[carry];
+  }
+
+  EccPoint_mult(_public, _public, p2[!carry], initial_Z,
+                (bitcount_t) (curve->num_n_bits + 1), curve);
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy((uint8_t *) secret, (uint8_t *) _public, num_bytes);
+#else
+  mg_uecc_vli_nativeToBytes(secret, num_bytes, _public);
+#endif
+  return !EccPoint_isZero(_public, curve);
+}
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+void mg_uecc_compress(const uint8_t *public_key, uint8_t *compressed,
+                      MG_UECC_Curve curve) {
+  wordcount_t i;
+  for (i = 0; i < curve->num_bytes; ++i) {
+    compressed[i + 1] = public_key[i];
+  }
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  compressed[0] = 2 + (public_key[curve->num_bytes] & 0x01);
+#else
+  compressed[0] = 2 + (public_key[curve->num_bytes * 2 - 1] & 0x01);
+#endif
+}
+
+void mg_uecc_decompress(const uint8_t *compressed, uint8_t *public_key,
+                        MG_UECC_Curve curve) {
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  mg_uecc_word_t *point = (mg_uecc_word_t *) public_key;
+#else
+  mg_uecc_word_t point[MG_UECC_MAX_WORDS * 2];
+#endif
+  mg_uecc_word_t *y = point + curve->num_words;
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy(public_key, compressed + 1, curve->num_bytes);
+#else
+  mg_uecc_vli_bytesToNative(point, compressed + 1, curve->num_bytes);
+#endif
+  curve->x_side(y, point, curve);
+  curve->mod_sqrt(y, curve);
+
+  if ((uint8_t) (y[0] & 0x01) != (compressed[0] & 0x01)) {
+    mg_uecc_vli_sub(y, curve->p, y, curve->num_words);
+  }
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN == 0
+  mg_uecc_vli_nativeToBytes(public_key, curve->num_bytes, point);
+  mg_uecc_vli_nativeToBytes(public_key + curve->num_bytes, curve->num_bytes, y);
+#endif
+}
+#endif /* MG_UECC_SUPPORT_COMPRESSED_POINT */
+
+MG_UECC_VLI_API int mg_uecc_valid_point(const mg_uecc_word_t *point,
+                                        MG_UECC_Curve curve) {
+  mg_uecc_word_t tmp1[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tmp2[MG_UECC_MAX_WORDS];
+  wordcount_t num_words = curve->num_words;
+
+  /* The point at infinity is invalid. */
+  if (EccPoint_isZero(point, curve)) {
+    return 0;
+  }
+
+  /* x and y must be smaller than p. */
+  if (mg_uecc_vli_cmp_unsafe(curve->p, point, num_words) != 1 ||
+      mg_uecc_vli_cmp_unsafe(curve->p, point + num_words, num_words) != 1) {
+    return 0;
+  }
+
+  mg_uecc_vli_modSquare_fast(tmp1, point + num_words, curve);
+  curve->x_side(tmp2, point, curve); /* tmp2 = x^3 + ax + b */
+
+  /* Make sure that y^2 == x^3 + ax + b */
+  return (int) (mg_uecc_vli_equal(tmp1, tmp2, num_words));
+}
+
+int mg_uecc_valid_public_key(const uint8_t *public_key, MG_UECC_Curve curve) {
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  mg_uecc_word_t *_public = (mg_uecc_word_t *) public_key;
+#else
+  mg_uecc_word_t _public[MG_UECC_MAX_WORDS * 2];
+#endif
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN == 0
+  mg_uecc_vli_bytesToNative(_public, public_key, curve->num_bytes);
+  mg_uecc_vli_bytesToNative(_public + curve->num_words,
+                            public_key + curve->num_bytes, curve->num_bytes);
+#endif
+  return mg_uecc_valid_point(_public, curve);
+}
+
+int mg_uecc_compute_public_key(const uint8_t *private_key, uint8_t *public_key,
+                               MG_UECC_Curve curve) {
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  mg_uecc_word_t *_private = (mg_uecc_word_t *) private_key;
+  mg_uecc_word_t *_public = (mg_uecc_word_t *) public_key;
+#else
+  mg_uecc_word_t _private[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t _public[MG_UECC_MAX_WORDS * 2];
+#endif
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN == 0
+  mg_uecc_vli_bytesToNative(_private, private_key,
+                            BITS_TO_BYTES(curve->num_n_bits));
+#endif
+
+  /* Make sure the private key is in the range [1, n-1]. */
+  if (mg_uecc_vli_isZero(_private, BITS_TO_WORDS(curve->num_n_bits))) {
+    return 0;
+  }
+
+  if (mg_uecc_vli_cmp(curve->n, _private, BITS_TO_WORDS(curve->num_n_bits)) !=
+      1) {
+    return 0;
+  }
+
+  /* Compute public key. */
+  if (!EccPoint_compute_public_key(_public, _private, curve)) {
+    return 0;
+  }
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN == 0
+  mg_uecc_vli_nativeToBytes(public_key, curve->num_bytes, _public);
+  mg_uecc_vli_nativeToBytes(public_key + curve->num_bytes, curve->num_bytes,
+                            _public + curve->num_words);
+#endif
+  return 1;
+}
+
+/* -------- ECDSA code -------- */
+
+static void bits2int(mg_uecc_word_t *native, const uint8_t *bits,
+                     unsigned bits_size, MG_UECC_Curve curve) {
+  unsigned num_n_bytes = (unsigned) BITS_TO_BYTES(curve->num_n_bits);
+  unsigned num_n_words = (unsigned) BITS_TO_WORDS(curve->num_n_bits);
+  int shift;
+  mg_uecc_word_t carry;
+  mg_uecc_word_t *ptr;
+
+  if (bits_size > num_n_bytes) {
+    bits_size = num_n_bytes;
+  }
+
+  mg_uecc_vli_clear(native, (wordcount_t) num_n_words);
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy((uint8_t *) native, bits, bits_size);
+#else
+  mg_uecc_vli_bytesToNative(native, bits, (int) bits_size);
+#endif
+  if (bits_size * 8 <= (unsigned) curve->num_n_bits) {
+    return;
+  }
+  shift = (int) bits_size * 8 - curve->num_n_bits;
+  carry = 0;
+  ptr = native + num_n_words;
+  while (ptr-- > native) {
+    mg_uecc_word_t temp = *ptr;
+    *ptr = (temp >> shift) | carry;
+    carry = temp << (MG_UECC_WORD_BITS - shift);
+  }
+
+  /* Reduce mod curve_n */
+  if (mg_uecc_vli_cmp_unsafe(curve->n, native, (wordcount_t) num_n_words) !=
+      1) {
+    mg_uecc_vli_sub(native, native, curve->n, (wordcount_t) num_n_words);
+  }
+}
+
+static int mg_uecc_sign_with_k_internal(const uint8_t *private_key,
+                                        const uint8_t *message_hash,
+                                        unsigned hash_size, mg_uecc_word_t *k,
+                                        uint8_t *signature,
+                                        MG_UECC_Curve curve) {
+  mg_uecc_word_t tmp[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t s[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t *k2[2] = {tmp, s};
+  mg_uecc_word_t *initial_Z = 0;
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  mg_uecc_word_t *p = (mg_uecc_word_t *) signature;
+#else
+  mg_uecc_word_t p[MG_UECC_MAX_WORDS * 2];
+#endif
+  mg_uecc_word_t carry;
+  wordcount_t num_words = curve->num_words;
+  wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+  bitcount_t num_n_bits = curve->num_n_bits;
+
+  /* Make sure 0 < k < curve_n */
+  if (mg_uecc_vli_isZero(k, num_words) ||
+      mg_uecc_vli_cmp(curve->n, k, num_n_words) != 1) {
+    return 0;
+  }
+
+  carry = regularize_k(k, tmp, s, curve);
+  /* If an RNG function was specified, try to get a random initial Z value to
+     improve protection against side-channel attacks. */
+  if (g_rng_function) {
+    if (!mg_uecc_generate_random_int(k2[carry], curve->p, num_words)) {
+      return 0;
+    }
+    initial_Z = k2[carry];
+  }
+  EccPoint_mult(p, curve->G, k2[!carry], initial_Z,
+                (bitcount_t) (num_n_bits + 1), curve);
+  if (mg_uecc_vli_isZero(p, num_words)) {
+    return 0;
+  }
+
+  /* If an RNG function was specified, get a random number
+     to prevent side channel analysis of k. */
+  if (!g_rng_function) {
+    mg_uecc_vli_clear(tmp, num_n_words);
+    tmp[0] = 1;
+  } else if (!mg_uecc_generate_random_int(tmp, curve->n, num_n_words)) {
+    return 0;
+  }
+
+  /* Prevent side channel analysis of mg_uecc_vli_modInv() to determine
+     bits of k / the private key by premultiplying by a random number */
+  mg_uecc_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k' = rand * k */
+  mg_uecc_vli_modInv(k, k, curve->n, num_n_words);       /* k = 1 / k' */
+  mg_uecc_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k = 1 / k */
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN == 0
+  mg_uecc_vli_nativeToBytes(signature, curve->num_bytes, p); /* store r */
+#endif
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy((uint8_t *) tmp, private_key, BITS_TO_BYTES(curve->num_n_bits));
+#else
+  mg_uecc_vli_bytesToNative(tmp, private_key,
+                            BITS_TO_BYTES(curve->num_n_bits)); /* tmp = d */
+#endif
+
+  s[num_n_words - 1] = 0;
+  mg_uecc_vli_set(s, p, num_words);
+  mg_uecc_vli_modMult(s, tmp, s, curve->n, num_n_words); /* s = r*d */
+
+  bits2int(tmp, message_hash, hash_size, curve);
+  mg_uecc_vli_modAdd(s, tmp, s, curve->n, num_n_words); /* s = e + r*d */
+  mg_uecc_vli_modMult(s, s, k, curve->n, num_n_words);  /* s = (e + r*d) / k */
+  if (mg_uecc_vli_numBits(s, num_n_words) > (bitcount_t) curve->num_bytes * 8) {
+    return 0;
+  }
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy((uint8_t *) signature + curve->num_bytes, (uint8_t *) s,
+        curve->num_bytes);
+#else
+  mg_uecc_vli_nativeToBytes(signature + curve->num_bytes, curve->num_bytes, s);
+#endif
+  return 1;
+}
+
+#if 0
+/* For testing - sign with an explicitly specified k value */
+int mg_uecc_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
+                     unsigned hash_size, const uint8_t *k, uint8_t *signature,
+                     MG_UECC_Curve curve) {
+  mg_uecc_word_t k2[MG_UECC_MAX_WORDS];
+  bits2int(k2, k, (unsigned) BITS_TO_BYTES(curve->num_n_bits), curve);
+  return mg_uecc_sign_with_k_internal(private_key, message_hash, hash_size, k2,
+                                   signature, curve);
+}
+#endif
+
+int mg_uecc_sign(const uint8_t *private_key, const uint8_t *message_hash,
+                 unsigned hash_size, uint8_t *signature, MG_UECC_Curve curve) {
+  mg_uecc_word_t k[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tries;
+
+  for (tries = 0; tries < MG_UECC_RNG_MAX_TRIES; ++tries) {
+    if (!mg_uecc_generate_random_int(k, curve->n,
+                                     BITS_TO_WORDS(curve->num_n_bits))) {
+      return 0;
+    }
+
+    if (mg_uecc_sign_with_k_internal(private_key, message_hash, hash_size, k,
+                                     signature, curve)) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/* Compute an HMAC using K as a key (as in RFC 6979). Note that K is always
+   the same size as the hash result size. */
+static void HMAC_init(const MG_UECC_HashContext *hash_context,
+                      const uint8_t *K) {
+  uint8_t *pad = hash_context->tmp + 2 * hash_context->result_size;
+  unsigned i;
+  for (i = 0; i < hash_context->result_size; ++i) pad[i] = K[i] ^ 0x36;
+  for (; i < hash_context->block_size; ++i) pad[i] = 0x36;
+
+  hash_context->init_hash(hash_context);
+  hash_context->update_hash(hash_context, pad, hash_context->block_size);
+}
+
+static void HMAC_update(const MG_UECC_HashContext *hash_context,
+                        const uint8_t *message, unsigned message_size) {
+  hash_context->update_hash(hash_context, message, message_size);
+}
+
+static void HMAC_finish(const MG_UECC_HashContext *hash_context,
+                        const uint8_t *K, uint8_t *result) {
+  uint8_t *pad = hash_context->tmp + 2 * hash_context->result_size;
+  unsigned i;
+  for (i = 0; i < hash_context->result_size; ++i) pad[i] = K[i] ^ 0x5c;
+  for (; i < hash_context->block_size; ++i) pad[i] = 0x5c;
+
+  hash_context->finish_hash(hash_context, result);
+
+  hash_context->init_hash(hash_context);
+  hash_context->update_hash(hash_context, pad, hash_context->block_size);
+  hash_context->update_hash(hash_context, result, hash_context->result_size);
+  hash_context->finish_hash(hash_context, result);
+}
+
+/* V = HMAC_K(V) */
+static void update_V(const MG_UECC_HashContext *hash_context, uint8_t *K,
+                     uint8_t *V) {
+  HMAC_init(hash_context, K);
+  HMAC_update(hash_context, V, hash_context->result_size);
+  HMAC_finish(hash_context, K, V);
+}
+
+/* Deterministic signing, similar to RFC 6979. Differences are:
+    * We just use H(m) directly rather than bits2octets(H(m))
+      (it is not reduced modulo curve_n).
+    * We generate a value for k (aka T) directly rather than converting
+   endianness.
+
+   Layout of hash_context->tmp: <K> | <V> | (1 byte overlapped 0x00 or 0x01) /
+   <HMAC pad> */
+int mg_uecc_sign_deterministic(const uint8_t *private_key,
+                               const uint8_t *message_hash, unsigned hash_size,
+                               const MG_UECC_HashContext *hash_context,
+                               uint8_t *signature, MG_UECC_Curve curve) {
+  uint8_t *K = hash_context->tmp;
+  uint8_t *V = K + hash_context->result_size;
+  wordcount_t num_bytes = curve->num_bytes;
+  wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+  bitcount_t num_n_bits = curve->num_n_bits;
+  mg_uecc_word_t tries;
+  unsigned i;
+  for (i = 0; i < hash_context->result_size; ++i) {
+    V[i] = 0x01;
+    K[i] = 0;
+  }
+
+  /* K = HMAC_K(V || 0x00 || int2octets(x) || h(m)) */
+  HMAC_init(hash_context, K);
+  V[hash_context->result_size] = 0x00;
+  HMAC_update(hash_context, V, hash_context->result_size + 1);
+  HMAC_update(hash_context, private_key, (unsigned int) num_bytes);
+  HMAC_update(hash_context, message_hash, hash_size);
+  HMAC_finish(hash_context, K, K);
+
+  update_V(hash_context, K, V);
+
+  /* K = HMAC_K(V || 0x01 || int2octets(x) || h(m)) */
+  HMAC_init(hash_context, K);
+  V[hash_context->result_size] = 0x01;
+  HMAC_update(hash_context, V, hash_context->result_size + 1);
+  HMAC_update(hash_context, private_key, (unsigned int) num_bytes);
+  HMAC_update(hash_context, message_hash, hash_size);
+  HMAC_finish(hash_context, K, K);
+
+  update_V(hash_context, K, V);
+
+  for (tries = 0; tries < MG_UECC_RNG_MAX_TRIES; ++tries) {
+    mg_uecc_word_t T[MG_UECC_MAX_WORDS];
+    uint8_t *T_ptr = (uint8_t *) T;
+    wordcount_t T_bytes = 0;
+    for (;;) {
+      update_V(hash_context, K, V);
+      for (i = 0; i < hash_context->result_size; ++i) {
+        T_ptr[T_bytes++] = V[i];
+        if (T_bytes >= num_n_words * MG_UECC_WORD_SIZE) {
+          goto filled;
+        }
+      }
+    }
+  filled:
+    if ((bitcount_t) num_n_words * MG_UECC_WORD_SIZE * 8 > num_n_bits) {
+      mg_uecc_word_t mask = (mg_uecc_word_t) -1;
+      T[num_n_words - 1] &=
+          mask >>
+          ((bitcount_t) (num_n_words * MG_UECC_WORD_SIZE * 8 - num_n_bits));
+    }
+
+    if (mg_uecc_sign_with_k_internal(private_key, message_hash, hash_size, T,
+                                     signature, curve)) {
+      return 1;
+    }
+
+    /* K = HMAC_K(V || 0x00) */
+    HMAC_init(hash_context, K);
+    V[hash_context->result_size] = 0x00;
+    HMAC_update(hash_context, V, hash_context->result_size + 1);
+    HMAC_finish(hash_context, K, K);
+
+    update_V(hash_context, K, V);
+  }
+  return 0;
+}
+
+static bitcount_t smax(bitcount_t a, bitcount_t b) {
+  return (a > b ? a : b);
+}
+
+int mg_uecc_verify(const uint8_t *public_key, const uint8_t *message_hash,
+                   unsigned hash_size, const uint8_t *signature,
+                   MG_UECC_Curve curve) {
+  mg_uecc_word_t u1[MG_UECC_MAX_WORDS], u2[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t z[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t sum[MG_UECC_MAX_WORDS * 2];
+  mg_uecc_word_t rx[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t ry[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tx[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t ty[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tz[MG_UECC_MAX_WORDS];
+  const mg_uecc_word_t *points[4];
+  const mg_uecc_word_t *point;
+  bitcount_t num_bits;
+  bitcount_t i;
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  mg_uecc_word_t *_public = (mg_uecc_word_t *) public_key;
+#else
+  mg_uecc_word_t _public[MG_UECC_MAX_WORDS * 2];
+#endif
+  mg_uecc_word_t r[MG_UECC_MAX_WORDS], s[MG_UECC_MAX_WORDS];
+  wordcount_t num_words = curve->num_words;
+  wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+
+  rx[num_n_words - 1] = 0;
+  r[num_n_words - 1] = 0;
+  s[num_n_words - 1] = 0;
+
+#if MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+  bcopy((uint8_t *) r, signature, curve->num_bytes);
+  bcopy((uint8_t *) s, signature + curve->num_bytes, curve->num_bytes);
+#else
+  mg_uecc_vli_bytesToNative(_public, public_key, curve->num_bytes);
+  mg_uecc_vli_bytesToNative(_public + num_words, public_key + curve->num_bytes,
+                            curve->num_bytes);
+  mg_uecc_vli_bytesToNative(r, signature, curve->num_bytes);
+  mg_uecc_vli_bytesToNative(s, signature + curve->num_bytes, curve->num_bytes);
+#endif
+
+  /* r, s must not be 0. */
+  if (mg_uecc_vli_isZero(r, num_words) || mg_uecc_vli_isZero(s, num_words)) {
+    return 0;
+  }
+
+  /* r, s must be < n. */
+  if (mg_uecc_vli_cmp_unsafe(curve->n, r, num_n_words) != 1 ||
+      mg_uecc_vli_cmp_unsafe(curve->n, s, num_n_words) != 1) {
+    return 0;
+  }
+
+  /* Calculate u1 and u2. */
+  mg_uecc_vli_modInv(z, s, curve->n, num_n_words); /* z = 1/s */
+  u1[num_n_words - 1] = 0;
+  bits2int(u1, message_hash, hash_size, curve);
+  mg_uecc_vli_modMult(u1, u1, z, curve->n, num_n_words); /* u1 = e/s */
+  mg_uecc_vli_modMult(u2, r, z, curve->n, num_n_words);  /* u2 = r/s */
+
+  /* Calculate sum = G + Q. */
+  mg_uecc_vli_set(sum, _public, num_words);
+  mg_uecc_vli_set(sum + num_words, _public + num_words, num_words);
+  mg_uecc_vli_set(tx, curve->G, num_words);
+  mg_uecc_vli_set(ty, curve->G + num_words, num_words);
+  mg_uecc_vli_modSub(z, sum, tx, curve->p, num_words); /* z = x2 - x1 */
+  XYcZ_add(tx, ty, sum, sum + num_words, curve);
+  mg_uecc_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
+  apply_z(sum, sum + num_words, z, curve);
+
+  /* Use Shamir's trick to calculate u1*G + u2*Q */
+  points[0] = 0;
+  points[1] = curve->G;
+  points[2] = _public;
+  points[3] = sum;
+  num_bits = smax(mg_uecc_vli_numBits(u1, num_n_words),
+                  mg_uecc_vli_numBits(u2, num_n_words));
+  point =
+      points[(!!mg_uecc_vli_testBit(u1, (bitcount_t) (num_bits - 1))) |
+             ((!!mg_uecc_vli_testBit(u2, (bitcount_t) (num_bits - 1))) << 1)];
+  mg_uecc_vli_set(rx, point, num_words);
+  mg_uecc_vli_set(ry, point + num_words, num_words);
+  mg_uecc_vli_clear(z, num_words);
+  z[0] = 1;
+
+  for (i = num_bits - 2; i >= 0; --i) {
+    mg_uecc_word_t index;
+    curve->double_jacobian(rx, ry, z, curve);
+
+    index = (!!mg_uecc_vli_testBit(u1, i)) |
+            (mg_uecc_word_t) ((!!mg_uecc_vli_testBit(u2, i)) << 1);
+    point = points[index];
+    if (point) {
+      mg_uecc_vli_set(tx, point, num_words);
+      mg_uecc_vli_set(ty, point + num_words, num_words);
+      apply_z(tx, ty, z, curve);
+      mg_uecc_vli_modSub(tz, rx, tx, curve->p, num_words); /* Z = x2 - x1 */
+      XYcZ_add(tx, ty, rx, ry, curve);
+      mg_uecc_vli_modMult_fast(z, z, tz, curve);
+    }
+  }
+
+  mg_uecc_vli_modInv(z, z, curve->p, num_words); /* Z = 1/Z */
+  apply_z(rx, ry, z, curve);
+
+  /* v = x1 (mod n) */
+  if (mg_uecc_vli_cmp_unsafe(curve->n, rx, num_n_words) != 1) {
+    mg_uecc_vli_sub(rx, rx, curve->n, num_n_words);
+  }
+
+  /* Accept only if v == r. */
+  return (int) (mg_uecc_vli_equal(rx, r, num_words));
+}
+
+#if MG_UECC_ENABLE_VLI_API
+
+unsigned mg_uecc_curve_num_words(MG_UECC_Curve curve) {
+  return curve->num_words;
+}
+
+unsigned mg_uecc_curve_num_bytes(MG_UECC_Curve curve) {
+  return curve->num_bytes;
+}
+
+unsigned mg_uecc_curve_num_bits(MG_UECC_Curve curve) {
+  return curve->num_bytes * 8;
+}
+
+unsigned mg_uecc_curve_num_n_words(MG_UECC_Curve curve) {
+  return BITS_TO_WORDS(curve->num_n_bits);
+}
+
+unsigned mg_uecc_curve_num_n_bytes(MG_UECC_Curve curve) {
+  return BITS_TO_BYTES(curve->num_n_bits);
+}
+
+unsigned mg_uecc_curve_num_n_bits(MG_UECC_Curve curve) {
+  return curve->num_n_bits;
+}
+
+const mg_uecc_word_t *mg_uecc_curve_p(MG_UECC_Curve curve) {
+  return curve->p;
+}
+
+const mg_uecc_word_t *mg_uecc_curve_n(MG_UECC_Curve curve) {
+  return curve->n;
+}
+
+const mg_uecc_word_t *mg_uecc_curve_G(MG_UECC_Curve curve) {
+  return curve->G;
+}
+
+const mg_uecc_word_t *mg_uecc_curve_b(MG_UECC_Curve curve) {
+  return curve->b;
+}
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+void mg_uecc_vli_mod_sqrt(mg_uecc_word_t *a, MG_UECC_Curve curve) {
+  curve->mod_sqrt(a, curve);
+}
+#endif
+
+void mg_uecc_vli_mmod_fast(mg_uecc_word_t *result, mg_uecc_word_t *product,
+                           MG_UECC_Curve curve) {
+#if (MG_UECC_OPTIMIZATION_LEVEL > 0)
+  curve->mmod_fast(result, product);
+#else
+  mg_uecc_vli_mmod(result, product, curve->p, curve->num_words);
+#endif
+}
+
+void mg_uecc_point_mult(mg_uecc_word_t *result, const mg_uecc_word_t *point,
+                        const mg_uecc_word_t *scalar, MG_UECC_Curve curve) {
+  mg_uecc_word_t tmp1[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t tmp2[MG_UECC_MAX_WORDS];
+  mg_uecc_word_t *p2[2] = {tmp1, tmp2};
+  mg_uecc_word_t carry = regularize_k(scalar, tmp1, tmp2, curve);
+
+  EccPoint_mult(result, point, p2[!carry], 0, curve->num_n_bits + 1, curve);
+}
+
+#endif  /* MG_UECC_ENABLE_VLI_API */
+#endif  // MG_TLS_BUILTIN
+// End of uecc BSD-2
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/tls_x25519.c"
+#endif
+/**
+ * Adapted from STROBE: https://strobe.sourceforge.io/
+ * Copyright (c) 2015-2016 Cryptography Research, Inc.
+ * Author: Mike Hamburg
+ * License: MIT License
+ */
+
+
+
+const uint8_t X25519_BASE_POINT[X25519_BYTES] = {9};
+
+#define X25519_WBITS 32
+
+typedef uint32_t limb_t;
+typedef uint64_t dlimb_t;
+typedef int64_t sdlimb_t;
+
+#define NLIMBS (256 / X25519_WBITS)
+typedef limb_t mg_fe[NLIMBS];
+
+static limb_t umaal(limb_t *carry, limb_t acc, limb_t mand, limb_t mier) {
+  dlimb_t tmp = (dlimb_t) mand * mier + acc + *carry;
+  *carry = (limb_t) (tmp >> X25519_WBITS);
+  return (limb_t) tmp;
+}
+
+// These functions are implemented in terms of umaal on ARM
+static limb_t adc(limb_t *carry, limb_t acc, limb_t mand) {
+  dlimb_t total = (dlimb_t) *carry + acc + mand;
+  *carry = (limb_t) (total >> X25519_WBITS);
+  return (limb_t) total;
+}
+
+static limb_t adc0(limb_t *carry, limb_t acc) {
+  dlimb_t total = (dlimb_t) *carry + acc;
+  *carry = (limb_t) (total >> X25519_WBITS);
+  return (limb_t) total;
+}
+
+// - Precondition: carry is small.
+// - Invariant: result of propagate is < 2^255 + 1 word
+// - In particular, always less than 2p.
+// - Also, output x >= min(x,19)
+static void propagate(mg_fe x, limb_t over) {
+  unsigned i;
+  limb_t carry;
+  over = x[NLIMBS - 1] >> (X25519_WBITS - 1) | over << 1;
+  x[NLIMBS - 1] &= ~((limb_t) 1 << (X25519_WBITS - 1));
+
+  carry = over * 19;
+  for (i = 0; i < NLIMBS; i++) {
+    x[i] = adc0(&carry, x[i]);
+  }
+}
+
+static void add(mg_fe out, const mg_fe a, const mg_fe b) {
+  unsigned i;
+  limb_t carry = 0;
+  for (i = 0; i < NLIMBS; i++) {
+    out[i] = adc(&carry, a[i], b[i]);
+  }
+  propagate(out, carry);
+}
+
+static void sub(mg_fe out, const mg_fe a, const mg_fe b) {
+  unsigned i;
+  sdlimb_t carry = -38;
+  for (i = 0; i < NLIMBS; i++) {
+    carry = carry + a[i] - b[i];
+    out[i] = (limb_t) carry;
+    carry >>= X25519_WBITS;
+  }
+  propagate(out, (limb_t) (1 + carry));
+}
+
+// `b` can contain less than 8 limbs, thus we use `limb_t *` instead of `mg_fe`
+// to avoid build warnings
+static void mul(mg_fe out, const mg_fe a, const limb_t *b, unsigned nb) {
+  limb_t accum[2 * NLIMBS] = {0};
+  unsigned i, j;
+
+  limb_t carry2;
+  for (i = 0; i < nb; i++) {
+    limb_t mand = b[i];
+    carry2 = 0;
+    for (j = 0; j < NLIMBS; j++) {
+      limb_t tmp;                        // "a" may be misaligned
+      memcpy(&tmp, &a[j], sizeof(tmp));  // So make an aligned copy
+      accum[i + j] = umaal(&carry2, accum[i + j], mand, tmp);
+    }
+    accum[i + j] = carry2;
+  }
+
+  carry2 = 0;
+  for (j = 0; j < NLIMBS; j++) {
+    out[j] = umaal(&carry2, accum[j], 38, accum[j + NLIMBS]);
+  }
+  propagate(out, carry2);
+}
+
+static void sqr(mg_fe out, const mg_fe a) {
+  mul(out, a, a, NLIMBS);
+}
+static void mul1(mg_fe out, const mg_fe a) {
+  mul(out, a, out, NLIMBS);
+}
+static void sqr1(mg_fe a) {
+  mul1(a, a);
+}
+
+static void condswap(limb_t a[2 * NLIMBS], limb_t b[2 * NLIMBS],
+                     limb_t doswap) {
+  unsigned i;
+  for (i = 0; i < 2 * NLIMBS; i++) {
+    limb_t xor_ab = (a[i] ^ b[i]) & doswap;
+    a[i] ^= xor_ab;
+    b[i] ^= xor_ab;
+  }
+}
+
+// Canonicalize a field element x, reducing it to the least residue which is
+// congruent to it mod 2^255-19
+// - Precondition: x < 2^255 + 1 word
+static limb_t canon(mg_fe x) {
+  // First, add 19.
+  unsigned i;
+  limb_t carry0 = 19;
+  limb_t res;
+  sdlimb_t carry;
+  for (i = 0; i < NLIMBS; i++) {
+    x[i] = adc0(&carry0, x[i]);
+  }
+  propagate(x, carry0);
+
+  // Here, 19 <= x2 < 2^255
+  // - This is because we added 19, so before propagate it can't be less
+  // than 19. After propagate, it still can't be less than 19, because if
+  // propagate does anything it adds 19.
+  // - We know that the high bit must be clear, because either the input was ~
+  // 2^255 + one word + 19 (in which case it propagates to at most 2 words) or
+  // it was < 2^255. So now, if we subtract 19, we will get back to something in
+  // [0,2^255-19).
+  carry = -19;
+  res = 0;
+  for (i = 0; i < NLIMBS; i++) {
+    carry += x[i];
+    res |= x[i] = (limb_t) carry;
+    carry >>= X25519_WBITS;
+  }
+  return (limb_t) (((dlimb_t) res - 1) >> X25519_WBITS);
+}
+
+static const limb_t a24[1] = {121665};
+
+static void ladder_part1(mg_fe xs[5]) {
+  limb_t *x2 = xs[0], *z2 = xs[1], *x3 = xs[2], *z3 = xs[3], *t1 = xs[4];
+  add(t1, x2, z2);                                 // t1 = A
+  sub(z2, x2, z2);                                 // z2 = B
+  add(x2, x3, z3);                                 // x2 = C
+  sub(z3, x3, z3);                                 // z3 = D
+  mul1(z3, t1);                                    // z3 = DA
+  mul1(x2, z2);                                    // x3 = BC
+  add(x3, z3, x2);                                 // x3 = DA+CB
+  sub(z3, z3, x2);                                 // z3 = DA-CB
+  sqr1(t1);                                        // t1 = AA
+  sqr1(z2);                                        // z2 = BB
+  sub(x2, t1, z2);                                 // x2 = E = AA-BB
+  mul(z2, x2, a24, sizeof(a24) / sizeof(a24[0]));  // z2 = E*a24
+  add(z2, z2, t1);                                 // z2 = E*a24 + AA
+}
+
+static void ladder_part2(mg_fe xs[5], const mg_fe x1) {
+  limb_t *x2 = xs[0], *z2 = xs[1], *x3 = xs[2], *z3 = xs[3], *t1 = xs[4];
+  sqr1(z3);         // z3 = (DA-CB)^2
+  mul1(z3, x1);     // z3 = x1 * (DA-CB)^2
+  sqr1(x3);         // x3 = (DA+CB)^2
+  mul1(z2, x2);     // z2 = AA*(E*a24+AA)
+  sub(x2, t1, x2);  // x2 = BB again
+  mul1(x2, t1);     // x2 = AA*BB
+}
+
+static void x25519_core(mg_fe xs[5], const uint8_t scalar[X25519_BYTES],
+                        const uint8_t *x1, int clamp) {
+  int i;
+  mg_fe x1_limbs;
+  limb_t swap = 0;
+  limb_t *x2 = xs[0], *x3 = xs[2], *z3 = xs[3];
+  memset(xs, 0, 4 * sizeof(mg_fe));
+  x2[0] = z3[0] = 1;
+  for (i = 0; i < NLIMBS; i++) {
+    x3[i] = x1_limbs[i] =
+        MG_U32(x1[i * 4 + 3], x1[i * 4 + 2], x1[i * 4 + 1], x1[i * 4]);
+  }
+
+  for (i = 255; i >= 0; i--) {
+    uint8_t bytei = scalar[i / 8];
+    limb_t doswap;
+    if (clamp) {
+      if (i / 8 == 0) {
+        bytei &= (uint8_t) ~7U;
+      } else if (i / 8 == X25519_BYTES - 1) {
+        bytei &= 0x7F;
+        bytei |= 0x40;
+      }
+    }
+    doswap = 0 - (limb_t) ((bytei >> (i % 8)) & 1);
+    condswap(x2, x3, swap ^ doswap);
+    swap = doswap;
+
+    ladder_part1(xs);
+    ladder_part2(xs, (const limb_t *) x1_limbs);
+  }
+  condswap(x2, x3, swap);
+}
+
+int mg_tls_x25519(uint8_t out[X25519_BYTES], const uint8_t scalar[X25519_BYTES],
+                  const uint8_t x1[X25519_BYTES], int clamp) {
+  int i, ret;
+  mg_fe xs[5], out_limbs;
+  limb_t *x2, *z2, *z3, *prev;
+  static const struct {
+    uint8_t a, c, n;
+  } steps[13] = {{2, 1, 1},  {2, 1, 1},  {4, 2, 3},  {2, 4, 6},  {3, 1, 1},
+                 {3, 2, 12}, {4, 3, 25}, {2, 3, 25}, {2, 4, 50}, {3, 2, 125},
+                 {3, 1, 2},  {3, 1, 2},  {3, 1, 1}};
+  x25519_core(xs, scalar, x1, clamp);
+
+  // Precomputed inversion chain
+  x2 = xs[0];
+  z2 = xs[1];
+  z3 = xs[3];
+
+  prev = z2;
+  for (i = 0; i < 13; i++) {
+    int j;
+    limb_t *a = xs[steps[i].a];
+    for (j = steps[i].n; j > 0; j--) {
+      sqr(a, prev);
+      prev = a;
+    }
+    mul1(a, xs[steps[i].c]);
+  }
+
+  // Here prev = z3
+  // x2 /= z2
+  mul(out_limbs, x2, z3, NLIMBS);
+  ret = (int) canon(out_limbs);
+  if (!clamp) ret = 0;
+  for (i = 0; i < NLIMBS; i++) {
+    uint32_t n = out_limbs[i];
+    out[i * 4] = (uint8_t) (n & 0xff);
+    out[i * 4 + 1] = (uint8_t) ((n >> 8) & 0xff);
+    out[i * 4 + 2] = (uint8_t) ((n >> 16) & 0xff);
+    out[i * 4 + 3] = (uint8_t) ((n >> 24) & 0xff);
+  }
+  return ret;
+}
 
 #ifdef MG_ENABLE_LINES
 #line 1 "src/url.c"
@@ -5807,7 +18848,7 @@ struct url {
 int mg_url_is_ssl(const char *url) {
   return strncmp(url, "wss:", 4) == 0 || strncmp(url, "https:", 6) == 0 ||
          strncmp(url, "mqtts:", 6) == 0 || strncmp(url, "ssl:", 4) == 0 ||
-         strncmp(url, "tls:", 4) == 0;
+         strncmp(url, "tls:", 4) == 0 || strncmp(url, "tcps:", 5) == 0;
 }
 
 static struct url urlparse(const char *url) {
@@ -5889,24 +18930,63 @@ struct mg_str mg_url_pass(const char *url) {
 #endif
 
 
+
+// Not using memset for zeroing memory, cause it can be dropped by compiler
+// See https://github.com/cesanta/mongoose/pull/1265
+void mg_bzero(volatile unsigned char *buf, size_t len) {
+  if (buf != NULL) {
+    while (len--) *buf++ = 0;
+  }
+}
+
 #if MG_ENABLE_CUSTOM_RANDOM
 #else
-void mg_random(void *buf, size_t len) {
-  bool done = false;
+bool mg_random(void *buf, size_t len) {
+  bool success = false;
   unsigned char *p = (unsigned char *) buf;
 #if MG_ARCH == MG_ARCH_ESP32
   while (len--) *p++ = (unsigned char) (esp_random() & 255);
-  done = true;
+  success = true;
+#elif MG_ARCH == MG_ARCH_PICOSDK
+  while (len--) *p++ = (unsigned char) (get_rand_32() & 255);
+  success = true;
 #elif MG_ARCH == MG_ARCH_WIN32
+#if defined(_MSC_VER) && _MSC_VER < 1700
+  static bool initialised = false;
+  static HCRYPTPROV hProv;
+  // CryptGenRandom() implementation earlier than 2008 is weak, see
+  // https://en.wikipedia.org/wiki/CryptGenRandom
+  if (!initialised) {
+    initialised = CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL,
+                                      CRYPT_VERIFYCONTEXT);
+  }
+  if (initialised) success = CryptGenRandom(hProv, len, p);
+#else
+  size_t i;
+  for (i = 0; i < len; i++) {
+    unsigned int rand_v;
+    if (rand_s(&rand_v) == 0) {
+      p[i] = (unsigned char) (rand_v & 255);
+    } else {
+      break;
+    }
+  }
+  success = (i == len);
+#endif
+
 #elif MG_ARCH == MG_ARCH_UNIX
   FILE *fp = fopen("/dev/urandom", "rb");
   if (fp != NULL) {
-    if (fread(buf, 1, len, fp) == len) done = true;
+    if (fread(buf, 1, len, fp) == len) success = true;
     fclose(fp);
   }
 #endif
   // If everything above did not work, fallback to a pseudo random generator
-  while (!done && len--) *p++ = (unsigned char) (rand() & 255);
+  if (success == false) {
+    MG_ERROR(("Weak RNG: using rand()"));
+    while (len--) *p++ = (unsigned char) (rand() & 255);
+  }
+  return success;
 }
 #endif
 
@@ -5944,9 +19024,9 @@ uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len) {
       0x9B64C2B0, 0x86D3D2D4, 0xA00AE278, 0xBDBDF21C};
   crc = ~crc;
   while (len--) {
-    uint8_t byte = *(uint8_t *)buf++;
-    crc = crclut[(crc ^ byte) & 0x0F] ^ (crc >> 4);
-    crc = crclut[(crc ^ (byte >> 4)) & 0x0F] ^ (crc >> 4);
+    uint8_t b = *(uint8_t *) buf++;
+    crc = crclut[(crc ^ b) & 0x0F] ^ (crc >> 4);
+    crc = crclut[(crc ^ (b >> 4)) & 0x0F] ^ (crc >> 4);
   }
   return ~crc;
 }
@@ -5969,16 +19049,34 @@ static int parse_net(const char *spec, uint32_t *net, uint32_t *mask) {
   return len;
 }
 
-int mg_check_ip_acl(struct mg_str acl, uint32_t remote_ip) {
-  struct mg_str k, v;
+int mg_check_ip_acl(struct mg_str acl, struct mg_addr *remote_ip) {
+  struct mg_str entry;
   int allowed = acl.len == 0 ? '+' : '-';  // If any ACL is set, deny by default
-  while (mg_commalist(&acl, &k, &v)) {
-    uint32_t net, mask;
-    if (k.ptr[0] != '+' && k.ptr[0] != '-') return -1;
-    if (parse_net(&k.ptr[1], &net, &mask) == 0) return -2;
-    if ((mg_ntohl(remote_ip) & mask) == net) allowed = k.ptr[0];
+  uint32_t remote_ip4;
+  if (remote_ip->is_ip6) {
+    return -1;  // TODO(): handle IPv6 ACL and addresses
+  } else {      // IPv4
+    memcpy((void *) &remote_ip4, remote_ip->ip, sizeof(remote_ip4));
+    while (mg_span(acl, &entry, &acl, ',')) {
+      uint32_t net, mask;
+      if (entry.buf[0] != '+' && entry.buf[0] != '-') return -1;
+      if (parse_net(&entry.buf[1], &net, &mask) == 0) return -2;
+      if ((mg_ntohl(remote_ip4) & mask) == net) allowed = entry.buf[0];
+    }
   }
   return allowed == '+';
+}
+
+bool mg_path_is_sane(const struct mg_str path) {
+  const char *s = path.buf;
+  size_t n = path.len;
+  if (path.buf[0] == '.' && path.buf[1] == '.') return false;  // Starts with ..
+  for (; s[0] != '\0' && n > 0; s++, n--) {
+    if ((s[0] == '/' || s[0] == '\\') && n >= 2) {   // Subdir?
+      if (s[1] == '.' && s[2] == '.') return false;  // Starts with ..
+    }
+  }
+  return true;
 }
 
 #if MG_ENABLE_CUSTOM_MILLIS
@@ -5986,11 +19084,10 @@ int mg_check_ip_acl(struct mg_str acl, uint32_t remote_ip) {
 uint64_t mg_millis(void) {
 #if MG_ARCH == MG_ARCH_WIN32
   return GetTickCount();
-#elif MG_ARCH == MG_ARCH_RP2040
+#elif MG_ARCH == MG_ARCH_PICOSDK
   return time_us_64() / 1000;
-#elif MG_ARCH == MG_ARCH_ESP32
-  return esp_timer_get_time() / 1000;
-#elif MG_ARCH == MG_ARCH_ESP8266 || MG_ARCH == MG_ARCH_FREERTOS
+#elif MG_ARCH == MG_ARCH_ESP8266 || MG_ARCH == MG_ARCH_ESP32 || \
+    MG_ARCH == MG_ARCH_FREERTOS
   return xTaskGetTickCount() * portTICK_PERIOD_MS;
 #elif MG_ARCH == MG_ARCH_AZURERTOS
   return tx_time_get() * (1000 /* MS per SEC */ / TX_TIMER_TICKS_PER_SECOND);
@@ -5999,9 +19096,11 @@ uint64_t mg_millis(void) {
 #elif MG_ARCH == MG_ARCH_ZEPHYR
   return (uint64_t) k_uptime_get();
 #elif MG_ARCH == MG_ARCH_CMSIS_RTOS1
-  return (uint64_t)rt_time_get();
+  return (uint64_t) rt_time_get();
 #elif MG_ARCH == MG_ARCH_CMSIS_RTOS2
-  return (uint64_t)((osKernelGetTickCount() * 1000) / osKernelGetTickFreq());
+  return (uint64_t) ((osKernelGetTickCount() * 1000) / osKernelGetTickFreq());
+#elif MG_ARCH == MG_ARCH_RTTHREAD
+  return (uint64_t) ((rt_tick_get() * 1000) / RT_TICK_PER_SECOND);
 #elif MG_ARCH == MG_ARCH_UNIX && defined(__APPLE__)
   // Apple CLOCK_MONOTONIC_RAW is equivalent to CLOCK_BOOTTIME on linux
   // Apple CLOCK_UPTIME_RAW is equivalent to CLOCK_MONOTONIC_RAW on linux
@@ -6074,10 +19173,10 @@ static void ws_handshake(struct mg_connection *c, const struct mg_str *wskey,
 
   mg_sha1_ctx sha_ctx;
   mg_sha1_init(&sha_ctx);
-  mg_sha1_update(&sha_ctx, (unsigned char *) wskey->ptr, wskey->len);
+  mg_sha1_update(&sha_ctx, (unsigned char *) wskey->buf, wskey->len);
   mg_sha1_update(&sha_ctx, (unsigned char *) magic, 36);
   mg_sha1_final(sha, &sha_ctx);
-  mg_base64_encode(sha, sizeof(sha), (char *) b64_sha);
+  mg_base64_encode(sha, sizeof(sha), (char *) b64_sha, sizeof(b64_sha));
   mg_xprintf(mg_pfn_iobuf, &c->send,
              "HTTP/1.1 101 Switching Protocols\r\n"
              "Upgrade: websocket\r\n"
@@ -6087,7 +19186,7 @@ static void ws_handshake(struct mg_connection *c, const struct mg_str *wskey,
   if (fmt != NULL) mg_vxprintf(mg_pfn_iobuf, &c->send, fmt, ap);
   if (wsproto != NULL) {
     mg_printf(c, "Sec-WebSocket-Protocol: %.*s\r\n", (int) wsproto->len,
-              wsproto->ptr);
+              wsproto->buf);
   }
   mg_send(c, "\r\n", 2);
 }
@@ -6167,9 +19266,9 @@ size_t mg_ws_send(struct mg_connection *c, const void *buf, size_t len,
                   int op) {
   uint8_t header[14];
   size_t header_len = mkhdr(len, op, c->is_client, header);
-  mg_send(c, header, header_len);
+  if (!mg_send(c, header, header_len)) return 0;
+  if (!mg_send(c, buf, len)) return header_len;
   MG_VERBOSE(("WS out: %d [%.*s]", (int) len, (int) len, buf));
-  mg_send(c, buf, len);
   mg_ws_mask(c, len);
   return header_len + len;
 }
@@ -6180,12 +19279,15 @@ static bool mg_ws_client_handshake(struct mg_connection *c) {
     mg_error(c, "not http");  // Some just, not an HTTP request
   } else if (n > 0) {
     if (n < 15 || memcmp(c->recv.buf + 9, "101", 3) != 0) {
-      mg_error(c, "handshake error");
+      mg_error(c, "ws handshake error");
     } else {
       struct mg_http_message hm;
-      mg_http_parse((char *) c->recv.buf, c->recv.len, &hm);
-      c->is_websocket = 1;
-      mg_call(c, MG_EV_WS_OPEN, &hm);
+      if (mg_http_parse((char *) c->recv.buf, c->recv.len, &hm)) {
+        c->is_websocket = 1;
+        mg_call(c, MG_EV_WS_OPEN, &hm);
+      } else {
+        mg_error(c, "ws handshake error");
+      }
     }
     mg_iobuf_del(&c->recv, 0, (size_t) n);
   } else {
@@ -6194,8 +19296,7 @@ static bool mg_ws_client_handshake(struct mg_connection *c) {
   return false;  // Continue event handler
 }
 
-static void mg_ws_cb(struct mg_connection *c, int ev, void *ev_data,
-                     void *fn_data) {
+static void mg_ws_cb(struct mg_connection *c, int ev, void *ev_data) {
   struct ws_msg msg;
   size_t ofs = (size_t) c->pfn_data;
 
@@ -6209,7 +19310,7 @@ static void mg_ws_cb(struct mg_connection *c, int ev, void *ev_data,
       size_t len = msg.header_len + msg.data_len;
       uint8_t final = msg.flags & 128, op = msg.flags & 15;
       // MG_VERBOSE ("fin %d op %d len %d [%.*s]", final, op,
-      //                       (int) m.data.len, (int) m.data.len, m.data.ptr));
+      //                       (int) m.data.len, (int) m.data.len, m.data.buf));
       switch (op) {
         case WEBSOCKET_OP_CONTINUE:
           mg_call(c, MG_EV_WS_CTL, &m);
@@ -6230,7 +19331,7 @@ static void mg_ws_cb(struct mg_connection *c, int ev, void *ev_data,
           MG_DEBUG(("%lu WS CLOSE", c->id));
           mg_call(c, MG_EV_WS_CTL, &m);
           // Echo the payload of the received CLOSE message back to the sender
-          mg_ws_send(c, m.data.ptr, m.data.len, WEBSOCKET_OP_CLOSE);
+          mg_ws_send(c, m.data.buf, m.data.len, WEBSOCKET_OP_CLOSE);
           c->is_draining = 1;
           break;
         default:
@@ -6261,7 +19362,6 @@ static void mg_ws_cb(struct mg_connection *c, int ev, void *ev_data,
       }
     }
   }
-  (void) fn_data;
   (void) ev_data;
 }
 
@@ -6273,7 +19373,7 @@ struct mg_connection *mg_ws_connect(struct mg_mgr *mgr, const char *url,
     char nonce[16], key[30];
     struct mg_str host = mg_url_host(url);
     mg_random(nonce, sizeof(nonce));
-    mg_base64_encode((unsigned char *) nonce, sizeof(nonce), key);
+    mg_base64_encode((unsigned char *) nonce, sizeof(nonce), key, sizeof(key));
     mg_xprintf(mg_pfn_iobuf, &c->send,
                "GET %s HTTP/1.1\r\n"
                "Upgrade: websocket\r\n"
@@ -6281,7 +19381,7 @@ struct mg_connection *mg_ws_connect(struct mg_mgr *mgr, const char *url,
                "Connection: Upgrade\r\n"
                "Sec-WebSocket-Version: 13\r\n"
                "Sec-WebSocket-Key: %s\r\n",
-               mg_url_uri(url), (int) host.len, host.ptr, key);
+               mg_url_uri(url), (int) host.len, host.buf, key);
     if (fmt != NULL) {
       va_list ap;
       va_start(ap, fmt);
@@ -6320,290 +19420,1536 @@ size_t mg_ws_wrap(struct mg_connection *c, size_t len, int op) {
   size_t header_len = mkhdr(len, op, c->is_client, header);
 
   // NOTE: order of operations is important!
-  mg_iobuf_add(&c->send, c->send.len, NULL, header_len);
-  p = &c->send.buf[c->send.len - len];         // p points to data
-  memmove(p, p - header_len, len);             // Shift data
-  memcpy(p - header_len, header, header_len);  // Prepend header
-  mg_ws_mask(c, len);                          // Mask data
-
+  if (mg_iobuf_add(&c->send, c->send.len, NULL, header_len) != 0) {
+    p = &c->send.buf[c->send.len - len];         // p points to data
+    memmove(p, p - header_len, len);             // Shift data
+    memcpy(p - header_len, header, header_len);  // Prepend header
+    mg_ws_mask(c, len);                          // Mask data
+  }
   return c->send.len;
 }
 
 #ifdef MG_ENABLE_LINES
-#line 1 "src/tcpip/driver_nxpimxrt1020.c"
+#line 1 "src/drivers/cmsis.c"
+#endif
+// https://arm-software.github.io/CMSIS_5/Driver/html/index.html
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_CMSIS) && MG_ENABLE_DRIVER_CMSIS
+
+
+
+
+
+extern ARM_DRIVER_ETH_MAC Driver_ETH_MAC0;
+extern ARM_DRIVER_ETH_PHY Driver_ETH_PHY0;
+
+static struct mg_tcpip_if *s_ifp;
+
+static void mac_cb(uint32_t);
+static bool cmsis_init(struct mg_tcpip_if *);
+static bool cmsis_up(struct mg_tcpip_if *);
+static size_t cmsis_tx(const void *, size_t, struct mg_tcpip_if *);
+static size_t cmsis_rx(void *, size_t, struct mg_tcpip_if *);
+
+struct mg_tcpip_driver mg_tcpip_driver_cmsis = {cmsis_init, cmsis_tx, NULL,
+                                                cmsis_up};
+
+static bool cmsis_init(struct mg_tcpip_if *ifp) {
+  ARM_ETH_MAC_ADDR addr;
+  s_ifp = ifp;
+
+  ARM_DRIVER_ETH_MAC *mac = &Driver_ETH_MAC0;
+  ARM_DRIVER_ETH_PHY *phy = &Driver_ETH_PHY0;
+  ARM_ETH_MAC_CAPABILITIES cap = mac->GetCapabilities();
+  if (mac->Initialize(mac_cb) != ARM_DRIVER_OK) return false;
+  if (phy->Initialize(mac->PHY_Read, mac->PHY_Write) != ARM_DRIVER_OK)
+    return false;
+  if (cap.event_rx_frame == 0)  // polled mode driver
+    mg_tcpip_driver_cmsis.rx = cmsis_rx;
+  mac->PowerControl(ARM_POWER_FULL);
+  if (cap.mac_address) {  // driver provides MAC address
+    mac->GetMacAddress(&addr);
+    memcpy(ifp->mac, &addr, sizeof(ifp->mac));
+  } else {  // we provide MAC address
+    memcpy(&addr, ifp->mac, sizeof(addr));
+    mac->SetMacAddress(&addr);
+  }
+  phy->PowerControl(ARM_POWER_FULL);
+  phy->SetInterface(cap.media_interface);
+  phy->SetMode(ARM_ETH_PHY_AUTO_NEGOTIATE);
+  return true;
+}
+
+static size_t cmsis_tx(const void *buf, size_t len, struct mg_tcpip_if *ifp) {
+  ARM_DRIVER_ETH_MAC *mac = &Driver_ETH_MAC0;
+  if (mac->SendFrame(buf, (uint32_t) len, 0) != ARM_DRIVER_OK) {
+    ifp->nerr++;
+    return 0;
+  }
+  ifp->nsent++;
+  return len;
+}
+
+static bool cmsis_up(struct mg_tcpip_if *ifp) {
+  ARM_DRIVER_ETH_PHY *phy = &Driver_ETH_PHY0;
+  ARM_DRIVER_ETH_MAC *mac = &Driver_ETH_MAC0;
+  bool up = (phy->GetLinkState() == ARM_ETH_LINK_UP) ? 1 : 0;  // link state
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {             // just went up
+    ARM_ETH_LINK_INFO st = phy->GetLinkInfo();
+    mac->Control(ARM_ETH_MAC_CONFIGURE,
+                 (st.speed << ARM_ETH_MAC_SPEED_Pos) |
+                     (st.duplex << ARM_ETH_MAC_DUPLEX_Pos) |
+                     ARM_ETH_MAC_ADDRESS_BROADCAST);
+    MG_DEBUG(("Link is %uM %s-duplex",
+              (st.speed == 2) ? 1000
+              : st.speed      ? 100
+                              : 10,
+              st.duplex ? "full" : "half"));
+    mac->Control(ARM_ETH_MAC_CONTROL_TX, 1);
+    mac->Control(ARM_ETH_MAC_CONTROL_RX, 1);
+  } else if ((ifp->state != MG_TCPIP_STATE_DOWN) && !up) {  // just went down
+    mac->Control(ARM_ETH_MAC_FLUSH,
+                 ARM_ETH_MAC_FLUSH_TX | ARM_ETH_MAC_FLUSH_RX);
+    mac->Control(ARM_ETH_MAC_CONTROL_TX, 0);
+    mac->Control(ARM_ETH_MAC_CONTROL_RX, 0);
+  }
+  return up;
+}
+
+static void mac_cb(uint32_t ev) {
+  if ((ev & ARM_ETH_MAC_EVENT_RX_FRAME) == 0) return;
+  ARM_DRIVER_ETH_MAC *mac = &Driver_ETH_MAC0;
+  uint32_t len = mac->GetRxFrameSize();  // CRC already stripped
+  if (len >= 60 && len <= 1518) {        // proper frame
+    char *p;
+    if (mg_queue_book(&s_ifp->recv_queue, &p, len) >= len) {  // have room
+      if ((len = mac->ReadFrame((uint8_t *) p, len)) > 0) {   // copy succeeds
+        mg_queue_add(&s_ifp->recv_queue, len);
+        s_ifp->nrecv++;
+      }
+      return;
+    }
+    s_ifp->ndrop++;
+  }
+  mac->ReadFrame(NULL, 0);  // otherwise, discard
+}
+
+static size_t cmsis_rx(void *buf, size_t buflen, struct mg_tcpip_if *ifp) {
+  ARM_DRIVER_ETH_MAC *mac = &Driver_ETH_MAC0;
+  uint32_t len = mac->GetRxFrameSize();  // CRC already stripped
+  if (len >= 60 && len <= 1518 &&
+      ((len = mac->ReadFrame(buf, (uint32_t) buflen)) > 0))
+    return len;
+  if (len > 0) mac->ReadFrame(NULL, 0);  // discard bad frames
+  (void) ifp;
+  return 0;
+}
+
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/imxrt.c"
 #endif
 
 
-/*
- * Todo
- * This driver doesn't support 10M line autoconfiguration yet.
- * Packets aren't sent if the link negociated 10M line.
- * todo: MAC back auto reconfiguration.
- */
-
-#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_IMXRT1020)
-struct imx_rt1020_enet {
-volatile uint32_t RESERVED0, EIR, EIMR, RESERVED1, RDAR, TDAR, RESERVED2[3], ECR, RESERVED3[6], MMFR, MSCR, RESERVED4[7], MIBC, RESERVED5[7], RCR, RESERVED6[15], TCR, RESERVED7[7], PALR, PAUR, OPD, TXIC0, TXIC1, TXIC2, RESERVED8, RXIC0, RXIC1, RXIC2, RESERVED9[3], IAUR, IALR, GAUR, GALR, RESERVED10[7], TFWR, RESERVED11[14], RDSR, TDSR, MRBR[2], RSFL, RSEM, RAEM, RAFL, TSEM, TAEM, TAFL, TIPG, FTRL, RESERVED12[3], TACC, RACC, RESERVED13[15], RMON_T_PACKETS, RMON_T_BC_PKT, RMON_T_MC_PKT, RMON_T_CRC_ALIGN, RMON_T_UNDERSIZE, RMON_T_OVERSIZE, RMON_T_FRAG, RMON_T_JAB, RMON_T_COL, RMON_T_P64, RMON_T_P65TO127, RMON_T_P128TO255, RMON_T_P256TO511, RMON_T_P512TO1023, RMON_T_P1024TO2048, RMON_T_GTE2048, RMON_T_OCTETS, IEEE_T_DROP, IEEE_T_FRAME_OK, IEEE_T_1COL, IEEE_T_MCOL, IEEE_T_DEF, IEEE_T_LCOL, IEEE_T_EXCOL, IEEE_T_MACERR, IEEE_T_CSERR, IEEE_T_SQE, IEEE_T_FDXFC, IEEE_T_OCTETS_OK, RESERVED14[3], RMON_R_PACKETS, RMON_R_BC_PKT, RMON_R_MC_PKT, RMON_R_CRC_ALIGN, RMON_R_UNDERSIZE, RMON_R_OVERSIZE, RMON_R_FRAG, RMON_R_JAB, RESERVED15, RMON_R_P64, RMON_R_P65TO127, RMON_R_P128TO255, RMON_R_P256TO511, RMON_R_P512TO1023, RMON_R_P1024TO2047, RMON_R_GTE2048, RMON_R_OCTETS, IEEE_R_DROP, IEEE_R_FRAME_OK, IEEE_R_CRC, IEEE_R_ALIGN, IEEE_R_MACERR, IEEE_R_FDXFC, IEEE_R_OCTETS_OK, RESERVED16[71], ATCR, ATVR, ATOFF, ATPER, ATCOR, ATINC, ATSTMP, RESERVED17[122], TGSR, TCSR0, TCCR0, TCSR1, TCCR1, TCSR2, TCCR2, TCSR3;
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_IMXRT) && MG_ENABLE_DRIVER_IMXRT
+struct imxrt_enet {
+  volatile uint32_t RESERVED0, EIR, EIMR, RESERVED1, RDAR, TDAR, RESERVED2[3],
+      ECR, RESERVED3[6], MMFR, MSCR, RESERVED4[7], MIBC, RESERVED5[7], RCR,
+      RESERVED6[15], TCR, RESERVED7[7], PALR, PAUR, OPD, TXIC0, TXIC1, TXIC2,
+      RESERVED8, RXIC0, RXIC1, RXIC2, RESERVED9[3], IAUR, IALR, GAUR, GALR,
+      RESERVED10[7], TFWR, RESERVED11[14], RDSR, TDSR, MRBR[2], RSFL, RSEM,
+      RAEM, RAFL, TSEM, TAEM, TAFL, TIPG, FTRL, RESERVED12[3], TACC, RACC,
+      RESERVED13[15], RMON_T_PACKETS, RMON_T_BC_PKT, RMON_T_MC_PKT,
+      RMON_T_CRC_ALIGN, RMON_T_UNDERSIZE, RMON_T_OVERSIZE, RMON_T_FRAG,
+      RMON_T_JAB, RMON_T_COL, RMON_T_P64, RMON_T_P65TO127, RMON_T_P128TO255,
+      RMON_T_P256TO511, RMON_T_P512TO1023, RMON_T_P1024TO2048, RMON_T_GTE2048,
+      RMON_T_OCTETS, IEEE_T_DROP, IEEE_T_FRAME_OK, IEEE_T_1COL, IEEE_T_MCOL,
+      IEEE_T_DEF, IEEE_T_LCOL, IEEE_T_EXCOL, IEEE_T_MACERR, IEEE_T_CSERR,
+      IEEE_T_SQE, IEEE_T_FDXFC, IEEE_T_OCTETS_OK, RESERVED14[3], RMON_R_PACKETS,
+      RMON_R_BC_PKT, RMON_R_MC_PKT, RMON_R_CRC_ALIGN, RMON_R_UNDERSIZE,
+      RMON_R_OVERSIZE, RMON_R_FRAG, RMON_R_JAB, RESERVED15, RMON_R_P64,
+      RMON_R_P65TO127, RMON_R_P128TO255, RMON_R_P256TO511, RMON_R_P512TO1023,
+      RMON_R_P1024TO2047, RMON_R_GTE2048, RMON_R_OCTETS, IEEE_R_DROP,
+      IEEE_R_FRAME_OK, IEEE_R_CRC, IEEE_R_ALIGN, IEEE_R_MACERR, IEEE_R_FDXFC,
+      IEEE_R_OCTETS_OK, RESERVED16[71], ATCR, ATVR, ATOFF, ATPER, ATCOR, ATINC,
+      ATSTMP, RESERVED17[122], TGSR, TCSR0, TCCR0, TCSR1, TCCR1, TCSR2, TCCR2,
+      TCSR3;
 };
 
 #undef ENET
-#define ENET ((struct imx_rt1020_enet *) (uintptr_t) 0x402D8000u)
+#if defined(MG_DRIVER_IMXRT_RT11) && MG_DRIVER_IMXRT_RT11
+#define ENET ((struct imxrt_enet *) (uintptr_t) 0x40424000U)
+#define ETH_DESC_CNT 5     // Descriptors count
+#else
+#define ENET ((struct imxrt_enet *) (uintptr_t) 0x402D8000U)
+#define ETH_DESC_CNT 4     // Descriptors count
+#endif
 
-#undef BIT
-#define BIT(x) ((uint32_t) 1 << (x))
+#define ETH_PKT_SIZE 1536  // Max frame size, 64-bit aligned
 
-#define ENET_RXBUFF_SIZE 1536 // 1522 Buffer must be 64bits aligned
-#define ENET_TXBUFF_SIZE 1536 // 1522 hence set to 0x600 (1536)
-#define ENET_RXBD_NUM          (4)
-#define ENET_TXBD_NUM          (4)
+struct enet_desc {
+  uint16_t length;   // Data length
+  uint16_t control;  // Control and status
+  uint32_t *buffer;  // Data ptr
+};
 
-const uint32_t EIMR_RX_ERR = 0x2400000;              // Intr mask RXF+EBERR
+// TODO(): handle these in a portable compiler-independent CMSIS-friendly way
+#define MG_64BYTE_ALIGNED __attribute__((aligned((64U))))
 
-void ETH_IRQHandler(void);
-static bool mg_tcpip_driver_imxrt1020_init(struct mg_tcpip_if *ifp);
-static void wait_phy_complete(void);
-static struct mg_tcpip_if *s_ifp;                         // MIP interface
+// Descriptors: in non-cached area (TODO(scaprile)), (37.5.1.22.2 37.5.1.23.2)
+// Buffers: 64-byte aligned (37.3.14)
+static volatile struct enet_desc s_rxdesc[ETH_DESC_CNT] MG_64BYTE_ALIGNED;
+static volatile struct enet_desc s_txdesc[ETH_DESC_CNT] MG_64BYTE_ALIGNED;
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE] MG_64BYTE_ALIGNED;
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE] MG_64BYTE_ALIGNED;
+static struct mg_tcpip_if *s_ifp;  // MIP interface
 
-static size_t mg_tcpip_driver_imxrt1020_tx(const void *, size_t , struct mg_tcpip_if *);
-static bool mg_tcpip_driver_imxrt1020_up(struct mg_tcpip_if *ifp);
-
-enum { IMXRT1020_PHY_ADDR = 0x02, IMXRT1020_PHY_BCR = 0, IMXRT1020_PHY_BSR = 1 };     // PHY constants
-
-void delay(uint32_t);
-void delay (uint32_t di) {
-  volatile int dno = 0; // Prevent optimization
-  for (uint32_t i = 0; i < di; i++)
-    for (int j=0; j<20; j++) // PLLx20 (500 MHz/24MHz)
-      dno++;
+static uint16_t enet_read_phy(uint8_t addr, uint8_t reg) {
+  ENET->EIR |= MG_BIT(23);  // MII interrupt clear
+  ENET->MMFR = (1 << 30) | (2 << 28) | (addr << 23) | (reg << 18) | (2 << 16);
+  while ((ENET->EIR & MG_BIT(23)) == 0) (void) 0;
+  return ENET->MMFR & 0xffff;
 }
 
-static void wait_phy_complete(void) {
-  delay(0x00010000);
-  const uint32_t delay_max = 0x00100000;
-  uint32_t delay_cnt = 0;
-  while (!(ENET->EIR & BIT(23)) && (delay_cnt < delay_max))
-  {delay_cnt++;}
-  ENET->EIR |= BIT(23); // MII interrupt clear
+static void enet_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  ENET->EIR |= MG_BIT(23);  // MII interrupt clear
+  ENET->MMFR =
+      (1 << 30) | (1 << 28) | (addr << 23) | (reg << 18) | (2 << 16) | val;
+  while ((ENET->EIR & MG_BIT(23)) == 0) (void) 0;
 }
 
-static uint32_t imxrt1020_eth_read_phy(uint8_t addr, uint8_t reg) {
-  ENET->EIR |= BIT(23); // MII interrupt clear
-  uint32_t mask_phy_adr_reg = 0x1f; // 0b00011111: Ensure we write 5 bits (Phy address & register)
-  uint32_t phy_transaction = 0x00;
-  phy_transaction = (0x1 << 30) \
-                  | (0x2 << 28) \
-                  | ((uint32_t)(addr & mask_phy_adr_reg) << 23) \
-                  | ((uint32_t)(reg & mask_phy_adr_reg)  << 18) \
-                  | (0x2 << 16);
-
-  ENET->MMFR = phy_transaction;
-  wait_phy_complete();
-
-  return (ENET->MMFR & 0x0000ffff);
-}
-
-static void imxrt1020_eth_write_phy(uint8_t addr, uint8_t reg, uint32_t val) {
-  ENET->EIR |= BIT(23); // MII interrupt clear
-  uint8_t mask_phy_adr_reg = 0x1f; // 0b00011111: Ensure we write 5 bits (Phy address & register)
-  uint32_t mask_phy_data = 0x0000ffff; // Ensure we write 16 bits (data)
-  addr &= mask_phy_adr_reg;
-  reg &= mask_phy_adr_reg;
-  val &= mask_phy_data;
-  uint32_t phy_transaction = 0x00;
-  phy_transaction = (uint32_t)(0x1 << 30) \
-                  | (uint32_t)(0x1 << 28) \
-                  | (uint32_t)(addr << 23) \
-                  | (uint32_t)(reg  << 18) \
-                  | (uint32_t)(0x2 << 16) \
-                  | (uint32_t)(val);
-  ENET->MMFR = phy_transaction;
-  wait_phy_complete();
-}
-
-// FEC RX/TX descriptors (Enhanced descriptor not enabled)
-// Descriptor buffer structure, little endian
-
-typedef struct enet_bd_struct_def
-{
-    uint16_t length;  // Data length
-    uint16_t control; // Control and status
-    uint32_t *buffer; // Data ptr
-} enet_bd_struct_t;
-
-// Descriptor and buffer globals, in non-cached area, 64 bits aligned.
-
-__attribute__((section("NonCacheable,\"aw\",%nobits @"))) enet_bd_struct_t rx_buffer_descriptor[(ENET_RXBD_NUM)] __attribute__((aligned((64U))));
-__attribute__((section("NonCacheable,\"aw\",%nobits @"))) enet_bd_struct_t tx_buffer_descriptor[(ENET_TXBD_NUM)] __attribute__((aligned((64U))));
-
-uint8_t rx_data_buffer[(ENET_RXBD_NUM)][((unsigned int)(((ENET_RXBUFF_SIZE)) + (((64U))-1U)) & (unsigned int)(~(unsigned int)(((64U))-1U)))] __attribute__((aligned((64U))));
-uint8_t tx_data_buffer[(ENET_TXBD_NUM)][((unsigned int)(((ENET_TXBUFF_SIZE)) + (((64U))-1U)) & (unsigned int)(~(unsigned int)(((64U))-1U)))] __attribute__((aligned((64U))));
-
-// Initialise driver imx_rt1020
-
-// static bool mg_tcpip_driver_imxrt1020_init(uint8_t *mac, void *data) { // VO
-static bool mg_tcpip_driver_imxrt1020_init(struct mg_tcpip_if *ifp) {
-
-  struct mg_tcpip_driver_imxrt1020_data *d = (struct mg_tcpip_driver_imxrt1020_data *) ifp->driver_data;
+//  MDC clock is generated from IPS Bus clock (ipg_clk); as per 802.3,
+//  it must not exceed 2.5MHz
+// The PHY receives the PLL6-generated 50MHz clock
+static bool mg_tcpip_driver_imxrt_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_imxrt_data *d =
+      (struct mg_tcpip_driver_imxrt_data *) ifp->driver_data;
   s_ifp = ifp;
 
-  // ENET Reset, wait complete
-  ENET->ECR |= BIT(0);
-  while((ENET->ECR & BIT(0)) != 0) {}
-
-  // Re-latches the pin strapping pin values
-  ENET->ECR |= BIT(0);
-  while((ENET->ECR & BIT(0)) != 0) {}
-
-  // Setup MII/RMII MDC clock divider (<= 2.5MHz).
-  ENET->MSCR = 0x130; // HOLDTIME 2 clk, Preamble enable, MDC MII_Speed Div 0x30
-  imxrt1020_eth_write_phy(IMXRT1020_PHY_ADDR, IMXRT1020_PHY_BCR, 0x8000); // PHY W @0x00 D=0x8000 Soft reset
-  while (imxrt1020_eth_read_phy(IMXRT1020_PHY_ADDR, IMXRT1020_PHY_BSR) & BIT(15)) {delay(0x5000);} // Wait finished poll 10ms
-
-  // PHY: Start Link
-  {
-    imxrt1020_eth_write_phy(IMXRT1020_PHY_ADDR, IMXRT1020_PHY_BCR, 0x1200); // PHY W @0x00 D=0x1200 Autonego enable + start
-    imxrt1020_eth_write_phy(IMXRT1020_PHY_ADDR, 0x1f, 0x8180);    // PHY W @0x1f D=0x8180 Ref clock 50 MHz at XI input
-
-    uint32_t bcr = imxrt1020_eth_read_phy(IMXRT1020_PHY_ADDR, IMXRT1020_PHY_BCR);
-    bcr &= ~BIT(10); // Isolation -> Normal
-    imxrt1020_eth_write_phy(IMXRT1020_PHY_ADDR, IMXRT1020_PHY_BCR, bcr);
+  // Init RX descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    s_rxdesc[i].control = MG_BIT(15);              // Own (E)
+    s_rxdesc[i].buffer = (uint32_t *) s_rxbuf[i];  // Point to data buffer
   }
+  s_rxdesc[ETH_DESC_CNT - 1].control |= MG_BIT(13);  // Wrap last descriptor
 
-  // Disable ENET
-  ENET->ECR = 0x0; //  Disable before configuration
-
-  // Configure ENET
-  ENET->RCR = 0x05ee0104; // #CRCFWD=0 (CRC kept in frame) + RMII + MII Enable
-  
-  ENET->TCR = BIT(8) | BIT(2); // Addins (MAC address from PAUR+PALR) + Full duplex enable
-  //ENET->TFWR = BIT(8); // Store And Forward Enable, 64 bytes (minimize tx latency)
-
-  // Configure descriptors and buffers
-  // RX
-  for (int i = 0; i < ENET_RXBD_NUM; i++) {
-    // Wrap last descriptor buffer ptr
-    rx_buffer_descriptor[i].control = (BIT(15) | ((i<(ENET_RXBD_NUM-1))?0:BIT(13))); // E+(W*)
-    rx_buffer_descriptor[i].buffer = (uint32_t *)rx_data_buffer[i];
+  // Init TX descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    // s_txdesc[i].control = MG_BIT(10);  // Own (TC)
+    s_txdesc[i].buffer = (uint32_t *) s_txbuf[i];
   }
+  s_txdesc[ETH_DESC_CNT - 1].control |= MG_BIT(13);  // Wrap last descriptor
 
-  // TX
-  for (int i = 0; i < ENET_TXBD_NUM; i++) {
-    // Wrap last descriptor buffer ptr
-    tx_buffer_descriptor[i].control = ((i<(ENET_RXBD_NUM-1))?0:BIT(13)) | BIT(10); // (W*)+TC
-    tx_buffer_descriptor[i].buffer = (uint32_t *)tx_data_buffer[i];
-  }
+  ENET->ECR = MG_BIT(0);                     // Software reset, disable
+  while ((ENET->ECR & MG_BIT(0))) (void) 0;  // Wait until done
 
-  // Continue ENET configuration
-  ENET->RDSR = (uint32_t)(uintptr_t)rx_buffer_descriptor;
-  ENET->TDSR = (uint32_t)(uintptr_t)tx_buffer_descriptor;
-  ENET->MRBR[0] = ENET_RXBUFF_SIZE; // Same size for RX/TX buffers
-
+  // Set MDC clock divider. If user told us the value, use it.
+  // TODO(): Otherwise, guess (currently assuming max freq)
+  int cr = (d == NULL || d->mdc_cr < 0) ? 24 : d->mdc_cr;
+  ENET->MSCR = (1 << 8) | ((cr & 0x3f) << 1);  // HOLDTIME 2 clks
+  struct mg_phy phy = {enet_read_phy, enet_write_phy};
+  mg_phy_init(&phy, d->phy_addr, MG_PHY_LEDS_ACTIVE_HIGH); // MAC clocks PHY  
+  // Select RMII mode, 100M, keep CRC, set max rx length, disable loop
+  ENET->RCR = (1518 << 16) | MG_BIT(8) | MG_BIT(2);
+  // ENET->RCR |= MG_BIT(3);     // Receive all
+  ENET->TCR = MG_BIT(2);  // Full-duplex
+  ENET->RDSR = (uint32_t) (uintptr_t) s_rxdesc;
+  ENET->TDSR = (uint32_t) (uintptr_t) s_txdesc;
+  ENET->MRBR[0] = ETH_PKT_SIZE;  // Same size for RX/TX buffers
   // MAC address filtering (bytes in reversed order)
   ENET->PAUR = ((uint32_t) ifp->mac[4] << 24U) | (uint32_t) ifp->mac[5] << 16U;
-  ENET->PALR = (uint32_t) (ifp->mac[0] << 24U) | ((uint32_t) ifp->mac[1] << 16U) |
-                 ((uint32_t) ifp->mac[2] << 8U) | ifp->mac[3];
-
-  // Init Hash tables (mac filtering)
-  ENET->IAUR = 0; // Unicast
-  ENET->IALR = 0;
-  ENET->GAUR = 0; // Multicast
-  ENET->GALR = 0;
-
-  // Set ENET Online
-  ENET->ECR |= BIT(8); // ENET Set Little-endian + (FEC buffer desc.)
-  ENET->ECR |= BIT(1); // Enable
-
-  // Set interrupt mask
-  ENET->EIMR = EIMR_RX_ERR;
-
-  // RX Descriptor activation
-  ENET->RDAR = BIT(24); // Activate Receive Descriptor
+  ENET->PALR = (uint32_t) (ifp->mac[0] << 24U) |
+               ((uint32_t) ifp->mac[1] << 16U) |
+               ((uint32_t) ifp->mac[2] << 8U) | ifp->mac[3];
+  ENET->ECR = MG_BIT(8) | MG_BIT(1);  // Little-endian CPU, Enable
+  ENET->EIMR = MG_BIT(25);            // Set interrupt mask
+  ENET->RDAR = MG_BIT(24);            // Receive Descriptors have changed
+  ENET->TDAR = MG_BIT(24);            // Transmit Descriptors have changed
+  // ENET->OPD = 0x10014;
   return true;
 }
 
 // Transmit frame
-static uint32_t s_rt1020_txno;
-
-static size_t mg_tcpip_driver_imxrt1020_tx(const void *buf, size_t len, struct mg_tcpip_if *ifp) {
-
-  if (len > sizeof(tx_data_buffer[ENET_TXBD_NUM])) {
-  //  MG_ERROR(("Frame too big, %ld", (long) len));
-    len = 0;  // Frame is too big
-  } else if ((tx_buffer_descriptor[s_rt1020_txno].control & BIT(15))) {
-  MG_ERROR(("No free descriptors"));
-    // printf("D0 %lx SR %lx\n", (long) s_txdesc[0][0], (long) ETH->DMASR);
-    len = 0;  // All descriptors are busy, fail
+static size_t mg_tcpip_driver_imxrt_tx(const void *buf, size_t len,
+                                       struct mg_tcpip_if *ifp) {
+  static int s_txno;  // Current descriptor index
+  if (len > sizeof(s_txbuf[ETH_DESC_CNT])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = (size_t) -1;  // fail
+  } else if ((s_txdesc[s_txno].control & MG_BIT(15))) {
+    ifp->nerr++;
+    MG_ERROR(("No descriptors available"));
+    len = 0;  // retry later
   } else {
-    memcpy(tx_data_buffer[s_rt1020_txno], buf, len);     // Copy data
-    tx_buffer_descriptor[s_rt1020_txno].length = (uint16_t) len;  // Set data len
-    tx_buffer_descriptor[s_rt1020_txno].control |= (uint16_t)(BIT(10)); // TC (transmit CRC)
-    //  tx_buffer_descriptor[s_rt1020_txno].control &= (uint16_t)(BIT(14) | BIT(12)); // Own doesn't affect HW
-    tx_buffer_descriptor[s_rt1020_txno].control |= (uint16_t)(BIT(15) | BIT(11)); // R+L (ready+last)
-    ENET->TDAR = BIT(24); // Descriptor updated. Hand over to DMA.
-    // INFO
-    // Relevant Descriptor bits: 15(R)  Ready
-    //                           11(L)  last in frame
-    //                           10(TC) transmis CRC
-    // __DSB(); // ARM errata 838869 Cortex-M4, M4F, M7, M7F: "store immediate overlapping
-                // exception" return might vector to incorrect interrupt.
-    if (++s_rt1020_txno >= ENET_TXBD_NUM) s_rt1020_txno = 0;
+    memcpy(s_txbuf[s_txno], buf, len);         // Copy data
+    s_txdesc[s_txno].length = (uint16_t) len;  // Set data len
+    // Table 37-34, R, L, TC (Ready, last, transmit CRC after frame
+    s_txdesc[s_txno].control |=
+        (uint16_t) (MG_BIT(15) | MG_BIT(11) | MG_BIT(10));
+    ENET->TDAR = MG_BIT(24);  // Descriptor ring updated
+    if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
   (void) ifp;
   return len;
 }
 
-// IRQ (RX)
-static uint32_t s_rt1020_rxno;
-
-void ENET_IRQHandler(void) {
-  ENET->EIMR = 0;           // Mask interrupts.
-  uint32_t eir = ENET->EIR; // Read EIR
-  ENET->EIR = 0xffffffff;   // Clear interrupts
-
-  if (eir & EIMR_RX_ERR) // Global mask used
-  {
-    if (rx_buffer_descriptor[s_rt1020_rxno].control & BIT(15)) {
-      ENET->EIMR = EIMR_RX_ERR; // Enable interrupts
-      return;  // Empty? -> exit.
-    }
-    // Read inframes
-    else { // Frame received, loop
-      for (uint32_t i = 0; i < 10; i++) {  // read as they arrive but not forever
-        if (rx_buffer_descriptor[s_rt1020_rxno].control & BIT(15)) break;  // exit when done
-        // Process if CRC OK and frame not truncated
-        if (!(rx_buffer_descriptor[s_rt1020_rxno].control & (BIT(2) | BIT(0)))) {
-          uint32_t len = (rx_buffer_descriptor[s_rt1020_rxno].length);
-          mg_tcpip_qwrite(rx_buffer_descriptor[s_rt1020_rxno].buffer, len > 4 ? len - 4 : len, s_ifp);
-        }
-        rx_buffer_descriptor[s_rt1020_rxno].control |= BIT(15); // Inform DMA RX is empty
-        if (++s_rt1020_rxno >= ENET_RXBD_NUM) s_rt1020_rxno = 0;
-      }
-    }
+static bool mg_tcpip_driver_imxrt_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_imxrt_data *d =
+      (struct mg_tcpip_driver_imxrt_data *) ifp->driver_data;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {enet_read_phy, enet_write_phy};
+  up = mg_phy_up(&phy, d->phy_addr, &full_duplex, &speed);
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    uint32_t tcr = ENET->TCR | MG_BIT(2);             // Full-duplex
+    uint32_t rcr = ENET->RCR & ~MG_BIT(9);            // 100M
+    if (speed == MG_PHY_SPEED_10M) rcr |= MG_BIT(9);  // 10M
+    if (full_duplex == false) tcr &= ~MG_BIT(2);      // Half-duplex
+    ENET->TCR = tcr;  // IRQ handler does not fiddle with these registers
+    ENET->RCR = rcr;
+    MG_DEBUG(("Link is %uM %s-duplex", rcr & MG_BIT(9) ? 10 : 100,
+              tcr & MG_BIT(2) ? "full" : "half"));
   }
-  ENET->EIMR = EIMR_RX_ERR; // Enable interrupts
+  return up;
 }
 
-// Up/down status
-static bool mg_tcpip_driver_imxrt1020_up(struct mg_tcpip_if *ifp) {
-  uint32_t bsr = imxrt1020_eth_read_phy(IMXRT1020_PHY_ADDR, IMXRT1020_PHY_BSR);
-  (void) ifp;
-  return bsr & BIT(2) ? 1 : 0;
+void ENET_IRQHandler(void);
+static uint32_t s_rxno;
+void ENET_IRQHandler(void) {
+  ENET->EIR = MG_BIT(25);  // Ack IRQ
+  // Frame received, loop
+  for (uint32_t i = 0; i < 10; i++) {  // read as they arrive but not forever
+    uint32_t r = s_rxdesc[s_rxno].control;
+    if (r & MG_BIT(15)) break;  // exit when done
+    // skip partial/errored frames (Table 37-32)
+    if ((r & MG_BIT(11)) &&
+        !(r & (MG_BIT(5) | MG_BIT(4) | MG_BIT(2) | MG_BIT(1) | MG_BIT(0)))) {
+      size_t len = s_rxdesc[s_rxno].length;
+      mg_tcpip_qwrite(s_rxbuf[s_rxno], len > 4 ? len - 4 : len, s_ifp);
+    }
+    s_rxdesc[s_rxno].control |= MG_BIT(15);
+    if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+  }
+  ENET->RDAR = MG_BIT(24);  // Receive Descriptors have changed
+  // If b24 == 0, descriptors were exhausted and probably frames were dropped
 }
 
-// API
-struct mg_tcpip_driver mg_tcpip_driver_imxrt1020 = {
-  mg_tcpip_driver_imxrt1020_init, mg_tcpip_driver_imxrt1020_tx, NULL,
-  mg_tcpip_driver_imxrt1020_up};
+struct mg_tcpip_driver mg_tcpip_driver_imxrt = {mg_tcpip_driver_imxrt_init,
+                                                mg_tcpip_driver_imxrt_tx, NULL,
+                                                mg_tcpip_driver_imxrt_up};
 
 #endif
 
 #ifdef MG_ENABLE_LINES
-#line 1 "src/tcpip/driver_stm32.c"
+#line 1 "src/drivers/phy.c"
 #endif
 
 
-#if MG_ENABLE_TCPIP && MG_ENABLE_DRIVER_STM32
-struct stm32_eth {
+enum {                      // ID1  ID2
+  MG_PHY_KSZ8x = 0x22,      // 0022 1561 - KSZ8081RNB
+  MG_PHY_DP83x = 0x2000,
+  MG_PHY_DP83867 = 0xa231,  // 2000 a231 - TI DP83867I
+  MG_PHY_DP83825 = 0xa140,  // 2000 a140 - TI DP83825I
+  MG_PHY_DP83848 = 0x5ca2,  // 2000 5ca2 - TI DP83848I
+  MG_PHY_LAN87x = 0x7,      // 0007 c0fx - LAN8720
+  MG_PHY_RTL8201 = 0x1C     // 001c c816 - RTL8201
+};
+
+enum {
+  MG_PHY_REG_BCR = 0,
+  MG_PHY_REG_BSR = 1,
+  MG_PHY_REG_ID1 = 2,
+  MG_PHY_REG_ID2 = 3,
+  MG_PHY_DP83x_REG_PHYSTS = 16,
+  MG_PHY_DP83867_REG_PHYSTS = 17,
+  MG_PHY_DP83x_REG_RCSR = 23,
+  MG_PHY_DP83x_REG_LEDCR = 24,
+  MG_PHY_KSZ8x_REG_PC1R = 30,
+  MG_PHY_KSZ8x_REG_PC2R = 31,
+  MG_PHY_LAN87x_REG_SCSR = 31,
+  MG_PHY_RTL8201_REG_RMSR = 16,  // in page 7
+  MG_PHY_RTL8201_REG_PAGESEL = 31
+};
+
+static const char *mg_phy_id_to_str(uint16_t id1, uint16_t id2) {
+  switch (id1) {
+    case MG_PHY_DP83x:
+      switch (id2) {
+        case MG_PHY_DP83867:
+          return "DP83867";
+        case MG_PHY_DP83848:
+          return "DP83848";
+        case MG_PHY_DP83825:
+          return "DP83825";
+        default:
+          return "DP83x";
+      }
+    case MG_PHY_KSZ8x:
+      return "KSZ8x";
+    case MG_PHY_LAN87x:
+      return "LAN87x";
+    case MG_PHY_RTL8201:
+      return "RTL8201";
+    default:
+      return "unknown";
+  }
+  (void) id2;
+}
+
+void mg_phy_init(struct mg_phy *phy, uint8_t phy_addr, uint8_t config) {
+  uint16_t id1, id2;
+  phy->write_reg(phy_addr, MG_PHY_REG_BCR, MG_BIT(15));  // Reset PHY
+  while (phy->read_reg(phy_addr, MG_PHY_REG_BCR) & MG_BIT(15)) (void) 0;
+  // MG_PHY_REG_BCR[12]: Autonegotiation is default unless hw says otherwise
+
+  id1 = phy->read_reg(phy_addr, MG_PHY_REG_ID1);
+  id2 = phy->read_reg(phy_addr, MG_PHY_REG_ID2);
+  MG_INFO(("PHY ID: %#04x %#04x (%s)", id1, id2, mg_phy_id_to_str(id1, id2)));
+
+  if (id1 == MG_PHY_DP83x && id2 == MG_PHY_DP83867) {
+    phy->write_reg(phy_addr, 0x0d, 0x1f);  // write 0x10d to IO_MUX_CFG (0x0170)
+    phy->write_reg(phy_addr, 0x0e, 0x170);
+    phy->write_reg(phy_addr, 0x0d, 0x401f);
+    phy->write_reg(phy_addr, 0x0e, 0x10d);
+  }
+
+  if (config & MG_PHY_CLOCKS_MAC) {
+    // Use PHY crystal oscillator (preserve defaults)
+    // nothing to do
+  } else {  // MAC clocks PHY, PHY has no xtal
+    // Enable 50 MHz external ref clock at XI (preserve defaults)
+    if (id1 == MG_PHY_DP83x && id2 != MG_PHY_DP83867 && id2 != MG_PHY_DP83848) {
+      phy->write_reg(phy_addr, MG_PHY_DP83x_REG_RCSR, MG_BIT(7) | MG_BIT(0));
+    } else if (id1 == MG_PHY_KSZ8x) {
+      // Disable isolation (override hw, it doesn't make sense at this point)
+      phy->write_reg(  // #2848, some NXP boards set ISO, even though
+          phy_addr, MG_PHY_REG_BCR,  // docs say they don't
+          phy->read_reg(phy_addr, MG_PHY_REG_BCR) & (uint16_t) ~MG_BIT(10));
+      phy->write_reg(phy_addr, MG_PHY_KSZ8x_REG_PC2R,  // now do clock stuff
+                     MG_BIT(15) | MG_BIT(8) | MG_BIT(7));
+    } else if (id1 == MG_PHY_LAN87x) {
+      // nothing to do
+    } else if (id1 == MG_PHY_RTL8201) {
+      // assume PHY has been hardware strapped properly
+#if 0
+      phy->write_reg(phy_addr, MG_PHY_RTL8201_REG_PAGESEL, 7);  // Select page 7
+      phy->write_reg(phy_addr, MG_PHY_RTL8201_REG_RMSR, 0x1ffa);
+      phy->write_reg(phy_addr, MG_PHY_RTL8201_REG_PAGESEL, 0);  // Select page 0
+#endif
+    }
+  }
+
+  if (config & MG_PHY_LEDS_ACTIVE_HIGH && id1 == MG_PHY_DP83x) {
+    phy->write_reg(phy_addr, MG_PHY_DP83x_REG_LEDCR,
+                   MG_BIT(9) | MG_BIT(7));  // LED status, active high
+  }  // Other PHYs do not support this feature
+}
+
+bool mg_phy_up(struct mg_phy *phy, uint8_t phy_addr, bool *full_duplex,
+               uint8_t *speed) {
+  bool up = false;
+  uint16_t bsr = phy->read_reg(phy_addr, MG_PHY_REG_BSR);
+  if ((bsr & MG_BIT(5)) && !(bsr & MG_BIT(2)))  // some PHYs latch down events
+    bsr = phy->read_reg(phy_addr, MG_PHY_REG_BSR);  // read again
+  up = bsr & MG_BIT(2);
+  if (up && full_duplex != NULL && speed != NULL) {
+    uint16_t id1 = phy->read_reg(phy_addr, MG_PHY_REG_ID1);
+    if (id1 == MG_PHY_DP83x) {
+      uint16_t id2 = phy->read_reg(phy_addr, MG_PHY_REG_ID2);
+      if (id2 == MG_PHY_DP83867) {
+        uint16_t physts = phy->read_reg(phy_addr, MG_PHY_DP83867_REG_PHYSTS);
+        *full_duplex = physts & MG_BIT(13);
+        *speed = (physts & MG_BIT(15))   ? MG_PHY_SPEED_1000M
+                 : (physts & MG_BIT(14)) ? MG_PHY_SPEED_100M
+                                         : MG_PHY_SPEED_10M;
+      } else {
+        uint16_t physts = phy->read_reg(phy_addr, MG_PHY_DP83x_REG_PHYSTS);
+        *full_duplex = physts & MG_BIT(2);
+        *speed = (physts & MG_BIT(1)) ? MG_PHY_SPEED_10M : MG_PHY_SPEED_100M;
+      }
+    } else if (id1 == MG_PHY_KSZ8x) {
+      uint16_t pc1r = phy->read_reg(phy_addr, MG_PHY_KSZ8x_REG_PC1R);
+      *full_duplex = pc1r & MG_BIT(2);
+      *speed = (pc1r & 3) == 1 ? MG_PHY_SPEED_10M : MG_PHY_SPEED_100M;
+    } else if (id1 == MG_PHY_LAN87x) {
+      uint16_t scsr = phy->read_reg(phy_addr, MG_PHY_LAN87x_REG_SCSR);
+      *full_duplex = scsr & MG_BIT(4);
+      *speed = (scsr & MG_BIT(3)) ? MG_PHY_SPEED_100M : MG_PHY_SPEED_10M;
+    } else if (id1 == MG_PHY_RTL8201) {
+      uint16_t bcr = phy->read_reg(phy_addr, MG_PHY_REG_BCR);
+      *full_duplex = bcr & MG_BIT(8);
+      *speed = (bcr & MG_BIT(13)) ? MG_PHY_SPEED_100M : MG_PHY_SPEED_10M;
+    }
+  }
+  return up;
+}
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/pico-w.c"
+#endif
+#if MG_ENABLE_TCPIP && MG_ARCH == MG_ARCH_PICOSDK && \
+    defined(MG_ENABLE_DRIVER_PICO_W) && MG_ENABLE_DRIVER_PICO_W
+
+
+
+
+
+static struct mg_tcpip_if *s_ifp;
+
+static bool mg_tcpip_driver_pico_w_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_pico_w_data *d =
+      (struct mg_tcpip_driver_pico_w_data *) ifp->driver_data;
+  s_ifp = ifp;
+  if (cyw43_arch_init() != 0)
+    return false;  // initialize async_context and WiFi chip
+  cyw43_arch_enable_sta_mode();
+  // start connecting to network
+  if (cyw43_arch_wifi_connect_bssid_async(d->ssid, NULL, d->pass,
+                                          CYW43_AUTH_WPA2_AES_PSK) != 0)
+    return false;
+  cyw43_wifi_get_mac(&cyw43_state, CYW43_ITF_STA, ifp->mac);
+  return true;
+}
+
+static size_t mg_tcpip_driver_pico_w_tx(const void *buf, size_t len,
+                                        struct mg_tcpip_if *ifp) {
+  (void) ifp;
+  return cyw43_send_ethernet(&cyw43_state, CYW43_ITF_STA, len, buf, false)
+             ? 0
+             : len;
+}
+
+static bool mg_tcpip_driver_pico_w_up(struct mg_tcpip_if *ifp) {
+  (void) ifp;
+  return (cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA) ==
+          CYW43_LINK_JOIN);
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_pico_w = {
+    mg_tcpip_driver_pico_w_init,
+    mg_tcpip_driver_pico_w_tx,
+    NULL,
+    mg_tcpip_driver_pico_w_up,
+};
+
+// Called once per outstanding frame by async_context
+void cyw43_cb_process_ethernet(void *cb_data, int itf, size_t len,
+                               const uint8_t *buf) {
+  if (itf != CYW43_ITF_STA) return;
+  mg_tcpip_qwrite((void *) buf, len, s_ifp);
+  (void) cb_data;
+}
+
+// Called by async_context
+void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf) {}
+void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf) {}
+
+// there's life beyond lwIP
+void pbuf_copy_partial(void) {(void) 0;}
+
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/ppp.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_PPP) && MG_ENABLE_DRIVER_PPP
+
+#define MG_PPP_FLAG 0x7e  // PPP frame delimiter
+#define MG_PPP_ESC 0x7d   // PPP escape byte for special characters
+#define MG_PPP_ADDR 0xff
+#define MG_PPP_CTRL 0x03
+
+#define MG_PPP_PROTO_IP 0x0021
+#define MG_PPP_PROTO_LCP 0xc021
+#define MG_PPP_PROTO_IPCP 0x8021
+
+#define MG_PPP_IPCP_REQ 1
+#define MG_PPP_IPCP_ACK 2
+#define MG_PPP_IPCP_NACK 3
+#define MG_PPP_IPCP_IPADDR 3
+
+#define MG_PPP_LCP_CFG_REQ 1
+#define MG_PPP_LCP_CFG_ACK 2
+#define MG_PPP_LCP_CFG_NACK 3
+#define MG_PPP_LCP_CFG_REJECT 4
+#define MG_PPP_LCP_CFG_TERM_REQ 5
+#define MG_PPP_LCP_CFG_TERM_ACK 6
+
+#define MG_PPP_AT_TIMEOUT 2000
+
+static size_t print_atcmd(void (*out)(char, void *), void *arg, va_list *ap) {
+  struct mg_str s = va_arg(*ap, struct mg_str);
+  for (size_t i = 0; i < s.len; i++) out(s.buf[i] < 0x20 ? '.' : s.buf[i], arg);
+  return s.len;
+}
+
+static void mg_ppp_reset(struct mg_tcpip_driver_ppp_data *dd) {
+  dd->script_index = 0;
+  dd->deadline = 0;
+  if (dd->reset) dd->reset(dd->uart);
+}
+
+static bool mg_ppp_atcmd_handle(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_ppp_data *dd =
+      (struct mg_tcpip_driver_ppp_data *) ifp->driver_data;
+  if (dd->script == NULL || dd->script_index < 0) return true;
+  if (dd->deadline == 0) dd->deadline = mg_millis() + MG_PPP_AT_TIMEOUT;
+  for (;;) {
+    if (dd->script_index % 2 == 0) {  // send AT command
+      const char *cmd = dd->script[dd->script_index];
+      MG_DEBUG(("send AT[%d]: %M", dd->script_index, print_atcmd, mg_str(cmd)));
+      while (*cmd) dd->tx(dd->uart, *cmd++);
+      dd->script_index++;
+      ifp->recv_queue.head = 0;
+    } else {  // check AT command response
+      const char *expect = dd->script[dd->script_index];
+      struct mg_queue *q = &ifp->recv_queue;
+      for (;;) {
+        int c;
+        int is_timeout = dd->deadline > 0 && mg_millis() > dd->deadline;
+        int is_overflow = q->head >= q->size - 1;
+        if (is_timeout || is_overflow) {
+          MG_ERROR(("AT error: %s, retrying...",
+                    is_timeout ? "timeout" : "overflow"));
+          mg_ppp_reset(dd);
+          return false;  // FAIL: timeout
+        }
+        if ((c = dd->rx(dd->uart)) < 0) return false;  // no data
+        q->buf[q->head++] = c;
+        if (mg_match(mg_str_n(q->buf, q->head), mg_str(expect), NULL)) {
+          MG_DEBUG(("recv AT[%d]: %M", dd->script_index, print_atcmd,
+                    mg_str_n(q->buf, q->head)));
+          dd->script_index++;
+          q->head = 0;
+          break;
+        }
+      }
+    }
+    if (dd->script[dd->script_index] == NULL) {
+      MG_DEBUG(("finished AT script"));
+      dd->script_index = -1;
+      return true;
+    }
+  }
+}
+
+static bool mg_ppp_init(struct mg_tcpip_if *ifp) {
+  ifp->recv_queue.size = 3000;  // MTU=1500, worst case escaping = 2x
+  return true;
+}
+
+// Calculate FCS/CRC for PPP frames. Could be implemented faster using lookup
+// tables.
+static uint32_t fcs_do(uint32_t fcs, uint8_t x) {
+  for (int i = 0; i < 8; i++) {
+    fcs = ((fcs ^ x) & 1) ? (fcs >> 1) ^ 0x8408 : fcs >> 1;
+    x >>= 1;
+  }
+  return fcs;
+}
+
+static bool mg_ppp_up(struct mg_tcpip_if *ifp) {
+  return ifp->driver_data != NULL;
+}
+
+// Transmit a single byte as part of the PPP frame (escaped, if needed)
+static void mg_ppp_tx_byte(struct mg_tcpip_driver_ppp_data *dd, uint8_t b) {
+  if ((b < 0x20) || (b == MG_PPP_ESC) || (b == MG_PPP_FLAG)) {
+    dd->tx(dd->uart, MG_PPP_ESC);
+    dd->tx(dd->uart, b ^ 0x20);
+  } else {
+    dd->tx(dd->uart, b);
+  }
+}
+
+// Transmit a single PPP frame for the given protocol
+static void mg_ppp_tx_frame(struct mg_tcpip_driver_ppp_data *dd, uint16_t proto,
+                            uint8_t *data, size_t datasz) {
+  uint16_t crc;
+  uint32_t fcs = 0xffff;
+
+  dd->tx(dd->uart, MG_PPP_FLAG);
+  mg_ppp_tx_byte(dd, MG_PPP_ADDR);
+  mg_ppp_tx_byte(dd, MG_PPP_CTRL);
+  mg_ppp_tx_byte(dd, proto >> 8);
+  mg_ppp_tx_byte(dd, proto & 0xff);
+  fcs = fcs_do(fcs, MG_PPP_ADDR);
+  fcs = fcs_do(fcs, MG_PPP_CTRL);
+  fcs = fcs_do(fcs, proto >> 8);
+  fcs = fcs_do(fcs, proto & 0xff);
+  for (unsigned int i = 0; i < datasz; i++) {
+    mg_ppp_tx_byte(dd, data[i]);
+    fcs = fcs_do(fcs, data[i]);
+  }
+  crc = fcs & 0xffff;
+  mg_ppp_tx_byte(dd, ~crc);  // send CRC, note the byte order
+  mg_ppp_tx_byte(dd, ~crc >> 8);
+  dd->tx(dd->uart, MG_PPP_FLAG);  // end of frame
+}
+
+// Send Ethernet frame as PPP frame
+static size_t mg_ppp_tx(const void *buf, size_t len, struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_ppp_data *dd =
+      (struct mg_tcpip_driver_ppp_data *) ifp->driver_data;
+  if (ifp->state != MG_TCPIP_STATE_READY) return 0;
+  // XXX: what if not an IP protocol?
+  mg_ppp_tx_frame(dd, MG_PPP_PROTO_IP, (uint8_t *) buf + 14, len - 14);
+  return len;
+}
+
+// Given a full PPP frame, unescape it in place and verify FCS, returns actual
+// data size on success or 0 on error.
+static size_t mg_ppp_verify_frame(uint8_t *buf, size_t bufsz) {
+  int unpack = 0;
+  uint16_t crc;
+  size_t pktsz = 0;
+  uint32_t fcs = 0xffff;
+  for (unsigned int i = 0; i < bufsz; i++) {
+    if (unpack == 0) {
+      if (buf[i] == 0x7d) {
+        unpack = 1;
+      } else {
+        buf[pktsz] = buf[i];
+        fcs = fcs_do(fcs, buf[pktsz]);
+        pktsz++;
+      }
+    } else {
+      unpack = 0;
+      buf[pktsz] = buf[i] ^ 0x20;
+      fcs = fcs_do(fcs, buf[pktsz]);
+      pktsz++;
+    }
+  }
+  crc = fcs & 0xffff;
+  if (crc != 0xf0b8) {
+    MG_DEBUG(("bad crc: %04x", crc));
+    return 0;
+  }
+  if (pktsz < 6 || buf[0] != MG_PPP_ADDR || buf[1] != MG_PPP_CTRL) {
+    return 0;
+  }
+  return pktsz - 2;  // strip FCS
+}
+
+// fetch as much data as we can, until a single PPP frame is received
+static size_t mg_ppp_rx_frame(struct mg_tcpip_driver_ppp_data *dd,
+                              struct mg_queue *q) {
+  while (q->head < q->size) {
+    int c;
+    if ((c = dd->rx(dd->uart)) < 0) {
+      return 0;
+    }
+    if (c == MG_PPP_FLAG) {
+      if (q->head > 0) {
+        break;
+      } else {
+        continue;
+      }
+    }
+    q->buf[q->head++] = c;
+  }
+
+  size_t n = mg_ppp_verify_frame((uint8_t *) q->buf, q->head);
+  if (n == 0) {
+    MG_DEBUG(("invalid PPP frame of %d bytes", q->head));
+    q->head = 0;
+    return 0;
+  }
+  q->head = n;
+  return q->head;
+}
+
+static void mg_ppp_handle_lcp(struct mg_tcpip_if *ifp, uint8_t *lcp,
+                              size_t lcpsz) {
+  uint8_t id;
+  uint16_t len;
+  struct mg_tcpip_driver_ppp_data *dd =
+      (struct mg_tcpip_driver_ppp_data *) ifp->driver_data;
+  if (lcpsz < 4) return;
+  id = lcp[1];
+  len = (((uint16_t) lcp[2]) << 8) | (lcp[3]);
+  switch (lcp[0]) {
+    case MG_PPP_LCP_CFG_REQ: {
+      if (len == 4) {
+        MG_DEBUG(("LCP config request of %d bytes, acknowledging...", len));
+        lcp[0] = MG_PPP_LCP_CFG_ACK;
+        mg_ppp_tx_frame(dd, MG_PPP_PROTO_LCP, lcp, len);
+        lcp[0] = MG_PPP_LCP_CFG_REQ;
+        mg_ppp_tx_frame(dd, MG_PPP_PROTO_LCP, lcp, len);
+      } else {
+        MG_DEBUG(("LCP config request of %d bytes, rejecting...", len));
+        lcp[0] = MG_PPP_LCP_CFG_REJECT;
+        mg_ppp_tx_frame(dd, MG_PPP_PROTO_LCP, lcp, len);
+      }
+    } break;
+    case MG_PPP_LCP_CFG_TERM_REQ: {
+      uint8_t ack[4] = {MG_PPP_LCP_CFG_TERM_ACK, id, 0, 4};
+      MG_DEBUG(("LCP termination request, acknowledging..."));
+      mg_ppp_tx_frame(dd, MG_PPP_PROTO_LCP, ack, sizeof(ack));
+      mg_ppp_reset(dd);
+      ifp->state = MG_TCPIP_STATE_UP;
+      if (dd->reset) dd->reset(dd->uart);
+    } break;
+  }
+}
+
+static void mg_ppp_handle_ipcp(struct mg_tcpip_if *ifp, uint8_t *ipcp,
+                               size_t ipcpsz) {
+  struct mg_tcpip_driver_ppp_data *dd =
+      (struct mg_tcpip_driver_ppp_data *) ifp->driver_data;
+  uint16_t len;
+  uint8_t id;
+  uint8_t req[] = {
+      MG_PPP_IPCP_REQ, 0, 0, 10, MG_PPP_IPCP_IPADDR, 6, 0, 0, 0, 0};
+  if (ipcpsz < 4) return;
+  id = ipcp[1];
+  len = (((uint16_t) ipcp[2]) << 8) | (ipcp[3]);
+  switch (ipcp[0]) {
+    case MG_PPP_IPCP_REQ:
+      MG_DEBUG(("got IPCP config request, acknowledging..."));
+      if (len >= 10 && ipcp[4] == MG_PPP_IPCP_IPADDR) {
+        uint8_t *ip = ipcp + 6;
+        MG_DEBUG(("host ip: %d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]));
+      }
+      ipcp[0] = MG_PPP_IPCP_ACK;
+      mg_ppp_tx_frame(dd, MG_PPP_PROTO_IPCP, ipcp, len);
+      req[1] = id;
+      // Request IP address 0.0.0.0
+      mg_ppp_tx_frame(dd, MG_PPP_PROTO_IPCP, req, sizeof(req));
+      break;
+    case MG_PPP_IPCP_ACK:
+      // This usually does not happen, as our "preferred" IP address is invalid
+      MG_DEBUG(("got IPCP config ack, link is online now"));
+      ifp->state = MG_TCPIP_STATE_READY;
+      break;
+    case MG_PPP_IPCP_NACK:
+      MG_DEBUG(("got IPCP config nack"));
+      // NACK contains our "suggested" IP address, use it
+      if (len >= 10 && ipcp[4] == MG_PPP_IPCP_IPADDR) {
+        uint8_t *ip = ipcp + 6;
+        MG_DEBUG(("ipcp ack, ip: %d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]));
+        ipcp[0] = MG_PPP_IPCP_REQ;
+        mg_ppp_tx_frame(dd, MG_PPP_PROTO_IPCP, ipcp, len);
+        ifp->ip = ifp->mask = MG_IPV4(ip[0], ip[1], ip[2], ip[3]);
+        ifp->state = MG_TCPIP_STATE_READY;
+      }
+      break;
+  }
+}
+
+static size_t mg_ppp_rx(void *ethbuf, size_t ethlen, struct mg_tcpip_if *ifp) {
+  uint8_t *eth = ethbuf;
+  size_t ethsz = 0;
+  struct mg_tcpip_driver_ppp_data *dd =
+      (struct mg_tcpip_driver_ppp_data *) ifp->driver_data;
+  uint8_t *buf = (uint8_t *) ifp->recv_queue.buf;
+
+  if (!mg_ppp_atcmd_handle(ifp)) return 0;
+
+  size_t bufsz = mg_ppp_rx_frame(dd, &ifp->recv_queue);
+  if (!bufsz) return 0;
+  uint16_t proto = (((uint16_t) buf[2]) << 8) | (uint16_t) buf[3];
+  switch (proto) {
+    case MG_PPP_PROTO_LCP: mg_ppp_handle_lcp(ifp, buf + 4, bufsz - 4); break;
+    case MG_PPP_PROTO_IPCP: mg_ppp_handle_ipcp(ifp, buf + 4, bufsz - 4); break;
+    case MG_PPP_PROTO_IP:
+      MG_VERBOSE(("got IP packet of %d bytes", bufsz - 4));
+      memmove(eth + 14, buf + 4, bufsz - 4);
+      memmove(eth, ifp->mac, 6);
+      memmove(eth + 6, "\xff\xff\xff\xff\xff\xff", 6);
+      eth[12] = 0x08;
+      eth[13] = 0x00;
+      ethsz = bufsz - 4 + 14;
+      ifp->recv_queue.head = 0;
+      return ethsz;
+#if 0
+    default:
+      MG_DEBUG(("unknown PPP frame:"));
+      mg_hexdump(ppp->buf, ppp->bufsz);
+#endif
+  }
+  ifp->recv_queue.head = 0;
+  return 0;
+  (void) ethlen;
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_ppp = {mg_ppp_init, mg_ppp_tx, mg_ppp_rx,
+                                              mg_ppp_up};
+
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/ra.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_RA) && MG_ENABLE_DRIVER_RA
+struct ra_etherc {
+  volatile uint32_t ECMR, RESERVED, RFLR, RESERVED1, ECSR, RESERVED2, ECSIPR,
+      RESERVED3, PIR, RESERVED4, PSR, RESERVED5[5], RDMLR, RESERVED6[3], IPGR,
+      APR, MPR, RESERVED7, RFCF, TPAUSER, TPAUSECR, BCFRR, RESERVED8[20], MAHR,
+      RESERVED9, MALR, RESERVED10, TROCR, CDCR, LCCR, CNDCR, RESERVED11, CEFCR,
+      FRECR, TSFRCR, TLFRCR, RFCR, MAFCR;
+};
+
+struct ra_edmac {
+  volatile uint32_t EDMR, RESERVED, EDTRR, RESERVED1, EDRRR, RESERVED2, TDLAR,
+      RESERVED3, RDLAR, RESERVED4, EESR, RESERVED5, EESIPR, RESERVED6, TRSCER,
+      RESERVED7, RMFCR, RESERVED8, TFTR, RESERVED9, FDR, RESERVED10, RMCR,
+      RESERVED11[2], TFUCR, RFOCR, IOSR, FCFTR, RESERVED12, RPADIR, TRIMD,
+      RESERVED13[18], RBWAR, RDFAR, RESERVED14, TBRAR, TDFAR;
+};
+
+#undef ETHERC
+#define ETHERC ((struct ra_etherc *) (uintptr_t) 0x40114100U)
+#undef EDMAC
+#define EDMAC ((struct ra_edmac *) (uintptr_t) 0x40114000U)
+#undef RASYSC
+#define RASYSC ((uint32_t *) (uintptr_t) 0x4001E000U)
+#undef ICU_IELSR
+#define ICU_IELSR ((uint32_t *) (uintptr_t) 0x40006300U)
+
+#define ETH_PKT_SIZE 1536  // Max frame size, multiple of 32
+#define ETH_DESC_CNT 4     // Descriptors count
+
+// TODO(): handle these in a portable compiler-independent CMSIS-friendly way
+#define MG_16BYTE_ALIGNED __attribute__((aligned((16U))))
+#define MG_32BYTE_ALIGNED __attribute__((aligned((32U))))
+
+// Descriptors: 16-byte aligned
+// Buffers: 32-byte aligned (27.3.1)
+static volatile uint32_t s_rxdesc[ETH_DESC_CNT][4] MG_16BYTE_ALIGNED;
+static volatile uint32_t s_txdesc[ETH_DESC_CNT][4] MG_16BYTE_ALIGNED;
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE] MG_32BYTE_ALIGNED;
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE] MG_32BYTE_ALIGNED;
+static struct mg_tcpip_if *s_ifp;  // MIP interface
+
+// fastest is 3 cycles (SUB + BNE) on a 3-stage pipeline or equivalent
+static inline void raspin(volatile uint32_t count) {
+  while (count--) (void) 0;
+}
+// count to get the 200ns SMC semi-cycle period (2.5MHz) calling raspin():
+// SYS_FREQUENCY * 200ns / 3 = SYS_FREQUENCY / 15000000
+static uint32_t s_smispin;
+
+// Bit-banged SMI
+static void smi_preamble(void) {
+  unsigned int i = 32;
+  uint32_t pir = MG_BIT(1) | MG_BIT(2);  // write, mdio = 1, mdc = 0
+  ETHERC->PIR = pir;
+  while (i--) {
+    pir &= ~MG_BIT(0);  // mdc = 0
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+    pir |= MG_BIT(0);  // mdc = 1
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+  }
+}
+static void smi_wr(uint16_t header, uint16_t data) {
+  uint32_t word = (header << 16) | data;
+  smi_preamble();
+  unsigned int i = 32;
+  while (i--) {
+    uint32_t pir = MG_BIT(1) |
+                   (word & 0x80000000 ? MG_BIT(2) : 0);  // write, mdc = 0, data
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+    pir |= MG_BIT(0);  // mdc = 1
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+    word <<= 1;
+  }
+}
+static uint16_t smi_rd(uint16_t header) {
+  smi_preamble();
+  unsigned int i = 16;  // 2 LSb as turnaround
+  uint32_t pir;
+  while (i--) {
+    pir = (i > 1 ? MG_BIT(1) : 0) |
+          (header & 0x8000
+               ? MG_BIT(2)
+               : 0);  // mdc = 0, header, set read direction at turnaround
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+    pir |= MG_BIT(0);  // mdc = 1
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+    header <<= 1;
+  }
+  i = 16;
+  uint16_t data = 0;
+  while (i--) {
+    data <<= 1;
+    pir = 0;  // read, mdc = 0
+    ETHERC->PIR = pir;
+    raspin(s_smispin / 2);  // 1/4 clock period, 300ns max access time
+    data |= (uint16_t)(ETHERC->PIR & MG_BIT(3) ? 1 : 0);  // read mdio
+    raspin(s_smispin / 2);                    // 1/4 clock period
+    pir |= MG_BIT(0);                         // mdc = 1
+    ETHERC->PIR = pir;
+    raspin(s_smispin);
+  }
+  return data;
+}
+
+static uint16_t raeth_read_phy(uint8_t addr, uint8_t reg) {
+  return smi_rd((uint16_t)((1 << 14) | (2 << 12) | (addr << 7) | (reg << 2) | (2 << 0)));
+}
+
+static void raeth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  smi_wr((uint16_t)((1 << 14) | (1 << 12) | (addr << 7) | (reg << 2) | (2 << 0)), val);
+}
+
+// MDC clock is generated manually; as per 802.3, it must not exceed 2.5MHz
+static bool mg_tcpip_driver_ra_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_ra_data *d =
+      (struct mg_tcpip_driver_ra_data *) ifp->driver_data;
+  s_ifp = ifp;
+
+  // Init SMI clock timing. If user told us the clock value, use it.
+  // TODO(): Otherwise, guess
+  s_smispin = d->clock / 15000000;
+
+  // Init RX descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    s_rxdesc[i][0] = MG_BIT(31);             // RACT
+    s_rxdesc[i][1] = ETH_PKT_SIZE << 16;     // RBL
+    s_rxdesc[i][2] = (uint32_t) s_rxbuf[i];  // Point to data buffer
+  }
+  s_rxdesc[ETH_DESC_CNT - 1][0] |= MG_BIT(30);  // Wrap last descriptor
+
+  // Init TX descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    // TACT = 0
+    s_txdesc[i][2] = (uint32_t) s_txbuf[i];
+  }
+  s_txdesc[ETH_DESC_CNT - 1][0] |= MG_BIT(30);  // Wrap last descriptor
+
+  EDMAC->EDMR = MG_BIT(0);  // Software reset, wait 64 PCLKA clocks (27.2.1)
+  uint32_t sckdivcr = RASYSC[8];  // get divisors from SCKDIVCR (8.2.2)
+  uint32_t ick = 1 << ((sckdivcr >> 24) & 7);   // sys_clock div
+  uint32_t pcka = 1 << ((sckdivcr >> 12) & 7);  // pclka div
+  raspin((64U * pcka) / (3U * ick));
+  EDMAC->EDMR = MG_BIT(6);  // Initialize, little-endian (27.2.1)
+
+  MG_DEBUG(("PHY addr: %d, smispin: %d", d->phy_addr, s_smispin));
+  struct mg_phy phy = {raeth_read_phy, raeth_write_phy};
+  mg_phy_init(&phy, d->phy_addr, 0); // MAC clocks PHY
+
+  // Select RMII mode,
+  ETHERC->ECMR = MG_BIT(2) | MG_BIT(1);  // 100M, Full-duplex, CRC
+  // ETHERC->ECMR |= MG_BIT(0);             // Receive all
+  ETHERC->RFLR = 1518;  // Set max rx length
+
+  EDMAC->RDLAR = (uint32_t) (uintptr_t) s_rxdesc;
+  EDMAC->TDLAR = (uint32_t) (uintptr_t) s_txdesc;
+  // MAC address filtering (bytes in reversed order)
+  ETHERC->MAHR = (uint32_t) (ifp->mac[0] << 24U) |
+                 ((uint32_t) ifp->mac[1] << 16U) |
+                 ((uint32_t) ifp->mac[2] << 8U) | ifp->mac[3];
+  ETHERC->MALR = ((uint32_t) ifp->mac[4] << 8U) | ifp->mac[5];
+
+  EDMAC->TFTR = 0;                        // Store and forward (27.2.10)
+  EDMAC->FDR = 0x070f;                    // (27.2.11)
+  EDMAC->RMCR = MG_BIT(0);                // (27.2.12)
+  ETHERC->ECMR |= MG_BIT(6) | MG_BIT(5);  // TE RE
+  EDMAC->EESIPR = MG_BIT(18);             // Enable Rx IRQ
+  EDMAC->EDRRR = MG_BIT(0);               // Receive Descriptors have changed
+  EDMAC->EDTRR = MG_BIT(0);               // Transmit Descriptors have changed
+  return true;
+}
+
+// Transmit frame
+static size_t mg_tcpip_driver_ra_tx(const void *buf, size_t len,
+                                    struct mg_tcpip_if *ifp) {
+  static int s_txno;  // Current descriptor index
+  if (len > sizeof(s_txbuf[ETH_DESC_CNT])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = (size_t) -1;  // fail
+  } else if ((s_txdesc[s_txno][0] & MG_BIT(31))) {
+    ifp->nerr++;
+    MG_ERROR(("No descriptors available"));
+    len = 0;  // retry later
+  } else {
+    memcpy(s_txbuf[s_txno], buf, len);            // Copy data
+    s_txdesc[s_txno][1] = len << 16;              // Set data len
+    s_txdesc[s_txno][0] |= MG_BIT(31) | 3 << 28;  // (27.3.1.1) mark valid
+    EDMAC->EDTRR = MG_BIT(0);                     // Transmit request
+    if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
+  }
+  return len;
+}
+
+static bool mg_tcpip_driver_ra_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_ra_data *d =
+      (struct mg_tcpip_driver_ra_data *) ifp->driver_data;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {raeth_read_phy, raeth_write_phy};
+  up = mg_phy_up(&phy, d->phy_addr, &full_duplex, &speed);
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    uint32_t ecmr = ETHERC->ECMR | MG_BIT(2) | MG_BIT(1);  // 100M Full-duplex
+    if (speed == MG_PHY_SPEED_10M) ecmr &= ~MG_BIT(2);     // 10M
+    if (full_duplex == false) ecmr &= ~MG_BIT(1);          // Half-duplex
+    ETHERC->ECMR = ecmr;  // IRQ handler does not fiddle with these registers
+    MG_DEBUG(("Link is %uM %s-duplex", ecmr & MG_BIT(2) ? 100 : 10,
+              ecmr & MG_BIT(1) ? "full" : "half"));
+  }
+  return up;
+}
+
+void EDMAC_IRQHandler(void);
+static uint32_t s_rxno;
+void EDMAC_IRQHandler(void) {
+  struct mg_tcpip_driver_ra_data *d =
+      (struct mg_tcpip_driver_ra_data *) s_ifp->driver_data;
+  EDMAC->EESR = MG_BIT(18);            // Ack IRQ in EDMAC 1st
+  ICU_IELSR[d->irqno] &= ~MG_BIT(16);  // Ack IRQ in ICU last
+  // Frame received, loop
+  for (uint32_t i = 0; i < 10; i++) {  // read as they arrive but not forever
+    uint32_t r = s_rxdesc[s_rxno][0];
+    if (r & MG_BIT(31)) break;  // exit when done
+    // skip partial/errored frames (27.3.1.2)
+    if ((r & (MG_BIT(29) | MG_BIT(28)) && !(r & MG_BIT(27)))) {
+      size_t len = s_rxdesc[s_rxno][1] & 0xffff;
+      mg_tcpip_qwrite(s_rxbuf[s_rxno], len, s_ifp);  // CRC already stripped
+    }
+    s_rxdesc[s_rxno][0] |= MG_BIT(31);
+    if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+  }
+  EDMAC->EDRRR = MG_BIT(0);  // Receive Descriptors have changed
+  // If b0 == 0, descriptors were exhausted and probably frames were dropped,
+  // (27.2.9 RMFCR counts them)
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_ra = {mg_tcpip_driver_ra_init,
+                                             mg_tcpip_driver_ra_tx, NULL,
+                                             mg_tcpip_driver_ra_up};
+
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/rw612.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_RW612) && MG_ENABLE_DRIVER_RW612
+
+struct ENET_Type {
+  volatile uint32_t RESERVED_0[1], EIR, EIMR, RESERVED_1[1], RDAR, TDAR,
+      RESERVED_2[3], ECR, RESERVED_3[6], MMFR, MSCR, RESERVED_4[7], MIBC,
+      RESERVED_5[7], RCR, RESERVED_6[15], TCR, RESERVED_7[7], PALR, PAUR, OPD,
+      TXIC[1], RESERVED_8[3], RXIC[1], RESERVED_9[5], IAUR, IALR, GAUR, GALR,
+      RESERVED_10[7], TFWR, RESERVED_11[14], RDSR, TDSR, MRBR, RESERVED_12[1],
+      RSFL, RSEM, RAEM, RAFL, TSEM, TAEM, TAFL, TIPG, FTRL, RESERVED_13[3],
+      TACC, RACC, RESERVED_14[15], RMON_T_PACKETS, RMON_T_BC_PKT, RMON_T_MC_PKT,
+      RMON_T_CRC_ALIGN, RMON_T_UNDERSIZE, RMON_T_OVERSIZE, RMON_T_FRAG,
+      RMON_T_JAB, RMON_T_COL, RMON_T_P64, RMON_T_P65TO127, RMON_T_P128TO255,
+      RMON_T_P256TO511, RMON_T_P512TO1023, RMON_T_P1024TO2047, RMON_T_P_GTE2048,
+      RMON_T_OCTETS, IEEE_T_DROP, IEEE_T_FRAME_OK, IEEE_T_1COL, IEEE_T_MCOL,
+      IEEE_T_DEF, IEEE_T_LCOL, IEEE_T_EXCOL, IEEE_T_MACERR, IEEE_T_CSERR,
+      IEEE_T_SQE, IEEE_T_FDXFC, IEEE_T_OCTETS_OK, RESERVED_15[3],
+      RMON_R_PACKETS, RMON_R_BC_PKT, RMON_R_MC_PKT, RMON_R_CRC_ALIGN,
+      RMON_R_UNDERSIZE, RMON_R_OVERSIZE, RMON_R_FRAG, RMON_R_JAB,
+      RESERVED_16[1], RMON_R_P64, RMON_R_P65TO127, RMON_R_P128TO255,
+      RMON_R_P256TO511, RMON_R_P512TO1023, RMON_R_P1024TO2047, RMON_R_P_GTE2048,
+      RMON_R_OCTETS, IEEE_R_DROP, IEEE_R_FRAME_OK, IEEE_R_CRC, IEEE_R_ALIGN,
+      IEEE_R_MACERR, IEEE_R_FDXFC, IEEE_R_OCTETS_OK, RESERVED_17[71], ATCR,
+      ATVR, ATOFF, ATPER, ATCOR, ATINC, ATSTMP, RESERVED_18[122], TGSR,
+      CHANNEL_TCSR[4], CHANNEL_TCCR[4];
+};
+
+#define ENET ((struct ENET_Type *) 0x40138000)
+
+#define ETH_PKT_SIZE 1536  // Max frame size
+#define ETH_DESC_CNT 4     // Descriptors count
+#define ETH_DS 2           // Descriptor size (words)
+
+#define MG_8BYTE_ALIGNED __attribute__((aligned((8U))))
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE] MG_8BYTE_ALIGNED;
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE] MG_8BYTE_ALIGNED;
+static uint32_t s_rxdesc[ETH_DESC_CNT][ETH_DS] MG_8BYTE_ALIGNED;
+static uint32_t s_txdesc[ETH_DESC_CNT][ETH_DS] MG_8BYTE_ALIGNED;
+static uint8_t s_txno;  // Current TX descriptor
+static uint8_t s_rxno;  // Current RX descriptor
+
+static struct mg_tcpip_if *s_ifp;  // MIP interface
+
+static uint16_t eth_read_phy(uint8_t addr, uint8_t reg) {
+  ENET->MMFR = MG_BIT(30) |  // Start of frame delimiter
+               MG_BIT(29) |  // Opcode
+               ((addr & 0x1f) << 23) | ((reg & 0x1f) << 18) | MG_BIT(17);
+  while ((ENET->EIR & MG_BIT(23)) == 0) (void) 0;
+  ENET->EIR |= MG_BIT(23);
+  return ENET->MMFR & 0xffff;
+}
+
+static void eth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  ENET->MMFR = MG_BIT(30) |  // Start of frame delimiter
+               MG_BIT(28) |  // Opcode
+               ((addr & 0x1f) << 23) | ((reg & 0x1f) << 18) | MG_BIT(17) | val;
+  while ((ENET->EIR & MG_BIT(23)) == 0) (void) 0;
+  ENET->EIR |= MG_BIT(23);
+}
+
+static bool mg_tcpip_driver_rw612_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_rw612_data *d =
+      (struct mg_tcpip_driver_rw612_data *) ifp->driver_data;
+  s_ifp = ifp;
+  ENET->MSCR = ((d->mdc_cr & 0x3f) << 1) | ((d->mdc_holdtime & 7) << 8);
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  mg_phy_init(&phy, d->phy_addr, 0);
+  ENET->ECR |= MG_BIT(0);  // reset ETH
+
+  // initialize descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    s_rxdesc[i][1] = (uint32_t) s_rxbuf[i];
+    s_rxdesc[i][0] = MG_BIT(31);  // OWN
+    if (i == ETH_DESC_CNT - 1) {
+      s_rxdesc[i][0] |= MG_BIT(29);  // mark last descriptor
+    }
+    s_txdesc[i][1] = (uint32_t) s_txbuf[i];
+    if (i == ETH_DESC_CNT - 1) {
+      s_txdesc[i][0] |= MG_BIT(29);  // mark last descriptor
+    }
+  }
+
+  ENET->RCR = (ENET->RCR & (0xffff << 16)) | MG_BIT(14) | MG_BIT(8) | MG_BIT(2);
+  ENET->TCR = MG_BIT(2);  // full duplex
+  ENET->TDSR = (uint32_t) &s_txdesc[0][0];
+  ENET->RDSR = (uint32_t) &s_rxdesc[0][0];
+  ENET->MRBR = ETH_PKT_SIZE;
+  ENET->PALR =
+      ifp->mac[0] << 24 | ifp->mac[1] << 16 | ifp->mac[2] << 8 | ifp->mac[3];
+  ENET->PAUR |= (ifp->mac[4] << 24 | ifp->mac[5] << 16);
+  ENET->MSCR = ((d->mdc_cr & 0x3f) << 1) | ((d->mdc_holdtime & 7) << 8);
+  ENET->EIMR = MG_BIT(25);             // Enable RX interrupt
+  ENET->ECR |= MG_BIT(8) | MG_BIT(1);  // DBSWP, Enable
+  ENET->RDAR = 0;                      // activate RX descriptors ring
+  return true;
+}
+
+static size_t mg_tcpip_driver_rw612_tx(const void *buf, size_t len,
+                                       struct mg_tcpip_if *ifp) {
+  if (len > sizeof(s_txbuf[s_txno])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = 0;  // Frame is too big
+  } else if (((s_txdesc[s_txno][0] & MG_BIT(31)) != 0)) {
+    ifp->nerr++;
+    MG_ERROR(("No free descriptors"));
+    len = 0;  // All descriptors are busy, fail
+  } else {
+    memcpy(s_txbuf[s_txno], buf, len);
+    s_txdesc[s_txno][0] = len | MG_BIT(27) | MG_BIT(26);  // last buffer, crc
+    if (s_txno == ETH_DESC_CNT - 1) {
+      s_txdesc[s_txno][0] |= MG_BIT(29);  // wrap
+    }
+    s_txdesc[s_txno][0] |= MG_BIT(31);  // release ownership
+    MG_DSB();
+    ENET->TDAR = 0;
+    // MG_INFO(("s_txdesc[%d][0]: 0x%x", s_txno, s_txdesc[s_txno][0]));
+    if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
+  }
+
+  return len;
+}
+
+static bool mg_tcpip_driver_rw612_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_rw612_data *d =
+      (struct mg_tcpip_driver_rw612_data *) ifp->driver_data;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  up = mg_phy_up(&phy, d->phy_addr, &full_duplex, &speed);
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    if (speed == MG_PHY_SPEED_100M && (ENET->RCR & MG_BIT(9))) {
+      ENET->RCR &= ~MG_BIT(9);
+    } else if (speed == MG_PHY_SPEED_10M && (ENET->RCR & MG_BIT(9)) == 0) {
+      ENET->RCR |= MG_BIT(9);
+    }
+    if (full_duplex && (ENET->TCR & MG_BIT(2)) == 0) {
+      ENET->ECR &= ~MG_BIT(1);
+      ENET->TCR |= MG_BIT(2);
+      ENET->ECR |= MG_BIT(1);
+    } else if (!full_duplex && (ENET->TCR & MG_BIT(2))) {
+      ENET->ECR &= ~MG_BIT(1);
+      ENET->TCR &= ~MG_BIT(2);
+      ENET->ECR |= MG_BIT(1);
+    }
+    MG_INFO(("Link is %uM %s-duplex",
+             speed == MG_PHY_SPEED_10M
+                 ? 10
+                 : (speed == MG_PHY_SPEED_100M ? 100 : 1000),
+             full_duplex ? "full" : "half"));
+  }
+  return up;
+}
+
+void ENET_IRQHandler(void) {
+  if (ENET->EIR & MG_BIT(25)) {
+    ENET->EIR = MG_BIT(25); // Ack RX
+    for (uint32_t i = 0; i < 10; i++) {  // read as they arrive but not forever
+      if ((s_rxdesc[s_rxno][0] & MG_BIT(31)) != 0) break;  // exit when done
+      // skip partial/errored frames
+      if ((s_rxdesc[s_rxno][0] & MG_BIT(27)) &&
+          !(s_rxdesc[s_rxno][0] &
+            (MG_BIT(21) | MG_BIT(20) | MG_BIT(18) | MG_BIT(17) | MG_BIT(16)))) {
+        size_t len = s_rxdesc[s_rxno][0] & 0xffff;
+        mg_tcpip_qwrite(s_rxbuf[s_rxno], len, s_ifp);
+        s_rxdesc[s_rxno][0] |= MG_BIT(31);  // OWN bit: handle control to DMA
+        MG_DSB();
+        ENET->RDAR = 0;
+        if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+      }
+    }
+  }
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_rw612 = {mg_tcpip_driver_rw612_init,
+                                                mg_tcpip_driver_rw612_tx, NULL,
+                                                mg_tcpip_driver_rw612_up};
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/same54.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_SAME54) && MG_ENABLE_DRIVER_SAME54
+
+#include <sam.h>
+
+#define ETH_PKT_SIZE 1536  // Max frame size
+#define ETH_DESC_CNT 4     // Descriptors count
+#define ETH_DS 2           // Descriptor size (words)
+
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE];
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE];
+static uint32_t s_rxdesc[ETH_DESC_CNT][ETH_DS];  // RX descriptors
+static uint32_t s_txdesc[ETH_DESC_CNT][ETH_DS];  // TX descriptors
+static uint8_t s_txno;                           // Current TX descriptor
+static uint8_t s_rxno;                           // Current RX descriptor
+
+static struct mg_tcpip_if *s_ifp;  // MIP interface
+enum { MG_PHY_ADDR = 0, MG_PHYREG_BCR = 0, MG_PHYREG_BSR = 1 };
+
+#define MG_PHYREGBIT_BCR_DUPLEX_MODE MG_BIT(8)
+#define MG_PHYREGBIT_BCR_SPEED MG_BIT(13)
+#define MG_PHYREGBIT_BSR_LINK_STATUS MG_BIT(2)
+
+static uint16_t eth_read_phy(uint8_t addr, uint8_t reg) {
+  GMAC_REGS->GMAC_MAN = GMAC_MAN_CLTTO_Msk |
+                        GMAC_MAN_OP(2) |  // Setting the read operation
+                        GMAC_MAN_WTN(2) | GMAC_MAN_PHYA(addr) |  // PHY address
+                        GMAC_MAN_REGA(reg);  // Setting the register
+  while (!(GMAC_REGS->GMAC_NSR & GMAC_NSR_IDLE_Msk)) (void) 0;
+  return GMAC_REGS->GMAC_MAN & GMAC_MAN_DATA_Msk;  // Getting the read value
+}
+
+#if 0
+static void eth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  GMAC_REGS->GMAC_MAN = GMAC_MAN_CLTTO_Msk | GMAC_MAN_OP(1) |   // Setting the write operation
+                        GMAC_MAN_WTN(2) | GMAC_MAN_PHYA(addr) | // PHY address
+                        GMAC_MAN_REGA(reg) | GMAC_MAN_DATA(val);  // Setting the register
+  while (!(GMAC_REGS->GMAC_NSR & GMAC_NSR_IDLE_Msk)); // Waiting until the write op is complete
+}
+#endif
+
+int get_clock_rate(struct mg_tcpip_driver_same54_data *d) {
+  if (d && d->mdc_cr >= 0 && d->mdc_cr <= 5) {
+    return d->mdc_cr;
+  } else {
+    // get MCLK from GCLK_GENERATOR 0
+    uint32_t div = 512;
+    uint32_t mclk;
+    if (!(GCLK_REGS->GCLK_GENCTRL[0] & GCLK_GENCTRL_DIVSEL_Msk)) {
+      div = ((GCLK_REGS->GCLK_GENCTRL[0] & 0x00FF0000) >> 16);
+      if (div == 0) div = 1;
+    }
+    switch (GCLK_REGS->GCLK_GENCTRL[0] & GCLK_GENCTRL_SRC_Msk) {
+      case GCLK_GENCTRL_SRC_XOSC0_Val:
+        mclk = 32000000UL; /* 32MHz */
+        break;
+      case GCLK_GENCTRL_SRC_XOSC1_Val:
+        mclk = 32000000UL; /* 32MHz */
+        break;
+      case GCLK_GENCTRL_SRC_OSCULP32K_Val:
+        mclk = 32000UL;
+        break;
+      case GCLK_GENCTRL_SRC_XOSC32K_Val:
+        mclk = 32000UL;
+        break;
+      case GCLK_GENCTRL_SRC_DFLL_Val:
+        mclk = 48000000UL; /* 48MHz */
+        break;
+      case GCLK_GENCTRL_SRC_DPLL0_Val:
+        mclk = 200000000UL; /* 200MHz */
+        break;
+      case GCLK_GENCTRL_SRC_DPLL1_Val:
+        mclk = 200000000UL; /* 200MHz */
+        break;
+      default:
+        mclk = 200000000UL; /* 200MHz */
+    }
+
+    mclk /= div;
+    uint8_t crs[] = {0, 1, 2, 3, 4, 5};            // GMAC->NCFGR::CLK values
+    uint8_t dividers[] = {8, 16, 32, 48, 64, 96};  // Respective CLK dividers
+    for (int i = 0; i < 6; i++) {
+      if (mclk / dividers[i] <= 2375000UL /* 2.5MHz - 5% */) {
+        return crs[i];
+      }
+    }
+
+    return 5;
+  }
+}
+
+static bool mg_tcpip_driver_same54_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_same54_data *d =
+      (struct mg_tcpip_driver_same54_data *) ifp->driver_data;
+  s_ifp = ifp;
+
+  MCLK_REGS->MCLK_APBCMASK |= MCLK_APBCMASK_GMAC_Msk;
+  MCLK_REGS->MCLK_AHBMASK |= MCLK_AHBMASK_GMAC_Msk;
+  GMAC_REGS->GMAC_NCFGR = GMAC_NCFGR_CLK(get_clock_rate(d));  // Set MDC divider
+  GMAC_REGS->GMAC_NCR = 0;                                    // Disable RX & TX
+  GMAC_REGS->GMAC_NCR |= GMAC_NCR_MPE_Msk;  // Enable MDC & MDIO
+
+  for (int i = 0; i < ETH_DESC_CNT; i++) {   // Init TX descriptors
+    s_txdesc[i][0] = (uint32_t) s_txbuf[i];  // Point to data buffer
+    s_txdesc[i][1] = MG_BIT(31);             // OWN bit
+  }
+  s_txdesc[ETH_DESC_CNT - 1][1] |= MG_BIT(30);  // Last tx descriptor - wrap
+
+  GMAC_REGS->GMAC_DCFGR = GMAC_DCFGR_DRBS(0x18)  // DMA recv buf 1536
+                          | GMAC_DCFGR_RXBMS(GMAC_DCFGR_RXBMS_FULL_Val) |
+                          GMAC_DCFGR_TXPBMS(1);  // See #2487
+  for (int i = 0; i < ETH_DESC_CNT; i++) {       // Init RX descriptors
+    s_rxdesc[i][0] = (uint32_t) s_rxbuf[i];      // Address of the data buffer
+    s_rxdesc[i][1] = 0;                          // Clear status
+  }
+  s_rxdesc[ETH_DESC_CNT - 1][0] |= MG_BIT(1);  // Last rx descriptor - wrap
+
+  GMAC_REGS->GMAC_TBQB = (uint32_t) s_txdesc;  // about the descriptor addresses
+  GMAC_REGS->GMAC_RBQB = (uint32_t) s_rxdesc;  // Let the controller know
+
+  GMAC_REGS->SA[0].GMAC_SAB =
+      MG_U32(ifp->mac[3], ifp->mac[2], ifp->mac[1], ifp->mac[0]);
+  GMAC_REGS->SA[0].GMAC_SAT = MG_U32(0, 0, ifp->mac[5], ifp->mac[4]);
+
+  GMAC_REGS->GMAC_UR &= ~GMAC_UR_MII_Msk;  // Disable MII, use RMII
+  GMAC_REGS->GMAC_NCFGR |= GMAC_NCFGR_MAXFS_Msk | GMAC_NCFGR_MTIHEN_Msk |
+                           GMAC_NCFGR_EFRHD_Msk | GMAC_NCFGR_CAF_Msk;
+  GMAC_REGS->GMAC_TSR = GMAC_TSR_HRESP_Msk | GMAC_TSR_UND_Msk |
+                        GMAC_TSR_TXCOMP_Msk | GMAC_TSR_TFC_Msk |
+                        GMAC_TSR_TXGO_Msk | GMAC_TSR_RLE_Msk |
+                        GMAC_TSR_COL_Msk | GMAC_TSR_UBR_Msk;
+  GMAC_REGS->GMAC_RSR = GMAC_RSR_HNO_Msk | GMAC_RSR_RXOVR_Msk |
+                        GMAC_RSR_REC_Msk | GMAC_RSR_BNA_Msk;
+  GMAC_REGS->GMAC_IDR = ~0U;  // Disable interrupts, then enable required
+  GMAC_REGS->GMAC_IER = GMAC_IER_HRESP_Msk | GMAC_IER_ROVR_Msk |
+                        GMAC_IER_TCOMP_Msk | GMAC_IER_TFC_Msk |
+                        GMAC_IER_RLEX_Msk | GMAC_IER_TUR_Msk |
+                        GMAC_IER_RXUBR_Msk | GMAC_IER_RCOMP_Msk;
+  GMAC_REGS->GMAC_NCR |= GMAC_NCR_TXEN_Msk | GMAC_NCR_RXEN_Msk;
+  NVIC_EnableIRQ(GMAC_IRQn);
+
+  return true;
+}
+
+static size_t mg_tcpip_driver_same54_tx(const void *buf, size_t len,
+                                        struct mg_tcpip_if *ifp) {
+  if (len > sizeof(s_txbuf[s_txno])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = 0;  // Frame is too big
+  } else if ((s_txdesc[s_txno][1] & MG_BIT(31)) == 0) {
+    ifp->nerr++;
+    MG_ERROR(("No free descriptors"));
+    len = 0;  // All descriptors are busy, fail
+  } else {
+    uint32_t status = len | MG_BIT(15);  // Frame length, last chunk
+    if (s_txno == ETH_DESC_CNT - 1) status |= MG_BIT(30);  // wrap
+    memcpy(s_txbuf[s_txno], buf, len);                     // Copy data
+    s_txdesc[s_txno][1] = status;
+    if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
+  }
+  __DSB();  // Ensure descriptors have been written
+  GMAC_REGS->GMAC_NCR |= GMAC_NCR_TSTART_Msk;  // Enable transmission
+  return len;
+}
+
+static bool mg_tcpip_driver_same54_up(struct mg_tcpip_if *ifp) {
+  uint16_t bsr = eth_read_phy(MG_PHY_ADDR, MG_PHYREG_BSR);
+  bool up = bsr & MG_PHYREGBIT_BSR_LINK_STATUS ? 1 : 0;
+
+  // If PHY is ready, update NCFGR accordingly
+  if (ifp->state == MG_TCPIP_STATE_DOWN && up) {
+    uint16_t bcr = eth_read_phy(MG_PHY_ADDR, MG_PHYREG_BCR);
+    bool fd = bcr & MG_PHYREGBIT_BCR_DUPLEX_MODE ? 1 : 0;
+    bool spd = bcr & MG_PHYREGBIT_BCR_SPEED ? 1 : 0;
+    GMAC_REGS->GMAC_NCFGR = (GMAC_REGS->GMAC_NCFGR &
+                             ~(GMAC_NCFGR_SPD_Msk | MG_PHYREGBIT_BCR_SPEED)) |
+                            GMAC_NCFGR_SPD(spd) | GMAC_NCFGR_FD(fd);
+  }
+
+  return up;
+}
+
+void GMAC_Handler(void);
+void GMAC_Handler(void) {
+  uint32_t isr = GMAC_REGS->GMAC_ISR;
+  uint32_t rsr = GMAC_REGS->GMAC_RSR;
+  uint32_t tsr = GMAC_REGS->GMAC_TSR;
+  if (isr & GMAC_ISR_RCOMP_Msk) {
+    if (rsr & GMAC_ISR_RCOMP_Msk) {
+      for (uint8_t i = 0; i < ETH_DESC_CNT; i++) {
+        if ((s_rxdesc[s_rxno][0] & MG_BIT(0)) == 0) break;
+        size_t len = s_rxdesc[s_rxno][1] & (MG_BIT(13) - 1);
+        mg_tcpip_qwrite(s_rxbuf[s_rxno], len, s_ifp);
+        s_rxdesc[s_rxno][0] &= ~MG_BIT(0);  // Disown
+        if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+      }
+    }
+  }
+
+  if ((tsr & (GMAC_TSR_HRESP_Msk | GMAC_TSR_UND_Msk | GMAC_TSR_TXCOMP_Msk |
+              GMAC_TSR_TFC_Msk | GMAC_TSR_TXGO_Msk | GMAC_TSR_RLE_Msk |
+              GMAC_TSR_COL_Msk | GMAC_TSR_UBR_Msk)) != 0) {
+    // MG_INFO((" --> %#x %#x", s_txdesc[s_txno][1], tsr));
+    if (!(s_txdesc[s_txno][1] & MG_BIT(31))) s_txdesc[s_txno][1] |= MG_BIT(31);
+  }
+
+  GMAC_REGS->GMAC_RSR = rsr;
+  GMAC_REGS->GMAC_TSR = tsr;
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_same54 = {
+    mg_tcpip_driver_same54_init, mg_tcpip_driver_same54_tx, NULL,
+    mg_tcpip_driver_same54_up};
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/stm32f.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_STM32F) && \
+    MG_ENABLE_DRIVER_STM32F
+struct stm32f_eth {
   volatile uint32_t MACCR, MACFFR, MACHTHR, MACHTLR, MACMIIAR, MACMIIDR, MACFCR,
       MACVLANTR, RESERVED0[2], MACRWUFFR, MACPMTCSR, RESERVED1, MACDBGR, MACSR,
       MACIMR, MACA0HR, MACA0LR, MACA1HR, MACA1LR, MACA2HR, MACA2LR, MACA3HR,
@@ -6617,10 +20963,8 @@ struct stm32_eth {
       DMACHRBAR;
 };
 #undef ETH
-#define ETH ((struct stm32_eth *) (uintptr_t) 0x40028000)
+#define ETH ((struct stm32f_eth *) (uintptr_t) 0x40028000)
 
-#undef BIT
-#define BIT(x) ((uint32_t) 1 << (x))
 #define ETH_PKT_SIZE 1540  // Max frame size
 #define ETH_DESC_CNT 4     // Descriptors count
 #define ETH_DS 4           // Descriptor size (words)
@@ -6633,22 +20977,21 @@ static uint8_t s_txno;                               // Current TX descriptor
 static uint8_t s_rxno;                               // Current RX descriptor
 
 static struct mg_tcpip_if *s_ifp;  // MIP interface
-enum { PHY_ADDR = 0, PHY_BCR = 0, PHY_BSR = 1, PHY_CSCR = 31 };
 
-static uint32_t eth_read_phy(uint8_t addr, uint8_t reg) {
+static uint16_t eth_read_phy(uint8_t addr, uint8_t reg) {
   ETH->MACMIIAR &= (7 << 2);
   ETH->MACMIIAR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6);
-  ETH->MACMIIAR |= BIT(0);
-  while (ETH->MACMIIAR & BIT(0)) (void) 0;
-  return ETH->MACMIIDR;
+  ETH->MACMIIAR |= MG_BIT(0);
+  while (ETH->MACMIIAR & MG_BIT(0)) (void) 0;
+  return ETH->MACMIIDR & 0xffff;
 }
 
-static void eth_write_phy(uint8_t addr, uint8_t reg, uint32_t val) {
+static void eth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
   ETH->MACMIIDR = val;
   ETH->MACMIIAR &= (7 << 2);
-  ETH->MACMIIAR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6) | BIT(1);
-  ETH->MACMIIAR |= BIT(0);
-  while (ETH->MACMIIAR & BIT(0)) (void) 0;
+  ETH->MACMIIAR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6) | MG_BIT(1);
+  ETH->MACMIIAR |= MG_BIT(0);
+  while (ETH->MACMIIAR & MG_BIT(0)) (void) 0;
 }
 
 static uint32_t get_hclk(void) {
@@ -6705,15 +21048,16 @@ static int guess_mdc_cr(void) {
   return result;
 }
 
-static bool mg_tcpip_driver_stm32_init(struct mg_tcpip_if *ifp) {
-  struct mg_tcpip_driver_stm32_data *d =
-      (struct mg_tcpip_driver_stm32_data *) ifp->driver_data;
+static bool mg_tcpip_driver_stm32f_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_stm32f_data *d =
+      (struct mg_tcpip_driver_stm32f_data *) ifp->driver_data;
+  uint8_t phy_addr = d == NULL ? 0 : d->phy_addr;
   s_ifp = ifp;
 
   // Init RX descriptors
   for (int i = 0; i < ETH_DESC_CNT; i++) {
-    s_rxdesc[i][0] = BIT(31);                            // Own
-    s_rxdesc[i][1] = sizeof(s_rxbuf[i]) | BIT(14);       // 2nd address chained
+    s_rxdesc[i][0] = MG_BIT(31);                         // Own
+    s_rxdesc[i][1] = sizeof(s_rxbuf[i]) | MG_BIT(14);    // 2nd address chained
     s_rxdesc[i][2] = (uint32_t) (uintptr_t) s_rxbuf[i];  // Point to data buffer
     s_rxdesc[i][3] =
         (uint32_t) (uintptr_t) s_rxdesc[(i + 1) % ETH_DESC_CNT];  // Chain
@@ -6726,8 +21070,8 @@ static bool mg_tcpip_driver_stm32_init(struct mg_tcpip_if *ifp) {
         (uint32_t) (uintptr_t) s_txdesc[(i + 1) % ETH_DESC_CNT];  // Chain
   }
 
-  ETH->DMABMR |= BIT(0);                         // Software reset
-  while ((ETH->DMABMR & BIT(0)) != 0) (void) 0;  // Wait until done
+  ETH->DMABMR |= MG_BIT(0);                         // Software reset
+  while ((ETH->DMABMR & MG_BIT(0)) != 0) (void) 0;  // Wait until done
 
   // Set MDC clock divider. If user told us the value, use it. Otherwise, guess
   int cr = (d == NULL || d->mdc_cr < 0) ? guess_mdc_cr() : d->mdc_cr;
@@ -6735,17 +21079,20 @@ static bool mg_tcpip_driver_stm32_init(struct mg_tcpip_if *ifp) {
 
   // NOTE(cpq): we do not use extended descriptor bit 7, and do not use
   // hardware checksum. Therefore, descriptor size is 4, not 8
-  // ETH->DMABMR = BIT(13) | BIT(16) | BIT(22) | BIT(23) | BIT(25);
-  ETH->MACIMR = BIT(3) | BIT(9);  // Mask timestamp & PMT IT
-  ETH->MACFCR = BIT(7);           // Disable zero quarta pause
-  // ETH->MACFFR = BIT(31);                            // Receive all
-  eth_write_phy(PHY_ADDR, PHY_BCR, BIT(15));           // Reset PHY
-  eth_write_phy(PHY_ADDR, PHY_BCR, BIT(12));           // Set autonegotiation
-  ETH->DMARDLAR = (uint32_t) (uintptr_t) s_rxdesc;     // RX descriptors
-  ETH->DMATDLAR = (uint32_t) (uintptr_t) s_txdesc;     // RX descriptors
-  ETH->DMAIER = BIT(6) | BIT(16);                      // RIE, NISE
-  ETH->MACCR = BIT(2) | BIT(3) | BIT(11) | BIT(14);    // RE, TE, Duplex, Fast
-  ETH->DMAOMR = BIT(1) | BIT(13) | BIT(21) | BIT(25);  // SR, ST, TSF, RSF
+  // ETH->DMABMR = MG_BIT(13) | MG_BIT(16) | MG_BIT(22) | MG_BIT(23) |
+  // MG_BIT(25);
+  ETH->MACIMR = MG_BIT(3) | MG_BIT(9);  // Mask timestamp & PMT IT
+  ETH->MACFCR = MG_BIT(7);              // Disable zero quarta pause
+  // ETH->MACFFR = MG_BIT(31);                            // Receive all
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  mg_phy_init(&phy, phy_addr, MG_PHY_CLOCKS_MAC);
+  ETH->DMARDLAR = (uint32_t) (uintptr_t) s_rxdesc;  // RX descriptors
+  ETH->DMATDLAR = (uint32_t) (uintptr_t) s_txdesc;  // RX descriptors
+  ETH->DMAIER = MG_BIT(6) | MG_BIT(16);             // RIE, NISE
+  ETH->MACCR =
+      MG_BIT(2) | MG_BIT(3) | MG_BIT(11) | MG_BIT(14);  // RE, TE, Duplex, Fast
+  ETH->DMAOMR =
+      MG_BIT(1) | MG_BIT(13) | MG_BIT(21) | MG_BIT(25);  // SR, ST, TSF, RSF
 
   // MAC address filtering
   ETH->MACA0HR = ((uint32_t) ifp->mac[5] << 8U) | ifp->mac[4];
@@ -6755,77 +21102,93 @@ static bool mg_tcpip_driver_stm32_init(struct mg_tcpip_if *ifp) {
   return true;
 }
 
-static size_t mg_tcpip_driver_stm32_tx(const void *buf, size_t len,
-                                       struct mg_tcpip_if *ifp) {
+static size_t mg_tcpip_driver_stm32f_tx(const void *buf, size_t len,
+                                        struct mg_tcpip_if *ifp) {
   if (len > sizeof(s_txbuf[s_txno])) {
     MG_ERROR(("Frame too big, %ld", (long) len));
     len = 0;  // Frame is too big
-  } else if ((s_txdesc[s_txno][0] & BIT(31))) {
+  } else if ((s_txdesc[s_txno][0] & MG_BIT(31))) {
     ifp->nerr++;
     MG_ERROR(("No free descriptors"));
     // printf("D0 %lx SR %lx\n", (long) s_txdesc[0][0], (long) ETH->DMASR);
     len = 0;  // All descriptors are busy, fail
   } else {
-    memcpy(s_txbuf[s_txno], buf, len);     // Copy data
-    s_txdesc[s_txno][1] = (uint32_t) len;  // Set data len
-    s_txdesc[s_txno][0] = BIT(20) | BIT(28) | BIT(29) | BIT(30);  // Chain,FS,LS
-    s_txdesc[s_txno][0] |= BIT(31);  // Set OWN bit - let DMA take over
+    memcpy(s_txbuf[s_txno], buf, len);                           // Copy data
+    s_txdesc[s_txno][1] = (uint32_t) len;                        // Set data len
+    s_txdesc[s_txno][0] = MG_BIT(20) | MG_BIT(28) | MG_BIT(29);  // Chain,FS,LS
+    s_txdesc[s_txno][0] |= MG_BIT(31);  // Set OWN bit - let DMA take over
     if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
-  ETH->DMASR = BIT(2) | BIT(5);  // Clear any prior TBUS/TUS
-  ETH->DMATPDR = 0;              // and resume
+  MG_DSB();                            // ensure descriptors have been written
+  ETH->DMASR = MG_BIT(2) | MG_BIT(5);  // Clear any prior TBUS/TUS
+  ETH->DMATPDR = 0;                    // and resume
   return len;
 }
 
-static bool mg_tcpip_driver_stm32_up(struct mg_tcpip_if *ifp) {
-  uint32_t bsr = eth_read_phy(PHY_ADDR, PHY_BSR);
-  bool up = bsr & BIT(2) ? 1 : 0;
+static bool mg_tcpip_driver_stm32f_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_stm32f_data *d =
+      (struct mg_tcpip_driver_stm32f_data *) ifp->driver_data;
+  uint8_t phy_addr = d == NULL ? 0 : d->phy_addr;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  up = mg_phy_up(&phy, phy_addr, &full_duplex, &speed);
   if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
-    uint32_t scsr = eth_read_phy(PHY_ADDR, PHY_CSCR);
-    uint32_t maccr = ETH->MACCR | BIT(14) | BIT(11);  // 100M, Full-duplex
-    if ((scsr & BIT(3)) == 0) maccr &= ~BIT(14);      // 10M
-    if ((scsr & BIT(4)) == 0) maccr &= ~BIT(11);      // Half-duplex
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    uint32_t maccr = ETH->MACCR | MG_BIT(14) | MG_BIT(11);  // 100M, Full-duplex
+    if (speed == MG_PHY_SPEED_10M) maccr &= ~MG_BIT(14);    // 10M
+    if (full_duplex == false) maccr &= ~MG_BIT(11);         // Half-duplex
     ETH->MACCR = maccr;  // IRQ handler does not fiddle with this register
-    MG_DEBUG(("Link is %uM %s-duplex", maccr & BIT(14) ? 100 : 10,
-              maccr & BIT(11) ? "full" : "half"));
+    MG_DEBUG(("Link is %uM %s-duplex", maccr & MG_BIT(14) ? 100 : 10,
+              maccr & MG_BIT(11) ? "full" : "half"));
   }
   return up;
 }
 
+#ifdef __riscv
+__attribute__((interrupt()))  // For RISCV CH32V307, which share the same MAC
+#endif
 void ETH_IRQHandler(void);
 void ETH_IRQHandler(void) {
-  if (ETH->DMASR & BIT(6)) {             // Frame received, loop
-    ETH->DMASR = BIT(16) | BIT(6);       // Clear flag
-    for (uint32_t i = 0; i < 10; i++) {  // read as they arrive but not forever
-      if (s_rxdesc[s_rxno][0] & BIT(31)) break;  // exit when done
-      if (((s_rxdesc[s_rxno][0] & (BIT(8) | BIT(9))) == (BIT(8) | BIT(9))) &&
-          !(s_rxdesc[s_rxno][0] & BIT(15))) {  // skip partial/errored frames
-        uint32_t len = ((s_rxdesc[s_rxno][0] >> 16) & (BIT(14) - 1));
+  if (ETH->DMASR & MG_BIT(6)) {           // Frame received, loop
+    ETH->DMASR = MG_BIT(16) | MG_BIT(6);  // Clear flag
+    for (uint32_t i = 0; i < 10; i++) {   // read as they arrive but not forever
+      if (s_rxdesc[s_rxno][0] & MG_BIT(31)) break;  // exit when done
+      if (((s_rxdesc[s_rxno][0] & (MG_BIT(8) | MG_BIT(9))) ==
+           (MG_BIT(8) | MG_BIT(9))) &&
+          !(s_rxdesc[s_rxno][0] & MG_BIT(15))) {  // skip partial/errored frames
+        uint32_t len = ((s_rxdesc[s_rxno][0] >> 16) & (MG_BIT(14) - 1));
         //  printf("%lx %lu %lx %.8lx\n", s_rxno, len, s_rxdesc[s_rxno][0],
         //  ETH->DMASR);
         mg_tcpip_qwrite(s_rxbuf[s_rxno], len > 4 ? len - 4 : len, s_ifp);
       }
-      s_rxdesc[s_rxno][0] = BIT(31);
+      s_rxdesc[s_rxno][0] = MG_BIT(31);
       if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
     }
   }
-  ETH->DMASR = BIT(7);  // Clear possible RBUS while processing
-  ETH->DMARPDR = 0;     // and resume RX
+  // Cleanup flags
+  ETH->DMASR = MG_BIT(16)    // NIS, normal interrupt summary
+               | MG_BIT(7);  // Clear possible RBUS while processing
+  ETH->DMARPDR = 0;          // and resume RX
 }
 
-struct mg_tcpip_driver mg_tcpip_driver_stm32 = {mg_tcpip_driver_stm32_init,
-                                                mg_tcpip_driver_stm32_tx, NULL,
-                                                mg_tcpip_driver_stm32_up};
+struct mg_tcpip_driver mg_tcpip_driver_stm32f = {
+    mg_tcpip_driver_stm32f_init, mg_tcpip_driver_stm32f_tx, NULL,
+    mg_tcpip_driver_stm32f_up};
 #endif
 
 #ifdef MG_ENABLE_LINES
-#line 1 "src/tcpip/driver_stm32h.c"
+#line 1 "src/drivers/stm32h.c"
 #endif
 
 
-#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_STM32H) && \
-    MG_ENABLE_DRIVER_STM32H
-struct stm32h_eth {
+#if MG_ENABLE_TCPIP && (MG_ENABLE_DRIVER_STM32H || MG_ENABLE_DRIVER_MCXN)
+// STM32H: vendor modded single-queue Synopsys v4.2
+// MCXNx4x: dual-queue Synopsys v5.2
+// RT1170 ENET_QOS: quad-queue Synopsys v5.1
+struct synopsys_enet_qos {
   volatile uint32_t MACCR, MACECR, MACPFR, MACWTR, MACHT0R, MACHT1R,
       RESERVED1[14], MACVTR, RESERVED2, MACVHTR, RESERVED3, MACVIR, MACIVIR,
       RESERVED4[2], MACTFCR, RESERVED5[7], MACRFCR, RESERVED6[7], MACISR,
@@ -6856,11 +21219,14 @@ struct stm32h_eth {
       DMACMFCR;
 };
 #undef ETH
-#define ETH \
-  ((struct stm32h_eth *) (uintptr_t) (0x40000000UL + 0x00020000UL + 0x8000UL))
+#if MG_ENABLE_DRIVER_STM32H
+#define ETH                                                                \
+  ((struct synopsys_enet_qos *) (uintptr_t) (0x40000000UL + 0x00020000UL + \
+                                             0x8000UL))
+#elif MG_ENABLE_DRIVER_MCXN
+#define ETH ((struct synopsys_enet_qos *) (uintptr_t) 0x40100000UL)
+#endif
 
-#undef BIT
-#define BIT(x) ((uint32_t) 1 << (x))
 #define ETH_PKT_SIZE 1540  // Max frame size
 #define ETH_DESC_CNT 4     // Descriptors count
 #define ETH_DS 4           // Descriptor size (words)
@@ -6870,114 +21236,34 @@ static volatile uint32_t s_txdesc[ETH_DESC_CNT][ETH_DS];  // TX descriptors
 static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE];       // RX ethernet buffers
 static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE];       // TX ethernet buffers
 static struct mg_tcpip_if *s_ifp;                         // MIP interface
-enum {
-  PHY_ADDR = 0,
-  PHY_BCR = 0,
-  PHY_BSR = 1,
-  PHY_CSCR = 31
-};  // PHY constants
 
-static uint32_t eth_read_phy(uint8_t addr, uint8_t reg) {
+static uint16_t eth_read_phy(uint8_t addr, uint8_t reg) {
   ETH->MACMDIOAR &= (0xF << 8);
   ETH->MACMDIOAR |= ((uint32_t) addr << 21) | ((uint32_t) reg << 16) | 3 << 2;
-  ETH->MACMDIOAR |= BIT(0);
-  while (ETH->MACMDIOAR & BIT(0)) (void) 0;
-  return ETH->MACMDIODR;
+  ETH->MACMDIOAR |= MG_BIT(0);
+  while (ETH->MACMDIOAR & MG_BIT(0)) (void) 0;
+  return (uint16_t) ETH->MACMDIODR;
 }
 
-static void eth_write_phy(uint8_t addr, uint8_t reg, uint32_t val) {
+static void eth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
   ETH->MACMDIODR = val;
   ETH->MACMDIOAR &= (0xF << 8);
   ETH->MACMDIOAR |= ((uint32_t) addr << 21) | ((uint32_t) reg << 16) | 1 << 2;
-  ETH->MACMDIOAR |= BIT(0);
-  while (ETH->MACMDIOAR & BIT(0)) (void) 0;
-}
-
-static uint32_t get_hclk(void) {
-  struct rcc {
-    volatile uint32_t CR, HSICFGR, CRRCR, CSICFGR, CFGR, RESERVED1, D1CFGR,
-        D2CFGR, D3CFGR, RESERVED2, PLLCKSELR, PLLCFGR, PLL1DIVR, PLL1FRACR,
-        PLL2DIVR, PLL2FRACR, PLL3DIVR, PLL3FRACR, RESERVED3, D1CCIPR, D2CCIP1R,
-        D2CCIP2R, D3CCIPR, RESERVED4, CIER, CIFR, CICR, RESERVED5, BDCR, CSR,
-        RESERVED6, AHB3RSTR, AHB1RSTR, AHB2RSTR, AHB4RSTR, APB3RSTR, APB1LRSTR,
-        APB1HRSTR, APB2RSTR, APB4RSTR, GCR, RESERVED8, D3AMR, RESERVED11[9],
-        RSR, AHB3ENR, AHB1ENR, AHB2ENR, AHB4ENR, APB3ENR, APB1LENR, APB1HENR,
-        APB2ENR, APB4ENR, RESERVED12, AHB3LPENR, AHB1LPENR, AHB2LPENR,
-        AHB4LPENR, APB3LPENR, APB1LLPENR, APB1HLPENR, APB2LPENR, APB4LPENR,
-        RESERVED13[4];
-  } *rcc = ((struct rcc *) (0x40000000 + 0x18020000 + 0x4400));
-  uint32_t clk = 0, hsi = 64000000 /* 64 MHz */, hse = 8000000 /* 8MHz */,
-           csi = 4000000 /* 4MHz */;
-  unsigned int sel = (rcc->CFGR & (7 << 3)) >> 3;
-
-  if (sel == 1) {
-    clk = csi;
-  } else if (sel == 2) {
-    clk = hse;
-  } else if (sel == 3) {
-    uint32_t vco, m, n, p;
-    unsigned int src = (rcc->PLLCKSELR & (3 << 0)) >> 0;
-    m = ((rcc->PLLCKSELR & (0x3F << 4)) >> 4);
-    n = ((rcc->PLL1DIVR & (0x1FF << 0)) >> 0) + 1 +
-        ((rcc->PLLCFGR & BIT(0)) ? 1 : 0);  // round-up in fractional mode
-    p = ((rcc->PLL1DIVR & (0x7F << 9)) >> 9) + 1;
-    if (src == 1) {
-      clk = csi;
-    } else if (src == 2) {
-      clk = hse;
-    } else {
-      clk = hsi;
-      clk >>= ((rcc->CR & 3) >> 3);
-    }
-    vco = (uint32_t) ((uint64_t) clk * n / m);
-    clk = vco / p;
-  } else {
-    clk = hsi;
-    clk >>= ((rcc->CR & 3) >> 3);
-  }
-  const uint8_t cptab[12] = {1, 2, 3, 4, 6, 7, 8, 9};  // log2(div)
-  uint32_t d1cpre = (rcc->D1CFGR & (0x0F << 8)) >> 8;
-  if (d1cpre >= 8) clk >>= cptab[d1cpre - 8];
-  MG_DEBUG(("D1 CLK: %u", clk));
-  uint32_t hpre = (rcc->D1CFGR & (0x0F << 0)) >> 0;
-  if (hpre < 8) return clk;
-  return ((uint32_t) clk) >> cptab[hpre - 8];
-}
-
-//  Guess CR from AHB1 clock. MDC clock is generated from the ETH peripheral
-//  clock (AHB1); as per 802.3, it must not exceed 2. As the AHB clock can
-//  be derived from HSI or CSI (internal RC) clocks, and those can go above
-//  specs, the datasheets specify a range of frequencies and activate one of a
-//  series of dividers to keep the MDC clock safely below 2.5MHz. We guess a
-//  divider setting based on HCLK with some drift. If the user uses a different
-//  clock from our defaults, needs to set the macros on top. Valid for
-//  STM32H74xxx/75xxx (58.11.4)(4.5% worst case drift)(CSI clock has a 7.5 %
-//  worst case drift @ max temp)
-static int guess_mdc_cr(void) {
-  const uint8_t crs[] = {2, 3, 0, 1, 4, 5};  // ETH->MACMDIOAR::CR values
-  const uint8_t div[] = {16, 26, 42, 62, 102, 124};  // Respective HCLK dividers
-  uint32_t hclk = get_hclk();                        // Guess system HCLK
-  int result = -1;                                   // Invalid CR value
-  for (int i = 0; i < 6; i++) {
-    if (hclk / div[i] <= 2375000UL /* 2.5MHz - 5% */) {
-      result = crs[i];
-      break;
-    }
-  }
-  if (result < 0) MG_ERROR(("HCLK too high"));
-  MG_DEBUG(("HCLK: %u, CR: %d", hclk, result));
-  return result;
+  ETH->MACMDIOAR |= MG_BIT(0);
+  while (ETH->MACMDIOAR & MG_BIT(0)) (void) 0;
 }
 
 static bool mg_tcpip_driver_stm32h_init(struct mg_tcpip_if *ifp) {
   struct mg_tcpip_driver_stm32h_data *d =
       (struct mg_tcpip_driver_stm32h_data *) ifp->driver_data;
   s_ifp = ifp;
+  uint8_t phy_addr = d == NULL ? 0 : d->phy_addr;
+  uint8_t phy_conf = d == NULL ? MG_PHY_CLOCKS_MAC : d->phy_conf;
 
   // Init RX descriptors
   for (int i = 0; i < ETH_DESC_CNT; i++) {
     s_rxdesc[i][0] = (uint32_t) (uintptr_t) s_rxbuf[i];  // Point to data buffer
-    s_rxdesc[i][3] = BIT(31) | BIT(30) | BIT(24);        // OWN, IOC, BUF1V
+    s_rxdesc[i][3] = MG_BIT(31) | MG_BIT(30) | MG_BIT(24);  // OWN, IOC, BUF1V
   }
 
   // Init TX descriptors
@@ -6985,22 +21271,24 @@ static bool mg_tcpip_driver_stm32h_init(struct mg_tcpip_if *ifp) {
     s_txdesc[i][0] = (uint32_t) (uintptr_t) s_txbuf[i];  // Buf pointer
   }
 
-  ETH->DMAMR |= BIT(0);                         // Software reset
-  while ((ETH->DMAMR & BIT(0)) != 0) (void) 0;  // Wait until done
+  ETH->DMAMR |= MG_BIT(0);  // Software reset
+  for (int i = 0; i < 4; i++)
+    (void) 0;  // wait at least 4 clocks before reading
+  while ((ETH->DMAMR & MG_BIT(0)) != 0) (void) 0;  // Wait until done
 
-  // Set MDC clock divider. If user told us the value, use it. Otherwise, guess
-  int cr = (d == NULL || d->mdc_cr < 0) ? guess_mdc_cr() : d->mdc_cr;
+  // Set MDC clock divider. Get user value, else, assume max freq
+  int cr = (d == NULL || d->mdc_cr < 0) ? 7 : d->mdc_cr;
   ETH->MACMDIOAR = ((uint32_t) cr & 0xF) << 8;
 
   // NOTE(scaprile): We do not use timing facilities so the DMA engine does not
   // re-write buffer address
-  ETH->DMAMR = 0 << 16;     // use interrupt mode 0 (58.8.1) (reset value)
-  ETH->DMASBMR |= BIT(12);  // AAL NOTE(scaprile): is this actually needed
-  ETH->MACIER = 0;        // Do not enable additional irq sources (reset value)
-  ETH->MACTFCR = BIT(7);  // Disable zero-quanta pause
-  // ETH->MACPFR = BIT(31);  // Receive all
-  eth_write_phy(PHY_ADDR, PHY_BCR, BIT(15));  // Reset PHY
-  eth_write_phy(PHY_ADDR, PHY_BCR, BIT(12));  // Set autonegotiation
+  ETH->DMAMR = 0 << 16;        // use interrupt mode 0 (58.8.1) (reset value)
+  ETH->DMASBMR |= MG_BIT(12);  // AAL NOTE(scaprile): is this actually needed
+  ETH->MACIER = 0;  // Do not enable additional irq sources (reset value)
+  ETH->MACTFCR = MG_BIT(7);  // Disable zero-quanta pause
+  // ETH->MACPFR = MG_BIT(31);  // Receive all
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  mg_phy_init(&phy, phy_addr, phy_conf);
   ETH->DMACRDLAR =
       (uint32_t) (uintptr_t) s_rxdesc;  // RX descriptors start address
   ETH->DMACRDRLR = ETH_DESC_CNT - 1;    // ring length
@@ -7013,13 +21301,23 @@ static bool mg_tcpip_driver_stm32h_init(struct mg_tcpip_if *ifp) {
   ETH->DMACTDTPR =
       (uint32_t) (uintptr_t) s_txdesc;  // first available descriptor address
   ETH->DMACCR = 0;  // DSL = 0 (contiguous descriptor table) (reset value)
-  ETH->DMACIER = BIT(6) | BIT(15);  // RIE, NIE
-  ETH->MACCR = BIT(0) | BIT(1) | BIT(13) | BIT(14) |
-               BIT(15);     // RE, TE, Duplex, Fast, Reserved
-  ETH->MTLTQOMR |= BIT(1);  // TSF
-  ETH->MTLRQOMR |= BIT(5);  // RSF
-  ETH->DMACTCR |= BIT(0);   // ST
-  ETH->DMACRCR |= BIT(0);   // SR
+#if !MG_ENABLE_DRIVER_STM32H
+  MG_SET_BITS(ETH->DMACTCR, 0x3F << 16, MG_BIT(16));
+  MG_SET_BITS(ETH->DMACRCR, 0x3F << 16, MG_BIT(16));
+#endif
+  ETH->DMACIER = MG_BIT(6) | MG_BIT(15);  // RIE, NIE
+  ETH->MACCR = MG_BIT(0) | MG_BIT(1) | MG_BIT(13) | MG_BIT(14) |
+               MG_BIT(15);  // RE, TE, Duplex, Fast, Reserved
+#if MG_ENABLE_DRIVER_STM32H
+  ETH->MTLTQOMR |= MG_BIT(1);  // TSF
+  ETH->MTLRQOMR |= MG_BIT(5);  // RSF
+#else
+  ETH->MTLTQOMR |= (7 << 16) | MG_BIT(3) | MG_BIT(1);  // 2KB Q0, TSF
+  ETH->MTLRQOMR |= (7 << 20) | MG_BIT(5);              // 2KB Q, RSF
+  MG_SET_BITS(ETH->RESERVED6[3], 3, 2);  // Enable RxQ0 (MAC_RXQ_CTRL0)
+#endif
+  ETH->DMACTCR |= MG_BIT(0);  // ST
+  ETH->DMACRCR |= MG_BIT(0);  // SR
 
   // MAC address filtering
   ETH->MACA0HR = ((uint32_t) ifp->mac[5] << 8U) | ifp->mac[4];
@@ -7035,59 +21333,74 @@ static size_t mg_tcpip_driver_stm32h_tx(const void *buf, size_t len,
   if (len > sizeof(s_txbuf[s_txno])) {
     MG_ERROR(("Frame too big, %ld", (long) len));
     len = 0;  // Frame is too big
-  } else if ((s_txdesc[s_txno][3] & BIT(31))) {
+  } else if ((s_txdesc[s_txno][3] & MG_BIT(31))) {
+    ifp->nerr++;
     MG_ERROR(("No free descriptors: %u %08X %08X %08X", s_txno,
               s_txdesc[s_txno][3], ETH->DMACSR, ETH->DMACTCR));
     for (int i = 0; i < ETH_DESC_CNT; i++) MG_ERROR(("%08X", s_txdesc[i][3]));
     len = 0;  // All descriptors are busy, fail
   } else {
-    memcpy(s_txbuf[s_txno], buf, len);        // Copy data
-    s_txdesc[s_txno][2] = (uint32_t) len;     // Set data len
-    s_txdesc[s_txno][3] = BIT(28) | BIT(29);  // FD, LD
-    s_txdesc[s_txno][3] |= BIT(31);           // Set OWN bit - let DMA take over
+    memcpy(s_txbuf[s_txno], buf, len);              // Copy data
+    s_txdesc[s_txno][2] = (uint32_t) len;           // Set data len
+    s_txdesc[s_txno][3] = MG_BIT(28) | MG_BIT(29);  // FD, LD
+    s_txdesc[s_txno][3] |= MG_BIT(31);  // Set OWN bit - let DMA take over
     if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
-  ETH->DMACSR |= BIT(2) | BIT(1);  // Clear any prior TBU, TPS
+  ETH->DMACSR |= MG_BIT(2) | MG_BIT(1);  // Clear any prior TBU, TPS
   ETH->DMACTDTPR = (uint32_t) (uintptr_t) &s_txdesc[s_txno];  // and resume
   return len;
   (void) ifp;
 }
 
 static bool mg_tcpip_driver_stm32h_up(struct mg_tcpip_if *ifp) {
-  uint32_t bsr = eth_read_phy(PHY_ADDR, PHY_BSR);
-  bool up = bsr & BIT(2) ? 1 : 0;
+  struct mg_tcpip_driver_stm32h_data *d =
+      (struct mg_tcpip_driver_stm32h_data *) ifp->driver_data;
+  uint8_t phy_addr = d == NULL ? 0 : d->phy_addr;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  up = mg_phy_up(&phy, phy_addr, &full_duplex, &speed);
   if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
-    uint32_t scsr = eth_read_phy(PHY_ADDR, PHY_CSCR);
-    uint32_t maccr = ETH->MACCR | BIT(14) | BIT(13);  // 100M, Full-duplex
-    if ((scsr & BIT(3)) == 0) maccr &= ~BIT(14);      // 10M
-    if ((scsr & BIT(4)) == 0) maccr &= ~BIT(13);      // Half-duplex
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    uint32_t maccr = ETH->MACCR | MG_BIT(14) | MG_BIT(13);  // 100M, Full-duplex
+    if (speed == MG_PHY_SPEED_10M) maccr &= ~MG_BIT(14);    // 10M
+    if (full_duplex == false) maccr &= ~MG_BIT(13);         // Half-duplex
     ETH->MACCR = maccr;  // IRQ handler does not fiddle with this register
-    MG_DEBUG(("Link is %uM %s-duplex", maccr & BIT(14) ? 100 : 10,
-              maccr & BIT(13) ? "full" : "half"));
+    MG_DEBUG(("Link is %uM %s-duplex", maccr & MG_BIT(14) ? 100 : 10,
+              maccr & MG_BIT(13) ? "full" : "half"));
   }
   return up;
 }
 
-void ETH_IRQHandler(void);
 static uint32_t s_rxno;
+#if MG_ENABLE_DRIVER_MCXN
+void ETHERNET_IRQHandler(void);
+void ETHERNET_IRQHandler(void) {
+#else
+void ETH_IRQHandler(void);
 void ETH_IRQHandler(void) {
-  if (ETH->DMACSR & BIT(6)) {            // Frame received, loop
-    ETH->DMACSR = BIT(15) | BIT(6);      // Clear flag
+#endif
+  if (ETH->DMACSR & MG_BIT(6)) {           // Frame received, loop
+    ETH->DMACSR = MG_BIT(15) | MG_BIT(6);  // Clear flag
     for (uint32_t i = 0; i < 10; i++) {  // read as they arrive but not forever
-      if (s_rxdesc[s_rxno][3] & BIT(31)) break;  // exit when done
-      if (((s_rxdesc[s_rxno][3] & (BIT(28) | BIT(29))) ==
-           (BIT(28) | BIT(29))) &&
-          !(s_rxdesc[s_rxno][3] & BIT(15))) {  // skip partial/errored frames
-        uint32_t len = s_rxdesc[s_rxno][3] & (BIT(15) - 1);
+      if (s_rxdesc[s_rxno][3] & MG_BIT(31)) break;  // exit when done
+      if (((s_rxdesc[s_rxno][3] & (MG_BIT(28) | MG_BIT(29))) ==
+           (MG_BIT(28) | MG_BIT(29))) &&
+          !(s_rxdesc[s_rxno][3] & MG_BIT(15))) {  // skip partial/errored frames
+        uint32_t len = s_rxdesc[s_rxno][3] & (MG_BIT(15) - 1);
         // MG_DEBUG(("%lx %lu %lx %08lx", s_rxno, len, s_rxdesc[s_rxno][3],
         // ETH->DMACSR));
         mg_tcpip_qwrite(s_rxbuf[s_rxno], len > 4 ? len - 4 : len, s_ifp);
       }
-      s_rxdesc[s_rxno][3] = BIT(31) | BIT(30) | BIT(24);  // OWN, IOC, BUF1V
+      s_rxdesc[s_rxno][3] =
+          MG_BIT(31) | MG_BIT(30) | MG_BIT(24);  // OWN, IOC, BUF1V
       if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
     }
   }
-  ETH->DMACSR = BIT(7) | BIT(8);  // Clear possible RBU RPS while processing
+  ETH->DMACSR =
+      MG_BIT(7) | MG_BIT(8);  // Clear possible RBU RPS while processing
   ETH->DMACRDTPR =
       (uint32_t) (uintptr_t) &s_rxdesc[ETH_DESC_CNT - 1];  // and resume RX
 }
@@ -7098,7 +21411,7 @@ struct mg_tcpip_driver mg_tcpip_driver_stm32h = {
 #endif
 
 #ifdef MG_ENABLE_LINES
-#line 1 "src/tcpip/driver_tm4c.c"
+#line 1 "src/drivers/tm4c.c"
 #endif
 
 
@@ -7126,8 +21439,6 @@ struct tm4c_emac {
 #undef EMAC
 #define EMAC ((struct tm4c_emac *) (uintptr_t) 0x400EC000)
 
-#undef BIT
-#define BIT(x) ((uint32_t) 1 << (x))
 #define ETH_PKT_SIZE 1540  // Max frame size
 #define ETH_DESC_CNT 4     // Descriptors count
 #define ETH_DS 4           // Descriptor size (words)
@@ -7151,17 +21462,17 @@ static inline void tm4cspin(volatile uint32_t count) {
 static uint32_t emac_read_phy(uint8_t addr, uint8_t reg) {
   EMAC->EMACMIIADDR &= (0xf << 2);
   EMAC->EMACMIIADDR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6);
-  EMAC->EMACMIIADDR |= BIT(0);
-  while (EMAC->EMACMIIADDR & BIT(0)) tm4cspin(1);
+  EMAC->EMACMIIADDR |= MG_BIT(0);
+  while (EMAC->EMACMIIADDR & MG_BIT(0)) tm4cspin(1);
   return EMAC->EMACMIIDATA;
 }
 
 static void emac_write_phy(uint8_t addr, uint8_t reg, uint32_t val) {
   EMAC->EMACMIIDATA = val;
   EMAC->EMACMIIADDR &= (0xf << 2);
-  EMAC->EMACMIIADDR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6) | BIT(1);
-  EMAC->EMACMIIADDR |= BIT(0);
-  while (EMAC->EMACMIIADDR & BIT(0)) tm4cspin(1);
+  EMAC->EMACMIIADDR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6) | MG_BIT(1);
+  EMAC->EMACMIIADDR |= MG_BIT(0);
+  while (EMAC->EMACMIIADDR & MG_BIT(0)) tm4cspin(1);
 }
 
 static uint32_t get_sysclk(void) {
@@ -7237,8 +21548,8 @@ static bool mg_tcpip_driver_tm4c_init(struct mg_tcpip_if *ifp) {
 
   // Init RX descriptors
   for (int i = 0; i < ETH_DESC_CNT; i++) {
-    s_rxdesc[i][0] = BIT(31);                            // Own
-    s_rxdesc[i][1] = sizeof(s_rxbuf[i]) | BIT(14);       // 2nd address chained
+    s_rxdesc[i][0] = MG_BIT(31);                            // Own
+    s_rxdesc[i][1] = sizeof(s_rxbuf[i]) | MG_BIT(14);       // 2nd address chained
     s_rxdesc[i][2] = (uint32_t) (uintptr_t) s_rxbuf[i];  // Point to data buffer
     s_rxdesc[i][3] =
         (uint32_t) (uintptr_t) s_rxdesc[(i + 1) % ETH_DESC_CNT];  // Chain
@@ -7252,8 +21563,8 @@ static bool mg_tcpip_driver_tm4c_init(struct mg_tcpip_if *ifp) {
         (uint32_t) (uintptr_t) s_txdesc[(i + 1) % ETH_DESC_CNT];  // Chain
   }
 
-  EMAC->EMACDMABUSMOD |= BIT(0);                            // Software reset
-  while ((EMAC->EMACDMABUSMOD & BIT(0)) != 0) tm4cspin(1);  // Wait until done
+  EMAC->EMACDMABUSMOD |= MG_BIT(0);                            // Software reset
+  while ((EMAC->EMACDMABUSMOD & MG_BIT(0)) != 0) tm4cspin(1);  // Wait until done
 
   // Set MDC clock divider. If user told us the value, use it. Otherwise, guess
   int cr = (d == NULL || d->mdc_cr < 0) ? guess_mdc_cr() : d->mdc_cr;
@@ -7261,19 +21572,19 @@ static bool mg_tcpip_driver_tm4c_init(struct mg_tcpip_if *ifp) {
 
   // NOTE(cpq): we do not use extended descriptor bit 7, and do not use
   // hardware checksum. Therefore, descriptor size is 4, not 8
-  // EMAC->EMACDMABUSMOD = BIT(13) | BIT(16) | BIT(22) | BIT(23) | BIT(25);
-  EMAC->EMACIM = BIT(3) | BIT(9);  // Mask timestamp & PMT IT
-  EMAC->EMACFLOWCTL = BIT(7);      // Disable zero-quanta pause
-  // EMAC->EMACFRAMEFLTR = BIT(31);   // Receive all
+  // EMAC->EMACDMABUSMOD = MG_BIT(13) | MG_BIT(16) | MG_BIT(22) | MG_BIT(23) | MG_BIT(25);
+  EMAC->EMACIM = MG_BIT(3) | MG_BIT(9);  // Mask timestamp & PMT IT
+  EMAC->EMACFLOWCTL = MG_BIT(7);      // Disable zero-quanta pause
+  // EMAC->EMACFRAMEFLTR = MG_BIT(31);   // Receive all
   // EMAC->EMACPC defaults to internal PHY (EPHY) in MMI mode
-  emac_write_phy(EPHY_ADDR, EPHYBMCR, BIT(15));  // Reset internal PHY (EPHY)
-  emac_write_phy(EPHY_ADDR, EPHYBMCR, BIT(12));  // Set autonegotiation
+  emac_write_phy(EPHY_ADDR, EPHYBMCR, MG_BIT(15));  // Reset internal PHY (EPHY)
+  emac_write_phy(EPHY_ADDR, EPHYBMCR, MG_BIT(12));  // Set autonegotiation
   EMAC->EMACRXDLADDR = (uint32_t) (uintptr_t) s_rxdesc;  // RX descriptors
   EMAC->EMACTXDLADDR = (uint32_t) (uintptr_t) s_txdesc;  // TX descriptors
-  EMAC->EMACDMAIM = BIT(6) | BIT(16);                    // RIE, NIE
-  EMAC->EMACCFG = BIT(2) | BIT(3) | BIT(11) | BIT(14);   // RE, TE, Duplex, Fast
+  EMAC->EMACDMAIM = MG_BIT(6) | MG_BIT(16);                    // RIE, NIE
+  EMAC->EMACCFG = MG_BIT(2) | MG_BIT(3) | MG_BIT(11) | MG_BIT(14);   // RE, TE, Duplex, Fast
   EMAC->EMACDMAOPMODE =
-      BIT(1) | BIT(13) | BIT(21) | BIT(25);  // SR, ST, TSF, RSF
+      MG_BIT(1) | MG_BIT(13) | MG_BIT(21) | MG_BIT(25);  // SR, ST, TSF, RSF
   EMAC->EMACADDR0H = ((uint32_t) ifp->mac[5] << 8U) | ifp->mac[4];
   EMAC->EMACADDR0L = (uint32_t) (ifp->mac[3] << 24) |
                      ((uint32_t) ifp->mac[2] << 16) |
@@ -7289,7 +21600,8 @@ static size_t mg_tcpip_driver_tm4c_tx(const void *buf, size_t len,
   if (len > sizeof(s_txbuf[s_txno])) {
     MG_ERROR(("Frame too big, %ld", (long) len));
     len = 0;  // fail
-  } else if ((s_txdesc[s_txno][0] & BIT(31))) {
+  } else if ((s_txdesc[s_txno][0] & MG_BIT(31))) {
+    ifp->nerr++;
     MG_ERROR(("No descriptors available"));
     // printf("D0 %lx SR %lx\n", (long) s_txdesc[0][0], (long)
     // EMAC->EMACDMARIS);
@@ -7298,11 +21610,11 @@ static size_t mg_tcpip_driver_tm4c_tx(const void *buf, size_t len,
     memcpy(s_txbuf[s_txno], buf, len);     // Copy data
     s_txdesc[s_txno][1] = (uint32_t) len;  // Set data len
     s_txdesc[s_txno][0] =
-        BIT(20) | BIT(28) | BIT(29) | BIT(30);  // Chain,FS,LS,IC
-    s_txdesc[s_txno][0] |= BIT(31);  // Set OWN bit - let DMA take over
+        MG_BIT(20) | MG_BIT(28) | MG_BIT(29) | MG_BIT(30);  // Chain,FS,LS,IC
+    s_txdesc[s_txno][0] |= MG_BIT(31);  // Set OWN bit - let DMA take over
     if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
-  EMAC->EMACDMARIS = BIT(2) | BIT(5);  // Clear any prior TU/UNF
+  EMAC->EMACDMARIS = MG_BIT(2) | MG_BIT(5);  // Clear any prior TU/UNF
   EMAC->EMACTXPOLLD = 0;               // and resume
   return len;
   (void) ifp;
@@ -7310,15 +21622,18 @@ static size_t mg_tcpip_driver_tm4c_tx(const void *buf, size_t len,
 
 static bool mg_tcpip_driver_tm4c_up(struct mg_tcpip_if *ifp) {
   uint32_t bmsr = emac_read_phy(EPHY_ADDR, EPHYBMSR);
-  bool up = (bmsr & BIT(2)) ? 1 : 0;
+  bool up = (bmsr & MG_BIT(2)) ? 1 : 0;
   if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
     uint32_t sts = emac_read_phy(EPHY_ADDR, EPHYSTS);
-    uint32_t emaccfg = EMAC->EMACCFG | BIT(14) | BIT(11);  // 100M, Full-duplex
-    if (sts & BIT(1)) emaccfg &= ~BIT(14);                 // 10M
-    if ((sts & BIT(2)) == 0) emaccfg &= ~BIT(11);          // Half-duplex
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    uint32_t emaccfg = EMAC->EMACCFG | MG_BIT(14) | MG_BIT(11);  // 100M, Full-duplex
+    if (sts & MG_BIT(1)) emaccfg &= ~MG_BIT(14);                 // 10M
+    if ((sts & MG_BIT(2)) == 0) emaccfg &= ~MG_BIT(11);          // Half-duplex
     EMAC->EMACCFG = emaccfg;  // IRQ handler does not fiddle with this register
-    MG_DEBUG(("Link is %uM %s-duplex", emaccfg & BIT(14) ? 100 : 10,
-              emaccfg & BIT(11) ? "full" : "half"));
+    MG_DEBUG(("Link is %uM %s-duplex", emaccfg & MG_BIT(14) ? 100 : 10,
+              emaccfg & MG_BIT(11) ? "full" : "half"));
   }
   return up;
 }
@@ -7326,22 +21641,22 @@ static bool mg_tcpip_driver_tm4c_up(struct mg_tcpip_if *ifp) {
 void EMAC0_IRQHandler(void);
 static uint32_t s_rxno;
 void EMAC0_IRQHandler(void) {
-  if (EMAC->EMACDMARIS & BIT(6)) {        // Frame received, loop
-    EMAC->EMACDMARIS = BIT(16) | BIT(6);  // Clear flag
+  if (EMAC->EMACDMARIS & MG_BIT(6)) {        // Frame received, loop
+    EMAC->EMACDMARIS = MG_BIT(16) | MG_BIT(6);  // Clear flag
     for (uint32_t i = 0; i < 10; i++) {   // read as they arrive but not forever
-      if (s_rxdesc[s_rxno][0] & BIT(31)) break;  // exit when done
-      if (((s_rxdesc[s_rxno][0] & (BIT(8) | BIT(9))) == (BIT(8) | BIT(9))) &&
-          !(s_rxdesc[s_rxno][0] & BIT(15))) {  // skip partial/errored frames
-        uint32_t len = ((s_rxdesc[s_rxno][0] >> 16) & (BIT(14) - 1));
+      if (s_rxdesc[s_rxno][0] & MG_BIT(31)) break;  // exit when done
+      if (((s_rxdesc[s_rxno][0] & (MG_BIT(8) | MG_BIT(9))) == (MG_BIT(8) | MG_BIT(9))) &&
+          !(s_rxdesc[s_rxno][0] & MG_BIT(15))) {  // skip partial/errored frames
+        uint32_t len = ((s_rxdesc[s_rxno][0] >> 16) & (MG_BIT(14) - 1));
         //  printf("%lx %lu %lx %.8lx\n", s_rxno, len, s_rxdesc[s_rxno][0],
         //  EMAC->EMACDMARIS);
         mg_tcpip_qwrite(s_rxbuf[s_rxno], len > 4 ? len - 4 : len, s_ifp);
       }
-      s_rxdesc[s_rxno][0] = BIT(31);
+      s_rxdesc[s_rxno][0] = MG_BIT(31);
       if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
     }
   }
-  EMAC->EMACDMARIS = BIT(7);  // Clear possible RU while processing
+  EMAC->EMACDMARIS = MG_BIT(7);  // Clear possible RU while processing
   EMAC->EMACRXPOLLD = 0;      // and resume RX
 }
 
@@ -7351,22 +21666,370 @@ struct mg_tcpip_driver mg_tcpip_driver_tm4c = {mg_tcpip_driver_tm4c_init,
 #endif
 
 #ifdef MG_ENABLE_LINES
-#line 1 "src/tcpip/driver_w5500.c"
+#line 1 "src/drivers/tms570.c"
 #endif
 
 
-#if MG_ENABLE_TCPIP
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_TMS570) && MG_ENABLE_DRIVER_TMS570
+struct tms570_emac_ctrl {
+  volatile uint32_t REVID, SOFTRESET, RESERVED1[1], INTCONTROL, C0RXTHRESHEN,
+  C0RXEN, C0TXEN, C0MISCEN, RESERVED2[8],
+  C0RXTHRESHSTAT, C0RXSTAT, C0TXSTAT, C0MISCSTAT,
+  RESERVED3[8],
+  C0RXIMAX, C0TXIMAX;
+};
+struct tms570_emac {
+  volatile uint32_t TXREVID, TXCONTROL, TXTEARDOWN, RESERVED1[1], RXREVID,
+  RXCONTROL, RXTEARDOWN, RESERVED2[25], TXINTSTATRAW,TXINTSTATMASKED,
+  TXINTMASKSET, TXINTMASKCLEAR, MACINVECTOR, MACEOIVECTOR, RESERVED8[2], RXINTSTATRAW,
+  RXINTSTATMASKED, RXINTMASKSET, RXINTMASKCLEAR, MACINTSTATRAW, MACINTSTATMASKED,
+  MACINTMASKSET, MACINTMASKCLEAR, RESERVED3[16], RXMBPENABLE, RXUNICASTSET,
+  RXUNICASTCLEAR, RXMAXLEN, RXBUFFEROFFSET, RXFILTERLOWTHRESH, RESERVED9[2], RXFLOWTHRESH[8],
+  RXFREEBUFFER[8], MACCONTROL, MACSTATUS, EMCONTROL, FIFOCONTROL, MACCONFIG,
+  SOFTRESET, RESERVED4[22], MACSRCADDRLO, MACSRCADDRHI, MACHASH1, MACHASH2,
+  BOFFTEST, TPACETEST, RXPAUSE, TXPAUSE, RESERVED5[4], RXGOODFRAMES, RXBCASTFRAMES,
+  RXMCASTFRAMES, RXPAUSEFRAMES, RXCRCERRORS, RXALIGNCODEERRORS, RXOVERSIZED,
+  RXJABBER, RXUNDERSIZED, RXFRAGMENTS, RXFILTERED, RXQOSFILTERED, RXOCTETS,
+  TXGOODFRAMES, TXBCASTFRAMES, TXMCASTFRAMES, TXPAUSEFRAMES, TXDEFERRED,
+  TXCOLLISION, TXSINGLECOLL, TXMULTICOLL, TXEXCESSIVECOLL, TXLATECOLL,
+  TXUNDERRUN, TXCARRIERSENSE, TXOCTETS, FRAME64, FRAME65T127, FRAME128T255,
+  FRAME256T511, FRAME512T1023, FRAME1024TUP, NETOCTETS, RXSOFOVERRUNS,
+  RXMOFOVERRUNS, RXDMAOVERRUNS, RESERVED6[156], MACADDRLO, MACADDRHI,
+  MACINDEX, RESERVED7[61], TXHDP[8], RXHDP[8], TXCP[8], RXCP[8];
+};
+struct tms570_mdio {
+  volatile uint32_t REVID, CONTROL, ALIVE, LINK, LINKINTRAW, LINKINTMASKED,
+  RESERVED1[2], USERINTRAW, USERINTMASKED, USERINTMASKSET, USERINTMASKCLEAR,
+  RESERVED2[20], USERACCESS0, USERPHYSEL0, USERACCESS1, USERPHYSEL1;
+};
+#define SWAP32(x) ( (((x) & 0x000000FF) << 24) | \
+                              (((x) & 0x0000FF00) << 8)  | \
+                              (((x) & 0x00FF0000) >> 8)  | \
+                              (((x) & 0xFF000000) >> 24) )
+#undef EMAC
+#undef EMAC_CTRL
+#undef MDIO
+#define EMAC ((struct tms570_emac *) (uintptr_t) 0xFCF78000)
+#define EMAC_CTRL ((struct tms570_emac_ctrl *) (uintptr_t) 0xFCF78800)
+#define MDIO ((struct tms570_mdio *) (uintptr_t) 0xFCF78900)
+#define ETH_PKT_SIZE 1540  // Max frame size
+#define ETH_DESC_CNT 4     // Descriptors count
+#define ETH_DS 4           // Descriptor size (words)
+static uint32_t s_txdesc[ETH_DESC_CNT][ETH_DS] 
+  __attribute__((section(".ETH_CPPI"), aligned(4)));      // TX descriptors
+static uint32_t s_rxdesc[ETH_DESC_CNT][ETH_DS] 
+  __attribute__((section(".ETH_CPPI"), aligned(4)));      // RX descriptors
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE] 
+  __attribute__((aligned(4)));  // RX ethernet buffers
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE] 
+  __attribute__((aligned(4)));  // TX ethernet buffers
+static struct mg_tcpip_if *s_ifp;                    // MIP interface
+static uint16_t emac_read_phy(uint8_t addr, uint8_t reg) {
+  while(MDIO->USERACCESS0 & MG_BIT(31)) (void) 0;
+  MDIO->USERACCESS0 = MG_BIT(31) | ((reg & 0x1f) << 21) |
+                      ((addr & 0x1f) << 16);
+  while(MDIO->USERACCESS0 & MG_BIT(31)) (void) 0;
+  return MDIO->USERACCESS0 & 0xffff;
+}
+static void emac_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  while(MDIO->USERACCESS0 & MG_BIT(31)) (void) 0;
+  MDIO->USERACCESS0 = MG_BIT(31) | MG_BIT(30) | ((reg & 0x1f) << 21) |
+                      ((addr & 0x1f) << 16) | (val & 0xffff);
+  while(MDIO->USERACCESS0 & MG_BIT(31)) (void) 0;
+}
+static bool mg_tcpip_driver_tms570_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_tms570_data *d =
+      (struct mg_tcpip_driver_tms570_data *) ifp->driver_data;
+  s_ifp = ifp;
+  EMAC_CTRL->SOFTRESET = MG_BIT(0); // Reset the EMAC Control Module
+  while(EMAC_CTRL->SOFTRESET & MG_BIT(0)) (void) 0; // wait
+  EMAC->SOFTRESET = MG_BIT(0); // Reset the EMAC Module
+  while(EMAC->SOFTRESET & MG_BIT(0)) (void) 0;
+  EMAC->MACCONTROL = 0;
+  EMAC->RXCONTROL = 0;
+  EMAC->TXCONTROL = 0;
+  // Initialize all the header descriptor pointer registers
+  uint32_t i;
+  for(i =  0; i < ETH_DESC_CNT; i++) {
+    EMAC->RXHDP[i] = 0;
+    EMAC->TXHDP[i] = 0;
+    EMAC->RXCP[i] = 0;
+    EMAC->TXCP[i] = 0;
+    ///EMAC->RXFREEBUFFER[i] = 0xff;
+  }
+  // Clear the interrupt enable for all the channels
+  EMAC->TXINTMASKCLEAR = 0xff;
+  EMAC->RXINTMASKCLEAR = 0xff;
+  EMAC->MACHASH1 = 0;
+  EMAC->MACHASH2 = 0;
+  EMAC->RXBUFFEROFFSET = 0;
+  EMAC->RXUNICASTCLEAR = 0xff;
+  EMAC->RXUNICASTSET = 0;
+  EMAC->RXMBPENABLE = 0;
+  // init MDIO
+  // MDIO_CLK frequency = VCLK3/(CLKDIV + 1). (MDIO must be between 1.0 - 2.5Mhz)
+  uint32_t clkdiv = 75; // VCLK is configured to 75Mhz
+  // CLKDIV, ENABLE, PREAMBLE, FAULTENB
+  MDIO->CONTROL = (clkdiv - 1) | MG_BIT(30) | MG_BIT(20) | MG_BIT(18);
+  volatile int delay = 0xfff;
+  while (delay-- != 0) (void) 0;
+  struct mg_phy phy = {emac_read_phy, emac_write_phy};
+  mg_phy_init(&phy, d->phy_addr, MG_PHY_CLOCKS_MAC);
+  // set the mac address
+  EMAC->MACSRCADDRHI = ifp->mac[0] | (ifp->mac[1] << 8) | (ifp->mac[2] << 16) |
+                       (ifp->mac[3] << 24);
+  EMAC->MACSRCADDRLO = ifp->mac[4] | (ifp->mac[5] << 8);
+  uint32_t channel;
+  for (channel = 0; channel < 8; channel++) {
+    EMAC->MACINDEX = channel;
+    EMAC->MACADDRHI = ifp->mac[0] | (ifp->mac[1] << 8) | (ifp->mac[2] << 16) |
+                       (ifp->mac[3] << 24);
+    EMAC->MACADDRLO = ifp->mac[4] | (ifp->mac[5] << 8) | MG_BIT(20) |
+                      MG_BIT(19) | (channel << 16);
+  }
+  EMAC->RXUNICASTSET = 1; // accept unicast frames;
+  EMAC->RXMBPENABLE = MG_BIT(30) | MG_BIT(13); // CRC, broadcast;
+  
+  // Initialize the descriptors
+  for (i = 0; i < ETH_DESC_CNT; i++) {
+    if (i < ETH_DESC_CNT - 1) {
+      s_txdesc[i][0] = 0;
+      s_rxdesc[i][0] = SWAP32(((uint32_t) &s_rxdesc[i + 1][0]));
+    }
+    s_txdesc[i][1] = SWAP32(((uint32_t) s_txbuf[i]));
+    s_rxdesc[i][1] = SWAP32(((uint32_t) s_rxbuf[i]));
+    s_txdesc[i][2] = 0;
+    s_rxdesc[i][2] = SWAP32(ETH_PKT_SIZE);
+    s_txdesc[i][3] = 0;
+    s_rxdesc[i][3] = SWAP32(MG_BIT(29)); // OWN
+  }
+  s_txdesc[ETH_DESC_CNT - 1][0] = 0;
+  s_rxdesc[ETH_DESC_CNT - 1][0] = 0;
+  
+  EMAC->MACCONTROL = MG_BIT(5) | MG_BIT(0); // Enable MII, Full-duplex
+  //EMAC->TXINTMASKSET = 1; // Enable TX interrupt
+  EMAC->RXINTMASKSET = 1; // Enable RX interrupt
+  //EMAC_CTRL->C0TXEN = 1; // TX completion interrupt
+  EMAC_CTRL->C0RXEN = 1; // RX completion interrupt
+  EMAC->TXCONTROL = 1; // TXEN
+  EMAC->RXCONTROL = 1; // RXEN
+  EMAC->RXHDP[0] = (uint32_t) &s_rxdesc[0][0];
+  return true;
+}
+static uint32_t s_txno;
+static size_t mg_tcpip_driver_tms570_tx(const void *buf, size_t len,
+                                      struct mg_tcpip_if *ifp) {
+  if (len > sizeof(s_txbuf[s_txno])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = 0;  // fail
+  } else if ((s_txdesc[s_txno][3] & SWAP32(MG_BIT(29)))) {
+    ifp->nerr++;
+    MG_ERROR(("No descriptors available"));
+    len = 0;  // fail
+  } else {
+    memcpy(s_txbuf[s_txno], buf, len);     // Copy data
+    if (len < 128) len = 128;
+    s_txdesc[s_txno][2] = SWAP32((uint32_t) len);  // Set data len
+    s_txdesc[s_txno][3] =
+        SWAP32(MG_BIT(31) | MG_BIT(30) | MG_BIT(29) | len);  // SOP, EOP, OWN, length
+    
+    while(EMAC->TXHDP[0] != 0) (void) 0;
+    EMAC->TXHDP[0] = (uint32_t) &s_txdesc[s_txno][0];
+    if(++s_txno == ETH_DESC_CNT) {
+      s_txno = 0;
+    }
+  }
+  return len;
+  (void) ifp;
+}
+static bool mg_tcpip_driver_tms570_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_tms570_data *d =
+      (struct mg_tcpip_driver_tms570_data *) ifp->driver_data;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {emac_read_phy, emac_write_phy};
+  up = mg_phy_up(&phy, d->phy_addr, &full_duplex, &speed);
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {
+    // link state just went up
+    MG_DEBUG(("Link is %uM %s-duplex", speed == MG_PHY_SPEED_10M ? 10 : 100,
+              full_duplex ? "full" : "half"));
+  }
+  return up;
+}
+#pragma CODE_STATE(EMAC_TX_IRQHandler, 32)
+#pragma INTERRUPT(EMAC_TX_IRQHandler, IRQ)
+void EMAC_TX_IRQHandler(void) {
+  uint32_t status = EMAC_CTRL->C0TXSTAT;
+  if (status & 1) { // interrupt caused on channel 0
+    while(s_txdesc[s_txno][3] & SWAP32(MG_BIT(29))) (void) 0;
+    EMAC->TXCP[0] = (uint32_t) &s_txdesc[s_txno][0];
+  }
+  //Write the DMA end of interrupt vector
+  EMAC->MACEOIVECTOR = 2;
+}
+static uint32_t s_rxno;
+#pragma CODE_STATE(EMAC_RX_IRQHandler, 32)
+#pragma INTERRUPT(EMAC_RX_IRQHandler, IRQ)
+void EMAC_RX_IRQHandler(void) {
+  uint32_t status = EMAC_CTRL->C0RXSTAT;
+  if (status & 1) { // Frame received, loop
+    uint32_t i;
+    //MG_INFO(("RX interrupt"));
+    for (i = 0; i < 10; i++) {   // read as they arrive but not forever
+      if ((s_rxdesc[s_rxno][3] & SWAP32(MG_BIT(29))) == 0) {
+        uint32_t len = SWAP32(s_rxdesc[s_rxno][3]) & 0xffff;
+        //MG_INFO(("recv len: %d", len));
+        //mg_hexdump(s_rxbuf[s_rxno], len);
+        mg_tcpip_qwrite(s_rxbuf[s_rxno], len > 4 ? len - 4 : len, s_ifp);
+        uint32_t flags = s_rxdesc[s_rxno][3];
+        s_rxdesc[s_rxno][3] = SWAP32(MG_BIT(29));
+        s_rxdesc[s_rxno][2] = SWAP32(ETH_PKT_SIZE);
+        EMAC->RXCP[0] = (uint32_t) &s_rxdesc[s_rxno][0];
+        if (flags & SWAP32(MG_BIT(28))) {
+          //MG_INFO(("EOQ detected"));
+          EMAC->RXHDP[0] = (uint32_t) &s_rxdesc[0][0];
+        }
+      }
+      if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+    }
+  }
+  //Write the DMA end of interrupt vector
+  EMAC->MACEOIVECTOR = 1;
+}
+struct mg_tcpip_driver mg_tcpip_driver_tms570 = {mg_tcpip_driver_tms570_init,
+                                               mg_tcpip_driver_tms570_tx, NULL,
+                                               mg_tcpip_driver_tms570_up};
+#endif
+
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/w5100.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_W5100) && MG_ENABLE_DRIVER_W5100
+
+static void w5100_txn(struct mg_tcpip_spi *s, uint16_t addr,
+                      bool wr, void *buf, size_t len) {
+  size_t i;
+  uint8_t *p = (uint8_t *) buf;
+  uint8_t control = wr ? 0xF0 : 0x0F;
+  uint8_t cmd[] = {control, (uint8_t) (addr >> 8), (uint8_t) (addr & 255)};
+  s->begin(s->spi);
+  for (i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
+  for (i = 0; i < len; i++) {
+    uint8_t r = s->txn(s->spi, p[i]);
+    if (!wr) p[i] = r;
+  }
+  s->end(s->spi);
+}
+
+// clang-format off
+static  void w5100_wn(struct mg_tcpip_spi *s, uint16_t addr, void *buf, size_t len) { w5100_txn(s, addr, true, buf, len); }
+static  void w5100_w1(struct mg_tcpip_spi *s, uint16_t addr, uint8_t val) { w5100_wn(s, addr, &val, 1); }
+static  void w5100_w2(struct mg_tcpip_spi *s, uint16_t addr, uint16_t val) { uint8_t buf[2] = {(uint8_t) (val >> 8), (uint8_t) (val & 255)}; w5100_wn(s, addr, buf, sizeof(buf)); }
+static  void w5100_rn(struct mg_tcpip_spi *s, uint16_t addr, void *buf, size_t len) { w5100_txn(s, addr, false, buf, len); }
+static  uint8_t w5100_r1(struct mg_tcpip_spi *s, uint16_t addr) { uint8_t r = 0; w5100_rn(s, addr, &r, 1); return r; }
+static  uint16_t w5100_r2(struct mg_tcpip_spi *s, uint16_t addr) { uint8_t buf[2] = {0, 0}; w5100_rn(s, addr, buf, sizeof(buf)); return (uint16_t) ((buf[0] << 8) | buf[1]); }
+// clang-format on
+
+static size_t w5100_rx(void *buf, size_t buflen, struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) ifp->driver_data;
+  uint16_t r = 0, n = 0, len = (uint16_t) buflen, n2;     // Read recv len
+  while ((n2 = w5100_r2(s, 0x426)) > n) n = n2;  // Until it is stable
+  if (n > 0) {
+    uint16_t ptr = w5100_r2(s, 0x428);  // Get read pointer
+    if (n <= len + 2 && n > 1) {
+      r = (uint16_t) (n - 2);
+    }
+    uint16_t rxbuf_size = (1 << (w5100_r1(s, 0x1a) & 3)) * 1024;
+    uint16_t rxbuf_addr = 0x6000;
+    uint16_t ptr_ofs = (ptr + 2) & (rxbuf_size - 1);
+    if (ptr_ofs + r < rxbuf_size) {
+      w5100_rn(s, rxbuf_addr + ptr_ofs, buf, r);
+    } else {
+      uint16_t remaining_len = rxbuf_size - ptr_ofs;
+      w5100_rn(s, rxbuf_addr + ptr_ofs, buf, remaining_len);
+      w5100_rn(s, rxbuf_addr, buf + remaining_len, n - remaining_len);
+    }
+    w5100_w2(s, 0x428, (uint16_t) (ptr + n));
+    w5100_w1(s, 0x401, 0x40);                     // Sock0 CR -> RECV
+  }
+  return r;
+}
+
+static size_t w5100_tx(const void *buf, size_t buflen,
+                       struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) ifp->driver_data;
+  uint16_t i, n = 0, ptr = 0, len = (uint16_t) buflen;
+  while (n < len) n = w5100_r2(s, 0x420);      // Wait for space
+  ptr = w5100_r2(s, 0x424);                    // Get write pointer
+  uint16_t txbuf_size = (1 << (w5100_r1(s, 0x1b) & 3)) * 1024;
+  uint16_t ptr_ofs = ptr & (txbuf_size - 1);
+  uint16_t txbuf_addr = 0x4000;
+  if (ptr_ofs + len > txbuf_size) {
+    uint16_t size = txbuf_size - ptr_ofs;
+    w5100_wn(s, txbuf_addr + ptr_ofs, (char*) buf, size);
+    w5100_wn(s, txbuf_addr, (char*) buf + size, len - size);
+  } else {
+    w5100_wn(s, txbuf_addr + ptr_ofs, (char*) buf, len);
+  }
+  w5100_w2(s, 0x424, (uint16_t) (ptr + len));  // Advance write pointer
+  w5100_w1(s, 0x401, 0x20);                       // Sock0 CR -> SEND
+  for (i = 0; i < 40; i++) {
+    uint8_t ir = w5100_r1(s, 0x402);  // Read S0 IR
+    if (ir == 0) continue;
+    // printf("IR %d, len=%d, free=%d, ptr %d\n", ir, (int) len, (int) n, ptr);
+    w5100_w1(s, 0x402, ir);  // Write S0 IR: clear it!
+    if (ir & 8) len = 0;           // Timeout. Report error
+    if (ir & (16 | 8)) break;      // Stop on SEND_OK or timeout
+  }
+  return len;
+}
+
+static bool w5100_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) ifp->driver_data;
+  s->end(s->spi);
+  w5100_w1(s, 0, 0x80);     // Reset chip: CR -> 0x80
+  w5100_w1(s, 0x72, 0x53);  // CR PHYLCKR -> unlock PHY
+  w5100_w1(s, 0x46, 0);     // CR PHYCR0 -> autonegotiation
+  w5100_w1(s, 0x47, 0);     // CR PHYCR1 -> reset
+  w5100_w1(s, 0x72, 0x00);  // CR PHYLCKR -> lock PHY
+  w5100_w1(s, 0x1a, 6);          // Sock0 RX buf size - 4KB
+  w5100_w1(s, 0x1b, 6);          // Sock0 TX buf size - 4KB
+  w5100_w1(s, 0x400, 4);              // Sock0 MR -> MACRAW
+  w5100_w1(s, 0x401, 1);              // Sock0 CR -> OPEN
+  return w5100_r1(s, 0x403) == 0x42;  // Sock0 SR == MACRAW
+}
+
+static bool w5100_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_spi *spi = (struct mg_tcpip_spi *) ifp->driver_data;
+  uint8_t physr0 = w5100_r1(spi, 0x3c);
+  return physr0 & 1;  // Bit 0 of PHYSR is LNK (0 - down, 1 - up)
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_w5100 = {w5100_init, w5100_tx, w5100_rx,
+                                                w5100_up};
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/w5500.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_W5500) && MG_ENABLE_DRIVER_W5500
 
 enum { W5500_CR = 0, W5500_S0 = 1, W5500_TX0 = 2, W5500_RX0 = 3 };
 
-static void w5500_txn(struct mg_tcpip_spi *s, uint8_t block, uint16_t addr, bool wr,
-                      void *buf, size_t len) {
+static void w5500_txn(struct mg_tcpip_spi *s, uint8_t block, uint16_t addr,
+                      bool wr, void *buf, size_t len) {
+  size_t i;
   uint8_t *p = (uint8_t *) buf;
   uint8_t cmd[] = {(uint8_t) (addr >> 8), (uint8_t) (addr & 255),
                    (uint8_t) ((block << 3) | (wr ? 4 : 0))};
   s->begin(s->spi);
-  for (size_t i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
-  for (size_t i = 0; i < len; i++) {
+  for (i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
+  for (i = 0; i < len; i++) {
     uint8_t r = s->txn(s->spi, p[i]);
     if (!wr) p[i] = r;
   }
@@ -7401,15 +22064,16 @@ static size_t w5500_rx(void *buf, size_t buflen, struct mg_tcpip_if *ifp) {
   return r;
 }
 
-static size_t w5500_tx(const void *buf, size_t buflen, struct mg_tcpip_if *ifp) {
+static size_t w5500_tx(const void *buf, size_t buflen,
+                       struct mg_tcpip_if *ifp) {
   struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) ifp->driver_data;
-  uint16_t n = 0, len = (uint16_t) buflen;
+  uint16_t i, ptr, n = 0, len = (uint16_t) buflen;
   while (n < len) n = w5500_r2(s, W5500_S0, 0x20);      // Wait for space
-  uint16_t ptr = w5500_r2(s, W5500_S0, 0x24);           // Get write pointer
+  ptr = w5500_r2(s, W5500_S0, 0x24);                    // Get write pointer
   w5500_wn(s, W5500_TX0, ptr, (void *) buf, len);       // Write data
   w5500_w2(s, W5500_S0, 0x24, (uint16_t) (ptr + len));  // Advance write pointer
   w5500_w1(s, W5500_S0, 1, 0x20);                       // Sock0 CR -> SEND
-  for (int i = 0; i < 40; i++) {
+  for (i = 0; i < 40; i++) {
     uint8_t ir = w5500_r1(s, W5500_S0, 2);  // Read S0 IR
     if (ir == 0) continue;
     // printf("IR %d, len=%d, free=%d, ptr %d\n", ir, (int) len, (int) n, ptr);
@@ -7440,975 +22104,482 @@ static bool w5500_up(struct mg_tcpip_if *ifp) {
   return phycfgr & 1;  // Bit 0 of PHYCFGR is LNK (0 - down, 1 - up)
 }
 
-struct mg_tcpip_driver mg_tcpip_driver_w5500 = {w5500_init, w5500_tx, w5500_rx, w5500_up};
+struct mg_tcpip_driver mg_tcpip_driver_w5500 = {w5500_init, w5500_tx, w5500_rx,
+                                                w5500_up};
 #endif
 
 #ifdef MG_ENABLE_LINES
-#line 1 "src/tcpip/tcpip.c"
+#line 1 "src/drivers/xmc.c"
 #endif
 
 
-#if MG_ENABLE_TCPIP
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_XMC) && MG_ENABLE_DRIVER_XMC
 
-#define MG_EPHEMERAL_PORT_BASE 32768
-#define PDIFF(a, b) ((size_t) (((char *) (b)) - ((char *) (a))))
+struct ETH_GLOBAL_TypeDef {
+  volatile uint32_t MAC_CONFIGURATION, MAC_FRAME_FILTER, HASH_TABLE_HIGH,
+  HASH_TABLE_LOW, GMII_ADDRESS, GMII_DATA, FLOW_CONTROL, VLAN_TAG, VERSION,
+  DEBUG, REMOTE_WAKE_UP_FRAME_FILTER, PMT_CONTROL_STATUS, RESERVED[2],
+  INTERRUPT_STATUS, INTERRUPT_MASK, MAC_ADDRESS0_HIGH, MAC_ADDRESS0_LOW,
+  MAC_ADDRESS1_HIGH, MAC_ADDRESS1_LOW, MAC_ADDRESS2_HIGH, MAC_ADDRESS2_LOW,
+  MAC_ADDRESS3_HIGH, MAC_ADDRESS3_LOW, RESERVED1[40], MMC_CONTROL,
+  MMC_RECEIVE_INTERRUPT, MMC_TRANSMIT_INTERRUPT, MMC_RECEIVE_INTERRUPT_MASK,
+  MMC_TRANSMIT_INTERRUPT_MASK, TX_STATISTICS[26], RESERVED2,
+  RX_STATISTICS_1[26], RESERVED3[6], MMC_IPC_RECEIVE_INTERRUPT_MASK,
+  RESERVED4, MMC_IPC_RECEIVE_INTERRUPT, RESERVED5, RX_STATISTICS_2[30],
+  RESERVED7[286], TIMESTAMP_CONTROL, SUB_SECOND_INCREMENT,
+  SYSTEM_TIME_SECONDS, SYSTEM_TIME_NANOSECONDS,
+  SYSTEM_TIME_SECONDS_UPDATE, SYSTEM_TIME_NANOSECONDS_UPDATE,
+  TIMESTAMP_ADDEND, TARGET_TIME_SECONDS, TARGET_TIME_NANOSECONDS,
+  SYSTEM_TIME_HIGHER_WORD_SECONDS, TIMESTAMP_STATUS,
+  PPS_CONTROL, RESERVED8[564], BUS_MODE, TRANSMIT_POLL_DEMAND,
+  RECEIVE_POLL_DEMAND, RECEIVE_DESCRIPTOR_LIST_ADDRESS,
+  TRANSMIT_DESCRIPTOR_LIST_ADDRESS, STATUS, OPERATION_MODE,
+  INTERRUPT_ENABLE, MISSED_FRAME_AND_BUFFER_OVERFLOW_COUNTER,
+  RECEIVE_INTERRUPT_WATCHDOG_TIMER, RESERVED9, AHB_STATUS,
+  RESERVED10[6], CURRENT_HOST_TRANSMIT_DESCRIPTOR,
+  CURRENT_HOST_RECEIVE_DESCRIPTOR, CURRENT_HOST_TRANSMIT_BUFFER_ADDRESS,
+  CURRENT_HOST_RECEIVE_BUFFER_ADDRESS, HW_FEATURE;
+};
 
-#ifndef MIP_TCP_KEEPALIVE_MS
-#define MIP_TCP_KEEPALIVE_MS 45000  // TCP keep-alive period, ms
+#undef ETH0
+#define ETH0  ((struct ETH_GLOBAL_TypeDef*) 0x5000C000UL)
+
+#define ETH_PKT_SIZE 1536 // Max frame size
+#define ETH_DESC_CNT 4     // Descriptors count
+#define ETH_DS 4           // Descriptor size (words)
+
+#ifndef ETH_RAM_SECTION
+// if no section is specified, then the data will be placed in the default
+// bss section
+#define ETH_RAM_SECTION
 #endif
 
-#define MIP_TCP_ACK_MS 150  // Timeout for ACKing
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE] ETH_RAM_SECTION;
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE] ETH_RAM_SECTION;
+static uint32_t s_rxdesc[ETH_DESC_CNT][ETH_DS] ETH_RAM_SECTION;  // RX descriptors
+static uint32_t s_txdesc[ETH_DESC_CNT][ETH_DS] ETH_RAM_SECTION;  // TX descriptors
+static uint8_t s_txno;                           // Current TX descriptor
+static uint8_t s_rxno;                           // Current RX descriptor
 
-struct connstate {
-  uint32_t seq, ack;           // TCP seq/ack counters
-  uint64_t timer;              // TCP keep-alive / ACK timer
-  uint8_t mac[6];              // Peer MAC address
-  uint8_t ttype;               // Timer type. 0: ack, 1: keep-alive
-#define MIP_TTYPE_KEEPALIVE 0  // Connection is idle for long, send keepalive
-#define MIP_TTYPE_ACK 1        // Peer sent us data, we have to ack it soon
-  uint8_t tmiss;               // Number of keep-alive misses
-  struct mg_iobuf raw;         // For TLS only. Incoming raw data
-};
+static struct mg_tcpip_if *s_ifp;  // MIP interface
+enum { MG_PHY_ADDR = 0, MG_PHYREG_BCR = 0, MG_PHYREG_BSR = 1 };
 
-#pragma pack(push, 1)
-
-struct lcp {
-  uint8_t addr, ctrl, proto[2], code, id, len[2];
-};
-
-struct eth {
-  uint8_t dst[6];  // Destination MAC address
-  uint8_t src[6];  // Source MAC address
-  uint16_t type;   // Ethernet type
-};
-
-struct ip {
-  uint8_t ver;    // Version
-  uint8_t tos;    // Unused
-  uint16_t len;   // Length
-  uint16_t id;    // Unused
-  uint16_t frag;  // Fragmentation
-  uint8_t ttl;    // Time to live
-  uint8_t proto;  // Upper level protocol
-  uint16_t csum;  // Checksum
-  uint32_t src;   // Source IP
-  uint32_t dst;   // Destination IP
-};
-
-struct ip6 {
-  uint8_t ver;      // Version
-  uint8_t opts[3];  // Options
-  uint16_t len;     // Length
-  uint8_t proto;    // Upper level protocol
-  uint8_t ttl;      // Time to live
-  uint8_t src[16];  // Source IP
-  uint8_t dst[16];  // Destination IP
-};
-
-struct icmp {
-  uint8_t type;
-  uint8_t code;
-  uint16_t csum;
-};
-
-struct arp {
-  uint16_t fmt;    // Format of hardware address
-  uint16_t pro;    // Format of protocol address
-  uint8_t hlen;    // Length of hardware address
-  uint8_t plen;    // Length of protocol address
-  uint16_t op;     // Operation
-  uint8_t sha[6];  // Sender hardware address
-  uint32_t spa;    // Sender protocol address
-  uint8_t tha[6];  // Target hardware address
-  uint32_t tpa;    // Target protocol address
-};
-
-struct tcp {
-  uint16_t sport;  // Source port
-  uint16_t dport;  // Destination port
-  uint32_t seq;    // Sequence number
-  uint32_t ack;    // Acknowledgement number
-  uint8_t off;     // Data offset
-  uint8_t flags;   // TCP flags
-#define TH_FIN 0x01
-#define TH_SYN 0x02
-#define TH_RST 0x04
-#define TH_PUSH 0x08
-#define TH_ACK 0x10
-#define TH_URG 0x20
-#define TH_ECE 0x40
-#define TH_CWR 0x80
-  uint16_t win;   // Window
-  uint16_t csum;  // Checksum
-  uint16_t urp;   // Urgent pointer
-};
-
-struct udp {
-  uint16_t sport;  // Source port
-  uint16_t dport;  // Destination port
-  uint16_t len;    // UDP length
-  uint16_t csum;   // UDP checksum
-};
-
-struct dhcp {
-  uint8_t op, htype, hlen, hops;
-  uint32_t xid;
-  uint16_t secs, flags;
-  uint32_t ciaddr, yiaddr, siaddr, giaddr;
-  uint8_t hwaddr[208];
-  uint32_t magic;
-  uint8_t options[32];
-};
-
-#pragma pack(pop)
-
-struct pkt {
-  struct mg_str raw;  // Raw packet data
-  struct mg_str pay;  // Payload data
-  struct eth *eth;
-  struct llc *llc;
-  struct arp *arp;
-  struct ip *ip;
-  struct ip6 *ip6;
-  struct icmp *icmp;
-  struct tcp *tcp;
-  struct udp *udp;
-  struct dhcp *dhcp;
-};
-
-static void mkpay(struct pkt *pkt, void *p) {
-  pkt->pay =
-      mg_str_n((char *) p, (size_t) (&pkt->raw.ptr[pkt->raw.len] - (char *) p));
+static uint16_t eth_read_phy(uint8_t addr, uint8_t reg) {
+  ETH0->GMII_ADDRESS = (ETH0->GMII_ADDRESS & 0x3c) |
+                        ((uint32_t)addr << 11) |
+                        ((uint32_t)reg << 6) | 1;
+  while ((ETH0->GMII_ADDRESS & 1) != 0) (void) 0;
+  return (uint16_t)(ETH0->GMII_DATA & 0xffff);
 }
 
-static uint32_t csumup(uint32_t sum, const void *buf, size_t len) {
-  const uint8_t *p = (const uint8_t *) buf;
-  for (size_t i = 0; i < len; i++) sum += i & 1 ? p[i] : (uint32_t) (p[i] << 8);
-  return sum;
+static void eth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  ETH0->GMII_DATA  = val;
+  ETH0->GMII_ADDRESS = (ETH0->GMII_ADDRESS & 0x3c) |
+                        ((uint32_t)addr << 11) |
+                        ((uint32_t)reg << 6) | 3;
+  while ((ETH0->GMII_ADDRESS & 1) != 0) (void) 0;
 }
 
-static uint16_t csumfin(uint32_t sum) {
-  while (sum >> 16) sum = (sum & 0xffff) + (sum >> 16);
-  return mg_htons(~sum & 0xffff);
-}
-
-static uint16_t ipcsum(const void *buf, size_t len) {
-  uint32_t sum = csumup(0, buf, len);
-  return csumfin(sum);
-}
-
-static size_t ether_output(struct mg_tcpip_if *ifp, size_t len) {
-  // size_t min = 64;  // Pad short frames to 64 bytes (minimum Ethernet size)
-  // if (len < min) memset(ifp->tx.ptr + len, 0, min - len), len = min;
-  // mg_hexdump(ifp->tx.ptr, len);
-  size_t n = ifp->driver->tx(ifp->tx.ptr, len, ifp);
-  if (n == len) ifp->nsent++;
-  return n;
-}
-
-static void arp_ask(struct mg_tcpip_if *ifp, uint32_t ip) {
-  struct eth *eth = (struct eth *) ifp->tx.ptr;
-  struct arp *arp = (struct arp *) (eth + 1);
-  memset(eth->dst, 255, sizeof(eth->dst));
-  memcpy(eth->src, ifp->mac, sizeof(eth->src));
-  eth->type = mg_htons(0x806);
-  memset(arp, 0, sizeof(*arp));
-  arp->fmt = mg_htons(1), arp->pro = mg_htons(0x800), arp->hlen = 6,
-  arp->plen = 4;
-  arp->op = mg_htons(1), arp->tpa = ip, arp->spa = ifp->ip;
-  memcpy(arp->sha, ifp->mac, sizeof(arp->sha));
-  ether_output(ifp, PDIFF(eth, arp + 1));
-}
-
-static void onstatechange(struct mg_tcpip_if *ifp) {
-  if (ifp->state == MG_TCPIP_STATE_READY) {
-    MG_INFO(("READY, IP: %M", mg_print_ip4, &ifp->ip));
-    MG_INFO(("       GW: %M", mg_print_ip4, &ifp->gw));
-    if (ifp->lease_expire > ifp->now) {
-      MG_INFO(
-          ("       Lease: %lld sec", (ifp->lease_expire - ifp->now) / 1000));
-    }
-    arp_ask(ifp, ifp->gw);
-  } else if (ifp->state == MG_TCPIP_STATE_UP) {
-    MG_ERROR(("Link up"));
-    srand((unsigned int) mg_millis());
-  } else if (ifp->state == MG_TCPIP_STATE_DOWN) {
-    MG_ERROR(("Link down"));
+static uint32_t get_clock_rate(struct mg_tcpip_driver_xmc_data *d) {
+  if (d->mdc_cr == -1) {
+    // assume ETH clock is 60MHz by default
+    // then according to 13.2.8.1, we need to set value 3
+    return 3;
   }
+
+  return d->mdc_cr;
 }
 
-static struct ip *tx_ip(struct mg_tcpip_if *ifp, uint8_t *mac_dst,
-                        uint8_t proto, uint32_t ip_src, uint32_t ip_dst,
-                        size_t plen) {
-  struct eth *eth = (struct eth *) ifp->tx.ptr;
-  struct ip *ip = (struct ip *) (eth + 1);
-  memcpy(eth->dst, mac_dst, sizeof(eth->dst));
-  memcpy(eth->src, ifp->mac, sizeof(eth->src));  // Use our MAC
-  eth->type = mg_htons(0x800);
-  memset(ip, 0, sizeof(*ip));
-  ip->ver = 0x45;   // Version 4, header length 5 words
-  ip->frag = 0x40;  // Don't fragment
-  ip->len = mg_htons((uint16_t) (sizeof(*ip) + plen));
-  ip->ttl = 64;
-  ip->proto = proto;
-  ip->src = ip_src;
-  ip->dst = ip_dst;
-  ip->csum = ipcsum(ip, sizeof(*ip));
-  return ip;
-}
+static bool mg_tcpip_driver_xmc_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_xmc_data *d =
+      (struct mg_tcpip_driver_xmc_data *) ifp->driver_data;
+  s_ifp = ifp;
 
-static void tx_udp(struct mg_tcpip_if *ifp, uint8_t *mac_dst, uint32_t ip_src,
-                   uint16_t sport, uint32_t ip_dst, uint16_t dport,
-                   const void *buf, size_t len) {
-  struct ip *ip =
-      tx_ip(ifp, mac_dst, 17, ip_src, ip_dst, len + sizeof(struct udp));
-  struct udp *udp = (struct udp *) (ip + 1);
-  // MG_DEBUG(("UDP XX LEN %d %d", (int) len, (int) ifp->tx.len));
-  udp->sport = sport;
-  udp->dport = dport;
-  udp->len = mg_htons((uint16_t) (sizeof(*udp) + len));
-  udp->csum = 0;
-  uint32_t cs = csumup(0, udp, sizeof(*udp));
-  cs = csumup(cs, buf, len);
-  cs = csumup(cs, &ip->src, sizeof(ip->src));
-  cs = csumup(cs, &ip->dst, sizeof(ip->dst));
-  cs += (uint32_t) (ip->proto + sizeof(*udp) + len);
-  udp->csum = csumfin(cs);
-  memmove(udp + 1, buf, len);
-  // MG_DEBUG(("UDP LEN %d %d", (int) len, (int) ifp->frame_len));
-  ether_output(ifp, sizeof(struct eth) + sizeof(*ip) + sizeof(*udp) + len);
-}
+  // reset MAC
+  ETH0->BUS_MODE |= 1;
+  while (ETH0->BUS_MODE & 1) (void) 0;
 
-static void tx_dhcp(struct mg_tcpip_if *ifp, uint8_t *mac_dst, uint32_t ip_src,
-                    uint32_t ip_dst, uint8_t *opts, size_t optslen) {
-  struct dhcp dhcp = {1, 1, 6, 0, 0, 0, 0, 0, 0, 0, 0, {0}, 0, {0}};
-  dhcp.magic = mg_htonl(0x63825363);
-  memcpy(&dhcp.hwaddr, ifp->mac, sizeof(ifp->mac));
-  memcpy(&dhcp.xid, ifp->mac + 2, sizeof(dhcp.xid));
-  memcpy(&dhcp.options, opts, optslen);
-  tx_udp(ifp, mac_dst, ip_src, mg_htons(68), ip_dst, mg_htons(67), &dhcp,
-         sizeof(dhcp));
-}
+  // set clock rate
+  ETH0->GMII_ADDRESS = get_clock_rate(d) << 2;
 
-static void tx_dhcp_request(struct mg_tcpip_if *ifp, uint8_t *mac_dst,
-                            uint32_t ip_src, uint32_t ip_dst) {
-  uint8_t opts[] = {
-      53, 1, 3,                 // Type: DHCP request
-      55, 2, 1,   3,            // GW and mask
-      12, 3, 'm', 'i', 'p',     // Host name: "mip"
-      54, 4, 0,   0,   0,   0,  // DHCP server ID
-      50, 4, 0,   0,   0,   0,  // Requested IP
-      255                       // End of options
-  };
-  memcpy(opts + 14, &ip_dst, sizeof(ip_dst));
-  memcpy(opts + 20, &ip_src, sizeof(ip_src));
-  tx_dhcp(ifp, mac_dst, ip_src, ip_dst, opts, sizeof(opts));
-}
+  // init phy
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  mg_phy_init(&phy, d->phy_addr, MG_PHY_CLOCKS_MAC);
 
-static void tx_dhcp_discover(struct mg_tcpip_if *ifp) {
-  uint8_t mac[6] = {255, 255, 255, 255, 255, 255};
-  uint8_t opts[] = {
-      53, 1, 1,     // Type: DHCP discover
-      55, 2, 1, 3,  // Parameters: ip, mask
-      255           // End of options
-  };
-  tx_dhcp(ifp, mac, 0, 0xffffffff, opts, sizeof(opts));
-  MG_DEBUG(("DHCP discover sent"));
-}
+  // configure MAC: DO, DM, FES, TC
+  ETH0->MAC_CONFIGURATION = MG_BIT(13) | MG_BIT(11) | MG_BIT(14) | MG_BIT(24);
 
-static struct mg_connection *getpeer(struct mg_mgr *mgr, struct pkt *pkt,
-                                     bool lsn) {
-  struct mg_connection *c = NULL;
-  for (c = mgr->conns; c != NULL; c = c->next) {
-    if (c->is_udp && pkt->udp && c->loc.port == pkt->udp->dport) break;
-    if (!c->is_udp && pkt->tcp && c->loc.port == pkt->tcp->dport &&
-        lsn == c->is_listening && (lsn || c->rem.port == pkt->tcp->sport))
-      break;
-  }
-  return c;
-}
+  // set the MAC address
+  ETH0->MAC_ADDRESS0_HIGH = MG_U32(0, 0, ifp->mac[5], ifp->mac[4]);
+  ETH0->MAC_ADDRESS0_LOW = 
+        MG_U32(ifp->mac[3], ifp->mac[2], ifp->mac[1], ifp->mac[0]);
 
-static void rx_arp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  if (pkt->arp->op == mg_htons(1) && pkt->arp->tpa == ifp->ip) {
-    // ARP request. Make a response, then send
-    // MG_DEBUG(("ARP op %d %M: %M", mg_ntohs(pkt->arp->op), mg_print_ip4,
-    //          &pkt->arp->spa, mg_print_ip4, &pkt->arp->tpa));
-    struct eth *eth = (struct eth *) ifp->tx.ptr;
-    struct arp *arp = (struct arp *) (eth + 1);
-    memcpy(eth->dst, pkt->eth->src, sizeof(eth->dst));
-    memcpy(eth->src, ifp->mac, sizeof(eth->src));
-    eth->type = mg_htons(0x806);
-    *arp = *pkt->arp;
-    arp->op = mg_htons(2);
-    memcpy(arp->tha, pkt->arp->sha, sizeof(pkt->arp->tha));
-    memcpy(arp->sha, ifp->mac, sizeof(pkt->arp->sha));
-    arp->tpa = pkt->arp->spa;
-    arp->spa = ifp->ip;
-    MG_DEBUG(("ARP: tell %M we're %M", mg_print_ip4, &arp->tpa, mg_print_ip4,
-              &ifp->ip));
-    ether_output(ifp, PDIFF(eth, arp + 1));
-  } else if (pkt->arp->op == mg_htons(2)) {
-    if (memcmp(pkt->arp->tha, ifp->mac, sizeof(pkt->arp->tha)) != 0) return;
-    if (pkt->arp->spa == ifp->gw) {
-      // Got response for the GW ARP request. Set ifp->gwmac
-      memcpy(ifp->gwmac, pkt->arp->sha, sizeof(ifp->gwmac));
+  // Configure the receive filter
+  ETH0->MAC_FRAME_FILTER = MG_BIT(10) | MG_BIT(2); // HFP, HMC
+  // Disable flow control
+  ETH0->FLOW_CONTROL = 0;
+  // Enable store and forward mode
+  ETH0->OPERATION_MODE = MG_BIT(25) | MG_BIT(21); // RSF, TSF
+
+  // Configure DMA bus mode (AAL, USP, RPBL, PBL)
+  ETH0->BUS_MODE = MG_BIT(25) | MG_BIT(23) | (32 << 17) |  (32 << 8);
+
+  // init RX descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    s_rxdesc[i][0] = MG_BIT(31); // OWN descriptor
+    s_rxdesc[i][1] = MG_BIT(14) | ETH_PKT_SIZE;
+    s_rxdesc[i][2] = (uint32_t) s_rxbuf[i];
+    if (i == ETH_DESC_CNT - 1) {
+      s_rxdesc[i][3] = (uint32_t) &s_rxdesc[0][0];
     } else {
-      struct mg_connection *c = getpeer(ifp->mgr, pkt, false);
-      if (c != NULL && c->is_arplooking) {
-        struct connstate *s = (struct connstate *) (c + 1);
-        memcpy(s->mac, pkt->arp->sha, sizeof(s->mac));
-        MG_DEBUG(("%lu ARP resolved %M -> %M", c->id, mg_print_ip4, &c->rem.ip,
-                  mg_print_mac, s->mac));
-        c->is_arplooking = 0;
-      }
+      s_rxdesc[i][3] = (uint32_t) &s_rxdesc[i + 1][0];
     }
   }
-}
+  ETH0->RECEIVE_DESCRIPTOR_LIST_ADDRESS = (uint32_t) &s_rxdesc[0][0];
 
-static void rx_icmp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  // MG_DEBUG(("ICMP %d", (int) len));
-  if (pkt->icmp->type == 8 && pkt->ip != NULL && pkt->ip->dst == ifp->ip) {
-    size_t hlen = sizeof(struct eth) + sizeof(struct ip) + sizeof(struct icmp);
-    size_t space = ifp->tx.len - hlen, plen = pkt->pay.len;
-    if (plen > space) plen = space;
-    struct ip *ip = tx_ip(ifp, pkt->eth->src, 1, ifp->ip, pkt->ip->src,
-                          sizeof(struct icmp) + plen);
-    struct icmp *icmp = (struct icmp *) (ip + 1);
-    memset(icmp, 0, sizeof(*icmp));        // Set csum to 0
-    memcpy(icmp + 1, pkt->pay.ptr, plen);  // Copy RX payload to TX
-    icmp->csum = ipcsum(icmp, sizeof(*icmp) + plen);
-    ether_output(ifp, hlen + plen);
-  }
-}
-
-static void rx_dhcp_client(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  uint32_t ip = 0, gw = 0, mask = 0;
-  uint8_t *p = pkt->dhcp->options,
-          *end = (uint8_t *) &pkt->raw.ptr[pkt->raw.len];
-  if (end < (uint8_t *) (pkt->dhcp + 1)) return;
-  while (p + 1 < end && p[0] != 255) {  // Parse options
-    if (p[0] == 1 && p[1] == sizeof(ifp->mask) && p + 6 < end) {  // Mask
-      memcpy(&mask, p + 2, sizeof(mask));
-    } else if (p[0] == 3 && p[1] == sizeof(ifp->gw) && p + 6 < end) {  // GW
-      memcpy(&gw, p + 2, sizeof(gw));
-      ip = pkt->dhcp->yiaddr;
-    } else if (p[0] == 51 && p[1] == 4 && p + 6 < end) {  // Lease
-      uint32_t lease = 0;
-      memcpy(&lease, p + 2, sizeof(lease));
-      ifp->lease_expire = ifp->now + mg_ntohl(lease) * 1000;
-    }
-    p += p[1] + 2;
-  }
-  if (ip && mask && gw && ifp->ip == 0) {
-    memcpy(ifp->gwmac, pkt->eth->src, sizeof(ifp->gwmac));
-    ifp->ip = ip, ifp->gw = gw, ifp->mask = mask;
-    ifp->state = MG_TCPIP_STATE_READY;
-    onstatechange(ifp);
-    tx_dhcp_request(ifp, pkt->eth->src, ip, pkt->dhcp->siaddr);
-    uint64_t rand;
-    mg_random(&rand, sizeof(rand));
-    srand((unsigned int) (rand + mg_millis()));
-  }
-}
-
-// Simple DHCP server that assigns a next IP address: ifp->ip + 1
-static void rx_dhcp_server(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  uint8_t op = 0, *p = pkt->dhcp->options,
-          *end = (uint8_t *) &pkt->raw.ptr[pkt->raw.len];
-  if (end < (uint8_t *) (pkt->dhcp + 1)) return;
-  // struct dhcp *req = pkt->dhcp;
-  struct dhcp res = {2, 1, 6, 0, 0, 0, 0, 0, 0, 0, 0, {0}, 0, {0}};
-  res.yiaddr = ifp->ip;
-  ((uint8_t *) (&res.yiaddr))[3]++;                // Offer our IP + 1
-  while (p + 1 < end && p[0] != 255) {             // Parse options
-    if (p[0] == 53 && p[1] == 1 && p + 2 < end) {  // Message type
-      op = p[2];
-    }
-    p += p[1] + 2;
-  }
-  if (op == 1 || op == 3) {         // DHCP Discover or DHCP Request
-    uint8_t msg = op == 1 ? 2 : 5;  // Message type: DHCP OFFER or DHCP ACK
-    uint8_t opts[] = {
-        53, 1, msg,                 // Message type
-        1,  4, 0,   0,   0,   0,    // Subnet mask
-        54, 4, 0,   0,   0,   0,    // Server ID
-        12, 3, 'm', 'i', 'p',       // Host name: "mip"
-        51, 4, 255, 255, 255, 255,  // Lease time
-        255                         // End of options
-    };
-    memcpy(&res.hwaddr, pkt->dhcp->hwaddr, 6);
-    memcpy(opts + 5, &ifp->mask, sizeof(ifp->mask));
-    memcpy(opts + 11, &ifp->ip, sizeof(ifp->ip));
-    memcpy(&res.options, opts, sizeof(opts));
-    res.magic = pkt->dhcp->magic;
-    res.xid = pkt->dhcp->xid;
-    // memcpy(ifp->gwmac, pkt->eth->src, sizeof(ifp->gwmac));
-    tx_udp(ifp, pkt->eth->src, ifp->ip, mg_htons(67),
-           op == 1 ? ~0U : res.yiaddr, mg_htons(68), &res, sizeof(res));
-  }
-}
-
-static void rx_udp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  struct mg_connection *c = getpeer(ifp->mgr, pkt, true);
-  if (c == NULL) {
-    // No UDP listener on this port. Should send ICMP, but keep silent.
-  } else {
-    c->rem.port = pkt->udp->sport;
-    c->rem.ip = pkt->ip->src;
-    struct connstate *s = (struct connstate *) (c + 1);
-    memcpy(s->mac, pkt->eth->src, sizeof(s->mac));
-    if (c->recv.len >= MG_MAX_RECV_SIZE) {
-      mg_error(c, "max_recv_buf_size reached");
-    } else if (c->recv.size - c->recv.len < pkt->pay.len &&
-               !mg_iobuf_resize(&c->recv, c->recv.len + pkt->pay.len)) {
-      mg_error(c, "oom");
+  // init TX descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    s_txdesc[i][0] = MG_BIT(30) | MG_BIT(20);
+    s_txdesc[i][2] = (uint32_t) s_txbuf[i];
+    if (i == ETH_DESC_CNT - 1) {
+      s_txdesc[i][3] = (uint32_t) &s_txdesc[0][0];
     } else {
-      memcpy(&c->recv.buf[c->recv.len], pkt->pay.ptr, pkt->pay.len);
-      c->recv.len += pkt->pay.len;
-      mg_call(c, MG_EV_READ, &pkt->pay.len);
+      s_txdesc[i][3] = (uint32_t) &s_txdesc[i + 1][0];
     }
   }
-}
+  ETH0->TRANSMIT_DESCRIPTOR_LIST_ADDRESS = (uint32_t) &s_txdesc[0][0];
 
-static size_t tx_tcp(struct mg_tcpip_if *ifp, uint8_t *dst_mac, uint32_t dst_ip,
-                     uint8_t flags, uint16_t sport, uint16_t dport,
-                     uint32_t seq, uint32_t ack, const void *buf, size_t len) {
-  struct ip *ip =
-      tx_ip(ifp, dst_mac, 6, ifp->ip, dst_ip, sizeof(struct tcp) + len);
-  struct tcp *tcp = (struct tcp *) (ip + 1);
-  memset(tcp, 0, sizeof(*tcp));
-  if (buf != NULL && len) memmove(tcp + 1, buf, len);
-  tcp->sport = sport;
-  tcp->dport = dport;
-  tcp->seq = seq;
-  tcp->ack = ack;
-  tcp->flags = flags;
-  tcp->win = mg_htons(8192);
-  tcp->off = (uint8_t) (sizeof(*tcp) / 4 << 4);
-  uint32_t cs = 0;
-  uint16_t n = (uint16_t) (sizeof(*tcp) + len);
-  uint8_t pseudo[] = {0, ip->proto, (uint8_t) (n >> 8), (uint8_t) (n & 255)};
-  cs = csumup(cs, tcp, n);
-  cs = csumup(cs, &ip->src, sizeof(ip->src));
-  cs = csumup(cs, &ip->dst, sizeof(ip->dst));
-  cs = csumup(cs, pseudo, sizeof(pseudo));
-  tcp->csum = csumfin(cs);
-  MG_DEBUG(("TCP %M:%hu -> %M:%hu fl %x len %u", mg_print_ip4, &ip->src,
-            mg_ntohs(tcp->sport), mg_print_ip4, &ip->dst, mg_ntohs(tcp->dport),
-            tcp->flags, (int) len));
-  return ether_output(ifp, PDIFF(ifp->tx.ptr, tcp + 1) + len);
-}
+  // Clear interrupts
+  ETH0->STATUS = 0xFFFFFFFF;
 
-static size_t tx_tcp_pkt(struct mg_tcpip_if *ifp, struct pkt *pkt,
-                         uint8_t flags, uint32_t seq, const void *buf,
-                         size_t len) {
-  uint32_t delta = (pkt->tcp->flags & (TH_SYN | TH_FIN)) ? 1 : 0;
-  return tx_tcp(ifp, pkt->eth->src, pkt->ip->src, flags, pkt->tcp->dport,
-                pkt->tcp->sport, seq, mg_htonl(mg_ntohl(pkt->tcp->seq) + delta),
-                buf, len);
-}
+  // Disable MAC interrupts
+  ETH0->MMC_TRANSMIT_INTERRUPT_MASK = 0xFFFFFFFF;
+  ETH0->MMC_RECEIVE_INTERRUPT_MASK = 0xFFFFFFFF;
+  ETH0->MMC_IPC_RECEIVE_INTERRUPT_MASK = 0xFFFFFFFF;
+  ETH0->INTERRUPT_MASK = MG_BIT(9) | MG_BIT(3); // TSIM, PMTIM
 
-static void settmout(struct mg_connection *c, uint8_t type) {
-  struct mg_tcpip_if *ifp = (struct mg_tcpip_if *) c->mgr->priv;
-  struct connstate *s = (struct connstate *) (c + 1);
-  unsigned n = type == MIP_TTYPE_ACK ? MIP_TCP_ACK_MS : MIP_TCP_KEEPALIVE_MS;
-  s->timer = ifp->now + n;
-  s->ttype = type;
-  MG_VERBOSE(("%lu %d -> %llx", c->id, type, s->timer));
-}
+  //Enable interrupts (NIE, RIE, TIE)
+  ETH0->INTERRUPT_ENABLE = MG_BIT(16) | MG_BIT(6) | MG_BIT(0);
 
-static struct mg_connection *accept_conn(struct mg_connection *lsn,
-                                         struct pkt *pkt) {
-  struct mg_connection *c = mg_alloc_conn(lsn->mgr);
-  if (c == NULL) {
-    MG_ERROR(("OOM"));
-    return NULL;
-  }
-  struct connstate *s = (struct connstate *) (c + 1);
-  s->seq = mg_ntohl(pkt->tcp->ack), s->ack = mg_ntohl(pkt->tcp->seq);
-  memcpy(s->mac, pkt->eth->src, sizeof(s->mac));
-  settmout(c, MIP_TTYPE_KEEPALIVE);
-  c->rem.ip = pkt->ip->src;
-  c->rem.port = pkt->tcp->sport;
-  MG_DEBUG(("%lu accepted %M", c->id, mg_print_ip_port, &c->rem));
-  LIST_ADD_HEAD(struct mg_connection, &lsn->mgr->conns, c);
-  c->is_accepted = 1;
-  c->is_hexdumping = lsn->is_hexdumping;
-  c->pfn = lsn->pfn;
-  c->loc = lsn->loc;
-  c->pfn_data = lsn->pfn_data;
-  c->fn = lsn->fn;
-  c->fn_data = lsn->fn_data;
-  mg_call(c, MG_EV_OPEN, NULL);
-  mg_call(c, MG_EV_ACCEPT, NULL);
-  return c;
-}
-
-long mg_io_send(struct mg_connection *c, const void *buf, size_t len) {
-  struct mg_tcpip_if *ifp = (struct mg_tcpip_if *) c->mgr->priv;
-  struct connstate *s = (struct connstate *) (c + 1);
-  if (c->is_udp) {
-    size_t max_headers_len = 14 + 24 /* max IP */ + 8 /* UDP */;
-    if (len + max_headers_len > ifp->tx.len) len = ifp->tx.len - max_headers_len;
-    tx_udp(ifp, s->mac, ifp->ip, c->loc.port, c->rem.ip, c->rem.port, buf, len);
-  } else {
-    size_t max_headers_len = 14 + 24 /* max IP */ + 60 /* max TCP */;
-    if (len + max_headers_len > ifp->tx.len) len = ifp->tx.len - max_headers_len;
-    if (tx_tcp(ifp, s->mac, c->rem.ip, TH_PUSH | TH_ACK, c->loc.port, c->rem.port,
-               mg_htonl(s->seq), mg_htonl(s->ack), buf, len) > 0) {
-      s->seq += (uint32_t) len;
-      if (s->ttype == MIP_TTYPE_ACK) settmout(c, MIP_TTYPE_KEEPALIVE);
-    } else {
-      return MG_IO_ERR;
-    }
-  }
-  return (long) len;
-}
-
-long mg_io_recv(struct mg_connection *c, void *buf, size_t len) {
-  struct connstate *s = (struct connstate *) (c + 1);
-  if (s->raw.len == 0) return MG_IO_WAIT;
-  if (len > s->raw.len) len = s->raw.len;
-  memcpy(buf, s->raw.buf, len);
-  mg_iobuf_del(&s->raw, 0, len);
-  MG_DEBUG(("%lu", len));
-  return (long) len;
-}
-
-static void read_conn(struct mg_connection *c, struct pkt *pkt) {
-  struct connstate *s = (struct connstate *) (c + 1);
-  struct mg_iobuf *io = c->is_tls ? &s->raw : &c->recv;
-  uint32_t seq = mg_ntohl(pkt->tcp->seq);
-  s->raw.align = c->recv.align;
-  if (pkt->tcp->flags & TH_FIN) {
-    s->ack = mg_htonl(pkt->tcp->seq) + 1, s->seq = mg_htonl(pkt->tcp->ack);
-    c->is_closing = 1;
-  } else if (pkt->pay.len == 0) {
-    // TODO(cpq): handle this peer's ACK
-  } else if (seq != s->ack) {
-    uint32_t ack = (uint32_t) (mg_htonl(pkt->tcp->seq) + pkt->pay.len);
-    if (s->ack == ack) {
-      MG_VERBOSE(("ignoring duplicate pkt"));
-    } else {
-      // TODO(cpq): peer sent us SEQ which we don't expect. Retransmit rather
-      // than close this connection
-      mg_error(c, "SEQ != ACK: %x %x %x", seq, s->ack, ack);
-    }
-  } else if (io->size - io->len < pkt->pay.len &&
-             !mg_iobuf_resize(io, io->len + pkt->pay.len)) {
-    mg_error(c, "oom");
-  } else {
-    // Copy TCP payload into the IO buffer. If the connection is plain text, we
-    // copy to c->recv. If the connection is TLS, this data is encrypted,
-    // therefore we copy that encrypted data to the s->raw iobuffer instead,
-    // and then call mg_tls_recv() to decrypt it. NOTE: mg_tls_recv() will
-    // call back mg_io_recv() which grabs raw data from s->raw
-    memcpy(&io->buf[io->len], pkt->pay.ptr, pkt->pay.len);
-    io->len += pkt->pay.len;
-
-    MG_DEBUG(("%lu SEQ %x -> %x", c->id, mg_htonl(pkt->tcp->seq), s->ack));
-    // Advance ACK counter
-    s->ack = (uint32_t) (mg_htonl(pkt->tcp->seq) + pkt->pay.len);
-#if 0
-    // Send ACK immediately
-    MG_DEBUG(("  imm ACK", c->id, mg_htonl(pkt->tcp->seq), s->ack));
-    tx_tcp((struct mg_tcpip_if *) c->mgr->priv, c->rem.ip, TH_ACK, c->loc.port,
-           c->rem.port, mg_htonl(s->seq), mg_htonl(s->ack), "", 0);
-#else
-    // if not already running, setup a timer to send an ACK later
-    if (s->ttype != MIP_TTYPE_ACK) settmout(c, MIP_TTYPE_ACK);
-#endif
-
-    if (c->is_tls) {
-      // TLS connection. Make room for decrypted data in c->recv
-      io = &c->recv;
-      if (io->size - io->len < pkt->pay.len &&
-          !mg_iobuf_resize(io, io->len + pkt->pay.len)) {
-        mg_error(c, "oom");
-      } else {
-        // Decrypt data directly into c->recv
-        long n = mg_tls_recv(c, &io->buf[io->len], io->size - io->len);
-        if (n == MG_IO_ERR) {
-          mg_error(c, "TLS recv error");
-        } else if (n > 0) {
-          // Decrypted successfully - trigger MG_EV_READ
-          io->len += (size_t) n;
-          mg_call(c, MG_EV_READ, &n);
-        }
-      }
-    } else {
-      // Plain text connection, data is already in c->recv, trigger MG_EV_READ
-      mg_call(c, MG_EV_READ, &pkt->pay.len);
-    }
-  }
-}
-
-static void rx_tcp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  struct mg_connection *c = getpeer(ifp->mgr, pkt, false);
-  struct connstate *s = c == NULL ? NULL : (struct connstate *) (c + 1);
-#if 0
-  MG_INFO(("%lu %hhu %d", c ? c->id : 0, pkt->tcp->flags, (int) pkt->pay.len));
-#endif
-  if (c != NULL && c->is_connecting && pkt->tcp->flags & (TH_SYN | TH_ACK)) {
-    s->seq = mg_ntohl(pkt->tcp->ack), s->ack = mg_ntohl(pkt->tcp->seq) + 1;
-    tx_tcp_pkt(ifp, pkt, TH_ACK, pkt->tcp->ack, NULL, 0);
-    c->is_connecting = 0;  // Client connected
-    settmout(c, MIP_TTYPE_KEEPALIVE);
-    mg_call(c, MG_EV_CONNECT, NULL);  // Let user know
-  } else if (c != NULL && c->is_connecting) {
-    tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
-  } else if (c != NULL && pkt->tcp->flags & TH_RST) {
-    mg_error(c, "peer RST");  // RFC-1122 4.2.2.13
-  } else if (c != NULL) {
-#if 0
-    MG_DEBUG(("%lu %d %M:%hu -> %M:%hu", c->id, (int) pkt->raw.len,
-              mg_print_ip4, &pkt->ip->src, mg_ntohs(pkt->tcp->sport),
-              mg_print_ip4, &pkt->ip->dst, mg_ntohs(pkt->tcp->dport)));
-    mg_hexdump(pkt->pay.buf, pkt->pay.len);
-#endif
-    s->tmiss = 0;                         // Reset missed keep-alive counter
-    if (s->ttype == MIP_TTYPE_KEEPALIVE)  // Advance keep-alive timer
-      settmout(c,
-               MIP_TTYPE_KEEPALIVE);  // unless a former ACK timeout is pending
-    read_conn(c, pkt);  // Override timer with ACK timeout if needed
-  } else if ((c = getpeer(ifp->mgr, pkt, true)) == NULL) {
-    tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
-  } else if (pkt->tcp->flags & TH_RST) {
-    if (c->is_accepted) mg_error(c, "peer RST");  // RFC-1122 4.2.2.13
-    // ignore RST if not connected
-  } else if (pkt->tcp->flags & TH_SYN) {
-    // Use peer's source port as ISN, in order to recognise the handshake
-    uint32_t isn = mg_htonl((uint32_t) mg_ntohs(pkt->tcp->sport));
-    tx_tcp_pkt(ifp, pkt, TH_SYN | TH_ACK, isn, NULL, 0);
-  } else if (pkt->tcp->flags & TH_FIN) {
-    tx_tcp_pkt(ifp, pkt, TH_FIN | TH_ACK, pkt->tcp->ack, NULL, 0);
-  } else if (mg_htonl(pkt->tcp->ack) == mg_htons(pkt->tcp->sport) + 1U) {
-    accept_conn(c, pkt);
-  } else if (!c->is_accepted) {  // no peer
-    tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
-  } else {
-    // MG_DEBUG(("dropped silently.."));
-  }
-}
-
-static void rx_ip(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  if (pkt->ip->proto == 1) {
-    pkt->icmp = (struct icmp *) (pkt->ip + 1);
-    if (pkt->pay.len < sizeof(*pkt->icmp)) return;
-    mkpay(pkt, pkt->icmp + 1);
-    rx_icmp(ifp, pkt);
-  } else if (pkt->ip->proto == 17) {
-    pkt->udp = (struct udp *) (pkt->ip + 1);
-    if (pkt->pay.len < sizeof(*pkt->udp)) return;
-    mkpay(pkt, pkt->udp + 1);
-    MG_DEBUG(("UDP %M:%hu -> %M:%hu len %u", mg_print_ip4, &pkt->ip->src,
-              mg_ntohs(pkt->udp->sport), mg_print_ip4, &pkt->ip->dst,
-              mg_ntohs(pkt->udp->dport), (int) pkt->pay.len));
-    if (pkt->udp->dport == mg_htons(68)) {
-      pkt->dhcp = (struct dhcp *) (pkt->udp + 1);
-      mkpay(pkt, pkt->dhcp + 1);
-      rx_dhcp_client(ifp, pkt);
-    } else if (ifp->enable_dhcp_server && pkt->udp->dport == mg_htons(67)) {
-      pkt->dhcp = (struct dhcp *) (pkt->udp + 1);
-      mkpay(pkt, pkt->dhcp + 1);
-      rx_dhcp_server(ifp, pkt);
-    } else {
-      rx_udp(ifp, pkt);
-    }
-  } else if (pkt->ip->proto == 6) {
-    pkt->tcp = (struct tcp *) (pkt->ip + 1);
-    if (pkt->pay.len < sizeof(*pkt->tcp)) return;
-    mkpay(pkt, pkt->tcp + 1);
-    uint16_t iplen = mg_ntohs(pkt->ip->len);
-    uint16_t off = (uint16_t) (sizeof(*pkt->ip) + ((pkt->tcp->off >> 4) * 4U));
-    if (iplen >= off) pkt->pay.len = (size_t) (iplen - off);
-    MG_DEBUG(("TCP %M:%hu -> %M:%hu len %u", mg_print_ip4, &pkt->ip->src,
-              mg_ntohs(pkt->tcp->sport), mg_print_ip4, &pkt->ip->dst,
-              mg_ntohs(pkt->tcp->dport), (int) pkt->pay.len));
-    rx_tcp(ifp, pkt);
-  }
-}
-
-static void rx_ip6(struct mg_tcpip_if *ifp, struct pkt *pkt) {
-  // MG_DEBUG(("IP %d", (int) len));
-  if (pkt->ip6->proto == 1 || pkt->ip6->proto == 58) {
-    pkt->icmp = (struct icmp *) (pkt->ip6 + 1);
-    if (pkt->pay.len < sizeof(*pkt->icmp)) return;
-    mkpay(pkt, pkt->icmp + 1);
-    rx_icmp(ifp, pkt);
-  } else if (pkt->ip6->proto == 17) {
-    pkt->udp = (struct udp *) (pkt->ip6 + 1);
-    if (pkt->pay.len < sizeof(*pkt->udp)) return;
-    // MG_DEBUG(("  UDP %u %u -> %u", len, mg_htons(udp->sport),
-    // mg_htons(udp->dport)));
-    mkpay(pkt, pkt->udp + 1);
-  }
-}
-
-static void mg_tcpip_rx(struct mg_tcpip_if *ifp, void *buf, size_t len) {
-  const uint8_t broadcast[] = {255, 255, 255, 255, 255, 255};
-  struct pkt pkt;
-  memset(&pkt, 0, sizeof(pkt));
-  pkt.raw.ptr = (char *) buf;
-  pkt.raw.len = len;
-  pkt.eth = (struct eth *) buf;
-  if (pkt.raw.len < sizeof(*pkt.eth)) return;  // Truncated - runt?
-  if (ifp->enable_mac_check &&
-      memcmp(pkt.eth->dst, ifp->mac, sizeof(pkt.eth->dst)) != 0 &&
-      memcmp(pkt.eth->dst, broadcast, sizeof(pkt.eth->dst)) != 0)
-    return;
-  if (ifp->enable_crc32_check && len > 4) {
-    len -= 4;  // TODO(scaprile): check on bigendian
-    uint32_t crc = mg_crc32(0, (const char *) buf, len);
-    if (memcmp((void *) ((size_t) buf + len), &crc, sizeof(crc))) return;
-  }
-  if (pkt.eth->type == mg_htons(0x806)) {
-    pkt.arp = (struct arp *) (pkt.eth + 1);
-    if (sizeof(*pkt.eth) + sizeof(*pkt.arp) > pkt.raw.len) return;  // Truncated
-    rx_arp(ifp, &pkt);
-  } else if (pkt.eth->type == mg_htons(0x86dd)) {
-    pkt.ip6 = (struct ip6 *) (pkt.eth + 1);
-    if (pkt.raw.len < sizeof(*pkt.eth) + sizeof(*pkt.ip6)) return;  // Truncated
-    if ((pkt.ip6->ver >> 4) != 0x6) return;                         // Not IP
-    mkpay(&pkt, pkt.ip6 + 1);
-    rx_ip6(ifp, &pkt);
-  } else if (pkt.eth->type == mg_htons(0x800)) {
-    pkt.ip = (struct ip *) (pkt.eth + 1);
-    if (pkt.raw.len < sizeof(*pkt.eth) + sizeof(*pkt.ip)) return;  // Truncated
-    // Truncate frame to what IP header tells us
-    if ((size_t) mg_ntohs(pkt.ip->len) + sizeof(struct eth) < pkt.raw.len) {
-      pkt.raw.len = (size_t) mg_ntohs(pkt.ip->len) + sizeof(struct eth);
-    }
-    if (pkt.raw.len < sizeof(*pkt.eth) + sizeof(*pkt.ip)) return;  // Truncated
-    if ((pkt.ip->ver >> 4) != 4) return;                           // Not IP
-    mkpay(&pkt, pkt.ip + 1);
-    rx_ip(ifp, &pkt);
-  } else {
-    MG_DEBUG(("  Unknown eth type %x", mg_htons(pkt.eth->type)));
-    mg_hexdump(buf, len >= 16 ? 16 : len);
-  }
-}
-
-static void mg_tcpip_poll(struct mg_tcpip_if *ifp, uint64_t uptime_ms) {
-  if (ifp == NULL || ifp->driver == NULL) return;
-  bool expired_1000ms = mg_timer_expired(&ifp->timer_1000ms, 1000, uptime_ms);
-  ifp->now = uptime_ms;
-
-  // Handle physical interface up/down status
-  if (expired_1000ms && ifp->driver->up) {
-    bool up = ifp->driver->up(ifp);
-    bool current = ifp->state != MG_TCPIP_STATE_DOWN;
-    if (up != current) {
-      ifp->state = up == false               ? MG_TCPIP_STATE_DOWN
-                   : ifp->enable_dhcp_client ? MG_TCPIP_STATE_UP
-                                             : MG_TCPIP_STATE_READY;
-      if (!up && ifp->enable_dhcp_client) ifp->ip = 0;
-      onstatechange(ifp);
-    }
-  }
-  if (ifp->state == MG_TCPIP_STATE_DOWN) return;
-
-  // If IP not configured, send DHCP
-  if (ifp->ip == 0 && expired_1000ms) tx_dhcp_discover(ifp);
-
-  // Read data from the network
-  if (ifp->driver->rx != NULL) {  // Polling driver. We must call it
-    size_t len =
-        ifp->driver->rx(ifp->recv_queue.buf, ifp->recv_queue.size, ifp);
-    if (len > 0) mg_tcpip_rx(ifp, ifp->recv_queue.buf, len);
-  } else {  // Interrupt-based driver. Fills recv queue itself
-    char *buf;
-    size_t len = mg_queue_next(&ifp->recv_queue, &buf);
-    if (len > 0) {
-      mg_tcpip_rx(ifp, buf, len);
-      mg_queue_del(&ifp->recv_queue, len);
-    }
-  }
-
-  // Process timeouts
-  for (struct mg_connection *c = ifp->mgr->conns; c != NULL; c = c->next) {
-    if (c->is_udp || c->is_listening) continue;
-    if (c->is_connecting || c->is_resolving) continue;
-    struct connstate *s = (struct connstate *) (c + 1);
-    if (uptime_ms > s->timer) {
-      if (s->ttype == MIP_TTYPE_ACK) {
-        MG_DEBUG(("%lu ack %x %x", c->id, s->seq, s->ack));
-        tx_tcp(ifp, s->mac, c->rem.ip, TH_ACK, c->loc.port, c->rem.port,
-               mg_htonl(s->seq), mg_htonl(s->ack), "", 0);
-      } else {
-        if (s->tmiss++ > 2) {
-          mg_error(c, "keepalive");
-        } else {
-          MG_DEBUG(("%lu keepalive", c->id));
-          tx_tcp(ifp, s->mac, c->rem.ip, TH_ACK, c->loc.port, c->rem.port,
-                 mg_htonl(s->seq - 1), mg_htonl(s->ack), "", 0);
-        }
-      }
-      settmout(c, MIP_TTYPE_KEEPALIVE);
-    }
-  }
-}
-
-// This function executes in interrupt context, thus it should copy data
-// somewhere fast. Note that newlib's malloc is not thread safe, thus use
-// our lock-free queue with preallocated buffer to copy data and return asap
-void mg_tcpip_qwrite(void *buf, size_t len, struct mg_tcpip_if *ifp) {
-  char *p;
-  if (mg_queue_book(&ifp->recv_queue, &p, len) >= len) {
-    memcpy(p, buf, len);
-    mg_queue_add(&ifp->recv_queue, len);
-    ifp->nrecv++;
-  } else {
-    ifp->ndrop++;
-  }
-}
-
-void mg_tcpip_init(struct mg_mgr *mgr, struct mg_tcpip_if *ifp) {
-  // If MAC address is not set, make a random one
-  if (ifp->mac[0] == 0 && ifp->mac[1] == 0 && ifp->mac[2] == 0 &&
-      ifp->mac[3] == 0 && ifp->mac[4] == 0 && ifp->mac[5] == 0) {
-    ifp->mac[0] = 0x02;  // Locally administered, unicast
-    mg_random(&ifp->mac[1], sizeof(ifp->mac) - 1);
-    MG_INFO(("MAC not set. Generated random: %M", mg_print_mac, ifp->mac));
-  }
-
-  if (ifp->driver->init && !ifp->driver->init(ifp)) {
-    MG_ERROR(("driver init failed"));
-  } else {
-    size_t framesize = 1540;
-    ifp->tx.ptr = (char *) calloc(1, framesize), ifp->tx.len = framesize;
-    if (ifp->recv_queue.size == 0)
-      ifp->recv_queue.size = ifp->driver->rx ? framesize : 8192;
-    ifp->recv_queue.buf = (char *) calloc(1, ifp->recv_queue.size);
-    ifp->timer_1000ms = mg_millis();
-    mgr->priv = ifp;
-    ifp->mgr = mgr;
-    mgr->extraconnsize = sizeof(struct connstate);
-    if (ifp->ip == 0) ifp->enable_dhcp_client = true;
-    memset(ifp->gwmac, 255, sizeof(ifp->gwmac));  // Set to broadcast
-    mg_random(&ifp->eport, sizeof(ifp->eport));   // Random from 0 to 65535
-    ifp->eport |=
-        MG_EPHEMERAL_PORT_BASE;  // Random from MG_EPHEMERAL_PORT_BASE to 65535
-    if (ifp->tx.ptr == NULL || ifp->recv_queue.buf == NULL) MG_ERROR(("OOM"));
-  }
-}
-
-void mg_tcpip_free(struct mg_tcpip_if *ifp) {
-  free(ifp->recv_queue.buf);
-  free((char *) ifp->tx.ptr);
-}
-
-int mg_mkpipe(struct mg_mgr *m, mg_event_handler_t fn, void *d, bool udp) {
-  (void) m, (void) fn, (void) d, (void) udp;
-  MG_ERROR(("Not implemented"));
-  return -1;
-}
-
-static void send_syn(struct mg_connection *c) {
-  struct connstate *s = (struct connstate *) (c + 1);
-  uint32_t isn = mg_htonl((uint32_t) mg_ntohs(c->loc.port));
-  struct mg_tcpip_if *ifp = (struct mg_tcpip_if *) c->mgr->priv;
-  tx_tcp(ifp, s->mac, c->rem.ip, TH_SYN, c->loc.port, c->rem.port, isn, 0, NULL,
-         0);
-}
-
-void mg_connect_resolved(struct mg_connection *c) {
-  struct mg_tcpip_if *ifp = (struct mg_tcpip_if *) c->mgr->priv;
-  c->is_resolving = 0;
-  if (ifp->eport < MG_EPHEMERAL_PORT_BASE) ifp->eport = MG_EPHEMERAL_PORT_BASE;
-  c->loc.ip = ifp->ip;
-  c->loc.port = mg_htons(ifp->eport++);
-  MG_DEBUG(("%lu %M -> %M", c->id, mg_print_ip_port, &c->loc, mg_print_ip_port,
-            &c->rem));
-  mg_call(c, MG_EV_RESOLVE, NULL);
-  if (((c->rem.ip & ifp->mask) == (ifp->ip & ifp->mask))) {
-    // If we're in the same LAN, fire an ARP lookup. TODO(cpq): handle this!
-    MG_DEBUG(("%lu ARP lookup...", c->id));
-    arp_ask(ifp, c->rem.ip);
-    c->is_arplooking = 1;
-  } else if (c->rem.ip == (ifp->ip | ~ifp->mask)) {
-    struct connstate *s = (struct connstate *) (c + 1);
-    memset(s->mac, 0xFF, sizeof(s->mac));  // local broadcast
-  } else if ((*((uint8_t *) &c->rem.ip) & 0xE0) == 0xE0) {
-    struct connstate *s = (struct connstate *) (c + 1);  // 224 to 239, E0 to EF
-    uint8_t mcastp[3] = {0x01, 0x00, 0x5E};              // multicast group
-    memcpy(s->mac, mcastp, 3);
-    memcpy(s->mac + 3, ((uint8_t *) &c->rem.ip) + 1, 3);  // 23 LSb
-    s->mac[3] &= 0x7F;
-  } else {
-    struct connstate *s = (struct connstate *) (c + 1);
-    memcpy(s->mac, ifp->gwmac, sizeof(ifp->gwmac));
-    if (c->is_udp) {
-      mg_call(c, MG_EV_CONNECT, NULL);
-    } else {
-      send_syn(c);
-      c->is_connecting = 1;
-    }
-  }
-}
-
-bool mg_open_listener(struct mg_connection *c, const char *url) {
-  c->loc.port = mg_htons(mg_url_port(url));
+  // Enable MAC transmission and reception (TE, RE)
+  ETH0->MAC_CONFIGURATION |= MG_BIT(3) | MG_BIT(2);
+  // Enable DMA transmission and reception (ST, SR)
+  ETH0->OPERATION_MODE |= MG_BIT(13) | MG_BIT(1);
   return true;
 }
 
-static void write_conn(struct mg_connection *c) {
-  long len = c->is_tls ? mg_tls_send(c, c->send.buf, c->send.len)
-                       : mg_io_send(c, c->send.buf, c->send.len);
-  if (len > 0) {
-    mg_iobuf_del(&c->send, 0, (size_t) len);
-    mg_call(c, MG_EV_WRITE, &len);
-  }
-}
-
-static void close_conn(struct mg_connection *c) {
-  struct connstate *s = (struct connstate *) (c + 1);
-  mg_iobuf_free(&s->raw);  // For TLS connections, release raw data
-  if (c->is_udp == false && c->is_listening == false) {  // For TCP conns,
-    struct mg_tcpip_if *ifp =
-        (struct mg_tcpip_if *) c->mgr->priv;  // send TCP FIN
-    tx_tcp(ifp, s->mac, c->rem.ip, TH_FIN | TH_ACK, c->loc.port, c->rem.port,
-           mg_htonl(s->seq), mg_htonl(s->ack), NULL, 0);
-  }
-  mg_close_conn(c);
-}
-
-static bool can_write(struct mg_connection *c) {
-  return c->is_connecting == 0 && c->is_resolving == 0 && c->send.len > 0 &&
-         c->is_tls_hs == 0 && c->is_arplooking == 0;
-}
-
-void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
-  struct mg_connection *c, *tmp;
-  uint64_t now = mg_millis();
-  mg_tcpip_poll((struct mg_tcpip_if *) mgr->priv, now);
-  mg_timer_poll(&mgr->timers, now);
-  for (c = mgr->conns; c != NULL; c = tmp) {
-    tmp = c->next;
-    mg_call(c, MG_EV_POLL, &now);
-    MG_VERBOSE(("%lu .. %c%c%c%c%c", c->id, c->is_tls ? 'T' : 't',
-                c->is_connecting ? 'C' : 'c', c->is_tls_hs ? 'H' : 'h',
-                c->is_resolving ? 'R' : 'r', c->is_closing ? 'C' : 'c'));
-    if (c->is_tls_hs) mg_tls_handshake(c);
-    if (can_write(c)) write_conn(c);
-    if (c->is_draining && c->send.len == 0) c->is_closing = 1;
-    if (c->is_closing) close_conn(c);
-  }
-  (void) ms;
-}
-
-bool mg_send(struct mg_connection *c, const void *buf, size_t len) {
-  struct mg_tcpip_if *ifp = (struct mg_tcpip_if *) c->mgr->priv;
-  bool res = false;
-  if (ifp->ip == 0 || ifp->state != MG_TCPIP_STATE_READY) {
-    mg_error(c, "net down");
-  } else if (c->is_udp) {
-    struct connstate *s = (struct connstate *) (c + 1);
-    tx_udp(ifp, s->mac, ifp->ip, c->loc.port, c->rem.ip, c->rem.port, buf, len);
-    res = true;
+static size_t mg_tcpip_driver_xmc_tx(const void *buf, size_t len,
+                                        struct mg_tcpip_if *ifp) {
+  if (len > sizeof(s_txbuf[s_txno])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = 0;  // Frame is too big
+  } else if ((s_txdesc[s_txno][0] & MG_BIT(31))) {
+    ifp->nerr++;
+    MG_ERROR(("No free descriptors"));
+    len = 0;  // All descriptors are busy, fail
   } else {
-    res = mg_iobuf_add(&c->send, c->send.len, buf, len);
+    memcpy(s_txbuf[s_txno], buf, len);
+    s_txdesc[s_txno][1] = len;
+    // Table 13-19 Transmit Descriptor Word 0 (IC, LS, FS, TCH)
+    s_txdesc[s_txno][0] = MG_BIT(30) | MG_BIT(29) | MG_BIT(28) | MG_BIT(20);
+    s_txdesc[s_txno][0] |= MG_BIT(31);  // OWN bit: handle control to DMA
+    if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
-  return res;
+
+  // Resume processing
+  ETH0->STATUS = MG_BIT(2); // clear Transmit unavailable
+  ETH0->TRANSMIT_POLL_DEMAND = 0;
+  return len;
 }
-#endif  // MG_ENABLE_TCPIP
+
+static bool mg_tcpip_driver_xmc_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_xmc_data *d =
+      (struct mg_tcpip_driver_xmc_data *) ifp->driver_data;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  up = mg_phy_up(&phy, d->phy_addr, &full_duplex, &speed);
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
+    MG_DEBUG(("Link is %uM %s-duplex", speed == MG_PHY_SPEED_10M ? 10 : 100,
+              full_duplex ? "full" : "half"));
+  }
+  return up;
+}
+
+void ETH0_0_IRQHandler(void);
+void ETH0_0_IRQHandler(void) {
+  uint32_t irq_status = ETH0->STATUS;
+
+  // check if a frame was received
+  if (irq_status & MG_BIT(6)) {
+    for (uint8_t i = 0; i < ETH_DESC_CNT; i++) {
+      if ((s_rxdesc[s_rxno][0] & MG_BIT(31)) == 0) {
+        size_t len = (s_rxdesc[s_rxno][0] & 0x3fff0000) >> 16;
+        mg_tcpip_qwrite(s_rxbuf[s_rxno], len, s_ifp);
+        s_rxdesc[s_rxno][0] = MG_BIT(31);   // OWN bit: handle control to DMA
+        // Resume processing
+        ETH0->STATUS = MG_BIT(7) | MG_BIT(6); // clear RU and RI
+        ETH0->RECEIVE_POLL_DEMAND = 0;
+        if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+      }
+    }
+    ETH0->STATUS = MG_BIT(6);
+  }
+
+  // clear Successful transmission interrupt
+  if (irq_status & 1) {
+    ETH0->STATUS = 1;
+  }
+
+  // clear normal interrupt
+  if (irq_status & MG_BIT(16)) {
+    ETH0->STATUS = MG_BIT(16);
+  }
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_xmc = {
+    mg_tcpip_driver_xmc_init, mg_tcpip_driver_xmc_tx, NULL,
+    mg_tcpip_driver_xmc_up};
+#endif
+
+#ifdef MG_ENABLE_LINES
+#line 1 "src/drivers/xmc7.c"
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_XMC7) && MG_ENABLE_DRIVER_XMC7
+
+struct ETH_Type {
+  volatile uint32_t CTL, STATUS, RESERVED[1022], NETWORK_CONTROL,
+      NETWORK_CONFIG, NETWORK_STATUS, USER_IO_REGISTER, DMA_CONFIG,
+      TRANSMIT_STATUS, RECEIVE_Q_PTR, TRANSMIT_Q_PTR, RECEIVE_STATUS,
+      INT_STATUS, INT_ENABLE, INT_DISABLE, INT_MASK, PHY_MANAGEMENT, PAUSE_TIME,
+      TX_PAUSE_QUANTUM, PBUF_TXCUTTHRU, PBUF_RXCUTTHRU, JUMBO_MAX_LENGTH,
+      EXTERNAL_FIFO_INTERFACE, RESERVED1, AXI_MAX_PIPELINE, RSC_CONTROL,
+      INT_MODERATION, SYS_WAKE_TIME, RESERVED2[7], HASH_BOTTOM, HASH_TOP,
+      SPEC_ADD1_BOTTOM, SPEC_ADD1_TOP, SPEC_ADD2_BOTTOM, SPEC_ADD2_TOP,
+      SPEC_ADD3_BOTTOM, SPEC_ADD3_TOP, SPEC_ADD4_BOTTOM, SPEC_ADD4_TOP,
+      SPEC_TYPE1, SPEC_TYPE2, SPEC_TYPE3, SPEC_TYPE4, WOL_REGISTER,
+      STRETCH_RATIO, STACKED_VLAN, TX_PFC_PAUSE, MASK_ADD1_BOTTOM,
+      MASK_ADD1_TOP, DMA_ADDR_OR_MASK, RX_PTP_UNICAST, TX_PTP_UNICAST,
+      TSU_NSEC_CMP, TSU_SEC_CMP, TSU_MSB_SEC_CMP, TSU_PTP_TX_MSB_SEC,
+      TSU_PTP_RX_MSB_SEC, TSU_PEER_TX_MSB_SEC, TSU_PEER_RX_MSB_SEC,
+      DPRAM_FILL_DBG, REVISION_REG, OCTETS_TXED_BOTTOM, OCTETS_TXED_TOP,
+      FRAMES_TXED_OK, BROADCAST_TXED, MULTICAST_TXED, PAUSE_FRAMES_TXED,
+      FRAMES_TXED_64, FRAMES_TXED_65, FRAMES_TXED_128, FRAMES_TXED_256,
+      FRAMES_TXED_512, FRAMES_TXED_1024, FRAMES_TXED_1519, TX_UNDERRUNS,
+      SINGLE_COLLISIONS, MULTIPLE_COLLISIONS, EXCESSIVE_COLLISIONS,
+      LATE_COLLISIONS, DEFERRED_FRAMES, CRS_ERRORS, OCTETS_RXED_BOTTOM,
+      OCTETS_RXED_TOP, FRAMES_RXED_OK, BROADCAST_RXED, MULTICAST_RXED,
+      PAUSE_FRAMES_RXED, FRAMES_RXED_64, FRAMES_RXED_65, FRAMES_RXED_128,
+      FRAMES_RXED_256, FRAMES_RXED_512, FRAMES_RXED_1024, FRAMES_RXED_1519,
+      UNDERSIZE_FRAMES, EXCESSIVE_RX_LENGTH, RX_JABBERS, FCS_ERRORS,
+      RX_LENGTH_ERRORS, RX_SYMBOL_ERRORS, ALIGNMENT_ERRORS, RX_RESOURCE_ERRORS,
+      RX_OVERRUNS, RX_IP_CK_ERRORS, RX_TCP_CK_ERRORS, RX_UDP_CK_ERRORS,
+      AUTO_FLUSHED_PKTS, RESERVED3, TSU_TIMER_INCR_SUB_NSEC, TSU_TIMER_MSB_SEC,
+      TSU_STROBE_MSB_SEC, TSU_STROBE_SEC, TSU_STROBE_NSEC, TSU_TIMER_SEC,
+      TSU_TIMER_NSEC, TSU_TIMER_ADJUST, TSU_TIMER_INCR, TSU_PTP_TX_SEC,
+      TSU_PTP_TX_NSEC, TSU_PTP_RX_SEC, TSU_PTP_RX_NSEC, TSU_PEER_TX_SEC,
+      TSU_PEER_TX_NSEC, TSU_PEER_RX_SEC, TSU_PEER_RX_NSEC, PCS_CONTROL,
+      PCS_STATUS, RESERVED4[2], PCS_AN_ADV, PCS_AN_LP_BASE, PCS_AN_EXP,
+      PCS_AN_NP_TX, PCS_AN_LP_NP, RESERVED5[6], PCS_AN_EXT_STATUS, RESERVED6[8],
+      TX_PAUSE_QUANTUM1, TX_PAUSE_QUANTUM2, TX_PAUSE_QUANTUM3, RESERVED7,
+      RX_LPI, RX_LPI_TIME, TX_LPI, TX_LPI_TIME, DESIGNCFG_DEBUG1,
+      DESIGNCFG_DEBUG2, DESIGNCFG_DEBUG3, DESIGNCFG_DEBUG4, DESIGNCFG_DEBUG5,
+      DESIGNCFG_DEBUG6, DESIGNCFG_DEBUG7, DESIGNCFG_DEBUG8, DESIGNCFG_DEBUG9,
+      DESIGNCFG_DEBUG10, RESERVED8[22], SPEC_ADD5_BOTTOM, SPEC_ADD5_TOP,
+      RESERVED9[60], SPEC_ADD36_BOTTOM, SPEC_ADD36_TOP, INT_Q1_STATUS,
+      INT_Q2_STATUS, INT_Q3_STATUS, RESERVED10[11], INT_Q15_STATUS, RESERVED11,
+      TRANSMIT_Q1_PTR, TRANSMIT_Q2_PTR, TRANSMIT_Q3_PTR, RESERVED12[11],
+      TRANSMIT_Q15_PTR, RESERVED13, RECEIVE_Q1_PTR, RECEIVE_Q2_PTR,
+      RECEIVE_Q3_PTR, RESERVED14[3], RECEIVE_Q7_PTR, RESERVED15,
+      DMA_RXBUF_SIZE_Q1, DMA_RXBUF_SIZE_Q2, DMA_RXBUF_SIZE_Q3, RESERVED16[3],
+      DMA_RXBUF_SIZE_Q7, CBS_CONTROL, CBS_IDLESLOPE_Q_A, CBS_IDLESLOPE_Q_B,
+      UPPER_TX_Q_BASE_ADDR, TX_BD_CONTROL, RX_BD_CONTROL, UPPER_RX_Q_BASE_ADDR,
+      RESERVED17[2], HIDDEN_REG0, HIDDEN_REG1, HIDDEN_REG2, HIDDEN_REG3,
+      RESERVED18[2], HIDDEN_REG4, HIDDEN_REG5;
+};
+
+#define ETH0 ((struct ETH_Type *) 0x40490000)
+
+#define ETH_PKT_SIZE 1536  // Max frame size
+#define ETH_DESC_CNT 4     // Descriptors count
+#define ETH_DS 2           // Descriptor size (words)
+
+// TODO(): handle these in a portable compiler-independent CMSIS-friendly way
+#define MG_8BYTE_ALIGNED __attribute__((aligned((8U))))
+
+static uint8_t s_rxbuf[ETH_DESC_CNT][ETH_PKT_SIZE];
+static uint8_t s_txbuf[ETH_DESC_CNT][ETH_PKT_SIZE];
+static uint32_t s_rxdesc[ETH_DESC_CNT][ETH_DS] MG_8BYTE_ALIGNED;
+static uint32_t s_txdesc[ETH_DESC_CNT][ETH_DS] MG_8BYTE_ALIGNED;
+static uint8_t s_txno MG_8BYTE_ALIGNED;     // Current TX descriptor
+static uint8_t s_rxno MG_8BYTE_ALIGNED;     // Current RX descriptor
+
+static struct mg_tcpip_if *s_ifp;  // MIP interface
+enum { MG_PHY_ADDR = 0, MG_PHYREG_BCR = 0, MG_PHYREG_BSR = 1 };
+
+static uint16_t eth_read_phy(uint8_t addr, uint8_t reg) {
+  // WRITE1, READ OPERATION, PHY, REG, WRITE10
+  ETH0->PHY_MANAGEMENT = MG_BIT(30) | MG_BIT(29) | ((addr & 0xf) << 24) |
+                         ((reg & 0x1f) << 18) | MG_BIT(17);
+  while ((ETH0->NETWORK_STATUS & MG_BIT(2)) == 0) (void) 0;
+  return ETH0->PHY_MANAGEMENT & 0xffff;
+}
+
+static void eth_write_phy(uint8_t addr, uint8_t reg, uint16_t val) {
+  ETH0->PHY_MANAGEMENT = MG_BIT(30) | MG_BIT(28) | ((addr & 0xf) << 24) |
+                         ((reg & 0x1f) << 18) | MG_BIT(17) | val;
+  while ((ETH0->NETWORK_STATUS & MG_BIT(2)) == 0) (void) 0;
+}
+
+static uint32_t get_clock_rate(struct mg_tcpip_driver_xmc7_data *d) {
+  // see ETH0 -> NETWORK_CONFIG register
+  (void) d;
+  return 3;
+}
+
+static bool mg_tcpip_driver_xmc7_init(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_xmc7_data *d =
+      (struct mg_tcpip_driver_xmc7_data *) ifp->driver_data;
+  s_ifp = ifp;
+
+  // enable controller, set RGMII mode
+  ETH0->CTL = MG_BIT(31) | (4 << 8) | 2;
+
+  uint32_t cr = get_clock_rate(d);
+  // set NSP change, ignore RX FCS, data bus width, clock rate
+  // frame length 1536, full duplex, speed
+  ETH0->NETWORK_CONFIG = MG_BIT(29) | MG_BIT(26) | MG_BIT(21) |
+                         ((cr & 7) << 18) | MG_BIT(8) | MG_BIT(4) | MG_BIT(1) |
+                         MG_BIT(0);
+
+  // config DMA settings: Force TX burst, Discard on Error, set RX buffer size
+  // to 1536, TX_PBUF_SIZE, RX_PBUF_SIZE, AMBA_BURST_LENGTH
+  ETH0->DMA_CONFIG =
+      MG_BIT(26) | MG_BIT(24) | (0x18 << 16) | MG_BIT(10) | (3 << 8) | 4;
+
+  // initialize descriptors
+  for (int i = 0; i < ETH_DESC_CNT; i++) {
+    s_rxdesc[i][0] = (uint32_t) s_rxbuf[i];
+    if (i == ETH_DESC_CNT - 1) {
+      s_rxdesc[i][0] |= MG_BIT(1);  // mark last descriptor
+    }
+
+    s_txdesc[i][0] = (uint32_t) s_txbuf[i];
+    s_txdesc[i][1] = MG_BIT(31);  // OWN descriptor
+    if (i == ETH_DESC_CNT - 1) {
+      s_txdesc[i][1] |= MG_BIT(30);  // mark last descriptor
+    }
+  }
+  ETH0->RECEIVE_Q_PTR = (uint32_t) s_rxdesc;
+  ETH0->TRANSMIT_Q_PTR = (uint32_t) s_txdesc;
+
+  // disable other queues
+  ETH0->TRANSMIT_Q2_PTR = 1;
+  ETH0->TRANSMIT_Q1_PTR = 1;
+  ETH0->RECEIVE_Q2_PTR = 1;
+  ETH0->RECEIVE_Q1_PTR = 1;
+
+  // enable interrupts (RX complete)
+  ETH0->INT_ENABLE = MG_BIT(1);
+
+  // set MAC address
+  ETH0->SPEC_ADD1_BOTTOM =
+      ifp->mac[3] << 24 | ifp->mac[2] << 16 | ifp->mac[1] << 8 | ifp->mac[0];
+  ETH0->SPEC_ADD1_TOP = ifp->mac[5] << 8 | ifp->mac[4];
+
+  // enable MDIO, TX, RX
+  ETH0->NETWORK_CONTROL = MG_BIT(4) | MG_BIT(3) | MG_BIT(2);
+
+  // start transmission
+  ETH0->NETWORK_CONTROL |= MG_BIT(9);
+
+  // init phy
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  mg_phy_init(&phy, d->phy_addr, MG_PHY_CLOCKS_MAC);
+
+  (void) d;
+  return true;
+}
+
+static size_t mg_tcpip_driver_xmc7_tx(const void *buf, size_t len,
+                                      struct mg_tcpip_if *ifp) {
+  if (len > sizeof(s_txbuf[s_txno])) {
+    MG_ERROR(("Frame too big, %ld", (long) len));
+    len = 0;  // Frame is too big
+  } else if (((s_txdesc[s_txno][1] & MG_BIT(31)) == 0)) {
+    ifp->nerr++;
+    MG_ERROR(("No free descriptors"));
+    len = 0;  // All descriptors are busy, fail
+  } else {
+    memcpy(s_txbuf[s_txno], buf, len);
+    s_txdesc[s_txno][1] = (s_txno == ETH_DESC_CNT - 1 ? MG_BIT(30) : 0) |
+                          MG_BIT(15) | len;  // Last buffer and length
+
+    ETH0->NETWORK_CONTROL |= MG_BIT(9);  // enable transmission
+    if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
+  }
+
+  MG_DSB();
+  ETH0->TRANSMIT_STATUS = ETH0->TRANSMIT_STATUS;
+  ETH0->NETWORK_CONTROL |= MG_BIT(9);  // enable transmission
+
+  return len;
+}
+
+static bool mg_tcpip_driver_xmc7_up(struct mg_tcpip_if *ifp) {
+  struct mg_tcpip_driver_xmc7_data *d =
+      (struct mg_tcpip_driver_xmc7_data *) ifp->driver_data;
+  uint8_t speed = MG_PHY_SPEED_10M;
+  bool up = false, full_duplex = false;
+  struct mg_phy phy = {eth_read_phy, eth_write_phy};
+  up = mg_phy_up(&phy, d->phy_addr, &full_duplex, &speed);
+  if ((ifp->state == MG_TCPIP_STATE_DOWN) && up) {  // link state just went up
+    // tmp = reg with flags set to the most likely situation: 100M full-duplex
+    // if(link is slow or half) set flags otherwise
+    // reg = tmp
+    uint32_t netconf = ETH0->NETWORK_CONFIG;
+    MG_SET_BITS(netconf, MG_BIT(10),
+                MG_BIT(1) | MG_BIT(0));  // 100M, Full-duplex
+    uint32_t ctl = ETH0->CTL;
+    MG_SET_BITS(ctl, 0xFF00, 4 << 8);  // /5 for 25M clock
+    if (speed == MG_PHY_SPEED_1000M) {
+      netconf |= MG_BIT(10);        // 1000M
+      MG_SET_BITS(ctl, 0xFF00, 0);  // /1 for 125M clock TODO() IS THIS NEEDED ?
+    } else if (speed == MG_PHY_SPEED_10M) {
+      netconf &= ~MG_BIT(0);         // 10M
+      MG_SET_BITS(ctl, 0xFF00, 49);  // /50 for 2.5M clock
+    }
+    if (full_duplex == false) netconf &= ~MG_BIT(1);  // Half-duplex
+    ETH0->NETWORK_CONFIG = netconf;  // IRQ handler does not fiddle with these
+    ETH0->CTL = ctl;
+    MG_DEBUG(("Link is %uM %s-duplex",
+              speed == MG_PHY_SPEED_10M
+                  ? 10
+                  : (speed == MG_PHY_SPEED_100M ? 100 : 1000),
+              full_duplex ? "full" : "half"));
+  }
+  return up;
+}
+
+void ETH_IRQHandler(void) {
+  uint32_t irq_status = ETH0->INT_STATUS;
+  if (irq_status & MG_BIT(1)) {
+    for (uint8_t i = 0; i < ETH_DESC_CNT; i++) {
+      if (s_rxdesc[s_rxno][0] & MG_BIT(0)) {
+        size_t len = s_rxdesc[s_rxno][1] & (MG_BIT(13) - 1);
+        mg_tcpip_qwrite(s_rxbuf[s_rxno], len, s_ifp);
+        s_rxdesc[s_rxno][0] &= ~MG_BIT(0);  // OWN bit: handle control to DMA
+        if (++s_rxno >= ETH_DESC_CNT) s_rxno = 0;
+      }
+    }
+  }
+
+  ETH0->INT_STATUS = irq_status;
+}
+
+struct mg_tcpip_driver mg_tcpip_driver_xmc7 = {mg_tcpip_driver_xmc7_init,
+                                               mg_tcpip_driver_xmc7_tx, NULL,
+                                               mg_tcpip_driver_xmc7_up};
+#endif

--- a/standalone/inc/webserver/mongoose.h
+++ b/standalone/inc/webserver/mongoose.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2004-2013 Sergey Lyubka
-// Copyright (c) 2013-2022 Cesanta Software Limited
+// Copyright (c) 2013-2025 Cesanta Software Limited
 // All rights reserved
 //
 // This software is dual-licensed: you can redistribute it and/or modify
@@ -20,59 +20,44 @@
 #ifndef MONGOOSE_H
 #define MONGOOSE_H
 
-#define MG_VERSION "7.10"
+#define MG_VERSION "7.17"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-#define MG_ARCH_CUSTOM 0       // User creates its own mongoose_custom.h
-#define MG_ARCH_UNIX 1         // Linux, BSD, Mac, ...
-#define MG_ARCH_WIN32 2        // Windows
-#define MG_ARCH_ESP32 3        // ESP32
-#define MG_ARCH_ESP8266 4      // ESP8266
-#define MG_ARCH_FREERTOS 5     // FreeRTOS
-#define MG_ARCH_AZURERTOS 6    // MS Azure RTOS
-#define MG_ARCH_ZEPHYR 7       // Zephyr RTOS
-#define MG_ARCH_NEWLIB 8       // Bare metal ARM
-#define MG_ARCH_CMSIS_RTOS1 9  // CMSIS-RTOS API v1 (Keil RTX)
-#define MG_ARCH_TIRTOS 10      // Texas Semi TI-RTOS
-#define MG_ARCH_RP2040 11      // Raspberry Pi RP2040
-#define MG_ARCH_ARMCC 12       // Keil MDK-Core with Configuration Wizard
-#define MG_ARCH_CMSIS_RTOS2 13 // CMSIS-RTOS API v2 (Keil RTX5, FreeRTOS)
+#define MG_ARCH_CUSTOM 0        // User creates its own mongoose_config.h
+#define MG_ARCH_UNIX 1          // Linux, BSD, Mac, ...
+#define MG_ARCH_WIN32 2         // Windows
+#define MG_ARCH_ESP32 3         // ESP32
+#define MG_ARCH_ESP8266 4       // ESP8266
+#define MG_ARCH_FREERTOS 5      // FreeRTOS
+#define MG_ARCH_AZURERTOS 6     // MS Azure RTOS
+#define MG_ARCH_ZEPHYR 7        // Zephyr RTOS
+#define MG_ARCH_NEWLIB 8        // Bare metal ARM
+#define MG_ARCH_CMSIS_RTOS1 9   // CMSIS-RTOS API v1 (Keil RTX)
+#define MG_ARCH_TIRTOS 10       // Texas Semi TI-RTOS
+#define MG_ARCH_PICOSDK 11      // Raspberry Pi Pico-SDK (RP2040, RP2350)
+#define MG_ARCH_ARMCC 12        // Keil MDK-Core with Configuration Wizard
+#define MG_ARCH_CMSIS_RTOS2 13  // CMSIS-RTOS API v2 (Keil RTX5, FreeRTOS)
+#define MG_ARCH_RTTHREAD 14     // RT-Thread RTOS
+#define MG_ARCH_ARMCGT 15       // Texas Semi ARM-CGT
 
 #if !defined(MG_ARCH)
 #if defined(__unix__) || defined(__APPLE__)
 #define MG_ARCH MG_ARCH_UNIX
 #elif defined(_WIN32)
 #define MG_ARCH MG_ARCH_WIN32
-#elif defined(ICACHE_FLASH) || defined(ICACHE_RAM_ATTR)
-#define MG_ARCH MG_ARCH_ESP8266
-#elif defined(__ZEPHYR__)
-#define MG_ARCH MG_ARCH_ZEPHYR
-#elif defined(ESP_PLATFORM)
-#define MG_ARCH MG_ARCH_ESP32
-#elif defined(FREERTOS_IP_H)
-#define MG_ARCH MG_ARCH_FREERTOS
-#define MG_ENABLE_FREERTOS_TCP 1
-#elif defined(AZURE_RTOS_THREADX)
-#define MG_ARCH MG_ARCH_AZURERTOS
-#elif defined(PICO_TARGET_NAME)
-#define MG_ARCH MG_ARCH_RP2040
-#elif defined(__ARMCC_VERSION)
-#define MG_ARCH MG_ARCH_ARMCC
 #endif
 #endif  // !defined(MG_ARCH)
 
-// if the user did not specify an MG_ARCH, or specified a custom one, OR
-// we guessed a known IDE, pull the customized config (Configuration Wizard)
-#if !defined(MG_ARCH) || (MG_ARCH == MG_ARCH_CUSTOM) || MG_ARCH == MG_ARCH_ARMCC
-#include "mongoose_custom.h"  // keep this include
+#if !defined(MG_ARCH) || (MG_ARCH == MG_ARCH_CUSTOM)
+#include "mongoose_config.h"  // keep this include
 #endif
 
 #if !defined(MG_ARCH)
-#error "MG_ARCH is not specified and we couldn't guess it. Set -D MG_ARCH=..."
+#error "MG_ARCH is not specified and we couldn't guess it. Define MG_ARCH=... in your compiler"
 #endif
 
 // http://esr.ibiblio.org/?p=5095
@@ -90,6 +75,25 @@ extern "C" {
 
 
 
+
+
+#if MG_ARCH == MG_ARCH_ARMCGT
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+
+#define MG_PATH_MAX 100
+#define MG_ENABLE_SOCKET 0
+#define MG_ENABLE_DIRLIST 0
+
+#endif
 
 
 #if MG_ARCH == MG_ARCH_AZURERTOS
@@ -136,7 +140,8 @@ extern "C" {
 #include <sys/types.h>
 #include <time.h>
 
-#include <esp_timer.h>
+#include <esp_ota_ops.h>  // Use angle brackets to avoid
+#include <esp_timer.h>    // amalgamation ditching them
 
 #define MG_PATH_MAX 128
 
@@ -180,11 +185,13 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h> // rand(), strtol(), atoi()
+#include <stdlib.h>  // rand(), strtol(), atoi()
 #include <string.h>
 #if defined(__ARMCC_VERSION)
 #define mode_t size_t
+#include <alloca.h>
 #include <time.h>
+#elif defined(__CCRH__)
 #else
 #include <sys/stat.h>
 #endif
@@ -192,14 +199,10 @@ extern "C" {
 #include <FreeRTOS.h>
 #include <task.h>
 
-#ifndef MG_IO_SIZE
-#define MG_IO_SIZE 512
-#endif
-
 #define calloc(a, b) mg_calloc(a, b)
 #define free(a) vPortFree(a)
 #define malloc(a) pvPortMalloc(a)
-#define strdup(s) ((char *) mg_strdup(mg_str(s)).ptr)
+#define strdup(s) ((char *) mg_strdup(mg_str(s)).buf)
 
 // Re-route calloc/free to the FreeRTOS's functions, don't use stdlib
 static inline void *mg_calloc(size_t cnt, size_t size) {
@@ -240,8 +243,10 @@ static inline int mg_mkdir(const char *path, mode_t mode) {
 #endif
 
 
-#if MG_ARCH == MG_ARCH_RP2040
+#if MG_ARCH == MG_ARCH_PICOSDK
+#if !defined(MG_ENABLE_LWIP) || !MG_ENABLE_LWIP
 #include <errno.h>
+#endif
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -251,8 +256,39 @@ static inline int mg_mkdir(const char *path, mode_t mode) {
 #include <time.h>
 
 #include <pico/stdlib.h>
+#include <pico/rand.h>
 int mkdir(const char *, mode_t);
+
+#if MG_OTA == MG_OTA_PICOSDK
+#include <hardware/flash.h>
+#include <pico/bootrom.h>
 #endif
+
+#endif
+
+
+#if MG_ARCH == MG_ARCH_RTTHREAD
+
+#include <rtthread.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+
+#ifndef MG_IO_SIZE
+#define MG_IO_SIZE 1460
+#endif
+
+#endif // MG_ARCH == MG_ARCH_RTTHREAD
 
 
 #if MG_ARCH == MG_ARCH_ARMCC || MG_ARCH == MG_ARCH_CMSIS_RTOS1 || \
@@ -266,6 +302,7 @@ int mkdir(const char *, mode_t);
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <alloca.h>
 #include <string.h>
 #include <time.h>
 #if MG_ARCH == MG_ARCH_CMSIS_RTOS1
@@ -276,7 +313,7 @@ extern uint32_t rt_time_get(void);
 #include "cmsis_os2.h"  // keep this include
 #endif
 
-#define strdup(s) ((char *) mg_strdup(mg_str(s)).ptr)
+#define strdup(s) ((char *) mg_strdup(mg_str(s)).buf)
 
 #if defined(__ARMCC_VERSION)
 #define mode_t size_t
@@ -291,6 +328,9 @@ static inline int mg_mkdir(const char *path, mode_t mode) {
     !defined MG_ENABLE_RL && (!defined(MG_ENABLE_LWIP) || !MG_ENABLE_LWIP) && \
     (!defined(MG_ENABLE_TCPIP) || !MG_ENABLE_TCPIP)
 #define MG_ENABLE_RL 1
+#ifndef MG_SOCK_LISTEN_BACKLOG_SIZE
+#define MG_SOCK_LISTEN_BACKLOG_SIZE 3
+#endif
 #endif
 
 #endif
@@ -371,10 +411,22 @@ static inline int mg_mkdir(const char *path, mode_t mode) {
 #define MG_PATH_MAX FILENAME_MAX
 #endif
 
+#ifndef MG_ENABLE_POSIX_FS
+#define MG_ENABLE_POSIX_FS 1
+#endif
+
+#ifndef MG_IO_SIZE
+#define MG_IO_SIZE 16384
+#endif
+
 #endif
 
 
 #if MG_ARCH == MG_ARCH_WIN32
+
+#ifndef _CRT_RAND_S
+#define _CRT_RAND_S
+#endif
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -424,6 +476,15 @@ typedef enum { false = 0, true = 1 } bool;
 #include <winerror.h>
 #include <winsock2.h>
 
+// For mg_random()
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x400  // Let vc98 pick up wincrypt.h
+#endif
+#include <wincrypt.h>
+#pragma comment(lib, "advapi32.lib")
+#endif
+
 // Protect from calls like std::snprintf in app code
 // See https://github.com/cesanta/mongoose/issues/1047
 #ifndef __cplusplus
@@ -468,15 +529,28 @@ typedef int socklen_t;
   (((errcode) < 0) && (WSAGetLastError() == WSAECONNRESET))
 
 #define realpath(a, b) _fullpath((b), (a), MG_PATH_MAX)
-#define sleep(x) Sleep(x)
+#define sleep(x) Sleep((x) * 1000)
 #define mkdir(a, b) _mkdir(a)
+#define timegm(x) _mkgmtime(x)
 
 #ifndef S_ISDIR
-#define S_ISDIR(x) (((x) &_S_IFMT) == _S_IFDIR)
+#define S_ISDIR(x) (((x) & _S_IFMT) == _S_IFDIR)
 #endif
 
 #ifndef MG_ENABLE_DIRLIST
 #define MG_ENABLE_DIRLIST 1
+#endif
+
+#ifndef SIGPIPE
+#define SIGPIPE 0
+#endif
+
+#ifndef MG_ENABLE_POSIX_FS
+#define MG_ENABLE_POSIX_FS 1
+#endif
+
+#ifndef MG_IO_SIZE
+#define MG_IO_SIZE 16384
 #endif
 
 #endif
@@ -488,8 +562,9 @@ typedef int socklen_t;
 
 #include <ctype.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/posix/fcntl.h>
+#include <zephyr/posix/sys/select.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -501,11 +576,18 @@ typedef int socklen_t;
 
 #define MG_PUTCHAR(x) printk("%c", x)
 #ifndef strdup
-#define strdup(s) ((char *) mg_strdup(mg_str(s)).ptr)
+#define strdup(s) ((char *) mg_strdup(mg_str(s)).buf)
 #endif
 #define strerror(x) zsock_gai_strerror(x)
+
+#ifndef FD_CLOEXEC
 #define FD_CLOEXEC 0
+#endif
+
+#ifndef F_SETFD
 #define F_SETFD 0
+#endif
+
 #define MG_ENABLE_SSI 0
 
 int rand(void);
@@ -521,7 +603,6 @@ int sscanf(const char *, const char *, ...);
 
 #include <FreeRTOS_IP.h>
 #include <FreeRTOS_Sockets.h>
-#include <FreeRTOS_errno_TCP.h>  // contents to be moved and file removed, some day
 
 #define MG_SOCKET_TYPE Socket_t
 #define MG_INVALID_SOCKET FREERTOS_INVALID_SOCKET
@@ -553,6 +634,9 @@ int sscanf(const char *, const char *, ...);
 
 #define sockaddr_in freertos_sockaddr
 #define sockaddr freertos_sockaddr
+#if ipFR_TCP_VERSION_MAJOR >= 4
+#define sin_addr sin_address.ulIP_IPv4
+#endif
 #define accept(a, b, c) FreeRTOS_accept((a), (b), (c))
 #define connect(a, b, c) FreeRTOS_connect((a), (b), (c))
 #define bind(a, b, c) FreeRTOS_bind((a), (b), (c))
@@ -625,7 +709,10 @@ struct timeval {
 #define MG_SOCK_RESET(errcode) \
   ((errcode) == BSD_ECONNABORTED || (errcode) == BSD_ECONNRESET)
 
-#define MG_SOCK_INTR(fd) 0
+// In blocking mode, which is enabled by default, accept() waits for a
+// connection request. In non blocking mode, you must call accept()
+// again if the error code BSD_EWOULDBLOCK is returned.
+#define MG_SOCK_INTR(fd) (fd == BSD_EWOULDBLOCK)
 
 #define socklen_t int
 #endif
@@ -633,6 +720,10 @@ struct timeval {
 
 #ifndef MG_ENABLE_LOG
 #define MG_ENABLE_LOG 1
+#endif
+
+#ifndef MG_ENABLE_CUSTOM_LOG
+#define MG_ENABLE_CUSTOM_LOG 0  // Let user define their own MG_LOG
 #endif
 
 #ifndef MG_ENABLE_TCPIP
@@ -667,24 +758,16 @@ struct timeval {
 #define MG_ENABLE_FATFS 0
 #endif
 
-#ifndef MG_ENABLE_MBEDTLS
-#define MG_ENABLE_MBEDTLS 0
-#endif
-
-#ifndef MG_ENABLE_OPENSSL
-#define MG_ENABLE_OPENSSL 0
-#endif
-
-#ifndef MG_ENABLE_CUSTOM_TLS
-#define MG_ENABLE_CUSTOM_TLS 0
-#endif
-
 #ifndef MG_ENABLE_SSI
 #define MG_ENABLE_SSI 0
 #endif
 
 #ifndef MG_ENABLE_IPV6
 #define MG_ENABLE_IPV6 0
+#endif
+
+#ifndef MG_IPV6_V6ONLY
+#define MG_IPV6_V6ONLY 0  // IPv6 socket binds only to V6, not V4 address
 #endif
 
 #ifndef MG_ENABLE_MD5
@@ -717,11 +800,11 @@ struct timeval {
 #endif
 
 #ifndef MG_IO_SIZE
-#define MG_IO_SIZE 2048  // Granularity of the send/recv IO buffer growth
+#define MG_IO_SIZE 512  // Granularity of the send/recv IO buffer growth
 #endif
 
 #ifndef MG_MAX_RECV_SIZE
-#define MG_MAX_RECV_SIZE (3 * 1024 * 1024)  // Maximum recv IO buffer size
+#define MG_MAX_RECV_SIZE (3UL * 1024UL * 1024UL)  // Maximum recv IO buffer size
 #endif
 
 #ifndef MG_DATA_SIZE
@@ -745,19 +828,15 @@ struct timeval {
 #endif
 
 #ifndef MG_SOCK_LISTEN_BACKLOG_SIZE
-#define MG_SOCK_LISTEN_BACKLOG_SIZE 3
+#define MG_SOCK_LISTEN_BACKLOG_SIZE 128
 #endif
 
 #ifndef MG_DIRSEP
 #define MG_DIRSEP '/'
 #endif
 
-#ifndef MG_ENABLE_FILE
-#if defined(FOPEN_MAX)
-#define MG_ENABLE_FILE 1
-#else
-#define MG_ENABLE_FILE 0
-#endif
+#ifndef MG_ENABLE_POSIX_FS
+#define MG_ENABLE_POSIX_FS 0
 #endif
 
 #ifndef MG_INVALID_SOCKET
@@ -789,45 +868,60 @@ struct timeval {
 #define MG_EPOLL_MOD(c, wr)
 #endif
 
+#ifndef MG_ENABLE_PROFILE
+#define MG_ENABLE_PROFILE 0
+#endif
+
+#ifndef MG_ENABLE_TCPIP_DRIVER_INIT    // mg_mgr_init() will also initialize
+#define MG_ENABLE_TCPIP_DRIVER_INIT 1  // enabled built-in driver for
+#endif                                 // Mongoose built-in network stack
+
+#ifndef MG_TCPIP_IP                      // e.g. MG_IPV4(192, 168, 0, 223)
+#define MG_TCPIP_IP MG_IPV4(0, 0, 0, 0)  // Default is 0.0.0.0 (DHCP)
+#endif
+
+#ifndef MG_TCPIP_MASK
+#define MG_TCPIP_MASK MG_IPV4(0, 0, 0, 0)  // Default is 0.0.0.0 (DHCP)
+#endif
+
+#ifndef MG_TCPIP_GW
+#define MG_TCPIP_GW MG_IPV4(0, 0, 0, 0)  // Default is 0.0.0.0 (DHCP)
+#endif
+
+#ifndef MG_SET_MAC_ADDRESS
+#define MG_SET_MAC_ADDRESS(mac)
+#endif
+
+#ifndef MG_SET_WIFI_CREDS
+#define MG_SET_WIFI_CREDS(ssid, pass)
+#endif
+
+#ifndef MG_ENABLE_TCPIP_PRINT_DEBUG_STATS
+#define MG_ENABLE_TCPIP_PRINT_DEBUG_STATS 0
+#endif
 
 
 
+
+// Describes an arbitrary chunk of memory
 struct mg_str {
-  const char *ptr;  // Pointer to string data
-  size_t len;       // String len
+  char *buf;   // String data
+  size_t len;  // String length
 };
-
-#define MG_NULL_STR \
-  { NULL, 0 }
-
-#define MG_C_STR(a) \
-  { (a), sizeof(a) - 1 }
 
 // Using macro to avoid shadowing C++ struct constructor, see #1298
 #define mg_str(s) mg_str_s(s)
 
 struct mg_str mg_str(const char *s);
 struct mg_str mg_str_n(const char *s, size_t n);
-int mg_lower(const char *s);
-int mg_ncasecmp(const char *s1, const char *s2, size_t len);
 int mg_casecmp(const char *s1, const char *s2);
-int mg_vcmp(const struct mg_str *s1, const char *s2);
-int mg_vcasecmp(const struct mg_str *str1, const char *str2);
 int mg_strcmp(const struct mg_str str1, const struct mg_str str2);
-struct mg_str mg_strstrip(struct mg_str s);
+int mg_strcasecmp(const struct mg_str str1, const struct mg_str str2);
 struct mg_str mg_strdup(const struct mg_str s);
-const char *mg_strstr(const struct mg_str haystack, const struct mg_str needle);
 bool mg_match(struct mg_str str, struct mg_str pattern, struct mg_str *caps);
-bool mg_globmatch(const char *pattern, size_t plen, const char *s, size_t n);
-bool mg_commalist(struct mg_str *s, struct mg_str *k, struct mg_str *v);
-bool mg_split(struct mg_str *s, struct mg_str *k, struct mg_str *v, char delim);
-char *mg_hex(const void *buf, size_t len, char *dst);
-void mg_unhex(const char *buf, size_t len, unsigned char *to);
-unsigned long mg_unhexn(const char *s, size_t len);
-int mg_check_ip_acl(struct mg_str acl, uint32_t remote_ip);
-int64_t mg_to64(struct mg_str str);
-uint64_t mg_tou64(struct mg_str str);
-char *mg_remove_double_dots(char *s);
+bool mg_span(struct mg_str s, struct mg_str *a, struct mg_str *b, char delim);
+
+bool mg_str_to_num(struct mg_str, int base, void *val, size_t val_len);
 
 
 
@@ -892,16 +986,23 @@ void mg_pfn_stdout(char c, void *param);  // param: ignored
 
 
 enum { MG_LL_NONE, MG_LL_ERROR, MG_LL_INFO, MG_LL_DEBUG, MG_LL_VERBOSE };
+extern int mg_log_level;  // Current log level, one of MG_LL_*
+
 void mg_log(const char *fmt, ...);
-bool mg_log_prefix(int ll, const char *file, int line, const char *fname);
-void mg_log_set(int log_level);
+void mg_log_prefix(int ll, const char *file, int line, const char *fname);
+// bool mg_log2(int ll, const char *file, int line, const char *fmt, ...);
 void mg_hexdump(const void *buf, size_t len);
 void mg_log_set_fn(mg_pfn_t fn, void *param);
 
+#define mg_log_set(level_) mg_log_level = (level_)
+
 #if MG_ENABLE_LOG
-#define MG_LOG(level, args)                                                \
-  do {                                                                     \
-    if (mg_log_prefix((level), __FILE__, __LINE__, __func__)) mg_log args; \
+#define MG_LOG(level, args)                                 \
+  do {                                                      \
+    if ((level) <= mg_log_level) {                          \
+      mg_log_prefix((level), __FILE__, __LINE__, __func__); \
+      mg_log args;                                          \
+    }                                                       \
   } while (0)
 #else
 #define MG_LOG(level, args) \
@@ -953,7 +1054,9 @@ enum { MG_FS_READ = 1, MG_FS_WRITE = 2, MG_FS_DIR = 4 };
 // stat(), write(), read() calls.
 struct mg_fs {
   int (*st)(const char *path, size_t *size, time_t *mtime);  // stat file
-  void (*ls)(const char *path, void (*fn)(const char *, void *), void *);
+  void (*ls)(const char *path, void (*fn)(const char *, void *),
+             void *);  // List directory entries: call fn(file_name, fn_data)
+                       // for each directory entry
   void *(*op)(const char *path, int flags);             // Open file
   void (*cl)(void *fd);                                 // Close file
   size_t (*rd)(void *fd, void *buf, size_t len);        // Read file
@@ -976,9 +1079,15 @@ struct mg_fd {
 
 struct mg_fd *mg_fs_open(struct mg_fs *fs, const char *path, int flags);
 void mg_fs_close(struct mg_fd *fd);
-char *mg_file_read(struct mg_fs *fs, const char *path, size_t *size);
+bool mg_fs_ls(struct mg_fs *fs, const char *path, char *buf, size_t len);
+struct mg_str mg_file_read(struct mg_fs *fs, const char *path);
 bool mg_file_write(struct mg_fs *fs, const char *path, const void *, size_t);
 bool mg_file_printf(struct mg_fs *fs, const char *path, const char *fmt, ...);
+
+// Packed API
+const char *mg_unpack(const char *path, size_t *size, time_t *mtime);
+const char *mg_unlist(size_t no);             // Get no'th packed filename
+struct mg_str mg_unpacked(const char *path);  // Packed file as mg_str
 
 
 
@@ -992,24 +1101,76 @@ bool mg_file_printf(struct mg_fs *fs, const char *path, const char *fmt, ...);
 #define assert(x)
 #endif
 
-void mg_random(void *buf, size_t len);
+void mg_bzero(volatile unsigned char *buf, size_t len);
+bool mg_random(void *buf, size_t len);
 char *mg_random_str(char *buf, size_t len);
 uint16_t mg_ntohs(uint16_t net);
 uint32_t mg_ntohl(uint32_t net);
 uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len);
-uint64_t mg_millis(void);
+uint64_t mg_millis(void);  // Return milliseconds since boot
+bool mg_path_is_sane(const struct mg_str path);
 
 #define mg_htons(x) mg_ntohs(x)
 #define mg_htonl(x) mg_ntohl(x)
 
-#define MG_U32(a, b, c, d)                                         \
-  (((uint32_t) ((a) &255) << 24) | ((uint32_t) ((b) &255) << 16) | \
-   ((uint32_t) ((c) &255) << 8) | (uint32_t) ((d) &255))
+#define MG_U32(a, b, c, d)                                           \
+  (((uint32_t) ((a) & 255) << 24) | ((uint32_t) ((b) & 255) << 16) | \
+   ((uint32_t) ((c) & 255) << 8) | (uint32_t) ((d) & 255))
+
+#define MG_IPV4(a, b, c, d) mg_htonl(MG_U32(a, b, c, d))
 
 // For printing IPv4 addresses: printf("%d.%d.%d.%d\n", MG_IPADDR_PARTS(&ip))
 #define MG_U8P(ADDR) ((uint8_t *) (ADDR))
 #define MG_IPADDR_PARTS(ADDR) \
   MG_U8P(ADDR)[0], MG_U8P(ADDR)[1], MG_U8P(ADDR)[2], MG_U8P(ADDR)[3]
+
+#define MG_LOAD_BE16(p) ((uint16_t) ((MG_U8P(p)[0] << 8U) | MG_U8P(p)[1]))
+#define MG_LOAD_BE24(p) \
+  ((uint32_t) ((MG_U8P(p)[0] << 16U) | (MG_U8P(p)[1] << 8U) | MG_U8P(p)[2]))
+#define MG_STORE_BE16(p, n)           \
+  do {                                \
+    MG_U8P(p)[0] = ((n) >> 8U) & 255; \
+    MG_U8P(p)[1] = (n) &255;          \
+  } while (0)
+#define MG_STORE_BE24(p, n)            \
+  do {                                 \
+    MG_U8P(p)[0] = ((n) >> 16U) & 255; \
+    MG_U8P(p)[1] = ((n) >> 8U) & 255;  \
+    MG_U8P(p)[2] = (n) &255;           \
+  } while (0)
+
+#define MG_REG(x) ((volatile uint32_t *) (x))[0]
+#define MG_BIT(x) (((uint32_t) 1U) << (x))
+#define MG_SET_BITS(R, CLRMASK, SETMASK) (R) = ((R) & ~(CLRMASK)) | (SETMASK)
+
+#define MG_ROUND_UP(x, a) ((a) == 0 ? (x) : ((((x) + (a) -1) / (a)) * (a)))
+#define MG_ROUND_DOWN(x, a) ((a) == 0 ? (x) : (((x) / (a)) * (a)))
+
+#if defined(__GNUC__)
+#define MG_ARM_DISABLE_IRQ() asm volatile("cpsid i" : : : "memory")
+#define MG_ARM_ENABLE_IRQ() asm volatile("cpsie i" : : : "memory")
+#elif defined(__CCRH__)
+#define MG_RH850_DISABLE_IRQ() __DI()
+#define MG_RH850_ENABLE_IRQ() __EI()
+#else
+#define MG_ARM_DISABLE_IRQ()
+#define MG_ARM_ENABLE_IRQ()
+#endif
+
+#if defined(__CC_ARM)
+#define MG_DSB() __dsb(0xf)
+#elif defined(__ARMCC_VERSION)
+#define MG_DSB() __builtin_arm_dsb(0xf)
+#elif defined(__GNUC__) && defined(__arm__) && defined(__thumb__)
+#define MG_DSB() asm("DSB 0xf")
+#elif defined(__ICCARM__)
+#define MG_DSB() __iar_builtin_DSB()
+#else
+#define MG_DSB()
+#endif
+
+struct mg_addr;
+int mg_check_ip_acl(struct mg_str acl, struct mg_addr *remote_ip);
 
 // Linked list management macros
 #define LIST_ADD_HEAD(type_, head_, elem_) \
@@ -1057,10 +1218,11 @@ void mg_iobuf_free(struct mg_iobuf *);
 size_t mg_iobuf_add(struct mg_iobuf *, size_t, const void *, size_t);
 size_t mg_iobuf_del(struct mg_iobuf *, size_t ofs, size_t len);
 
-int mg_base64_update(unsigned char p, char *to, int len);
-int mg_base64_final(char *to, int len);
-int mg_base64_encode(const unsigned char *p, int n, char *to);
-int mg_base64_decode(const char *src, int n, char *dst);
+
+size_t mg_base64_update(unsigned char input_byte, char *buf, size_t len);
+size_t mg_base64_final(char *buf, size_t len);
+size_t mg_base64_encode(const unsigned char *p, size_t n, char *buf, size_t);
+size_t mg_base64_decode(const char *src, size_t n, char *dst, size_t);
 
 
 
@@ -1087,36 +1249,924 @@ typedef struct {
 void mg_sha1_init(mg_sha1_ctx *);
 void mg_sha1_update(mg_sha1_ctx *, const unsigned char *data, size_t len);
 void mg_sha1_final(unsigned char digest[20], mg_sha1_ctx *);
+// https://github.com/B-Con/crypto-algorithms
+// Author:     Brad Conte (brad AT bradconte.com)
+// Disclaimer: This code is presented "as is" without any guarantees.
+// Details:    Defines the API for the corresponding SHA1 implementation.
+// Copyright:  public domain
+
+
+
+
+
+typedef struct {
+  uint32_t state[8];
+  uint64_t bits;
+  uint32_t len;
+  unsigned char buffer[64];
+} mg_sha256_ctx;
+
+
+void mg_sha256_init(mg_sha256_ctx *);
+void mg_sha256_update(mg_sha256_ctx *, const unsigned char *data, size_t len);
+void mg_sha256_final(unsigned char digest[32], mg_sha256_ctx *);
+void mg_sha256(uint8_t dst[32], uint8_t *data, size_t datasz);
+void mg_hmac_sha256(uint8_t dst[32], uint8_t *key, size_t keysz, uint8_t *data,
+                    size_t datasz);
+
+typedef struct {
+    uint64_t state[8];
+    uint8_t buffer[128];
+    uint64_t bitlen[2];
+    uint32_t datalen;
+} mg_sha384_ctx;
+void mg_sha384_init(mg_sha384_ctx *ctx);
+void mg_sha384_update(mg_sha384_ctx *ctx, const uint8_t *data, size_t len);
+void mg_sha384_final(uint8_t digest[48], mg_sha384_ctx *ctx);
+void mg_sha384(uint8_t dst[48], uint8_t *data, size_t datasz);
+
+#ifndef TLS_X15519_H
+#define TLS_X15519_H
+
+
+
+#define X25519_BYTES 32
+extern const uint8_t X25519_BASE_POINT[X25519_BYTES];
+
+int mg_tls_x25519(uint8_t out[X25519_BYTES], const uint8_t scalar[X25519_BYTES],
+                  const uint8_t x1[X25519_BYTES], int clamp);
+
+
+#endif /* TLS_X15519_H */
+/******************************************************************************
+ *
+ * THIS SOURCE CODE IS HEREBY PLACED INTO THE PUBLIC DOMAIN FOR THE GOOD OF ALL
+ *
+ * This is a simple and straightforward implementation of AES-GCM authenticated
+ * encryption. The focus of this work was correctness & accuracy. It is written
+ * in straight 'C' without any particular focus upon optimization or speed. It
+ * should be endian (memory byte order) neutral since the few places that care
+ * are handled explicitly.
+ *
+ * This implementation of AES-GCM was created by Steven M. Gibson of GRC.com.
+ *
+ * It is intended for general purpose use, but was written in support of GRC's
+ * reference implementation of the SQRL (Secure Quick Reliable Login) client.
+ *
+ * See:    http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+ *         http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/ \
+ *         gcm/gcm-revised-spec.pdf
+ *
+ * NO COPYRIGHT IS CLAIMED IN THIS WORK, HOWEVER, NEITHER IS ANY WARRANTY MADE
+ * REGARDING ITS FITNESS FOR ANY PARTICULAR PURPOSE. USE IT AT YOUR OWN RISK.
+ *
+ *******************************************************************************/
+#ifndef TLS_AES128_H
+#define TLS_AES128_H
+
+/******************************************************************************
+ *  AES_CONTEXT : cipher context / holds inter-call data
+ ******************************************************************************/
+typedef struct {
+  int mode;          // 1 for Encryption, 0 for Decryption
+  int rounds;        // keysize-based rounds count
+  uint32_t *rk;      // pointer to current round key
+  uint32_t buf[68];  // key expansion buffer
+} aes_context;
+
+
+#define GCM_AUTH_FAILURE 0x55555555  // authentication failure
+
+/******************************************************************************
+ *  GCM_CONTEXT : MUST be called once before ANY use of this library
+ ******************************************************************************/
+int mg_gcm_initialize(void);
+
+//
+//  aes-gcm.h
+//  MKo
+//
+//  Created by Markus Kosmal on 20/11/14.
+//
+//
+int mg_aes_gcm_encrypt(unsigned char *output, const unsigned char *input,
+                       size_t input_length, const unsigned char *key,
+                       const size_t key_len, const unsigned char *iv,
+                       const size_t iv_len, unsigned char *aead,
+                       size_t aead_len, unsigned char *tag,
+                       const size_t tag_len);
+
+int mg_aes_gcm_decrypt(unsigned char *output, const unsigned char *input,
+                       size_t input_length, const unsigned char *key,
+                       const size_t key_len, const unsigned char *iv,
+                       const size_t iv_len);
+
+#endif /* TLS_AES128_H */
+
+// End of aes128 PD
+
+
+
+#define MG_UECC_SUPPORTS_secp256r1 1
+/* Copyright 2014, Kenneth MacKay. Licensed under the BSD 2-clause license. */
+
+#ifndef _UECC_H_
+#define _UECC_H_
+
+/* Platform selection options.
+If MG_UECC_PLATFORM is not defined, the code will try to guess it based on
+compiler macros. Possible values for MG_UECC_PLATFORM are defined below: */
+#define mg_uecc_arch_other 0
+#define mg_uecc_x86 1
+#define mg_uecc_x86_64 2
+#define mg_uecc_arm 3
+#define mg_uecc_arm_thumb 4
+#define mg_uecc_arm_thumb2 5
+#define mg_uecc_arm64 6
+#define mg_uecc_avr 7
+
+/* If desired, you can define MG_UECC_WORD_SIZE as appropriate for your platform
+(1, 4, or 8 bytes). If MG_UECC_WORD_SIZE is not explicitly defined then it will
+be automatically set based on your platform. */
+
+/* Optimization level; trade speed for code size.
+   Larger values produce code that is faster but larger.
+   Currently supported values are 0 - 4; 0 is unusably slow for most
+   applications. Optimization level 4 currently only has an effect ARM platforms
+   where more than one curve is enabled. */
+#ifndef MG_UECC_OPTIMIZATION_LEVEL
+#define MG_UECC_OPTIMIZATION_LEVEL 2
+#endif
+
+/* MG_UECC_SQUARE_FUNC - If enabled (defined as nonzero), this will cause a
+specific function to be used for (scalar) squaring instead of the generic
+multiplication function. This can make things faster somewhat faster, but
+increases the code size. */
+#ifndef MG_UECC_SQUARE_FUNC
+#define MG_UECC_SQUARE_FUNC 0
+#endif
+
+/* MG_UECC_VLI_NATIVE_LITTLE_ENDIAN - If enabled (defined as nonzero), this will
+switch to native little-endian format for *all* arrays passed in and out of the
+public API. This includes public and private keys, shared secrets, signatures
+and message hashes. Using this switch reduces the amount of call stack memory
+used by uECC, since less intermediate translations are required. Note that this
+will *only* work on native little-endian processors and it will treat the
+uint8_t arrays passed into the public API as word arrays, therefore requiring
+the provided byte arrays to be word aligned on architectures that do not support
+unaligned accesses. IMPORTANT: Keys and signatures generated with
+MG_UECC_VLI_NATIVE_LITTLE_ENDIAN=1 are incompatible with keys and signatures
+generated with MG_UECC_VLI_NATIVE_LITTLE_ENDIAN=0; all parties must use the same
+endianness. */
+#ifndef MG_UECC_VLI_NATIVE_LITTLE_ENDIAN
+#define MG_UECC_VLI_NATIVE_LITTLE_ENDIAN 0
+#endif
+
+/* Curve support selection. Set to 0 to remove that curve. */
+#ifndef MG_UECC_SUPPORTS_secp160r1
+#define MG_UECC_SUPPORTS_secp160r1 0
+#endif
+#ifndef MG_UECC_SUPPORTS_secp192r1
+#define MG_UECC_SUPPORTS_secp192r1 0
+#endif
+#ifndef MG_UECC_SUPPORTS_secp224r1
+#define MG_UECC_SUPPORTS_secp224r1 0
+#endif
+#ifndef MG_UECC_SUPPORTS_secp256r1
+#define MG_UECC_SUPPORTS_secp256r1 1
+#endif
+#ifndef MG_UECC_SUPPORTS_secp256k1
+#define MG_UECC_SUPPORTS_secp256k1 0
+#endif
+
+/* Specifies whether compressed point format is supported.
+   Set to 0 to disable point compression/decompression functions. */
+#ifndef MG_UECC_SUPPORT_COMPRESSED_POINT
+#define MG_UECC_SUPPORT_COMPRESSED_POINT 1
+#endif
+
+struct MG_UECC_Curve_t;
+typedef const struct MG_UECC_Curve_t *MG_UECC_Curve;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MG_UECC_SUPPORTS_secp160r1
+MG_UECC_Curve mg_uecc_secp160r1(void);
+#endif
+#if MG_UECC_SUPPORTS_secp192r1
+MG_UECC_Curve mg_uecc_secp192r1(void);
+#endif
+#if MG_UECC_SUPPORTS_secp224r1
+MG_UECC_Curve mg_uecc_secp224r1(void);
+#endif
+#if MG_UECC_SUPPORTS_secp256r1
+MG_UECC_Curve mg_uecc_secp256r1(void);
+#endif
+#if MG_UECC_SUPPORTS_secp256k1
+MG_UECC_Curve mg_uecc_secp256k1(void);
+#endif
+
+/* MG_UECC_RNG_Function type
+The RNG function should fill 'size' random bytes into 'dest'. It should return 1
+if 'dest' was filled with random data, or 0 if the random data could not be
+generated. The filled-in values should be either truly random, or from a
+cryptographically-secure PRNG.
+
+A correctly functioning RNG function must be set (using mg_uecc_set_rng())
+before calling mg_uecc_make_key() or mg_uecc_sign().
+
+Setting a correctly functioning RNG function improves the resistance to
+side-channel attacks for mg_uecc_shared_secret() and
+mg_uecc_sign_deterministic().
+
+A correct RNG function is set by default when building for Windows, Linux, or OS
+X. If you are building on another POSIX-compliant system that supports
+/dev/random or /dev/urandom, you can define MG_UECC_POSIX to use the predefined
+RNG. For embedded platforms there is no predefined RNG function; you must
+provide your own.
+*/
+typedef int (*MG_UECC_RNG_Function)(uint8_t *dest, unsigned size);
+
+/* mg_uecc_set_rng() function.
+Set the function that will be used to generate random bytes. The RNG function
+should return 1 if the random data was generated, or 0 if the random data could
+not be generated.
+
+On platforms where there is no predefined RNG function (eg embedded platforms),
+this must be called before mg_uecc_make_key() or mg_uecc_sign() are used.
+
+Inputs:
+    rng_function - The function that will be used to generate random bytes.
+*/
+void mg_uecc_set_rng(MG_UECC_RNG_Function rng_function);
+
+/* mg_uecc_get_rng() function.
+
+Returns the function that will be used to generate random bytes.
+*/
+MG_UECC_RNG_Function mg_uecc_get_rng(void);
+
+/* mg_uecc_curve_private_key_size() function.
+
+Returns the size of a private key for the curve in bytes.
+*/
+int mg_uecc_curve_private_key_size(MG_UECC_Curve curve);
+
+/* mg_uecc_curve_public_key_size() function.
+
+Returns the size of a public key for the curve in bytes.
+*/
+int mg_uecc_curve_public_key_size(MG_UECC_Curve curve);
+
+/* mg_uecc_make_key() function.
+Create a public/private key pair.
+
+Outputs:
+    public_key  - Will be filled in with the public key. Must be at least 2 *
+the curve size (in bytes) long. For example, if the curve is secp256r1,
+public_key must be 64 bytes long. private_key - Will be filled in with the
+private key. Must be as long as the curve order; this is typically the same as
+the curve size, except for secp160r1. For example, if the curve is secp256r1,
+private_key must be 32 bytes long.
+
+                  For secp160r1, private_key must be 21 bytes long! Note that
+the first byte will almost always be 0 (there is about a 1 in 2^80 chance of it
+being non-zero).
+
+Returns 1 if the key pair was generated successfully, 0 if an error occurred.
+*/
+int mg_uecc_make_key(uint8_t *public_key, uint8_t *private_key,
+                     MG_UECC_Curve curve);
+
+/* mg_uecc_shared_secret() function.
+Compute a shared secret given your secret key and someone else's public key. If
+the public key is not from a trusted source and has not been previously
+verified, you should verify it first using mg_uecc_valid_public_key(). Note: It
+is recommended that you hash the result of mg_uecc_shared_secret() before using
+it for symmetric encryption or HMAC.
+
+Inputs:
+    public_key  - The public key of the remote party.
+    private_key - Your private key.
+
+Outputs:
+    secret - Will be filled in with the shared secret value. Must be the same
+size as the curve size; for example, if the curve is secp256r1, secret must be
+32 bytes long.
+
+Returns 1 if the shared secret was generated successfully, 0 if an error
+occurred.
+*/
+int mg_uecc_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
+                          uint8_t *secret, MG_UECC_Curve curve);
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+/* mg_uecc_compress() function.
+Compress a public key.
+
+Inputs:
+    public_key - The public key to compress.
+
+Outputs:
+    compressed - Will be filled in with the compressed public key. Must be at
+least (curve size + 1) bytes long; for example, if the curve is secp256r1,
+                 compressed must be 33 bytes long.
+*/
+void mg_uecc_compress(const uint8_t *public_key, uint8_t *compressed,
+                      MG_UECC_Curve curve);
+
+/* mg_uecc_decompress() function.
+Decompress a compressed public key.
+
+Inputs:
+    compressed - The compressed public key.
+
+Outputs:
+    public_key - Will be filled in with the decompressed public key.
+*/
+void mg_uecc_decompress(const uint8_t *compressed, uint8_t *public_key,
+                        MG_UECC_Curve curve);
+#endif /* MG_UECC_SUPPORT_COMPRESSED_POINT */
+
+/* mg_uecc_valid_public_key() function.
+Check to see if a public key is valid.
+
+Note that you are not required to check for a valid public key before using any
+other uECC functions. However, you may wish to avoid spending CPU time computing
+a shared secret or verifying a signature using an invalid public key.
+
+Inputs:
+    public_key - The public key to check.
+
+Returns 1 if the public key is valid, 0 if it is invalid.
+*/
+int mg_uecc_valid_public_key(const uint8_t *public_key, MG_UECC_Curve curve);
+
+/* mg_uecc_compute_public_key() function.
+Compute the corresponding public key for a private key.
+
+Inputs:
+    private_key - The private key to compute the public key for
+
+Outputs:
+    public_key - Will be filled in with the corresponding public key
+
+Returns 1 if the key was computed successfully, 0 if an error occurred.
+*/
+int mg_uecc_compute_public_key(const uint8_t *private_key, uint8_t *public_key,
+                               MG_UECC_Curve curve);
+
+/* mg_uecc_sign() function.
+Generate an ECDSA signature for a given hash value.
+
+Usage: Compute a hash of the data you wish to sign (SHA-2 is recommended) and
+pass it in to this function along with your private key.
+
+Inputs:
+    private_key  - Your private key.
+    message_hash - The hash of the message to sign.
+    hash_size    - The size of message_hash in bytes.
+
+Outputs:
+    signature - Will be filled in with the signature value. Must be at least 2 *
+curve size long. For example, if the curve is secp256r1, signature must be 64
+bytes long.
+
+Returns 1 if the signature generated successfully, 0 if an error occurred.
+*/
+int mg_uecc_sign(const uint8_t *private_key, const uint8_t *message_hash,
+                 unsigned hash_size, uint8_t *signature, MG_UECC_Curve curve);
+
+/* MG_UECC_HashContext structure.
+This is used to pass in an arbitrary hash function to
+mg_uecc_sign_deterministic(). The structure will be used for multiple hash
+computations; each time a new hash is computed, init_hash() will be called,
+followed by one or more calls to update_hash(), and finally a call to
+finish_hash() to produce the resulting hash.
+
+The intention is that you will create a structure that includes
+MG_UECC_HashContext followed by any hash-specific data. For example:
+
+typedef struct SHA256_HashContext {
+    MG_UECC_HashContext uECC;
+    SHA256_CTX ctx;
+} SHA256_HashContext;
+
+void init_SHA256(MG_UECC_HashContext *base) {
+    SHA256_HashContext *context = (SHA256_HashContext *)base;
+    SHA256_Init(&context->ctx);
+}
+
+void update_SHA256(MG_UECC_HashContext *base,
+                   const uint8_t *message,
+                   unsigned message_size) {
+    SHA256_HashContext *context = (SHA256_HashContext *)base;
+    SHA256_Update(&context->ctx, message, message_size);
+}
+
+void finish_SHA256(MG_UECC_HashContext *base, uint8_t *hash_result) {
+    SHA256_HashContext *context = (SHA256_HashContext *)base;
+    SHA256_Final(hash_result, &context->ctx);
+}
+
+... when signing ...
+{
+    uint8_t tmp[32 + 32 + 64];
+    SHA256_HashContext ctx = {{&init_SHA256, &update_SHA256, &finish_SHA256, 64,
+32, tmp}}; mg_uecc_sign_deterministic(key, message_hash, &ctx.uECC, signature);
+}
+*/
+typedef struct MG_UECC_HashContext {
+  void (*init_hash)(const struct MG_UECC_HashContext *context);
+  void (*update_hash)(const struct MG_UECC_HashContext *context,
+                      const uint8_t *message, unsigned message_size);
+  void (*finish_hash)(const struct MG_UECC_HashContext *context,
+                      uint8_t *hash_result);
+  unsigned
+      block_size; /* Hash function block size in bytes, eg 64 for SHA-256. */
+  unsigned
+      result_size; /* Hash function result size in bytes, eg 32 for SHA-256. */
+  uint8_t *tmp;    /* Must point to a buffer of at least (2 * result_size +
+                      block_size) bytes. */
+} MG_UECC_HashContext;
+
+/* mg_uecc_sign_deterministic() function.
+Generate an ECDSA signature for a given hash value, using a deterministic
+algorithm (see RFC 6979). You do not need to set the RNG using mg_uecc_set_rng()
+before calling this function; however, if the RNG is defined it will improve
+resistance to side-channel attacks.
+
+Usage: Compute a hash of the data you wish to sign (SHA-2 is recommended) and
+pass it to this function along with your private key and a hash context. Note
+that the message_hash does not need to be computed with the same hash function
+used by hash_context.
+
+Inputs:
+    private_key  - Your private key.
+    message_hash - The hash of the message to sign.
+    hash_size    - The size of message_hash in bytes.
+    hash_context - A hash context to use.
+
+Outputs:
+    signature - Will be filled in with the signature value.
+
+Returns 1 if the signature generated successfully, 0 if an error occurred.
+*/
+int mg_uecc_sign_deterministic(const uint8_t *private_key,
+                               const uint8_t *message_hash, unsigned hash_size,
+                               const MG_UECC_HashContext *hash_context,
+                               uint8_t *signature, MG_UECC_Curve curve);
+
+/* mg_uecc_verify() function.
+Verify an ECDSA signature.
+
+Usage: Compute the hash of the signed data using the same hash as the signer and
+pass it to this function along with the signer's public key and the signature
+values (r and s).
+
+Inputs:
+    public_key   - The signer's public key.
+    message_hash - The hash of the signed data.
+    hash_size    - The size of message_hash in bytes.
+    signature    - The signature value.
+
+Returns 1 if the signature is valid, 0 if it is invalid.
+*/
+int mg_uecc_verify(const uint8_t *public_key, const uint8_t *message_hash,
+                   unsigned hash_size, const uint8_t *signature,
+                   MG_UECC_Curve curve);
+
+#ifdef __cplusplus
+} /* end of extern "C" */
+#endif
+
+#endif /* _UECC_H_ */
+
+/* Copyright 2015, Kenneth MacKay. Licensed under the BSD 2-clause license. */
+
+#ifndef _UECC_TYPES_H_
+#define _UECC_TYPES_H_
+
+#ifndef MG_UECC_PLATFORM
+#if defined(__AVR__) && __AVR__
+#define MG_UECC_PLATFORM mg_uecc_avr
+#elif defined(__thumb2__) || \
+    defined(_M_ARMT) /* I think MSVC only supports Thumb-2 targets */
+#define MG_UECC_PLATFORM mg_uecc_arm_thumb2
+#elif defined(__thumb__)
+#define MG_UECC_PLATFORM mg_uecc_arm_thumb
+#elif defined(__arm__) || defined(_M_ARM)
+#define MG_UECC_PLATFORM mg_uecc_arm
+#elif defined(__aarch64__)
+#define MG_UECC_PLATFORM mg_uecc_arm64
+#elif defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \
+    defined(__I86__)
+#define MG_UECC_PLATFORM mg_uecc_x86
+#elif defined(__amd64__) || defined(_M_X64)
+#define MG_UECC_PLATFORM mg_uecc_x86_64
+#else
+#define MG_UECC_PLATFORM mg_uecc_arch_other
+#endif
+#endif
+
+#ifndef MG_UECC_ARM_USE_UMAAL
+#if (MG_UECC_PLATFORM == mg_uecc_arm) && (__ARM_ARCH >= 6)
+#define MG_UECC_ARM_USE_UMAAL 1
+#elif (MG_UECC_PLATFORM == mg_uecc_arm_thumb2) && (__ARM_ARCH >= 6) && \
+    (!defined(__ARM_ARCH_7M__) || !__ARM_ARCH_7M__)
+#define MG_UECC_ARM_USE_UMAAL 1
+#else
+#define MG_UECC_ARM_USE_UMAAL 0
+#endif
+#endif
+
+#ifndef MG_UECC_WORD_SIZE
+#if MG_UECC_PLATFORM == mg_uecc_avr
+#define MG_UECC_WORD_SIZE 1
+#elif (MG_UECC_PLATFORM == mg_uecc_x86_64 || MG_UECC_PLATFORM == mg_uecc_arm64)
+#define MG_UECC_WORD_SIZE 8
+#else
+#define MG_UECC_WORD_SIZE 4
+#endif
+#endif
+
+#if (MG_UECC_WORD_SIZE != 1) && (MG_UECC_WORD_SIZE != 4) && \
+    (MG_UECC_WORD_SIZE != 8)
+#error "Unsupported value for MG_UECC_WORD_SIZE"
+#endif
+
+#if ((MG_UECC_PLATFORM == mg_uecc_avr) && (MG_UECC_WORD_SIZE != 1))
+#pragma message("MG_UECC_WORD_SIZE must be 1 for AVR")
+#undef MG_UECC_WORD_SIZE
+#define MG_UECC_WORD_SIZE 1
+#endif
+
+#if ((MG_UECC_PLATFORM == mg_uecc_arm ||         \
+      MG_UECC_PLATFORM == mg_uecc_arm_thumb ||   \
+      MG_UECC_PLATFORM == mg_uecc_arm_thumb2) && \
+     (MG_UECC_WORD_SIZE != 4))
+#pragma message("MG_UECC_WORD_SIZE must be 4 for ARM")
+#undef MG_UECC_WORD_SIZE
+#define MG_UECC_WORD_SIZE 4
+#endif
+
+typedef int8_t wordcount_t;
+typedef int16_t bitcount_t;
+typedef int8_t cmpresult_t;
+
+#if (MG_UECC_WORD_SIZE == 1)
+
+typedef uint8_t mg_uecc_word_t;
+typedef uint16_t mg_uecc_dword_t;
+
+#define HIGH_BIT_SET 0x80
+#define MG_UECC_WORD_BITS 8
+#define MG_UECC_WORD_BITS_SHIFT 3
+#define MG_UECC_WORD_BITS_MASK 0x07
+
+#elif (MG_UECC_WORD_SIZE == 4)
+
+typedef uint32_t mg_uecc_word_t;
+typedef uint64_t mg_uecc_dword_t;
+
+#define HIGH_BIT_SET 0x80000000
+#define MG_UECC_WORD_BITS 32
+#define MG_UECC_WORD_BITS_SHIFT 5
+#define MG_UECC_WORD_BITS_MASK 0x01F
+
+#elif (MG_UECC_WORD_SIZE == 8)
+
+typedef uint64_t mg_uecc_word_t;
+
+#define HIGH_BIT_SET 0x8000000000000000U
+#define MG_UECC_WORD_BITS 64
+#define MG_UECC_WORD_BITS_SHIFT 6
+#define MG_UECC_WORD_BITS_MASK 0x03F
+
+#endif /* MG_UECC_WORD_SIZE */
+
+#endif /* _UECC_TYPES_H_ */
+
+/* Copyright 2015, Kenneth MacKay. Licensed under the BSD 2-clause license. */
+
+#ifndef _UECC_VLI_H_
+#define _UECC_VLI_H_
+
+// 
+// 
+
+/* Functions for raw large-integer manipulation. These are only available
+   if uECC.c is compiled with MG_UECC_ENABLE_VLI_API defined to 1. */
+#ifndef MG_UECC_ENABLE_VLI_API
+#define MG_UECC_ENABLE_VLI_API 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MG_UECC_ENABLE_VLI_API
+
+void mg_uecc_vli_clear(mg_uecc_word_t *vli, wordcount_t num_words);
+
+/* Constant-time comparison to zero - secure way to compare long integers */
+/* Returns 1 if vli == 0, 0 otherwise. */
+mg_uecc_word_t mg_uecc_vli_isZero(const mg_uecc_word_t *vli,
+                                  wordcount_t num_words);
+
+/* Returns nonzero if bit 'bit' of vli is set. */
+mg_uecc_word_t mg_uecc_vli_testBit(const mg_uecc_word_t *vli, bitcount_t bit);
+
+/* Counts the number of bits required to represent vli. */
+bitcount_t mg_uecc_vli_numBits(const mg_uecc_word_t *vli,
+                               const wordcount_t max_words);
+
+/* Sets dest = src. */
+void mg_uecc_vli_set(mg_uecc_word_t *dest, const mg_uecc_word_t *src,
+                     wordcount_t num_words);
+
+/* Constant-time comparison function - secure way to compare long integers */
+/* Returns one if left == right, zero otherwise */
+mg_uecc_word_t mg_uecc_vli_equal(const mg_uecc_word_t *left,
+                                 const mg_uecc_word_t *right,
+                                 wordcount_t num_words);
+
+/* Constant-time comparison function - secure way to compare long integers */
+/* Returns sign of left - right, in constant time. */
+cmpresult_t mg_uecc_vli_cmp(const mg_uecc_word_t *left,
+                            const mg_uecc_word_t *right, wordcount_t num_words);
+
+/* Computes vli = vli >> 1. */
+void mg_uecc_vli_rshift1(mg_uecc_word_t *vli, wordcount_t num_words);
+
+/* Computes result = left + right, returning carry. Can modify in place. */
+mg_uecc_word_t mg_uecc_vli_add(mg_uecc_word_t *result,
+                               const mg_uecc_word_t *left,
+                               const mg_uecc_word_t *right,
+                               wordcount_t num_words);
+
+/* Computes result = left - right, returning borrow. Can modify in place. */
+mg_uecc_word_t mg_uecc_vli_sub(mg_uecc_word_t *result,
+                               const mg_uecc_word_t *left,
+                               const mg_uecc_word_t *right,
+                               wordcount_t num_words);
+
+/* Computes result = left * right. Result must be 2 * num_words long. */
+void mg_uecc_vli_mult(mg_uecc_word_t *result, const mg_uecc_word_t *left,
+                      const mg_uecc_word_t *right, wordcount_t num_words);
+
+/* Computes result = left^2. Result must be 2 * num_words long. */
+void mg_uecc_vli_square(mg_uecc_word_t *result, const mg_uecc_word_t *left,
+                        wordcount_t num_words);
+
+/* Computes result = (left + right) % mod.
+   Assumes that left < mod and right < mod, and that result does not overlap
+   mod. */
+void mg_uecc_vli_modAdd(mg_uecc_word_t *result, const mg_uecc_word_t *left,
+                        const mg_uecc_word_t *right, const mg_uecc_word_t *mod,
+                        wordcount_t num_words);
+
+/* Computes result = (left - right) % mod.
+   Assumes that left < mod and right < mod, and that result does not overlap
+   mod. */
+void mg_uecc_vli_modSub(mg_uecc_word_t *result, const mg_uecc_word_t *left,
+                        const mg_uecc_word_t *right, const mg_uecc_word_t *mod,
+                        wordcount_t num_words);
+
+/* Computes result = product % mod, where product is 2N words long.
+   Currently only designed to work for mod == curve->p or curve_n. */
+void mg_uecc_vli_mmod(mg_uecc_word_t *result, mg_uecc_word_t *product,
+                      const mg_uecc_word_t *mod, wordcount_t num_words);
+
+/* Calculates result = product (mod curve->p), where product is up to
+   2 * curve->num_words long. */
+void mg_uecc_vli_mmod_fast(mg_uecc_word_t *result, mg_uecc_word_t *product,
+                           MG_UECC_Curve curve);
+
+/* Computes result = (left * right) % mod.
+   Currently only designed to work for mod == curve->p or curve_n. */
+void mg_uecc_vli_modMult(mg_uecc_word_t *result, const mg_uecc_word_t *left,
+                         const mg_uecc_word_t *right, const mg_uecc_word_t *mod,
+                         wordcount_t num_words);
+
+/* Computes result = (left * right) % curve->p. */
+void mg_uecc_vli_modMult_fast(mg_uecc_word_t *result,
+                              const mg_uecc_word_t *left,
+                              const mg_uecc_word_t *right, MG_UECC_Curve curve);
+
+/* Computes result = left^2 % mod.
+   Currently only designed to work for mod == curve->p or curve_n. */
+void mg_uecc_vli_modSquare(mg_uecc_word_t *result, const mg_uecc_word_t *left,
+                           const mg_uecc_word_t *mod, wordcount_t num_words);
+
+/* Computes result = left^2 % curve->p. */
+void mg_uecc_vli_modSquare_fast(mg_uecc_word_t *result,
+                                const mg_uecc_word_t *left,
+                                MG_UECC_Curve curve);
+
+/* Computes result = (1 / input) % mod.*/
+void mg_uecc_vli_modInv(mg_uecc_word_t *result, const mg_uecc_word_t *input,
+                        const mg_uecc_word_t *mod, wordcount_t num_words);
+
+#if MG_UECC_SUPPORT_COMPRESSED_POINT
+/* Calculates a = sqrt(a) (mod curve->p) */
+void mg_uecc_vli_mod_sqrt(mg_uecc_word_t *a, MG_UECC_Curve curve);
+#endif
+
+/* Converts an integer in uECC native format to big-endian bytes. */
+void mg_uecc_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
+                               const mg_uecc_word_t *native);
+/* Converts big-endian bytes to an integer in uECC native format. */
+void mg_uecc_vli_bytesToNative(mg_uecc_word_t *native, const uint8_t *bytes,
+                               int num_bytes);
+
+unsigned mg_uecc_curve_num_words(MG_UECC_Curve curve);
+unsigned mg_uecc_curve_num_bytes(MG_UECC_Curve curve);
+unsigned mg_uecc_curve_num_bits(MG_UECC_Curve curve);
+unsigned mg_uecc_curve_num_n_words(MG_UECC_Curve curve);
+unsigned mg_uecc_curve_num_n_bytes(MG_UECC_Curve curve);
+unsigned mg_uecc_curve_num_n_bits(MG_UECC_Curve curve);
+
+const mg_uecc_word_t *mg_uecc_curve_p(MG_UECC_Curve curve);
+const mg_uecc_word_t *mg_uecc_curve_n(MG_UECC_Curve curve);
+const mg_uecc_word_t *mg_uecc_curve_G(MG_UECC_Curve curve);
+const mg_uecc_word_t *mg_uecc_curve_b(MG_UECC_Curve curve);
+
+int mg_uecc_valid_point(const mg_uecc_word_t *point, MG_UECC_Curve curve);
+
+/* Multiplies a point by a scalar. Points are represented by the X coordinate
+   followed by the Y coordinate in the same array, both coordinates are
+   curve->num_words long. Note that scalar must be curve->num_n_words long (NOT
+   curve->num_words). */
+void mg_uecc_point_mult(mg_uecc_word_t *result, const mg_uecc_word_t *point,
+                        const mg_uecc_word_t *scalar, MG_UECC_Curve curve);
+
+/* Generates a random integer in the range 0 < random < top.
+   Both random and top have num_words words. */
+int mg_uecc_generate_random_int(mg_uecc_word_t *random,
+                                const mg_uecc_word_t *top,
+                                wordcount_t num_words);
+
+#endif /* MG_UECC_ENABLE_VLI_API */
+
+#ifdef __cplusplus
+} /* end of extern "C" */
+#endif
+
+#endif /* _UECC_VLI_H_ */
+
+// End of uecc BSD-2
+// portable8439 v1.0.1
+// Source: https://github.com/DavyLandman/portable8439
+// Licensed under CC0-1.0
+// Contains poly1305-donna e6ad6e091d30d7f4ec2d4f978be1fcfcbce72781 (Public
+// Domain)
+
+
+
+
+#ifndef __PORTABLE_8439_H
+#define __PORTABLE_8439_H
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// provide your own decl specificier like -DPORTABLE_8439_DECL=ICACHE_RAM_ATTR
+#ifndef PORTABLE_8439_DECL
+#define PORTABLE_8439_DECL
+#endif
+
+/*
+ This library implements RFC 8439 a.k.a. ChaCha20-Poly1305 AEAD
+
+ You can use this library to avoid attackers mutating or reusing your
+ encrypted messages. This does assume you never reuse a nonce+key pair and,
+ if possible, carefully pick your associated data.
+*/
+
+/* Make sure we are either nested in C++ or running in a C99+ compiler
+#if !defined(__cplusplus) && !defined(_MSC_VER) && \
+    (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+#error "C99 or newer required"
+#endif */
+
+// #if CHAR_BIT > 8
+// #    error "Systems without native octals not suppoted"
+// #endif
+
+#if defined(_MSC_VER) || defined(__cplusplus)
+// add restrict support is possible
+#if (defined(_MSC_VER) && _MSC_VER >= 1900) || defined(__clang__) || \
+    defined(__GNUC__)
+#define restrict __restrict
+#else
+#define restrict
+#endif
+#endif
+
+#define RFC_8439_TAG_SIZE (16)
+#define RFC_8439_KEY_SIZE (32)
+#define RFC_8439_NONCE_SIZE (12)
+
+/*
+    Encrypt/Seal plain text bytes into a cipher text that can only be
+    decrypted by knowing the key, nonce and associated data.
+
+    input:
+        - key: RFC_8439_KEY_SIZE bytes that all parties have agreed
+            upon beforehand
+        - nonce: RFC_8439_NONCE_SIZE bytes that should never be repeated
+            for the same key. A counter or a pseudo-random value are fine.
+        - ad: associated data to include with calculating the tag of the
+            cipher text. Can be null for empty.
+        - plain_text: data to be encrypted, pointer + size should not overlap
+            with cipher_text pointer
+
+    output:
+        - cipher_text: encrypted plain_text with a tag appended. Make sure to
+            allocate at least plain_text_size + RFC_8439_TAG_SIZE
+
+    returns:
+        - size of bytes written to cipher_text, can be -1 if overlapping
+            pointers are passed for plain_text and cipher_text
+*/
+PORTABLE_8439_DECL size_t mg_chacha20_poly1305_encrypt(
+    uint8_t *restrict cipher_text, const uint8_t key[RFC_8439_KEY_SIZE],
+    const uint8_t nonce[RFC_8439_NONCE_SIZE], const uint8_t *restrict ad,
+    size_t ad_size, const uint8_t *restrict plain_text, size_t plain_text_size);
+
+/*
+    Decrypt/unseal cipher text given the right key, nonce, and additional data.
+
+    input:
+        - key: RFC_8439_KEY_SIZE bytes that all parties have agreed
+            upon beforehand
+        - nonce: RFC_8439_NONCE_SIZE bytes that should never be repeated for
+            the same key. A counter or a pseudo-random value are fine.
+        - ad: associated data to include with calculating the tag of the
+            cipher text. Can be null for empty.
+        - cipher_text: encrypted message.
+
+    output:
+        - plain_text: data to be encrypted, pointer + size should not overlap
+            with cipher_text pointer, leave at least enough room for
+            cipher_text_size - RFC_8439_TAG_SIZE
+
+    returns:
+        - size of bytes written to plain_text, -1 signals either:
+            - incorrect key/nonce/ad
+            - corrupted cipher_text
+            - overlapping pointers are passed for plain_text and cipher_text
+*/
+PORTABLE_8439_DECL size_t mg_chacha20_poly1305_decrypt(
+    uint8_t *restrict plain_text, const uint8_t key[RFC_8439_KEY_SIZE],
+    const uint8_t nonce[RFC_8439_NONCE_SIZE],
+    const uint8_t *restrict cipher_text, size_t cipher_text_size);
+#if defined(__cplusplus)
+}
+#endif
+#endif
+#ifndef TLS_RSA_H
+#define TLS_RSA_H
+
+
+int mg_rsa_mod_pow(const uint8_t *mod, size_t modsz, const uint8_t *exp, size_t expsz, const uint8_t *msg, size_t msgsz, uint8_t *out, size_t outsz);
+
+#endif // TLS_RSA_H
 
 
 struct mg_connection;
 typedef void (*mg_event_handler_t)(struct mg_connection *, int ev,
-                                   void *ev_data, void *fn_data);
+                                   void *ev_data);
 void mg_call(struct mg_connection *c, int ev, void *ev_data);
 void mg_error(struct mg_connection *c, const char *fmt, ...);
 
 enum {
-  MG_EV_ERROR,       // Error                        char *error_message
-  MG_EV_OPEN,        // Connection created           NULL
-  MG_EV_POLL,        // mg_mgr_poll iteration        uint64_t *uptime_millis
-  MG_EV_RESOLVE,     // Host name is resolved        NULL
-  MG_EV_CONNECT,     // Connection established       NULL
-  MG_EV_ACCEPT,      // Connection accepted          NULL
-  MG_EV_TLS_HS,      // TLS handshake succeeded      NULL
-  MG_EV_READ,        // Data received from socket    long *bytes_read
-  MG_EV_WRITE,       // Data written to socket       long *bytes_written
-  MG_EV_CLOSE,       // Connection closed            NULL
-  MG_EV_HTTP_MSG,    // HTTP request/response        struct mg_http_message *
-  MG_EV_HTTP_CHUNK,  // HTTP chunk (partial msg)     struct mg_http_message *
-  MG_EV_WS_OPEN,     // Websocket handshake done     struct mg_http_message *
-  MG_EV_WS_MSG,      // Websocket msg, text or bin   struct mg_ws_message *
-  MG_EV_WS_CTL,      // Websocket control msg        struct mg_ws_message *
-  MG_EV_MQTT_CMD,    // MQTT low-level command       struct mg_mqtt_message *
-  MG_EV_MQTT_MSG,    // MQTT PUBLISH received        struct mg_mqtt_message *
-  MG_EV_MQTT_OPEN,   // MQTT CONNACK received        int *connack_status_code
-  MG_EV_SNTP_TIME,   // SNTP time received           uint64_t *epoch_millis
-  MG_EV_USER         // Starting ID for user events
+  MG_EV_ERROR,      // Error                        char *error_message
+  MG_EV_OPEN,       // Connection created           NULL
+  MG_EV_POLL,       // mg_mgr_poll iteration        uint64_t *uptime_millis
+  MG_EV_RESOLVE,    // Host name is resolved        NULL
+  MG_EV_CONNECT,    // Connection established       NULL
+  MG_EV_ACCEPT,     // Connection accepted          NULL
+  MG_EV_TLS_HS,     // TLS handshake succeeded      NULL
+  MG_EV_READ,       // Data received from socket    long *bytes_read
+  MG_EV_WRITE,      // Data written to socket       long *bytes_written
+  MG_EV_CLOSE,      // Connection closed            NULL
+  MG_EV_HTTP_HDRS,  // HTTP headers                 struct mg_http_message *
+  MG_EV_HTTP_MSG,   // Full HTTP request/response   struct mg_http_message *
+  MG_EV_WS_OPEN,    // Websocket handshake done     struct mg_http_message *
+  MG_EV_WS_MSG,     // Websocket msg, text or bin   struct mg_ws_message *
+  MG_EV_WS_CTL,     // Websocket control msg        struct mg_ws_message *
+  MG_EV_MQTT_CMD,   // MQTT low-level command       struct mg_mqtt_message *
+  MG_EV_MQTT_MSG,   // MQTT PUBLISH received        struct mg_mqtt_message *
+  MG_EV_MQTT_OPEN,  // MQTT CONNACK received        int *connack_status_code
+  MG_EV_SNTP_TIME,  // SNTP time received           uint64_t *epoch_millis
+  MG_EV_WAKEUP,     // mg_wakeup() data received    struct mg_str *data
+  MG_EV_USER        // Starting ID for user events
 };
+
 
 
 
@@ -1132,10 +2182,10 @@ struct mg_dns {
 };
 
 struct mg_addr {
-  uint16_t port;    // TCP or UDP port in network byte order
-  uint32_t ip;      // IP address in network byte order
-  uint8_t ip6[16];  // IPv6 address
-  bool is_ip6;      // True when address is IPv6 address
+  uint8_t ip[16];    // Holds IPv4 or IPv6 address, in network byte order
+  uint16_t port;     // TCP or UDP port in network byte order
+  uint8_t scope_id;  // IPv6 scope ID
+  bool is_ip6;       // True when address is IPv6 address
 };
 
 struct mg_mgr {
@@ -1147,12 +2197,14 @@ struct mg_mgr {
   unsigned long nextid;         // Next connection ID
   unsigned long timerid;        // Next timer ID
   void *userdata;               // Arbitrary user data pointer
+  void *tls_ctx;                // TLS context shared by all TLS sessions
   uint16_t mqtt_id;             // MQTT IDs for pub/sub
   void *active_dns_requests;    // DNS requests in progress
   struct mg_timer *timers;      // Active timers
   int epoll_fd;                 // Used when MG_EPOLL_ENABLE=1
-  void *priv;                   // Used by the MIP stack
-  size_t extraconnsize;         // Used by the MIP stack
+  struct mg_tcpip_if *ifp;      // Builtin TCP/IP stack only. Interface pointer
+  size_t extraconnsize;         // Builtin TCP/IP stack only. Extra space
+  MG_SOCKET_TYPE pipe;          // Socketpair end for mg_wakeup()
 #if MG_ENABLE_FREERTOS_TCP
   SocketSet_t ss;  // NOTE(lsm): referenced from socket struct
 #endif
@@ -1167,6 +2219,8 @@ struct mg_connection {
   unsigned long id;            // Auto-incrementing unique connection ID
   struct mg_iobuf recv;        // Incoming data
   struct mg_iobuf send;        // Outgoing data
+  struct mg_iobuf prof;        // Profile data enabled by MG_ENABLE_PROFILE
+  struct mg_iobuf rtls;        // TLS only. Incoming encrypted data
   mg_event_handler_t fn;       // User-specified event handler function
   void *fn_data;               // User-specified function parameter
   mg_event_handler_t pfn;      // Protocol-specific handler function
@@ -1208,7 +2262,6 @@ bool mg_send(struct mg_connection *, const void *, size_t);
 size_t mg_printf(struct mg_connection *, const char *fmt, ...);
 size_t mg_vprintf(struct mg_connection *, const char *fmt, va_list *ap);
 bool mg_aton(struct mg_str str, struct mg_addr *addr);
-int mg_mkpipe(struct mg_mgr *, mg_event_handler_t, void *, bool udp);
 
 // These functions are used to integrate with custom network stacks
 struct mg_connection *mg_alloc_conn(struct mg_mgr *);
@@ -1216,13 +2269,10 @@ void mg_close_conn(struct mg_connection *c);
 bool mg_open_listener(struct mg_connection *c, const char *url);
 
 // Utility functions
+bool mg_wakeup(struct mg_mgr *, unsigned long id, const void *buf, size_t len);
+bool mg_wakeup_init(struct mg_mgr *);
 struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
                               unsigned flags, void (*fn)(void *), void *arg);
-
-// Low-level IO primives used by TLS layer
-enum { MG_IO_ERR = -1, MG_IO_WAIT = -2, MG_IO_RESET = -3 };
-long mg_io_send(struct mg_connection *c, const void *buf, size_t len);
-long mg_io_recv(struct mg_connection *c, void *buf, size_t len);
 
 
 
@@ -1241,7 +2291,6 @@ struct mg_http_message {
   struct mg_http_header headers[MG_MAX_HTTP_HEADERS];  // Headers
   struct mg_str body;                                  // Body
   struct mg_str head;                                  // Request + headers
-  struct mg_str chunk;    // Chunk for chunked encoding,  or partial body
   struct mg_str message;  // Request + headers + body
 };
 
@@ -1283,9 +2332,8 @@ int mg_http_get_var(const struct mg_str *, const char *name, char *, size_t);
 int mg_url_decode(const char *s, size_t n, char *to, size_t to_len, int form);
 size_t mg_url_encode(const char *s, size_t n, char *buf, size_t len);
 void mg_http_creds(struct mg_http_message *, char *, size_t, char *, size_t);
-bool mg_http_match_uri(const struct mg_http_message *, const char *glob);
 long mg_http_upload(struct mg_connection *c, struct mg_http_message *hm,
-                    struct mg_fs *fs, const char *path, size_t max_size);
+                    struct mg_fs *fs, const char *dir, size_t max_size);
 void mg_http_bauth(struct mg_connection *, const char *user, const char *pass);
 struct mg_str mg_http_get_header_var(struct mg_str s, struct mg_str v);
 size_t mg_http_next_multipart(struct mg_str, size_t, struct mg_http_part *);
@@ -1297,55 +2345,84 @@ void mg_http_serve_ssi(struct mg_connection *c, const char *root,
                        const char *fullpath);
 
 
+#define MG_TLS_NONE 0     // No TLS support
+#define MG_TLS_MBED 1     // mbedTLS
+#define MG_TLS_OPENSSL 2  // OpenSSL
+#define MG_TLS_WOLFSSL 5  // WolfSSL (based on OpenSSL)
+#define MG_TLS_BUILTIN 3  // Built-in
+#define MG_TLS_CUSTOM 4   // Custom implementation
+
+#ifndef MG_TLS
+#define MG_TLS MG_TLS_NONE
+#endif
+
 
 
 
 
 struct mg_tls_opts {
-  const char *ca;         // CA certificate file. For both listeners and clients
-  const char *crl;        // Certificate Revocation List. For clients
-  const char *cert;       // Certificate
-  const char *certkey;    // Certificate key
-  const char *ciphers;    // Cipher list
-  struct mg_str srvname;  // If not empty, enables server name verification
-  struct mg_fs *fs;       // FS API for reading certificate files
+  struct mg_str ca;       // PEM or DER
+  struct mg_str cert;     // PEM or DER
+  struct mg_str key;      // PEM or DER
+  struct mg_str name;     // If not empty, enable host name verification
+  int skip_verification;  // Skip certificate and host name verification
 };
 
-void mg_tls_init(struct mg_connection *, const struct mg_tls_opts *);
+void mg_tls_init(struct mg_connection *, const struct mg_tls_opts *opts);
 void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);
 size_t mg_tls_pending(struct mg_connection *);
 void mg_tls_handshake(struct mg_connection *);
 
+// Private
+void mg_tls_ctx_init(struct mg_mgr *);
+void mg_tls_ctx_free(struct mg_mgr *);
+
+// Low-level IO primives used by TLS layer
+enum { MG_IO_ERR = -1, MG_IO_WAIT = -2, MG_IO_RESET = -3 };
+long mg_io_send(struct mg_connection *c, const void *buf, size_t len);
+long mg_io_recv(struct mg_connection *c, void *buf, size_t len);
 
 
 
 
 
 
-#if MG_ENABLE_MBEDTLS
+
+#if MG_TLS == MG_TLS_MBED
 #include <mbedtls/debug.h>
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/ssl.h>
+#include <mbedtls/ssl_ticket.h>
+
+struct mg_tls_ctx {
+  int dummy;
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+  mbedtls_ssl_ticket_context tickets;
+#endif
+};
 
 struct mg_tls {
-  char *cafile;             // CA certificate path
   mbedtls_x509_crt ca;      // Parsed CA certificate
   mbedtls_x509_crt cert;    // Parsed certificate
+  mbedtls_pk_context pk;    // Private key context
   mbedtls_ssl_context ssl;  // SSL/TLS context
   mbedtls_ssl_config conf;  // SSL-TLS config
-  mbedtls_pk_context pk;    // Private key context
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+  mbedtls_ssl_ticket_context ticket;  // Session tickets context
+#endif
 };
 #endif
 
 
-#if MG_ENABLE_OPENSSL
+#if MG_TLS == MG_TLS_OPENSSL || MG_TLS == MG_TLS_WOLFSSL
 
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
 struct mg_tls {
+  BIO_METHOD *bm;
   SSL_CTX *ctx;
   SSL *ssl;
 };
@@ -1384,6 +2461,8 @@ struct mg_connection *mg_sntp_connect(struct mg_mgr *mgr, const char *url,
                                       mg_event_handler_t fn, void *fn_data);
 void mg_sntp_request(struct mg_connection *c);
 int64_t mg_sntp_parse(const unsigned char *buf, size_t len);
+
+uint64_t mg_now(void);     // Return milliseconds since Epoch
 
 
 
@@ -1456,28 +2535,29 @@ struct mg_mqtt_opts {
   struct mg_str user;               // Username, can be empty
   struct mg_str pass;               // Password, can be empty
   struct mg_str client_id;          // Client ID
-  struct mg_str topic;              // topic
-  struct mg_str message;            // message
+  struct mg_str topic;              // message/subscription topic
+  struct mg_str message;            // message content
   uint8_t qos;                      // message quality of service
-  uint8_t version;                  // Can be 4 (3.1.1), or 5. If 0, assume 4.
+  uint8_t version;                  // Can be 4 (3.1.1), or 5. If 0, assume 4
   uint16_t keepalive;               // Keep-alive timer in seconds
-  bool retain;                      // Retain last will
-  bool clean;                       // Use clean session, 0 or 1
+  uint16_t retransmit_id;           // For PUBLISH, init to 0
+  bool retain;                      // Retain flag
+  bool clean;                       // Clean session flag
   struct mg_mqtt_prop *props;       // MQTT5 props array
   size_t num_props;                 // number of props
-  struct mg_mqtt_prop *will_props;  // Valid only for CONNECT packet
+  struct mg_mqtt_prop *will_props;  // Valid only for CONNECT packet (MQTT5)
   size_t num_will_props;            // Number of will props
 };
 
 struct mg_mqtt_message {
-  struct mg_str topic;  // Parsed topic
-  struct mg_str data;   // Parsed message
-  struct mg_str dgram;  // Whole MQTT datagram, including headers
+  struct mg_str topic;  // Parsed topic for PUBLISH
+  struct mg_str data;   // Parsed message for PUBLISH
+  struct mg_str dgram;  // Whole MQTT packet, including headers
   uint16_t id;          // For PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK, PUBLISH
   uint8_t cmd;          // MQTT command, one of MQTT_CMD_*
   uint8_t qos;          // Quality of service
-  uint8_t ack;          // Connack return code. 0 - success
-  size_t props_start;   // Offset to the start of the properties
+  uint8_t ack;          // CONNACK return code, 0 = success
+  size_t props_start;   // Offset to the start of the properties (MQTT5)
   size_t props_size;    // Length of the properties
 };
 
@@ -1487,7 +2567,7 @@ struct mg_connection *mg_mqtt_connect(struct mg_mgr *, const char *url,
 struct mg_connection *mg_mqtt_listen(struct mg_mgr *mgr, const char *url,
                                      mg_event_handler_t fn, void *fn_data);
 void mg_mqtt_login(struct mg_connection *c, const struct mg_mqtt_opts *opts);
-void mg_mqtt_pub(struct mg_connection *c, const struct mg_mqtt_opts *opts);
+uint16_t mg_mqtt_pub(struct mg_connection *c, const struct mg_mqtt_opts *opts);
 void mg_mqtt_sub(struct mg_connection *, const struct mg_mqtt_opts *opts);
 int mg_mqtt_parse(const uint8_t *, size_t, uint8_t, struct mg_mqtt_message *);
 void mg_mqtt_send_header(struct mg_connection *, uint8_t cmd, uint8_t flags,
@@ -1548,12 +2628,17 @@ size_t mg_dns_parse_rr(const uint8_t *buf, size_t len, size_t ofs,
 enum { MG_JSON_TOO_DEEP = -1, MG_JSON_INVALID = -2, MG_JSON_NOT_FOUND = -3 };
 int mg_json_get(struct mg_str json, const char *path, int *toklen);
 
+struct mg_str mg_json_get_tok(struct mg_str json, const char *path);
 bool mg_json_get_num(struct mg_str json, const char *path, double *v);
 bool mg_json_get_bool(struct mg_str json, const char *path, bool *v);
 long mg_json_get_long(struct mg_str json, const char *path, long dflt);
 char *mg_json_get_str(struct mg_str json, const char *path);
 char *mg_json_get_hex(struct mg_str json, const char *path, int *len);
 char *mg_json_get_b64(struct mg_str json, const char *path, int *len);
+
+bool mg_json_unescape(struct mg_str str, char *buf, size_t len);
+size_t mg_json_next(struct mg_str obj, size_t ofs, struct mg_str *key,
+                    struct mg_str *val);
 
 
 
@@ -1587,20 +2672,91 @@ void mg_rpc_vok(struct mg_rpc_req *, const char *fmt, va_list *ap);
 void mg_rpc_err(struct mg_rpc_req *, int code, const char *fmt, ...);
 void mg_rpc_verr(struct mg_rpc_req *, int code, const char *fmt, va_list *);
 void mg_rpc_list(struct mg_rpc_req *r);
+// Copyright (c) 2023 Cesanta Software Limited
+// All rights reserved
 
 
-#if MG_ENABLE_TCPIP
+
+
+
+#define MG_OTA_NONE 0       // No OTA support
+#define MG_OTA_STM32H5 1    // STM32 H5
+#define MG_OTA_STM32H7 2    // STM32 H7
+#define MG_OTA_STM32H7_DUAL_CORE 3 // STM32 H7 dual core
+#define MG_OTA_STM32F  4    // STM32 F7/F4/F2
+#define MG_OTA_CH32V307 100 // WCH CH32V307
+#define MG_OTA_U2A 200      // Renesas U2A16, U2A8, U2A6
+#define MG_OTA_RT1020 300   // IMXRT1020
+#define MG_OTA_RT1060 301   // IMXRT1060
+#define MG_OTA_RT1064 302   // IMXRT1064
+#define MG_OTA_RT1170 303   // IMXRT1170
+#define MG_OTA_MCXN 310 	  // MCXN947
+#define MG_OTA_FLASH 900    // OTA via an internal flash
+#define MG_OTA_ESP32 910    // ESP32 OTA implementation
+#define MG_OTA_PICOSDK 920  // RP2040/2350 using Pico-SDK hardware_flash
+#define MG_OTA_CUSTOM 1000  // Custom implementation
+
+#ifndef MG_OTA
+#define MG_OTA MG_OTA_NONE
+#else
+#ifndef MG_IRAM
+#if defined(__GNUC__)
+#define MG_IRAM __attribute__((noinline, section(".iram")))
+#else
+#define MG_IRAM
+#endif // compiler
+#endif // IRAM
+#endif // OTA
+
+// Firmware update API
+bool mg_ota_begin(size_t new_firmware_size);     // Start writing
+bool mg_ota_write(const void *buf, size_t len);  // Write chunk, aligned to 1k
+bool mg_ota_end(void);                           // Stop writing
+
+
+
+#if MG_OTA != MG_OTA_NONE && MG_OTA != MG_OTA_CUSTOM
+
+struct mg_flash {
+  void *start;    // Address at which flash starts
+  size_t size;    // Flash size
+  size_t secsz;   // Sector size
+  size_t align;   // Write alignment
+  bool (*write_fn)(void *, const void *, size_t);  // Write function
+  bool (*swap_fn)(void);                           // Swap partitions
+};
+
+bool mg_ota_flash_begin(size_t new_firmware_size, struct mg_flash *flash);
+bool mg_ota_flash_write(const void *buf, size_t len, struct mg_flash *flash);
+bool mg_ota_flash_end(struct mg_flash *flash);
+
+#endif
 
 
 
 
-struct mg_tcpip_if;  // MIP network interface
+
+
+
+struct mg_tcpip_if;  // Mongoose TCP/IP network interface
 
 struct mg_tcpip_driver {
   bool (*init)(struct mg_tcpip_if *);                         // Init driver
   size_t (*tx)(const void *, size_t, struct mg_tcpip_if *);   // Transmit frame
   size_t (*rx)(void *buf, size_t len, struct mg_tcpip_if *);  // Receive frame
   bool (*up)(struct mg_tcpip_if *);                           // Up/down status
+};
+
+typedef void (*mg_tcpip_event_handler_t)(struct mg_tcpip_if *ifp, int ev,
+                                         void *ev_data);
+
+enum {
+  MG_TCPIP_EV_ST_CHG,     // state change             uint8_t * (&ifp->state)
+  MG_TCPIP_EV_DHCP_DNS,   // DHCP DNS assignment      uint32_t *ipaddr
+  MG_TCPIP_EV_DHCP_SNTP,  // DHCP SNTP assignment     uint32_t *ipaddr
+  MG_TCPIP_EV_ARP,        // Got ARP packet           struct mg_str *
+  MG_TCPIP_EV_TIMER_1S,   // 1 second timer           NULL
+  MG_TCPIP_EV_USER        // Starting ID for user events
 };
 
 // Network interface
@@ -1610,18 +2766,24 @@ struct mg_tcpip_if {
   struct mg_str tx;                // Output (TX) buffer
   bool enable_dhcp_client;         // Enable DCHP client
   bool enable_dhcp_server;         // Enable DCHP server
-  bool enable_crc32_check;         // Do a CRC check on rx frames and strip it
-  bool enable_mac_check;           // Do a MAC check on rx frames
+  bool enable_get_gateway;         // DCHP server sets client as gateway
+  bool enable_req_dns;             // DCHP client requests DNS server
+  bool enable_req_sntp;            // DCHP client requests SNTP server
+  bool enable_crc32_check;         // Do a CRC check on RX frames and strip it
+  bool enable_mac_check;           // Do a MAC check on RX frames
   struct mg_tcpip_driver *driver;  // Low level driver
   void *driver_data;               // Driver-specific data
+  mg_tcpip_event_handler_t fn;     // User-specified event handler function
   struct mg_mgr *mgr;              // Mongoose event manager
   struct mg_queue recv_queue;      // Receive queue
+  uint16_t mtu;                    // Interface MTU
+#define MG_TCPIP_MTU_DEFAULT 1500
 
   // Internal state, user can use it but should not change it
   uint8_t gwmac[6];             // Router's MAC
   uint64_t now;                 // Current time
   uint64_t timer_1000ms;        // 1000 ms timer: for DHCP and link state
-  uint64_t lease_expire;        // Lease expiration time
+  uint64_t lease_expire;        // Lease expiration time, in ms
   uint16_t eport;               // Next ephemeral port
   volatile uint32_t ndrop;      // Number of received, but dropped frames
   volatile uint32_t nrecv;      // Number of received frames
@@ -1630,18 +2792,30 @@ struct mg_tcpip_if {
   uint8_t state;                // Current state
 #define MG_TCPIP_STATE_DOWN 0   // Interface is down
 #define MG_TCPIP_STATE_UP 1     // Interface is up
-#define MG_TCPIP_STATE_READY 2  // Interface is up and has IP
+#define MG_TCPIP_STATE_REQ 2    // Interface is up, DHCP REQUESTING state
+#define MG_TCPIP_STATE_IP 3     // Interface is up and has an IP assigned
+#define MG_TCPIP_STATE_READY 4  // Interface has fully come up, ready to work
 };
 
 void mg_tcpip_init(struct mg_mgr *, struct mg_tcpip_if *);
 void mg_tcpip_free(struct mg_tcpip_if *);
 void mg_tcpip_qwrite(void *buf, size_t len, struct mg_tcpip_if *ifp);
+void mg_tcpip_arp_request(struct mg_tcpip_if *ifp, uint32_t ip, uint8_t *mac);
 
-extern struct mg_tcpip_driver mg_tcpip_driver_stm32;
+extern struct mg_tcpip_driver mg_tcpip_driver_stm32f;
 extern struct mg_tcpip_driver mg_tcpip_driver_w5500;
 extern struct mg_tcpip_driver mg_tcpip_driver_tm4c;
+extern struct mg_tcpip_driver mg_tcpip_driver_tms570;
 extern struct mg_tcpip_driver mg_tcpip_driver_stm32h;
 extern struct mg_tcpip_driver mg_tcpip_driver_imxrt;
+extern struct mg_tcpip_driver mg_tcpip_driver_same54;
+extern struct mg_tcpip_driver mg_tcpip_driver_cmsis;
+extern struct mg_tcpip_driver mg_tcpip_driver_ra;
+extern struct mg_tcpip_driver mg_tcpip_driver_xmc;
+extern struct mg_tcpip_driver mg_tcpip_driver_xmc7;
+extern struct mg_tcpip_driver mg_tcpip_driver_ppp;
+extern struct mg_tcpip_driver mg_tcpip_driver_pico_w;
+extern struct mg_tcpip_driver mg_tcpip_driver_rw612;
 
 // Drivers that require SPI, can use this SPI abstraction
 struct mg_tcpip_spi {
@@ -1651,30 +2825,274 @@ struct mg_tcpip_spi {
   uint8_t (*txn)(void *, uint8_t);  // SPI transaction: write 1 byte, read reply
 };
 
-#if !defined(MG_ENABLE_DRIVER_STM32H) && !defined(MG_ENABLE_DRIVER_TM4C)
-#define MG_ENABLE_DRIVER_STM32 1
+
+
+// Macros to record timestamped events that happens with a connection.
+// They are saved into a c->prof IO buffer, each event is a name and a 32-bit
+// timestamp in milliseconds since connection init time.
+//
+// Test (run in two separate terminals):
+//   make -C examples/http-server/ CFLAGS_EXTRA=-DMG_ENABLE_PROFILE=1
+//   curl localhost:8000
+// Output:
+//   1ea1f1e7 2 net.c:150:mg_close_conn      3 profile:                                                            
+//   1ea1f1e8 2 net.c:150:mg_close_conn      1ea1f1e6 init                                                         
+//   1ea1f1e8 2 net.c:150:mg_close_conn          0 EV_OPEN
+//   1ea1f1e8 2 net.c:150:mg_close_conn          0 EV_ACCEPT 
+//   1ea1f1e8 2 net.c:150:mg_close_conn          0 EV_READ
+//   1ea1f1e8 2 net.c:150:mg_close_conn          0 EV_HTTP_MSG
+//   1ea1f1e8 2 net.c:150:mg_close_conn          0 EV_WRITE
+//   1ea1f1e8 2 net.c:150:mg_close_conn          1 EV_CLOSE
+//
+// Usage:
+//   Enable profiling by setting MG_ENABLE_PROFILE=1
+//   Invoke MG_PROF_ADD(c, "MY_EVENT_1") in the places you'd like to measure
+
+#if MG_ENABLE_PROFILE
+struct mg_profitem {
+  const char *name;    // Event name
+  uint32_t timestamp;  // Milliseconds since connection creation (MG_EV_OPEN)
+};
+
+#define MG_PROFILE_ALLOC_GRANULARITY 256  // Can save 32 items wih to realloc
+
+// Adding a profile item to the c->prof. Must be as fast as possible.
+// Reallocation of the c->prof iobuf is not desirable here, that's why we
+// pre-allocate c->prof with MG_PROFILE_ALLOC_GRANULARITY.
+// This macro just inits and copies 8 bytes, and calls mg_millis(),
+// which should be fast enough.
+#define MG_PROF_ADD(c, name_)                                             \
+  do {                                                                    \
+    struct mg_iobuf *io = &c->prof;                                       \
+    uint32_t inittime = ((struct mg_profitem *) io->buf)->timestamp;      \
+    struct mg_profitem item = {name_, (uint32_t) mg_millis() - inittime}; \
+    mg_iobuf_add(io, io->len, &item, sizeof(item));                       \
+  } while (0)
+
+// Initialising profile for a new connection. Not time sensitive
+#define MG_PROF_INIT(c)                                          \
+  do {                                                           \
+    struct mg_profitem first = {"init", (uint32_t) mg_millis()}; \
+    mg_iobuf_init(&(c)->prof, 0, MG_PROFILE_ALLOC_GRANULARITY);  \
+    mg_iobuf_add(&c->prof, c->prof.len, &first, sizeof(first));  \
+  } while (0)
+
+#define MG_PROF_FREE(c) mg_iobuf_free(&(c)->prof)
+
+// Dumping the profile. Not time sensitive
+#define MG_PROF_DUMP(c)                                            \
+  do {                                                             \
+    struct mg_iobuf *io = &c->prof;                                \
+    struct mg_profitem *p = (struct mg_profitem *) io->buf;        \
+    struct mg_profitem *e = &p[io->len / sizeof(*p)];              \
+    MG_INFO(("%lu profile:", c->id));                              \
+    while (p < e) {                                                \
+      MG_INFO(("%5lx %s", (unsigned long) p->timestamp, p->name)); \
+      p++;                                                         \
+    }                                                              \
+  } while (0)
+
 #else
-#define MG_ENABLE_DRIVER_STM32 0
-#endif
+#define MG_PROF_INIT(c)
+#define MG_PROF_FREE(c)
+#define MG_PROF_ADD(c, name)
+#define MG_PROF_DUMP(c)
 #endif
 
 
-struct mg_tcpip_driver_imxrt1020_data {
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_CMSIS) && MG_ENABLE_DRIVER_CMSIS
+
+#include "Driver_ETH_MAC.h"  // keep this include
+#include "Driver_ETH_PHY.h"  // keep this include
+
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_IMXRT) && MG_ENABLE_DRIVER_IMXRT
+
+struct mg_tcpip_driver_imxrt_data {
   // MDC clock divider. MDC clock is derived from IPS Bus clock (ipg_clk),
   // must not exceed 2.5MHz. Configuration for clock range 2.36~2.50 MHz
-  //    ipg_clk       MSCR       mdc_cr VALUE
-  //    -------------------------------------
-  //                                -1  <-- tell driver to guess the value
-  //    25 MHz        0x04           0
-  //    33 MHz        0x06           1
-  //    40 MHz        0x07           2
-  //    50 MHz        0x09           3
-  //    66 MHz        0x0D           4  <-- value for iMXRT1020-EVK at max freq.
-  int mdc_cr;  // Valid values: -1, 0, 1, 2, 3, 4
+  // 37.5.1.8.2, Table 37-46 : f = ipg_clk / (2(mdc_cr + 1))
+  //    ipg_clk       mdc_cr VALUE
+  //    --------------------------
+  //                  -1  <-- TODO() tell driver to guess the value
+  //    25 MHz         4
+  //    33 MHz         6
+  //    40 MHz         7
+  //    50 MHz         9
+  //    66 MHz        13
+  int mdc_cr;  // Valid values: -1 to 63
+
+  uint8_t phy_addr;  // PHY address
+};
+
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 2
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 24
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                \
+  do {                                                           \
+    static struct mg_tcpip_driver_imxrt_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                              \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                      \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                   \
+    mif_.ip = MG_TCPIP_IP;                                       \
+    mif_.mask = MG_TCPIP_MASK;                                   \
+    mif_.gw = MG_TCPIP_GW;                                       \
+    mif_.driver = &mg_tcpip_driver_imxrt;                        \
+    mif_.driver_data = &driver_data_;                            \
+    MG_SET_MAC_ADDRESS(mif_.mac);                                \
+    mg_tcpip_init(mgr, &mif_);                                   \
+    MG_INFO(("Driver: imxrt, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+
+
+
+
+struct mg_phy {
+  uint16_t (*read_reg)(uint8_t addr, uint8_t reg);
+  void (*write_reg)(uint8_t addr, uint8_t reg, uint16_t value);
+};
+
+// PHY configuration settings, bitmask
+enum {
+  // Set if PHY LEDs are connected to ground
+  MG_PHY_LEDS_ACTIVE_HIGH = (1 << 0),
+  // Set when PHY clocks MAC. Otherwise, MAC clocks PHY
+  MG_PHY_CLOCKS_MAC = (1 << 1)
+};
+
+enum { MG_PHY_SPEED_10M, MG_PHY_SPEED_100M, MG_PHY_SPEED_1000M };
+
+void mg_phy_init(struct mg_phy *, uint8_t addr, uint8_t config);
+bool mg_phy_up(struct mg_phy *, uint8_t addr, bool *full_duplex,
+               uint8_t *speed);
+
+
+#if MG_ENABLE_TCPIP && MG_ARCH == MG_ARCH_PICOSDK && \
+    defined(MG_ENABLE_DRIVER_PICO_W) && MG_ENABLE_DRIVER_PICO_W
+
+#include "cyw43.h"              // keep this include
+#include "pico/cyw43_arch.h"    // keep this include
+#include "pico/unique_id.h"     // keep this include
+
+struct mg_tcpip_driver_pico_w_data {
+  char *ssid;
+  char *pass;
+};
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                 \
+  do {                                                            \
+    static struct mg_tcpip_driver_pico_w_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                               \
+    MG_SET_WIFI_CREDS(&driver_data_.ssid, &driver_data_.pass);    \
+    mif_.ip = MG_TCPIP_IP;                                        \
+    mif_.mask = MG_TCPIP_MASK;                                    \
+    mif_.gw = MG_TCPIP_GW;                                        \
+    mif_.driver = &mg_tcpip_driver_pico_w;                        \
+    mif_.driver_data = &driver_data_;                             \
+    mif_.recv_queue.size = 8192;                                  \
+    mif_.mac[0] = 2; /* MAC read from OTP at driver init */       \
+    mg_tcpip_init(mgr, &mif_);                                    \
+    MG_INFO(("Driver: pico-w, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+
+
+struct mg_tcpip_driver_ppp_data {
+  void *uart;                   // Opaque UART bus descriptor
+  void (*reset)(void *);        // Modem hardware reset
+  void (*tx)(void *, uint8_t);  // UART transmit single byte
+  int (*rx)(void *);            // UART receive single byte
+  const char **script;          // List of AT commands and expected replies
+  int script_index;             // Index of the current AT command in the list
+  uint64_t deadline;            // AT command deadline in ms
 };
 
 
-struct mg_tcpip_driver_stm32_data {
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_RA) && MG_ENABLE_DRIVER_RA
+
+struct mg_tcpip_driver_ra_data {
+  // MDC clock "divider". MDC clock is software generated,
+  uint32_t clock;    // core clock frequency in Hz
+  uint16_t irqno;    // IRQn, R_ICU->IELSR[irqno]
+  uint8_t phy_addr;  // PHY address
+};
+
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_RW612) && MG_ENABLE_DRIVER_RW612
+
+struct mg_tcpip_driver_rw612_data {
+  // 38.1.8 MII Speed Control Register (MSCR)
+  // MDC clock frequency must not exceed 2.5 MHz and is calculated as follows:
+  // MDC_freq = P_clock / ((mdc_cr + 1) * 2), where P_clock is the
+  // peripheral bus clock.
+  // IEEE802.3 clause 22 defines a minimum of 10 ns for the hold time on the
+  // MDIO output. Depending on the host bus frequency, the setting may need
+  // to be increased.
+  int mdc_cr;
+  int mdc_holdtime; // Valid values: [0-7]
+  uint8_t phy_addr;
+};
+
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 2
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 51
+#endif
+
+#ifndef MG_DRIVER_MDC_HOLDTIME
+#define MG_DRIVER_MDC_HOLDTIME 3
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                 \
+  do {                                                            \
+    static struct mg_tcpip_driver_rw612_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                               \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                       \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                    \
+    mif_.ip = MG_TCPIP_IP;                                        \
+    mif_.mask = MG_TCPIP_MASK;                                    \
+    mif_.gw = MG_TCPIP_GW;                                        \
+    mif_.driver = &mg_tcpip_driver_rw612;                        \
+    mif_.driver_data = &driver_data_;                             \
+    MG_SET_MAC_ADDRESS(mif_.mac);                                 \
+    mg_tcpip_init(mgr, &mif_);                                    \
+    MG_INFO(("Driver: rw612, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_SAME54) && MG_ENABLE_DRIVER_SAME54
+
+struct mg_tcpip_driver_same54_data {
+    int mdc_cr;
+};
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 5
+#endif
+
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_STM32F) && \
+    MG_ENABLE_DRIVER_STM32F
+
+struct mg_tcpip_driver_stm32f_data {
   // MDC clock divider. MDC clock is derived from HCLK, must not exceed 2.5MHz
   //    HCLK range    DIVIDER    mdc_cr VALUE
   //    -------------------------------------
@@ -1687,8 +3105,45 @@ struct mg_tcpip_driver_stm32_data {
   //    216-310 MHz   HCLK/124       5
   //    110, 111 Reserved
   int mdc_cr;  // Valid values: -1, 0, 1, 2, 3, 4, 5
+
+  uint8_t phy_addr;  // PHY address
 };
 
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 0
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 4
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                 \
+  do {                                                            \
+    static struct mg_tcpip_driver_stm32f_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                               \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                       \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                    \
+    mif_.ip = MG_TCPIP_IP;                                        \
+    mif_.mask = MG_TCPIP_MASK;                                    \
+    mif_.gw = MG_TCPIP_GW;                                        \
+    mif_.driver = &mg_tcpip_driver_stm32f;                        \
+    mif_.driver_data = &driver_data_;                             \
+    MG_SET_MAC_ADDRESS(mif_.mac);                                 \
+    mg_tcpip_init(mgr, &mif_);                                    \
+    MG_INFO(("Driver: stm32f, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+
+
+#if MG_ENABLE_TCPIP
+#if !defined(MG_ENABLE_DRIVER_STM32H)
+#define MG_ENABLE_DRIVER_STM32H 0
+#endif
+#if !defined(MG_ENABLE_DRIVER_MCXN)
+#define MG_ENABLE_DRIVER_MCXN 0
+#endif
+#if MG_ENABLE_DRIVER_STM32H || MG_ENABLE_DRIVER_MCXN
 
 struct mg_tcpip_driver_stm32h_data {
   // MDC clock divider. MDC clock is derived from HCLK, must not exceed 2.5MHz
@@ -1699,12 +3154,50 @@ struct mg_tcpip_driver_stm32h_data {
   //    100-150 MHz   HCLK/62        1
   //    20-35 MHz     HCLK/16        2
   //    35-60 MHz     HCLK/26        3
-  //    150-250 MHz   HCLK/102       4  <-- value for Nucleo-H* on max speed driven by HSI
-  //    250-300 MHz   HCLK/124       5  <-- value for Nucleo-H* on max speed driven by CSI
-  //    110, 111 Reserved
+  //    150-250 MHz   HCLK/102       4  <-- value for max speed HSI
+  //    250-300 MHz   HCLK/124       5  <-- value for Nucleo-H* on CSI
+  //    300-500 MHz   HCLK/204       6
+  //    500-800 MHz   HCLK/324       7
   int mdc_cr;  // Valid values: -1, 0, 1, 2, 3, 4, 5
+
+  uint8_t phy_addr;  // PHY address
+  uint8_t phy_conf;  // PHY config
 };
 
+#ifndef MG_TCPIP_PHY_CONF
+#define MG_TCPIP_PHY_CONF MG_PHY_CLOCKS_MAC
+#endif
+
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 0
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 4
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                 \
+  do {                                                            \
+    static struct mg_tcpip_driver_stm32h_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                               \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                       \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                    \
+    driver_data_.phy_conf = MG_TCPIP_PHY_CONF;                    \
+    mif_.ip = MG_TCPIP_IP;                                        \
+    mif_.mask = MG_TCPIP_MASK;                                    \
+    mif_.gw = MG_TCPIP_GW;                                        \
+    mif_.driver = &mg_tcpip_driver_stm32h;                        \
+    mif_.driver_data = &driver_data_;                             \
+    MG_SET_MAC_ADDRESS(mif_.mac);                                 \
+    mg_tcpip_init(mgr, &mif_);                                    \
+    MG_INFO(("Driver: stm32h, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_TM4C) && MG_ENABLE_DRIVER_TM4C
 
 struct mg_tcpip_driver_tm4c_data {
   // MDC clock divider. MDC clock is derived from SYSCLK, must not exceed 2.5MHz
@@ -1718,6 +3211,142 @@ struct mg_tcpip_driver_tm4c_data {
   //    0x4-0xF Reserved
   int mdc_cr;  // Valid values: -1, 0, 1, 2, 3
 };
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 1
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                               \
+  do {                                                          \
+    static struct mg_tcpip_driver_tm4c_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                             \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                     \
+    mif_.ip = MG_TCPIP_IP;                                      \
+    mif_.mask = MG_TCPIP_MASK;                                  \
+    mif_.gw = MG_TCPIP_GW;                                      \
+    mif_.driver = &mg_tcpip_driver_tm4c;                        \
+    mif_.driver_data = &driver_data_;                           \
+    MG_SET_MAC_ADDRESS(mif_.mac);                               \
+    mg_tcpip_init(mgr, &mif_);                                  \
+    MG_INFO(("Driver: tm4c, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_TMS570) && MG_ENABLE_DRIVER_TMS570
+struct mg_tcpip_driver_tms570_data {
+  int mdc_cr;
+  int phy_addr;
+};
+
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 0
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 1
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                               \
+  do {                                                          \
+    static struct mg_tcpip_driver_tms570_data driver_data_;     \
+    static struct mg_tcpip_if mif_;                             \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                     \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                  \
+    mif_.ip = MG_TCPIP_IP;                                      \
+    mif_.mask = MG_TCPIP_MASK;                                  \
+    mif_.gw = MG_TCPIP_GW;                                      \
+    mif_.driver = &mg_tcpip_driver_tms570;                      \
+    mif_.driver_data = &driver_data_;                           \
+    MG_SET_MAC_ADDRESS(mif_.mac);                               \
+    mg_tcpip_init(mgr, &mif_);                                  \
+    MG_INFO(("Driver: tms570, MAC: %M", mg_print_mac, mif_.mac));\
+  } while (0)
+#endif
+
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_XMC7) && MG_ENABLE_DRIVER_XMC7
+
+struct mg_tcpip_driver_xmc7_data {
+  int mdc_cr;  // Valid values: -1, 0, 1, 2, 3, 4, 5
+  uint8_t phy_addr;
+};
+
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 0
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 3
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                 \
+  do {                                                            \
+    static struct mg_tcpip_driver_xmc7_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                               \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                       \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                    \
+    mif_.ip = MG_TCPIP_IP;                                        \
+    mif_.mask = MG_TCPIP_MASK;                                    \
+    mif_.gw = MG_TCPIP_GW;                                        \
+    mif_.driver = &mg_tcpip_driver_xmc7;                        \
+    mif_.driver_data = &driver_data_;                             \
+    MG_SET_MAC_ADDRESS(mif_.mac);                                 \
+    mg_tcpip_init(mgr, &mif_);                                    \
+    MG_INFO(("Driver: xmc7, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
+
+
+
+#if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_XMC) && MG_ENABLE_DRIVER_XMC
+
+struct mg_tcpip_driver_xmc_data {
+  // 13.2.8.1 Station Management Functions
+  // MDC clock divider (). MDC clock is derived from ETH MAC clock
+  // It must not exceed 2.5MHz
+  // ETH Clock range  DIVIDER       mdc_cr VALUE
+  // --------------------------------------------
+  //                                     -1  <-- tell driver to guess the value
+  // 60-100 MHz       ETH Clock/42        0
+  // 100-150 MHz      ETH Clock/62        1
+  // 20-35 MHz        ETH Clock/16        2
+  // 35-60 MHz        ETH Clock/26        3
+  // 150-250 MHz      ETH Clock/102       4
+  // 250-300 MHz      ETH Clock/124       5
+  // 110, 111 Reserved
+  int mdc_cr;  // Valid values: -1, 0, 1, 2, 3, 4, 5
+  uint8_t phy_addr;
+};
+
+#ifndef MG_TCPIP_PHY_ADDR
+#define MG_TCPIP_PHY_ADDR 0
+#endif
+
+#ifndef MG_DRIVER_MDC_CR
+#define MG_DRIVER_MDC_CR 4
+#endif
+
+#define MG_TCPIP_DRIVER_INIT(mgr)                                 \
+  do {                                                            \
+    static struct mg_tcpip_driver_xmc_data driver_data_;       \
+    static struct mg_tcpip_if mif_;                               \
+    driver_data_.mdc_cr = MG_DRIVER_MDC_CR;                       \
+    driver_data_.phy_addr = MG_TCPIP_PHY_ADDR;                    \
+    mif_.ip = MG_TCPIP_IP;                                        \
+    mif_.mask = MG_TCPIP_MASK;                                    \
+    mif_.gw = MG_TCPIP_GW;                                        \
+    mif_.driver = &mg_tcpip_driver_xmc;                        \
+    mif_.driver_data = &driver_data_;                             \
+    MG_SET_MAC_ADDRESS(mif_.mac);                                 \
+    mg_tcpip_init(mgr, &mif_);                                    \
+    MG_INFO(("Driver: xmc, MAC: %M", mg_print_mac, mif_.mac)); \
+  } while (0)
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/standalone/inc/wine/dlls/vbscript/vbregexp.c
+++ b/standalone/inc/wine/dlls/vbscript/vbregexp.c
@@ -314,9 +314,11 @@ static HRESULT create_sub_matches(DWORD pos, match_state_t *result, SubMatches *
     DWORD i;
     HRESULT hres;
 
+#ifndef __STANDALONE__
     hres = init_regexp_typeinfo(SubMatches_tid);
     if(FAILED(hres))
         return hres;
+#endif
 
     ret = calloc(1, sizeof(*ret));
     if(!ret)
@@ -634,9 +636,11 @@ static HRESULT create_match2(DWORD pos, match_state_t **result, IMatch2 **match)
     Match2 *ret;
     HRESULT hres;
 
+#ifndef __STANDALONE__
     hres = init_regexp_typeinfo(Match2_tid);
     if(FAILED(hres))
         return hres;
+#endif
 
     ret = calloc(1, sizeof(*ret));
     if(!ret)

--- a/third-party/include/miniz/miniz.c
+++ b/third-party/include/miniz/miniz.c
@@ -1,3 +1,4 @@
+#include "miniz.h"
 /**************************************************************************
  *
  * Copyright 2013-2014 RAD Game Tools and Valve Software
@@ -24,45 +25,46 @@
  *
  **************************************************************************/
 
-#include "miniz.h"
+
 
 typedef unsigned char mz_validate_uint16[sizeof(mz_uint16) == 2 ? 1 : -1];
 typedef unsigned char mz_validate_uint32[sizeof(mz_uint32) == 4 ? 1 : -1];
 typedef unsigned char mz_validate_uint64[sizeof(mz_uint64) == 8 ? 1 : -1];
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* ------------------- zlib-style API's */
+    /* ------------------- zlib-style API's */
 
-mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len)
-{
-    mz_uint32 i, s1 = (mz_uint32)(adler & 0xffff), s2 = (mz_uint32)(adler >> 16);
-    size_t block_len = buf_len % 5552;
-    if (!ptr)
-        return MZ_ADLER32_INIT;
-    while (buf_len)
+    mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len)
     {
-        for (i = 0; i + 7 < block_len; i += 8, ptr += 8)
+        mz_uint32 i, s1 = (mz_uint32)(adler & 0xffff), s2 = (mz_uint32)(adler >> 16);
+        size_t block_len = buf_len % 5552;
+        if (!ptr)
+            return MZ_ADLER32_INIT;
+        while (buf_len)
         {
-            s1 += ptr[0], s2 += s1;
-            s1 += ptr[1], s2 += s1;
-            s1 += ptr[2], s2 += s1;
-            s1 += ptr[3], s2 += s1;
-            s1 += ptr[4], s2 += s1;
-            s1 += ptr[5], s2 += s1;
-            s1 += ptr[6], s2 += s1;
-            s1 += ptr[7], s2 += s1;
+            for (i = 0; i + 7 < block_len; i += 8, ptr += 8)
+            {
+                s1 += ptr[0], s2 += s1;
+                s1 += ptr[1], s2 += s1;
+                s1 += ptr[2], s2 += s1;
+                s1 += ptr[3], s2 += s1;
+                s1 += ptr[4], s2 += s1;
+                s1 += ptr[5], s2 += s1;
+                s1 += ptr[6], s2 += s1;
+                s1 += ptr[7], s2 += s1;
+            }
+            for (; i < block_len; ++i)
+                s1 += *ptr++, s2 += s1;
+            s1 %= 65521U, s2 %= 65521U;
+            buf_len -= block_len;
+            block_len = 5552;
         }
-        for (; i < block_len; ++i)
-            s1 += *ptr++, s2 += s1;
-        s1 %= 65521U, s2 %= 65521U;
-        buf_len -= block_len;
-        block_len = 5552;
+        return (s2 << 16) + s1;
     }
-    return (s2 << 16) + s1;
-}
 
 /* Karl Malbrain's compact CRC-32. See "A compact CCITT crc16 and crc32 C implementation that balances processor cache usage against speed": http://www.geocities.com/malbrain/ */
 #if 0
@@ -93,46 +95,45 @@ mz_ulong mz_crc32(mz_ulong crc, const mz_uint8 *ptr, size_t buf_len);
  */
 mz_ulong mz_crc32(mz_ulong crc, const mz_uint8 *ptr, size_t buf_len)
 {
-    static const mz_uint32 s_crc_table[256] =
-        {
-          0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535,
-          0x9E6495A3, 0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD,
-          0xE7B82D07, 0x90BF1D91, 0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D,
-          0x6DDDE4EB, 0xF4D4B551, 0x83D385C7, 0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC,
-          0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5, 0x3B6E20C8, 0x4C69105E, 0xD56041E4,
-          0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B, 0x35B5A8FA, 0x42B2986C,
-          0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59, 0x26D930AC,
-          0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
-          0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB,
-          0xB6662D3D, 0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F,
-          0x9FBFE4A5, 0xE8B8D433, 0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB,
-          0x086D3D2D, 0x91646C97, 0xE6635C01, 0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E,
-          0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457, 0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA,
-          0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65, 0x4DB26158, 0x3AB551CE,
-          0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB, 0x4369E96A,
-          0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
-          0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409,
-          0xCE61E49F, 0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81,
-          0xB7BD5C3B, 0xC0BA6CAD, 0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739,
-          0x9DD277AF, 0x04DB2615, 0x73DC1683, 0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8,
-          0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1, 0xF00F9344, 0x8708A3D2, 0x1E01F268,
-          0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7, 0xFED41B76, 0x89D32BE0,
-          0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5, 0xD6D6A3E8,
-          0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
-          0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF,
-          0x4669BE79, 0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703,
-          0x220216B9, 0x5505262F, 0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7,
-          0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D, 0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A,
-          0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713, 0x95BF4A82, 0xE2B87A14, 0x7BB12BAE,
-          0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21, 0x86D3D2D4, 0xF1D4E242,
-          0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777, 0x88085AE6,
-          0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
-          0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D,
-          0x3E6E77DB, 0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5,
-          0x47B2CF7F, 0x30B5FFE9, 0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605,
-          0xCDD70693, 0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94,
-          0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
-        };
+    static const mz_uint32 s_crc_table[256] = {
+        0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535,
+        0x9E6495A3, 0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD,
+        0xE7B82D07, 0x90BF1D91, 0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D,
+        0x6DDDE4EB, 0xF4D4B551, 0x83D385C7, 0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC,
+        0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5, 0x3B6E20C8, 0x4C69105E, 0xD56041E4,
+        0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B, 0x35B5A8FA, 0x42B2986C,
+        0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59, 0x26D930AC,
+        0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+        0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB,
+        0xB6662D3D, 0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F,
+        0x9FBFE4A5, 0xE8B8D433, 0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB,
+        0x086D3D2D, 0x91646C97, 0xE6635C01, 0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E,
+        0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457, 0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA,
+        0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65, 0x4DB26158, 0x3AB551CE,
+        0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB, 0x4369E96A,
+        0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+        0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409,
+        0xCE61E49F, 0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81,
+        0xB7BD5C3B, 0xC0BA6CAD, 0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739,
+        0x9DD277AF, 0x04DB2615, 0x73DC1683, 0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8,
+        0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1, 0xF00F9344, 0x8708A3D2, 0x1E01F268,
+        0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7, 0xFED41B76, 0x89D32BE0,
+        0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5, 0xD6D6A3E8,
+        0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+        0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF,
+        0x4669BE79, 0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703,
+        0x220216B9, 0x5505262F, 0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7,
+        0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D, 0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A,
+        0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713, 0x95BF4A82, 0xE2B87A14, 0x7BB12BAE,
+        0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21, 0x86D3D2D4, 0xF1D4E242,
+        0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777, 0x88085AE6,
+        0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+        0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D,
+        0x3E6E77DB, 0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5,
+        0x47B2CF7F, 0x30B5FFE9, 0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605,
+        0xCDD70693, 0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94,
+        0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
+    };
 
     mz_uint32 crc32 = (mz_uint32)crc ^ 0xFFFFFFFF;
     const mz_uint8 *pByte_buf = (const mz_uint8 *)ptr;
@@ -158,460 +159,459 @@ mz_ulong mz_crc32(mz_ulong crc, const mz_uint8 *ptr, size_t buf_len)
 }
 #endif
 
-void mz_free(void *p)
-{
-    MZ_FREE(p);
-}
+    void mz_free(void *p)
+    {
+        MZ_FREE(p);
+    }
 
-MINIZ_EXPORT void *miniz_def_alloc_func(void *opaque, size_t items, size_t size)
-{
-    (void)opaque, (void)items, (void)size;
-    return MZ_MALLOC(items * size);
-}
-MINIZ_EXPORT void miniz_def_free_func(void *opaque, void *address)
-{
-    (void)opaque, (void)address;
-    MZ_FREE(address);
-}
-MINIZ_EXPORT void *miniz_def_realloc_func(void *opaque, void *address, size_t items, size_t size)
-{
-    (void)opaque, (void)address, (void)items, (void)size;
-    return MZ_REALLOC(address, items * size);
-}
+    MINIZ_EXPORT void *miniz_def_alloc_func(void *opaque, size_t items, size_t size)
+    {
+        (void)opaque, (void)items, (void)size;
+        return MZ_MALLOC(items * size);
+    }
+    MINIZ_EXPORT void miniz_def_free_func(void *opaque, void *address)
+    {
+        (void)opaque, (void)address;
+        MZ_FREE(address);
+    }
+    MINIZ_EXPORT void *miniz_def_realloc_func(void *opaque, void *address, size_t items, size_t size)
+    {
+        (void)opaque, (void)address, (void)items, (void)size;
+        return MZ_REALLOC(address, items * size);
+    }
 
-const char *mz_version(void)
-{
-    return MZ_VERSION;
-}
+    const char *mz_version(void)
+    {
+        return MZ_VERSION;
+    }
 
 #ifndef MINIZ_NO_ZLIB_APIS
 
 #ifndef MINIZ_NO_DEFLATE_APIS
 
-int mz_deflateInit(mz_streamp pStream, int level)
-{
-    return mz_deflateInit2(pStream, level, MZ_DEFLATED, MZ_DEFAULT_WINDOW_BITS, 9, MZ_DEFAULT_STRATEGY);
-}
-
-int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits, int mem_level, int strategy)
-{
-    tdefl_compressor *pComp;
-    mz_uint comp_flags = TDEFL_COMPUTE_ADLER32 | tdefl_create_comp_flags_from_zip_params(level, window_bits, strategy);
-
-    if (!pStream)
-        return MZ_STREAM_ERROR;
-    if ((method != MZ_DEFLATED) || ((mem_level < 1) || (mem_level > 9)) || ((window_bits != MZ_DEFAULT_WINDOW_BITS) && (-window_bits != MZ_DEFAULT_WINDOW_BITS)))
-        return MZ_PARAM_ERROR;
-
-    pStream->data_type = 0;
-    pStream->adler = MZ_ADLER32_INIT;
-    pStream->msg = NULL;
-    pStream->reserved = 0;
-    pStream->total_in = 0;
-    pStream->total_out = 0;
-    if (!pStream->zalloc)
-        pStream->zalloc = miniz_def_alloc_func;
-    if (!pStream->zfree)
-        pStream->zfree = miniz_def_free_func;
-
-    pComp = (tdefl_compressor *)pStream->zalloc(pStream->opaque, 1, sizeof(tdefl_compressor));
-    if (!pComp)
-        return MZ_MEM_ERROR;
-
-    pStream->state = (struct mz_internal_state *)pComp;
-
-    if (tdefl_init(pComp, NULL, NULL, comp_flags) != TDEFL_STATUS_OKAY)
+    int mz_deflateInit(mz_streamp pStream, int level)
     {
-        mz_deflateEnd(pStream);
-        return MZ_PARAM_ERROR;
+        return mz_deflateInit2(pStream, level, MZ_DEFLATED, MZ_DEFAULT_WINDOW_BITS, 9, MZ_DEFAULT_STRATEGY);
     }
 
-    return MZ_OK;
-}
-
-int mz_deflateReset(mz_streamp pStream)
-{
-    if ((!pStream) || (!pStream->state) || (!pStream->zalloc) || (!pStream->zfree))
-        return MZ_STREAM_ERROR;
-    pStream->total_in = pStream->total_out = 0;
-    tdefl_init((tdefl_compressor *)pStream->state, NULL, NULL, ((tdefl_compressor *)pStream->state)->m_flags);
-    return MZ_OK;
-}
-
-int mz_deflate(mz_streamp pStream, int flush)
-{
-    size_t in_bytes, out_bytes;
-    mz_ulong orig_total_in, orig_total_out;
-    int mz_status = MZ_OK;
-
-    if ((!pStream) || (!pStream->state) || (flush < 0) || (flush > MZ_FINISH) || (!pStream->next_out))
-        return MZ_STREAM_ERROR;
-    if (!pStream->avail_out)
-        return MZ_BUF_ERROR;
-
-    if (flush == MZ_PARTIAL_FLUSH)
-        flush = MZ_SYNC_FLUSH;
-
-    if (((tdefl_compressor *)pStream->state)->m_prev_return_status == TDEFL_STATUS_DONE)
-        return (flush == MZ_FINISH) ? MZ_STREAM_END : MZ_BUF_ERROR;
-
-    orig_total_in = pStream->total_in;
-    orig_total_out = pStream->total_out;
-    for (;;)
+    int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits, int mem_level, int strategy)
     {
-        tdefl_status defl_status;
-        in_bytes = pStream->avail_in;
-        out_bytes = pStream->avail_out;
+        tdefl_compressor *pComp;
+        mz_uint comp_flags = TDEFL_COMPUTE_ADLER32 | tdefl_create_comp_flags_from_zip_params(level, window_bits, strategy);
 
-        defl_status = tdefl_compress((tdefl_compressor *)pStream->state, pStream->next_in, &in_bytes, pStream->next_out, &out_bytes, (tdefl_flush)flush);
-        pStream->next_in += (mz_uint)in_bytes;
-        pStream->avail_in -= (mz_uint)in_bytes;
-        pStream->total_in += (mz_uint)in_bytes;
-        pStream->adler = tdefl_get_adler32((tdefl_compressor *)pStream->state);
+        if (!pStream)
+            return MZ_STREAM_ERROR;
+        if ((method != MZ_DEFLATED) || ((mem_level < 1) || (mem_level > 9)) || ((window_bits != MZ_DEFAULT_WINDOW_BITS) && (-window_bits != MZ_DEFAULT_WINDOW_BITS)))
+            return MZ_PARAM_ERROR;
 
-        pStream->next_out += (mz_uint)out_bytes;
-        pStream->avail_out -= (mz_uint)out_bytes;
-        pStream->total_out += (mz_uint)out_bytes;
+        pStream->data_type = 0;
+        pStream->adler = MZ_ADLER32_INIT;
+        pStream->msg = NULL;
+        pStream->reserved = 0;
+        pStream->total_in = 0;
+        pStream->total_out = 0;
+        if (!pStream->zalloc)
+            pStream->zalloc = miniz_def_alloc_func;
+        if (!pStream->zfree)
+            pStream->zfree = miniz_def_free_func;
 
-        if (defl_status < 0)
+        pComp = (tdefl_compressor *)pStream->zalloc(pStream->opaque, 1, sizeof(tdefl_compressor));
+        if (!pComp)
+            return MZ_MEM_ERROR;
+
+        pStream->state = (struct mz_internal_state *)pComp;
+
+        if (tdefl_init(pComp, NULL, NULL, comp_flags) != TDEFL_STATUS_OKAY)
         {
-            mz_status = MZ_STREAM_ERROR;
-            break;
+            mz_deflateEnd(pStream);
+            return MZ_PARAM_ERROR;
         }
-        else if (defl_status == TDEFL_STATUS_DONE)
+
+        return MZ_OK;
+    }
+
+    int mz_deflateReset(mz_streamp pStream)
+    {
+        if ((!pStream) || (!pStream->state) || (!pStream->zalloc) || (!pStream->zfree))
+            return MZ_STREAM_ERROR;
+        pStream->total_in = pStream->total_out = 0;
+        tdefl_init((tdefl_compressor *)pStream->state, NULL, NULL, ((tdefl_compressor *)pStream->state)->m_flags);
+        return MZ_OK;
+    }
+
+    int mz_deflate(mz_streamp pStream, int flush)
+    {
+        size_t in_bytes, out_bytes;
+        mz_ulong orig_total_in, orig_total_out;
+        int mz_status = MZ_OK;
+
+        if ((!pStream) || (!pStream->state) || (flush < 0) || (flush > MZ_FINISH) || (!pStream->next_out))
+            return MZ_STREAM_ERROR;
+        if (!pStream->avail_out)
+            return MZ_BUF_ERROR;
+
+        if (flush == MZ_PARTIAL_FLUSH)
+            flush = MZ_SYNC_FLUSH;
+
+        if (((tdefl_compressor *)pStream->state)->m_prev_return_status == TDEFL_STATUS_DONE)
+            return (flush == MZ_FINISH) ? MZ_STREAM_END : MZ_BUF_ERROR;
+
+        orig_total_in = pStream->total_in;
+        orig_total_out = pStream->total_out;
+        for (;;)
         {
-            mz_status = MZ_STREAM_END;
-            break;
-        }
-        else if (!pStream->avail_out)
-            break;
-        else if ((!pStream->avail_in) && (flush != MZ_FINISH))
-        {
-            if ((flush) || (pStream->total_in != orig_total_in) || (pStream->total_out != orig_total_out))
+            tdefl_status defl_status;
+            in_bytes = pStream->avail_in;
+            out_bytes = pStream->avail_out;
+
+            defl_status = tdefl_compress((tdefl_compressor *)pStream->state, pStream->next_in, &in_bytes, pStream->next_out, &out_bytes, (tdefl_flush)flush);
+            pStream->next_in += (mz_uint)in_bytes;
+            pStream->avail_in -= (mz_uint)in_bytes;
+            pStream->total_in += (mz_uint)in_bytes;
+            pStream->adler = tdefl_get_adler32((tdefl_compressor *)pStream->state);
+
+            pStream->next_out += (mz_uint)out_bytes;
+            pStream->avail_out -= (mz_uint)out_bytes;
+            pStream->total_out += (mz_uint)out_bytes;
+
+            if (defl_status < 0)
+            {
+                mz_status = MZ_STREAM_ERROR;
                 break;
-            return MZ_BUF_ERROR; /* Can't make forward progress without some input.
- */
+            }
+            else if (defl_status == TDEFL_STATUS_DONE)
+            {
+                mz_status = MZ_STREAM_END;
+                break;
+            }
+            else if (!pStream->avail_out)
+                break;
+            else if ((!pStream->avail_in) && (flush != MZ_FINISH))
+            {
+                if ((flush) || (pStream->total_in != orig_total_in) || (pStream->total_out != orig_total_out))
+                    break;
+                return MZ_BUF_ERROR; /* Can't make forward progress without some input.
+                                      */
+            }
         }
+        return mz_status;
     }
-    return mz_status;
-}
 
-int mz_deflateEnd(mz_streamp pStream)
-{
-    if (!pStream)
-        return MZ_STREAM_ERROR;
-    if (pStream->state)
+    int mz_deflateEnd(mz_streamp pStream)
     {
-        pStream->zfree(pStream->opaque, pStream->state);
-        pStream->state = NULL;
+        if (!pStream)
+            return MZ_STREAM_ERROR;
+        if (pStream->state)
+        {
+            pStream->zfree(pStream->opaque, pStream->state);
+            pStream->state = NULL;
+        }
+        return MZ_OK;
     }
-    return MZ_OK;
-}
 
-mz_ulong mz_deflateBound(mz_streamp pStream, mz_ulong source_len)
-{
-    (void)pStream;
-    /* This is really over conservative. (And lame, but it's actually pretty tricky to compute a true upper bound given the way tdefl's blocking works.) */
-    return MZ_MAX(128 + (source_len * 110) / 100, 128 + source_len + ((source_len / (31 * 1024)) + 1) * 5);
-}
-
-int mz_compress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len, int level)
-{
-    int status;
-    mz_stream stream;
-    memset(&stream, 0, sizeof(stream));
-
-    /* In case mz_ulong is 64-bits (argh I hate longs). */
-    if ((mz_uint64)(source_len | *pDest_len) > 0xFFFFFFFFU)
-        return MZ_PARAM_ERROR;
-
-    stream.next_in = pSource;
-    stream.avail_in = (mz_uint32)source_len;
-    stream.next_out = pDest;
-    stream.avail_out = (mz_uint32)*pDest_len;
-
-    status = mz_deflateInit(&stream, level);
-    if (status != MZ_OK)
-        return status;
-
-    status = mz_deflate(&stream, MZ_FINISH);
-    if (status != MZ_STREAM_END)
+    mz_ulong mz_deflateBound(mz_streamp pStream, mz_ulong source_len)
     {
-        mz_deflateEnd(&stream);
-        return (status == MZ_OK) ? MZ_BUF_ERROR : status;
+        (void)pStream;
+        /* This is really over conservative. (And lame, but it's actually pretty tricky to compute a true upper bound given the way tdefl's blocking works.) */
+        return MZ_MAX(128 + (source_len * 110) / 100, 128 + source_len + ((source_len / (31 * 1024)) + 1) * 5);
     }
 
-    *pDest_len = stream.total_out;
-    return mz_deflateEnd(&stream);
-}
+    int mz_compress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len, int level)
+    {
+        int status;
+        mz_stream stream;
+        memset(&stream, 0, sizeof(stream));
 
-int mz_compress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len)
-{
-    return mz_compress2(pDest, pDest_len, pSource, source_len, MZ_DEFAULT_COMPRESSION);
-}
+        /* In case mz_ulong is 64-bits (argh I hate longs). */
+        if ((mz_uint64)(source_len | *pDest_len) > 0xFFFFFFFFU)
+            return MZ_PARAM_ERROR;
 
-mz_ulong mz_compressBound(mz_ulong source_len)
-{
-    return mz_deflateBound(NULL, source_len);
-}
+        stream.next_in = pSource;
+        stream.avail_in = (mz_uint32)source_len;
+        stream.next_out = pDest;
+        stream.avail_out = (mz_uint32)*pDest_len;
+
+        status = mz_deflateInit(&stream, level);
+        if (status != MZ_OK)
+            return status;
+
+        status = mz_deflate(&stream, MZ_FINISH);
+        if (status != MZ_STREAM_END)
+        {
+            mz_deflateEnd(&stream);
+            return (status == MZ_OK) ? MZ_BUF_ERROR : status;
+        }
+
+        *pDest_len = stream.total_out;
+        return mz_deflateEnd(&stream);
+    }
+
+    int mz_compress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len)
+    {
+        return mz_compress2(pDest, pDest_len, pSource, source_len, MZ_DEFAULT_COMPRESSION);
+    }
+
+    mz_ulong mz_compressBound(mz_ulong source_len)
+    {
+        return mz_deflateBound(NULL, source_len);
+    }
 
 #endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
 
 #ifndef MINIZ_NO_INFLATE_APIS
 
-typedef struct
-{
-    tinfl_decompressor m_decomp;
-    mz_uint m_dict_ofs, m_dict_avail, m_first_call, m_has_flushed;
-    int m_window_bits;
-    mz_uint8 m_dict[TINFL_LZ_DICT_SIZE];
-    tinfl_status m_last_status;
-} inflate_state;
-
-int mz_inflateInit2(mz_streamp pStream, int window_bits)
-{
-    inflate_state *pDecomp;
-    if (!pStream)
-        return MZ_STREAM_ERROR;
-    if ((window_bits != MZ_DEFAULT_WINDOW_BITS) && (-window_bits != MZ_DEFAULT_WINDOW_BITS))
-        return MZ_PARAM_ERROR;
-
-    pStream->data_type = 0;
-    pStream->adler = 0;
-    pStream->msg = NULL;
-    pStream->total_in = 0;
-    pStream->total_out = 0;
-    pStream->reserved = 0;
-    if (!pStream->zalloc)
-        pStream->zalloc = miniz_def_alloc_func;
-    if (!pStream->zfree)
-        pStream->zfree = miniz_def_free_func;
-
-    pDecomp = (inflate_state *)pStream->zalloc(pStream->opaque, 1, sizeof(inflate_state));
-    if (!pDecomp)
-        return MZ_MEM_ERROR;
-
-    pStream->state = (struct mz_internal_state *)pDecomp;
-
-    tinfl_init(&pDecomp->m_decomp);
-    pDecomp->m_dict_ofs = 0;
-    pDecomp->m_dict_avail = 0;
-    pDecomp->m_last_status = TINFL_STATUS_NEEDS_MORE_INPUT;
-    pDecomp->m_first_call = 1;
-    pDecomp->m_has_flushed = 0;
-    pDecomp->m_window_bits = window_bits;
-
-    return MZ_OK;
-}
-
-int mz_inflateInit(mz_streamp pStream)
-{
-    return mz_inflateInit2(pStream, MZ_DEFAULT_WINDOW_BITS);
-}
-
-int mz_inflateReset(mz_streamp pStream)
-{
-    inflate_state *pDecomp;
-    if (!pStream)
-        return MZ_STREAM_ERROR;
-
-    pStream->data_type = 0;
-    pStream->adler = 0;
-    pStream->msg = NULL;
-    pStream->total_in = 0;
-    pStream->total_out = 0;
-    pStream->reserved = 0;
-
-    pDecomp = (inflate_state *)pStream->state;
-
-    tinfl_init(&pDecomp->m_decomp);
-    pDecomp->m_dict_ofs = 0;
-    pDecomp->m_dict_avail = 0;
-    pDecomp->m_last_status = TINFL_STATUS_NEEDS_MORE_INPUT;
-    pDecomp->m_first_call = 1;
-    pDecomp->m_has_flushed = 0;
-    /* pDecomp->m_window_bits = window_bits */;
-
-    return MZ_OK;
-}
-
-int mz_inflate(mz_streamp pStream, int flush)
-{
-    inflate_state *pState;
-    mz_uint n, first_call, decomp_flags = TINFL_FLAG_COMPUTE_ADLER32;
-    size_t in_bytes, out_bytes, orig_avail_in;
-    tinfl_status status;
-
-    if ((!pStream) || (!pStream->state))
-        return MZ_STREAM_ERROR;
-    if (flush == MZ_PARTIAL_FLUSH)
-        flush = MZ_SYNC_FLUSH;
-    if ((flush) && (flush != MZ_SYNC_FLUSH) && (flush != MZ_FINISH))
-        return MZ_STREAM_ERROR;
-
-    pState = (inflate_state *)pStream->state;
-    if (pState->m_window_bits > 0)
-        decomp_flags |= TINFL_FLAG_PARSE_ZLIB_HEADER;
-    orig_avail_in = pStream->avail_in;
-
-    first_call = pState->m_first_call;
-    pState->m_first_call = 0;
-    if (pState->m_last_status < 0)
-        return MZ_DATA_ERROR;
-
-    if (pState->m_has_flushed && (flush != MZ_FINISH))
-        return MZ_STREAM_ERROR;
-    pState->m_has_flushed |= (flush == MZ_FINISH);
-
-    if ((flush == MZ_FINISH) && (first_call))
+    typedef struct
     {
-        /* MZ_FINISH on the first call implies that the input and output buffers are large enough to hold the entire compressed/decompressed file. */
-        decomp_flags |= TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
-        in_bytes = pStream->avail_in;
-        out_bytes = pStream->avail_out;
-        status = tinfl_decompress(&pState->m_decomp, pStream->next_in, &in_bytes, pStream->next_out, pStream->next_out, &out_bytes, decomp_flags);
-        pState->m_last_status = status;
-        pStream->next_in += (mz_uint)in_bytes;
-        pStream->avail_in -= (mz_uint)in_bytes;
-        pStream->total_in += (mz_uint)in_bytes;
-        pStream->adler = tinfl_get_adler32(&pState->m_decomp);
-        pStream->next_out += (mz_uint)out_bytes;
-        pStream->avail_out -= (mz_uint)out_bytes;
-        pStream->total_out += (mz_uint)out_bytes;
+        tinfl_decompressor m_decomp;
+        mz_uint m_dict_ofs, m_dict_avail, m_first_call, m_has_flushed;
+        int m_window_bits;
+        mz_uint8 m_dict[TINFL_LZ_DICT_SIZE];
+        tinfl_status m_last_status;
+    } inflate_state;
 
-        if (status < 0)
+    int mz_inflateInit2(mz_streamp pStream, int window_bits)
+    {
+        inflate_state *pDecomp;
+        if (!pStream)
+            return MZ_STREAM_ERROR;
+        if ((window_bits != MZ_DEFAULT_WINDOW_BITS) && (-window_bits != MZ_DEFAULT_WINDOW_BITS))
+            return MZ_PARAM_ERROR;
+
+        pStream->data_type = 0;
+        pStream->adler = 0;
+        pStream->msg = NULL;
+        pStream->total_in = 0;
+        pStream->total_out = 0;
+        pStream->reserved = 0;
+        if (!pStream->zalloc)
+            pStream->zalloc = miniz_def_alloc_func;
+        if (!pStream->zfree)
+            pStream->zfree = miniz_def_free_func;
+
+        pDecomp = (inflate_state *)pStream->zalloc(pStream->opaque, 1, sizeof(inflate_state));
+        if (!pDecomp)
+            return MZ_MEM_ERROR;
+
+        pStream->state = (struct mz_internal_state *)pDecomp;
+
+        tinfl_init(&pDecomp->m_decomp);
+        pDecomp->m_dict_ofs = 0;
+        pDecomp->m_dict_avail = 0;
+        pDecomp->m_last_status = TINFL_STATUS_NEEDS_MORE_INPUT;
+        pDecomp->m_first_call = 1;
+        pDecomp->m_has_flushed = 0;
+        pDecomp->m_window_bits = window_bits;
+
+        return MZ_OK;
+    }
+
+    int mz_inflateInit(mz_streamp pStream)
+    {
+        return mz_inflateInit2(pStream, MZ_DEFAULT_WINDOW_BITS);
+    }
+
+    int mz_inflateReset(mz_streamp pStream)
+    {
+        inflate_state *pDecomp;
+        if (!pStream)
+            return MZ_STREAM_ERROR;
+
+        pStream->data_type = 0;
+        pStream->adler = 0;
+        pStream->msg = NULL;
+        pStream->total_in = 0;
+        pStream->total_out = 0;
+        pStream->reserved = 0;
+
+        pDecomp = (inflate_state *)pStream->state;
+
+        tinfl_init(&pDecomp->m_decomp);
+        pDecomp->m_dict_ofs = 0;
+        pDecomp->m_dict_avail = 0;
+        pDecomp->m_last_status = TINFL_STATUS_NEEDS_MORE_INPUT;
+        pDecomp->m_first_call = 1;
+        pDecomp->m_has_flushed = 0;
+        /* pDecomp->m_window_bits = window_bits */;
+
+        return MZ_OK;
+    }
+
+    int mz_inflate(mz_streamp pStream, int flush)
+    {
+        inflate_state *pState;
+        mz_uint n, first_call, decomp_flags = TINFL_FLAG_COMPUTE_ADLER32;
+        size_t in_bytes, out_bytes, orig_avail_in;
+        tinfl_status status;
+
+        if ((!pStream) || (!pStream->state))
+            return MZ_STREAM_ERROR;
+        if (flush == MZ_PARTIAL_FLUSH)
+            flush = MZ_SYNC_FLUSH;
+        if ((flush) && (flush != MZ_SYNC_FLUSH) && (flush != MZ_FINISH))
+            return MZ_STREAM_ERROR;
+
+        pState = (inflate_state *)pStream->state;
+        if (pState->m_window_bits > 0)
+            decomp_flags |= TINFL_FLAG_PARSE_ZLIB_HEADER;
+        orig_avail_in = pStream->avail_in;
+
+        first_call = pState->m_first_call;
+        pState->m_first_call = 0;
+        if (pState->m_last_status < 0)
             return MZ_DATA_ERROR;
-        else if (status != TINFL_STATUS_DONE)
+
+        if (pState->m_has_flushed && (flush != MZ_FINISH))
+            return MZ_STREAM_ERROR;
+        pState->m_has_flushed |= (flush == MZ_FINISH);
+
+        if ((flush == MZ_FINISH) && (first_call))
         {
-            pState->m_last_status = TINFL_STATUS_FAILED;
-            return MZ_BUF_ERROR;
-        }
-        return MZ_STREAM_END;
-    }
-    /* flush != MZ_FINISH then we must assume there's more input. */
-    if (flush != MZ_FINISH)
-        decomp_flags |= TINFL_FLAG_HAS_MORE_INPUT;
+            /* MZ_FINISH on the first call implies that the input and output buffers are large enough to hold the entire compressed/decompressed file. */
+            decomp_flags |= TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
+            in_bytes = pStream->avail_in;
+            out_bytes = pStream->avail_out;
+            status = tinfl_decompress(&pState->m_decomp, pStream->next_in, &in_bytes, pStream->next_out, pStream->next_out, &out_bytes, decomp_flags);
+            pState->m_last_status = status;
+            pStream->next_in += (mz_uint)in_bytes;
+            pStream->avail_in -= (mz_uint)in_bytes;
+            pStream->total_in += (mz_uint)in_bytes;
+            pStream->adler = tinfl_get_adler32(&pState->m_decomp);
+            pStream->next_out += (mz_uint)out_bytes;
+            pStream->avail_out -= (mz_uint)out_bytes;
+            pStream->total_out += (mz_uint)out_bytes;
 
-    if (pState->m_dict_avail)
-    {
-        n = MZ_MIN(pState->m_dict_avail, pStream->avail_out);
-        memcpy(pStream->next_out, pState->m_dict + pState->m_dict_ofs, n);
-        pStream->next_out += n;
-        pStream->avail_out -= n;
-        pStream->total_out += n;
-        pState->m_dict_avail -= n;
-        pState->m_dict_ofs = (pState->m_dict_ofs + n) & (TINFL_LZ_DICT_SIZE - 1);
-        return ((pState->m_last_status == TINFL_STATUS_DONE) && (!pState->m_dict_avail)) ? MZ_STREAM_END : MZ_OK;
-    }
-
-    for (;;)
-    {
-        in_bytes = pStream->avail_in;
-        out_bytes = TINFL_LZ_DICT_SIZE - pState->m_dict_ofs;
-
-        status = tinfl_decompress(&pState->m_decomp, pStream->next_in, &in_bytes, pState->m_dict, pState->m_dict + pState->m_dict_ofs, &out_bytes, decomp_flags);
-        pState->m_last_status = status;
-
-        pStream->next_in += (mz_uint)in_bytes;
-        pStream->avail_in -= (mz_uint)in_bytes;
-        pStream->total_in += (mz_uint)in_bytes;
-        pStream->adler = tinfl_get_adler32(&pState->m_decomp);
-
-        pState->m_dict_avail = (mz_uint)out_bytes;
-
-        n = MZ_MIN(pState->m_dict_avail, pStream->avail_out);
-        memcpy(pStream->next_out, pState->m_dict + pState->m_dict_ofs, n);
-        pStream->next_out += n;
-        pStream->avail_out -= n;
-        pStream->total_out += n;
-        pState->m_dict_avail -= n;
-        pState->m_dict_ofs = (pState->m_dict_ofs + n) & (TINFL_LZ_DICT_SIZE - 1);
-
-        if (status < 0)
-            return MZ_DATA_ERROR; /* Stream is corrupted (there could be some uncompressed data left in the output dictionary - oh well). */
-        else if ((status == TINFL_STATUS_NEEDS_MORE_INPUT) && (!orig_avail_in))
-            return MZ_BUF_ERROR; /* Signal caller that we can't make forward progress without supplying more input or by setting flush to MZ_FINISH. */
-        else if (flush == MZ_FINISH)
-        {
-            /* The output buffer MUST be large to hold the remaining uncompressed data when flush==MZ_FINISH. */
-            if (status == TINFL_STATUS_DONE)
-                return pState->m_dict_avail ? MZ_BUF_ERROR : MZ_STREAM_END;
-            /* status here must be TINFL_STATUS_HAS_MORE_OUTPUT, which means there's at least 1 more byte on the way. If there's no more room left in the output buffer then something is wrong. */
-            else if (!pStream->avail_out)
+            if (status < 0)
+                return MZ_DATA_ERROR;
+            else if (status != TINFL_STATUS_DONE)
+            {
+                pState->m_last_status = TINFL_STATUS_FAILED;
                 return MZ_BUF_ERROR;
+            }
+            return MZ_STREAM_END;
         }
-        else if ((status == TINFL_STATUS_DONE) || (!pStream->avail_in) || (!pStream->avail_out) || (pState->m_dict_avail))
-            break;
+        /* flush != MZ_FINISH then we must assume there's more input. */
+        if (flush != MZ_FINISH)
+            decomp_flags |= TINFL_FLAG_HAS_MORE_INPUT;
+
+        if (pState->m_dict_avail)
+        {
+            n = MZ_MIN(pState->m_dict_avail, pStream->avail_out);
+            memcpy(pStream->next_out, pState->m_dict + pState->m_dict_ofs, n);
+            pStream->next_out += n;
+            pStream->avail_out -= n;
+            pStream->total_out += n;
+            pState->m_dict_avail -= n;
+            pState->m_dict_ofs = (pState->m_dict_ofs + n) & (TINFL_LZ_DICT_SIZE - 1);
+            return ((pState->m_last_status == TINFL_STATUS_DONE) && (!pState->m_dict_avail)) ? MZ_STREAM_END : MZ_OK;
+        }
+
+        for (;;)
+        {
+            in_bytes = pStream->avail_in;
+            out_bytes = TINFL_LZ_DICT_SIZE - pState->m_dict_ofs;
+
+            status = tinfl_decompress(&pState->m_decomp, pStream->next_in, &in_bytes, pState->m_dict, pState->m_dict + pState->m_dict_ofs, &out_bytes, decomp_flags);
+            pState->m_last_status = status;
+
+            pStream->next_in += (mz_uint)in_bytes;
+            pStream->avail_in -= (mz_uint)in_bytes;
+            pStream->total_in += (mz_uint)in_bytes;
+            pStream->adler = tinfl_get_adler32(&pState->m_decomp);
+
+            pState->m_dict_avail = (mz_uint)out_bytes;
+
+            n = MZ_MIN(pState->m_dict_avail, pStream->avail_out);
+            memcpy(pStream->next_out, pState->m_dict + pState->m_dict_ofs, n);
+            pStream->next_out += n;
+            pStream->avail_out -= n;
+            pStream->total_out += n;
+            pState->m_dict_avail -= n;
+            pState->m_dict_ofs = (pState->m_dict_ofs + n) & (TINFL_LZ_DICT_SIZE - 1);
+
+            if (status < 0)
+                return MZ_DATA_ERROR; /* Stream is corrupted (there could be some uncompressed data left in the output dictionary - oh well). */
+            else if ((status == TINFL_STATUS_NEEDS_MORE_INPUT) && (!orig_avail_in))
+                return MZ_BUF_ERROR; /* Signal caller that we can't make forward progress without supplying more input or by setting flush to MZ_FINISH. */
+            else if (flush == MZ_FINISH)
+            {
+                /* The output buffer MUST be large to hold the remaining uncompressed data when flush==MZ_FINISH. */
+                if (status == TINFL_STATUS_DONE)
+                    return pState->m_dict_avail ? MZ_BUF_ERROR : MZ_STREAM_END;
+                /* status here must be TINFL_STATUS_HAS_MORE_OUTPUT, which means there's at least 1 more byte on the way. If there's no more room left in the output buffer then something is wrong. */
+                else if (!pStream->avail_out)
+                    return MZ_BUF_ERROR;
+            }
+            else if ((status == TINFL_STATUS_DONE) || (!pStream->avail_in) || (!pStream->avail_out) || (pState->m_dict_avail))
+                break;
+        }
+
+        return ((status == TINFL_STATUS_DONE) && (!pState->m_dict_avail)) ? MZ_STREAM_END : MZ_OK;
     }
 
-    return ((status == TINFL_STATUS_DONE) && (!pState->m_dict_avail)) ? MZ_STREAM_END : MZ_OK;
-}
-
-int mz_inflateEnd(mz_streamp pStream)
-{
-    if (!pStream)
-        return MZ_STREAM_ERROR;
-    if (pStream->state)
+    int mz_inflateEnd(mz_streamp pStream)
     {
-        pStream->zfree(pStream->opaque, pStream->state);
-        pStream->state = NULL;
+        if (!pStream)
+            return MZ_STREAM_ERROR;
+        if (pStream->state)
+        {
+            pStream->zfree(pStream->opaque, pStream->state);
+            pStream->state = NULL;
+        }
+        return MZ_OK;
     }
-    return MZ_OK;
-}
-int mz_uncompress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong *pSource_len)
-{
-    mz_stream stream;
-    int status;
-    memset(&stream, 0, sizeof(stream));
-
-    /* In case mz_ulong is 64-bits (argh I hate longs). */
-    if ((mz_uint64)(*pSource_len | *pDest_len) > 0xFFFFFFFFU)
-        return MZ_PARAM_ERROR;
-
-    stream.next_in = pSource;
-    stream.avail_in = (mz_uint32)*pSource_len;
-    stream.next_out = pDest;
-    stream.avail_out = (mz_uint32)*pDest_len;
-
-    status = mz_inflateInit(&stream);
-    if (status != MZ_OK)
-        return status;
-
-    status = mz_inflate(&stream, MZ_FINISH);
-    *pSource_len = *pSource_len - stream.avail_in;
-    if (status != MZ_STREAM_END)
+    int mz_uncompress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong *pSource_len)
     {
-        mz_inflateEnd(&stream);
-        return ((status == MZ_BUF_ERROR) && (!stream.avail_in)) ? MZ_DATA_ERROR : status;
+        mz_stream stream;
+        int status;
+        memset(&stream, 0, sizeof(stream));
+
+        /* In case mz_ulong is 64-bits (argh I hate longs). */
+        if ((mz_uint64)(*pSource_len | *pDest_len) > 0xFFFFFFFFU)
+            return MZ_PARAM_ERROR;
+
+        stream.next_in = pSource;
+        stream.avail_in = (mz_uint32)*pSource_len;
+        stream.next_out = pDest;
+        stream.avail_out = (mz_uint32)*pDest_len;
+
+        status = mz_inflateInit(&stream);
+        if (status != MZ_OK)
+            return status;
+
+        status = mz_inflate(&stream, MZ_FINISH);
+        *pSource_len = *pSource_len - stream.avail_in;
+        if (status != MZ_STREAM_END)
+        {
+            mz_inflateEnd(&stream);
+            return ((status == MZ_BUF_ERROR) && (!stream.avail_in)) ? MZ_DATA_ERROR : status;
+        }
+        *pDest_len = stream.total_out;
+
+        return mz_inflateEnd(&stream);
     }
-    *pDest_len = stream.total_out;
 
-    return mz_inflateEnd(&stream);
-}
-
-int mz_uncompress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len)
-{
-    return mz_uncompress2(pDest, pDest_len, pSource, &source_len);
-}
+    int mz_uncompress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len)
+    {
+        return mz_uncompress2(pDest, pDest_len, pSource, &source_len);
+    }
 
 #endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
 
-const char *mz_error(int err)
-{
-    static struct
+    const char *mz_error(int err)
     {
-        int m_err;
-        const char *m_pDesc;
-    } s_error_descs[] =
+        static struct
         {
-          { MZ_OK, "" }, { MZ_STREAM_END, "stream end" }, { MZ_NEED_DICT, "need dictionary" }, { MZ_ERRNO, "file error" }, { MZ_STREAM_ERROR, "stream error" }, { MZ_DATA_ERROR, "data error" }, { MZ_MEM_ERROR, "out of memory" }, { MZ_BUF_ERROR, "buf error" }, { MZ_VERSION_ERROR, "version error" }, { MZ_PARAM_ERROR, "parameter error" }
+            int m_err;
+            const char *m_pDesc;
+        } s_error_descs[] = {
+            { MZ_OK, "" }, { MZ_STREAM_END, "stream end" }, { MZ_NEED_DICT, "need dictionary" }, { MZ_ERRNO, "file error" }, { MZ_STREAM_ERROR, "stream error" }, { MZ_DATA_ERROR, "data error" }, { MZ_MEM_ERROR, "out of memory" }, { MZ_BUF_ERROR, "buf error" }, { MZ_VERSION_ERROR, "version error" }, { MZ_PARAM_ERROR, "parameter error" }
         };
-    mz_uint i;
-    for (i = 0; i < sizeof(s_error_descs) / sizeof(s_error_descs[0]); ++i)
-        if (s_error_descs[i].m_err == err)
-            return s_error_descs[i].m_pDesc;
-    return NULL;
-}
+        mz_uint i;
+        for (i = 0; i < sizeof(s_error_descs) / sizeof(s_error_descs[0]); ++i)
+            if (s_error_descs[i].m_err == err)
+                return s_error_descs[i].m_pDesc;
+        return NULL;
+    }
 
 #endif /*MINIZ_NO_ZLIB_APIS */
 
@@ -672,252 +672,248 @@ const char *mz_error(int err)
  **************************************************************************/
 
 
+
 #ifndef MINIZ_NO_DEFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* ------------------- Low-level Compression (independent from all decompression API's) */
+    /* ------------------- Low-level Compression (independent from all decompression API's) */
 
-/* Purposely making these tables static for faster init and thread safety. */
-static const mz_uint16 s_tdefl_len_sym[256] =
-    {
-      257, 258, 259, 260, 261, 262, 263, 264, 265, 265, 266, 266, 267, 267, 268, 268, 269, 269, 269, 269, 270, 270, 270, 270, 271, 271, 271, 271, 272, 272, 272, 272,
-      273, 273, 273, 273, 273, 273, 273, 273, 274, 274, 274, 274, 274, 274, 274, 274, 275, 275, 275, 275, 275, 275, 275, 275, 276, 276, 276, 276, 276, 276, 276, 276,
-      277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278,
-      279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280,
-      281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281,
-      282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282,
-      283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283,
-      284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 285
+    /* Purposely making these tables static for faster init and thread safety. */
+    static const mz_uint16 s_tdefl_len_sym[256] = {
+        257, 258, 259, 260, 261, 262, 263, 264, 265, 265, 266, 266, 267, 267, 268, 268, 269, 269, 269, 269, 270, 270, 270, 270, 271, 271, 271, 271, 272, 272, 272, 272,
+        273, 273, 273, 273, 273, 273, 273, 273, 274, 274, 274, 274, 274, 274, 274, 274, 275, 275, 275, 275, 275, 275, 275, 275, 276, 276, 276, 276, 276, 276, 276, 276,
+        277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 277, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278, 278,
+        279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 279, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 280,
+        281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281, 281,
+        282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282, 282,
+        283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283, 283,
+        284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 284, 285
     };
 
-static const mz_uint8 s_tdefl_len_extra[256] =
-    {
-      0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 0
+    static const mz_uint8 s_tdefl_len_extra[256] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 0
     };
 
-static const mz_uint8 s_tdefl_small_dist_sym[512] =
-    {
-      0, 1, 2, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11,
-      11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13,
-      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
-      14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
-      14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
-      15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
-      16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
-      16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
-      16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
-      17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
-      17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
-      17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17
+    static const mz_uint8 s_tdefl_small_dist_sym[512] = {
+        0, 1, 2, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11,
+        11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
+        14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
+        14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+        15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+        17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+        17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+        17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17
     };
 
-static const mz_uint8 s_tdefl_small_dist_extra[512] =
-    {
-      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5,
-      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-      6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-      6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-      7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-      7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-      7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-      7, 7, 7, 7, 7, 7, 7, 7
+    static const mz_uint8 s_tdefl_small_dist_extra[512] = {
+        0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7, 7, 7, 7, 7
     };
 
-static const mz_uint8 s_tdefl_large_dist_sym[128] =
-    {
-      0, 0, 18, 19, 20, 20, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 24, 24, 24, 24, 25, 25, 25, 25, 25, 25, 25, 25, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26,
-      26, 26, 26, 26, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28,
-      28, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29
+    static const mz_uint8 s_tdefl_large_dist_sym[128] = {
+        0, 0, 18, 19, 20, 20, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 24, 24, 24, 24, 25, 25, 25, 25, 25, 25, 25, 25, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26,
+        26, 26, 26, 26, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28,
+        28, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29
     };
 
-static const mz_uint8 s_tdefl_large_dist_extra[128] =
-    {
-      0, 0, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
-      12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
-      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13
+    static const mz_uint8 s_tdefl_large_dist_extra[128] = {
+        0, 0, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+        12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13
     };
 
-/* Radix sorts tdefl_sym_freq[] array by 16-bit key m_key. Returns ptr to sorted values. */
-typedef struct
-{
-    mz_uint16 m_key, m_sym_index;
-} tdefl_sym_freq;
-static tdefl_sym_freq *tdefl_radix_sort_syms(mz_uint num_syms, tdefl_sym_freq *pSyms0, tdefl_sym_freq *pSyms1)
-{
-    mz_uint32 total_passes = 2, pass_shift, pass, i, hist[256 * 2];
-    tdefl_sym_freq *pCur_syms = pSyms0, *pNew_syms = pSyms1;
-    MZ_CLEAR_ARR(hist);
-    for (i = 0; i < num_syms; i++)
+    /* Radix sorts tdefl_sym_freq[] array by 16-bit key m_key. Returns ptr to sorted values. */
+    typedef struct
     {
-        mz_uint freq = pSyms0[i].m_key;
-        hist[freq & 0xFF]++;
-        hist[256 + ((freq >> 8) & 0xFF)]++;
-    }
-    while ((total_passes > 1) && (num_syms == hist[(total_passes - 1) * 256]))
-        total_passes--;
-    for (pass_shift = 0, pass = 0; pass < total_passes; pass++, pass_shift += 8)
+        mz_uint16 m_key, m_sym_index;
+    } tdefl_sym_freq;
+    static tdefl_sym_freq *tdefl_radix_sort_syms(mz_uint num_syms, tdefl_sym_freq *pSyms0, tdefl_sym_freq *pSyms1)
     {
-        const mz_uint32 *pHist = &hist[pass << 8];
-        mz_uint offsets[256], cur_ofs = 0;
-        for (i = 0; i < 256; i++)
-        {
-            offsets[i] = cur_ofs;
-            cur_ofs += pHist[i];
-        }
+        mz_uint32 total_passes = 2, pass_shift, pass, i, hist[256 * 2];
+        tdefl_sym_freq *pCur_syms = pSyms0, *pNew_syms = pSyms1;
+        MZ_CLEAR_ARR(hist);
         for (i = 0; i < num_syms; i++)
-            pNew_syms[offsets[(pCur_syms[i].m_key >> pass_shift) & 0xFF]++] = pCur_syms[i];
         {
-            tdefl_sym_freq *t = pCur_syms;
-            pCur_syms = pNew_syms;
-            pNew_syms = t;
+            mz_uint freq = pSyms0[i].m_key;
+            hist[freq & 0xFF]++;
+            hist[256 + ((freq >> 8) & 0xFF)]++;
+        }
+        while ((total_passes > 1) && (num_syms == hist[(total_passes - 1) * 256]))
+            total_passes--;
+        for (pass_shift = 0, pass = 0; pass < total_passes; pass++, pass_shift += 8)
+        {
+            const mz_uint32 *pHist = &hist[pass << 8];
+            mz_uint offsets[256], cur_ofs = 0;
+            for (i = 0; i < 256; i++)
+            {
+                offsets[i] = cur_ofs;
+                cur_ofs += pHist[i];
+            }
+            for (i = 0; i < num_syms; i++)
+                pNew_syms[offsets[(pCur_syms[i].m_key >> pass_shift) & 0xFF]++] = pCur_syms[i];
+            {
+                tdefl_sym_freq *t = pCur_syms;
+                pCur_syms = pNew_syms;
+                pNew_syms = t;
+            }
+        }
+        return pCur_syms;
+    }
+
+    /* tdefl_calculate_minimum_redundancy() originally written by: Alistair Moffat, alistair@cs.mu.oz.au, Jyrki Katajainen, jyrki@diku.dk, November 1996. */
+    static void tdefl_calculate_minimum_redundancy(tdefl_sym_freq *A, int n)
+    {
+        int root, leaf, next, avbl, used, dpth;
+        if (n == 0)
+            return;
+        else if (n == 1)
+        {
+            A[0].m_key = 1;
+            return;
+        }
+        A[0].m_key += A[1].m_key;
+        root = 0;
+        leaf = 2;
+        for (next = 1; next < n - 1; next++)
+        {
+            if (leaf >= n || A[root].m_key < A[leaf].m_key)
+            {
+                A[next].m_key = A[root].m_key;
+                A[root++].m_key = (mz_uint16)next;
+            }
+            else
+                A[next].m_key = A[leaf++].m_key;
+            if (leaf >= n || (root < next && A[root].m_key < A[leaf].m_key))
+            {
+                A[next].m_key = (mz_uint16)(A[next].m_key + A[root].m_key);
+                A[root++].m_key = (mz_uint16)next;
+            }
+            else
+                A[next].m_key = (mz_uint16)(A[next].m_key + A[leaf++].m_key);
+        }
+        A[n - 2].m_key = 0;
+        for (next = n - 3; next >= 0; next--)
+            A[next].m_key = A[A[next].m_key].m_key + 1;
+        avbl = 1;
+        used = dpth = 0;
+        root = n - 2;
+        next = n - 1;
+        while (avbl > 0)
+        {
+            while (root >= 0 && (int)A[root].m_key == dpth)
+            {
+                used++;
+                root--;
+            }
+            while (avbl > used)
+            {
+                A[next--].m_key = (mz_uint16)(dpth);
+                avbl--;
+            }
+            avbl = 2 * used;
+            dpth++;
+            used = 0;
         }
     }
-    return pCur_syms;
-}
 
-/* tdefl_calculate_minimum_redundancy() originally written by: Alistair Moffat, alistair@cs.mu.oz.au, Jyrki Katajainen, jyrki@diku.dk, November 1996. */
-static void tdefl_calculate_minimum_redundancy(tdefl_sym_freq *A, int n)
-{
-    int root, leaf, next, avbl, used, dpth;
-    if (n == 0)
-        return;
-    else if (n == 1)
+    /* Limits canonical Huffman code table's max code size. */
+    enum
     {
-        A[0].m_key = 1;
-        return;
-    }
-    A[0].m_key += A[1].m_key;
-    root = 0;
-    leaf = 2;
-    for (next = 1; next < n - 1; next++)
+        TDEFL_MAX_SUPPORTED_HUFF_CODESIZE = 32
+    };
+    static void tdefl_huffman_enforce_max_code_size(int *pNum_codes, int code_list_len, int max_code_size)
     {
-        if (leaf >= n || A[root].m_key < A[leaf].m_key)
+        int i;
+        mz_uint32 total = 0;
+        if (code_list_len <= 1)
+            return;
+        for (i = max_code_size + 1; i <= TDEFL_MAX_SUPPORTED_HUFF_CODESIZE; i++)
+            pNum_codes[max_code_size] += pNum_codes[i];
+        for (i = max_code_size; i > 0; i--)
+            total += (((mz_uint32)pNum_codes[i]) << (max_code_size - i));
+        while (total != (1UL << max_code_size))
         {
-            A[next].m_key = A[root].m_key;
-            A[root++].m_key = (mz_uint16)next;
+            pNum_codes[max_code_size]--;
+            for (i = max_code_size - 1; i > 0; i--)
+                if (pNum_codes[i])
+                {
+                    pNum_codes[i]--;
+                    pNum_codes[i + 1] += 2;
+                    break;
+                }
+            total--;
+        }
+    }
+
+    static void tdefl_optimize_huffman_table(tdefl_compressor *d, int table_num, int table_len, int code_size_limit, int static_table)
+    {
+        int i, j, l, num_codes[1 + TDEFL_MAX_SUPPORTED_HUFF_CODESIZE];
+        mz_uint next_code[TDEFL_MAX_SUPPORTED_HUFF_CODESIZE + 1];
+        MZ_CLEAR_ARR(num_codes);
+        if (static_table)
+        {
+            for (i = 0; i < table_len; i++)
+                num_codes[d->m_huff_code_sizes[table_num][i]]++;
         }
         else
-            A[next].m_key = A[leaf++].m_key;
-        if (leaf >= n || (root < next && A[root].m_key < A[leaf].m_key))
         {
-            A[next].m_key = (mz_uint16)(A[next].m_key + A[root].m_key);
-            A[root++].m_key = (mz_uint16)next;
-        }
-        else
-            A[next].m_key = (mz_uint16)(A[next].m_key + A[leaf++].m_key);
-    }
-    A[n - 2].m_key = 0;
-    for (next = n - 3; next >= 0; next--)
-        A[next].m_key = A[A[next].m_key].m_key + 1;
-    avbl = 1;
-    used = dpth = 0;
-    root = n - 2;
-    next = n - 1;
-    while (avbl > 0)
-    {
-        while (root >= 0 && (int)A[root].m_key == dpth)
-        {
-            used++;
-            root--;
-        }
-        while (avbl > used)
-        {
-            A[next--].m_key = (mz_uint16)(dpth);
-            avbl--;
-        }
-        avbl = 2 * used;
-        dpth++;
-        used = 0;
-    }
-}
+            tdefl_sym_freq syms0[TDEFL_MAX_HUFF_SYMBOLS], syms1[TDEFL_MAX_HUFF_SYMBOLS], *pSyms;
+            int num_used_syms = 0;
+            const mz_uint16 *pSym_count = &d->m_huff_count[table_num][0];
+            for (i = 0; i < table_len; i++)
+                if (pSym_count[i])
+                {
+                    syms0[num_used_syms].m_key = (mz_uint16)pSym_count[i];
+                    syms0[num_used_syms++].m_sym_index = (mz_uint16)i;
+                }
 
-/* Limits canonical Huffman code table's max code size. */
-enum
-{
-    TDEFL_MAX_SUPPORTED_HUFF_CODESIZE = 32
-};
-static void tdefl_huffman_enforce_max_code_size(int *pNum_codes, int code_list_len, int max_code_size)
-{
-    int i;
-    mz_uint32 total = 0;
-    if (code_list_len <= 1)
-        return;
-    for (i = max_code_size + 1; i <= TDEFL_MAX_SUPPORTED_HUFF_CODESIZE; i++)
-        pNum_codes[max_code_size] += pNum_codes[i];
-    for (i = max_code_size; i > 0; i--)
-        total += (((mz_uint32)pNum_codes[i]) << (max_code_size - i));
-    while (total != (1UL << max_code_size))
-    {
-        pNum_codes[max_code_size]--;
-        for (i = max_code_size - 1; i > 0; i--)
-            if (pNum_codes[i])
-            {
-                pNum_codes[i]--;
-                pNum_codes[i + 1] += 2;
-                break;
-            }
-        total--;
-    }
-}
+            pSyms = tdefl_radix_sort_syms(num_used_syms, syms0, syms1);
+            tdefl_calculate_minimum_redundancy(pSyms, num_used_syms);
 
-static void tdefl_optimize_huffman_table(tdefl_compressor *d, int table_num, int table_len, int code_size_limit, int static_table)
-{
-    int i, j, l, num_codes[1 + TDEFL_MAX_SUPPORTED_HUFF_CODESIZE];
-    mz_uint next_code[TDEFL_MAX_SUPPORTED_HUFF_CODESIZE + 1];
-    MZ_CLEAR_ARR(num_codes);
-    if (static_table)
-    {
+            for (i = 0; i < num_used_syms; i++)
+                num_codes[pSyms[i].m_key]++;
+
+            tdefl_huffman_enforce_max_code_size(num_codes, num_used_syms, code_size_limit);
+
+            MZ_CLEAR_ARR(d->m_huff_code_sizes[table_num]);
+            MZ_CLEAR_ARR(d->m_huff_codes[table_num]);
+            for (i = 1, j = num_used_syms; i <= code_size_limit; i++)
+                for (l = num_codes[i]; l > 0; l--)
+                    d->m_huff_code_sizes[table_num][pSyms[--j].m_sym_index] = (mz_uint8)(i);
+        }
+
+        next_code[1] = 0;
+        for (j = 0, i = 2; i <= code_size_limit; i++)
+            next_code[i] = j = ((j + num_codes[i - 1]) << 1);
+
         for (i = 0; i < table_len; i++)
-            num_codes[d->m_huff_code_sizes[table_num][i]]++;
+        {
+            mz_uint rev_code = 0, code, code_size;
+            if ((code_size = d->m_huff_code_sizes[table_num][i]) == 0)
+                continue;
+            code = next_code[code_size]++;
+            for (l = code_size; l > 0; l--, code >>= 1)
+                rev_code = (rev_code << 1) | (code & 1);
+            d->m_huff_codes[table_num][i] = (mz_uint16)rev_code;
+        }
     }
-    else
-    {
-        tdefl_sym_freq syms0[TDEFL_MAX_HUFF_SYMBOLS], syms1[TDEFL_MAX_HUFF_SYMBOLS], *pSyms;
-        int num_used_syms = 0;
-        const mz_uint16 *pSym_count = &d->m_huff_count[table_num][0];
-        for (i = 0; i < table_len; i++)
-            if (pSym_count[i])
-            {
-                syms0[num_used_syms].m_key = (mz_uint16)pSym_count[i];
-                syms0[num_used_syms++].m_sym_index = (mz_uint16)i;
-            }
-
-        pSyms = tdefl_radix_sort_syms(num_used_syms, syms0, syms1);
-        tdefl_calculate_minimum_redundancy(pSyms, num_used_syms);
-
-        for (i = 0; i < num_used_syms; i++)
-            num_codes[pSyms[i].m_key]++;
-
-        tdefl_huffman_enforce_max_code_size(num_codes, num_used_syms, code_size_limit);
-
-        MZ_CLEAR_ARR(d->m_huff_code_sizes[table_num]);
-        MZ_CLEAR_ARR(d->m_huff_codes[table_num]);
-        for (i = 1, j = num_used_syms; i <= code_size_limit; i++)
-            for (l = num_codes[i]; l > 0; l--)
-                d->m_huff_code_sizes[table_num][pSyms[--j].m_sym_index] = (mz_uint8)(i);
-    }
-
-    next_code[1] = 0;
-    for (j = 0, i = 2; i <= code_size_limit; i++)
-        next_code[i] = j = ((j + num_codes[i - 1]) << 1);
-
-    for (i = 0; i < table_len; i++)
-    {
-        mz_uint rev_code = 0, code, code_size;
-        if ((code_size = d->m_huff_code_sizes[table_num][i]) == 0)
-            continue;
-        code = next_code[code_size]++;
-        for (l = code_size; l > 0; l--, code >>= 1)
-            rev_code = (rev_code << 1) | (code & 1);
-        d->m_huff_codes[table_num][i] = (mz_uint16)rev_code;
-    }
-}
 
 #define TDEFL_PUT_BITS(b, l)                                       \
     do                                                             \
@@ -983,128 +979,128 @@ static void tdefl_optimize_huffman_table(tdefl_compressor *d, int table_num, int
         }                                                                                  \
     }
 
-static const mz_uint8 s_tdefl_packed_code_size_syms_swizzle[] = { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
+    static const mz_uint8 s_tdefl_packed_code_size_syms_swizzle[] = { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
 
-static void tdefl_start_dynamic_block(tdefl_compressor *d)
-{
-    int num_lit_codes, num_dist_codes, num_bit_lengths;
-    mz_uint i, total_code_sizes_to_pack, num_packed_code_sizes, rle_z_count, rle_repeat_count, packed_code_sizes_index;
-    mz_uint8 code_sizes_to_pack[TDEFL_MAX_HUFF_SYMBOLS_0 + TDEFL_MAX_HUFF_SYMBOLS_1], packed_code_sizes[TDEFL_MAX_HUFF_SYMBOLS_0 + TDEFL_MAX_HUFF_SYMBOLS_1], prev_code_size = 0xFF;
-
-    d->m_huff_count[0][256] = 1;
-
-    tdefl_optimize_huffman_table(d, 0, TDEFL_MAX_HUFF_SYMBOLS_0, 15, MZ_FALSE);
-    tdefl_optimize_huffman_table(d, 1, TDEFL_MAX_HUFF_SYMBOLS_1, 15, MZ_FALSE);
-
-    for (num_lit_codes = 286; num_lit_codes > 257; num_lit_codes--)
-        if (d->m_huff_code_sizes[0][num_lit_codes - 1])
-            break;
-    for (num_dist_codes = 30; num_dist_codes > 1; num_dist_codes--)
-        if (d->m_huff_code_sizes[1][num_dist_codes - 1])
-            break;
-
-    memcpy(code_sizes_to_pack, &d->m_huff_code_sizes[0][0], num_lit_codes);
-    memcpy(code_sizes_to_pack + num_lit_codes, &d->m_huff_code_sizes[1][0], num_dist_codes);
-    total_code_sizes_to_pack = num_lit_codes + num_dist_codes;
-    num_packed_code_sizes = 0;
-    rle_z_count = 0;
-    rle_repeat_count = 0;
-
-    memset(&d->m_huff_count[2][0], 0, sizeof(d->m_huff_count[2][0]) * TDEFL_MAX_HUFF_SYMBOLS_2);
-    for (i = 0; i < total_code_sizes_to_pack; i++)
+    static void tdefl_start_dynamic_block(tdefl_compressor *d)
     {
-        mz_uint8 code_size = code_sizes_to_pack[i];
-        if (!code_size)
+        int num_lit_codes, num_dist_codes, num_bit_lengths;
+        mz_uint i, total_code_sizes_to_pack, num_packed_code_sizes, rle_z_count, rle_repeat_count, packed_code_sizes_index;
+        mz_uint8 code_sizes_to_pack[TDEFL_MAX_HUFF_SYMBOLS_0 + TDEFL_MAX_HUFF_SYMBOLS_1], packed_code_sizes[TDEFL_MAX_HUFF_SYMBOLS_0 + TDEFL_MAX_HUFF_SYMBOLS_1], prev_code_size = 0xFF;
+
+        d->m_huff_count[0][256] = 1;
+
+        tdefl_optimize_huffman_table(d, 0, TDEFL_MAX_HUFF_SYMBOLS_0, 15, MZ_FALSE);
+        tdefl_optimize_huffman_table(d, 1, TDEFL_MAX_HUFF_SYMBOLS_1, 15, MZ_FALSE);
+
+        for (num_lit_codes = 286; num_lit_codes > 257; num_lit_codes--)
+            if (d->m_huff_code_sizes[0][num_lit_codes - 1])
+                break;
+        for (num_dist_codes = 30; num_dist_codes > 1; num_dist_codes--)
+            if (d->m_huff_code_sizes[1][num_dist_codes - 1])
+                break;
+
+        memcpy(code_sizes_to_pack, &d->m_huff_code_sizes[0][0], num_lit_codes);
+        memcpy(code_sizes_to_pack + num_lit_codes, &d->m_huff_code_sizes[1][0], num_dist_codes);
+        total_code_sizes_to_pack = num_lit_codes + num_dist_codes;
+        num_packed_code_sizes = 0;
+        rle_z_count = 0;
+        rle_repeat_count = 0;
+
+        memset(&d->m_huff_count[2][0], 0, sizeof(d->m_huff_count[2][0]) * TDEFL_MAX_HUFF_SYMBOLS_2);
+        for (i = 0; i < total_code_sizes_to_pack; i++)
         {
-            TDEFL_RLE_PREV_CODE_SIZE();
-            if (++rle_z_count == 138)
+            mz_uint8 code_size = code_sizes_to_pack[i];
+            if (!code_size)
+            {
+                TDEFL_RLE_PREV_CODE_SIZE();
+                if (++rle_z_count == 138)
+                {
+                    TDEFL_RLE_ZERO_CODE_SIZE();
+                }
+            }
+            else
             {
                 TDEFL_RLE_ZERO_CODE_SIZE();
+                if (code_size != prev_code_size)
+                {
+                    TDEFL_RLE_PREV_CODE_SIZE();
+                    d->m_huff_count[2][code_size] = (mz_uint16)(d->m_huff_count[2][code_size] + 1);
+                    packed_code_sizes[num_packed_code_sizes++] = code_size;
+                }
+                else if (++rle_repeat_count == 6)
+                {
+                    TDEFL_RLE_PREV_CODE_SIZE();
+                }
             }
+            prev_code_size = code_size;
+        }
+        if (rle_repeat_count)
+        {
+            TDEFL_RLE_PREV_CODE_SIZE();
         }
         else
         {
             TDEFL_RLE_ZERO_CODE_SIZE();
-            if (code_size != prev_code_size)
-            {
-                TDEFL_RLE_PREV_CODE_SIZE();
-                d->m_huff_count[2][code_size] = (mz_uint16)(d->m_huff_count[2][code_size] + 1);
-                packed_code_sizes[num_packed_code_sizes++] = code_size;
-            }
-            else if (++rle_repeat_count == 6)
-            {
-                TDEFL_RLE_PREV_CODE_SIZE();
-            }
         }
-        prev_code_size = code_size;
+
+        tdefl_optimize_huffman_table(d, 2, TDEFL_MAX_HUFF_SYMBOLS_2, 7, MZ_FALSE);
+
+        TDEFL_PUT_BITS(2, 2);
+
+        TDEFL_PUT_BITS(num_lit_codes - 257, 5);
+        TDEFL_PUT_BITS(num_dist_codes - 1, 5);
+
+        for (num_bit_lengths = 18; num_bit_lengths >= 0; num_bit_lengths--)
+            if (d->m_huff_code_sizes[2][s_tdefl_packed_code_size_syms_swizzle[num_bit_lengths]])
+                break;
+        num_bit_lengths = MZ_MAX(4, (num_bit_lengths + 1));
+        TDEFL_PUT_BITS(num_bit_lengths - 4, 4);
+        for (i = 0; (int)i < num_bit_lengths; i++)
+            TDEFL_PUT_BITS(d->m_huff_code_sizes[2][s_tdefl_packed_code_size_syms_swizzle[i]], 3);
+
+        for (packed_code_sizes_index = 0; packed_code_sizes_index < num_packed_code_sizes;)
+        {
+            mz_uint code = packed_code_sizes[packed_code_sizes_index++];
+            MZ_ASSERT(code < TDEFL_MAX_HUFF_SYMBOLS_2);
+            TDEFL_PUT_BITS(d->m_huff_codes[2][code], d->m_huff_code_sizes[2][code]);
+            if (code >= 16)
+                TDEFL_PUT_BITS(packed_code_sizes[packed_code_sizes_index++], "\02\03\07"[code - 16]);
+        }
     }
-    if (rle_repeat_count)
+
+    static void tdefl_start_static_block(tdefl_compressor *d)
     {
-        TDEFL_RLE_PREV_CODE_SIZE();
+        mz_uint i;
+        mz_uint8 *p = &d->m_huff_code_sizes[0][0];
+
+        for (i = 0; i <= 143; ++i)
+            *p++ = 8;
+        for (; i <= 255; ++i)
+            *p++ = 9;
+        for (; i <= 279; ++i)
+            *p++ = 7;
+        for (; i <= 287; ++i)
+            *p++ = 8;
+
+        memset(d->m_huff_code_sizes[1], 5, 32);
+
+        tdefl_optimize_huffman_table(d, 0, 288, 15, MZ_TRUE);
+        tdefl_optimize_huffman_table(d, 1, 32, 15, MZ_TRUE);
+
+        TDEFL_PUT_BITS(1, 2);
     }
-    else
-    {
-        TDEFL_RLE_ZERO_CODE_SIZE();
-    }
 
-    tdefl_optimize_huffman_table(d, 2, TDEFL_MAX_HUFF_SYMBOLS_2, 7, MZ_FALSE);
-
-    TDEFL_PUT_BITS(2, 2);
-
-    TDEFL_PUT_BITS(num_lit_codes - 257, 5);
-    TDEFL_PUT_BITS(num_dist_codes - 1, 5);
-
-    for (num_bit_lengths = 18; num_bit_lengths >= 0; num_bit_lengths--)
-        if (d->m_huff_code_sizes[2][s_tdefl_packed_code_size_syms_swizzle[num_bit_lengths]])
-            break;
-    num_bit_lengths = MZ_MAX(4, (num_bit_lengths + 1));
-    TDEFL_PUT_BITS(num_bit_lengths - 4, 4);
-    for (i = 0; (int)i < num_bit_lengths; i++)
-        TDEFL_PUT_BITS(d->m_huff_code_sizes[2][s_tdefl_packed_code_size_syms_swizzle[i]], 3);
-
-    for (packed_code_sizes_index = 0; packed_code_sizes_index < num_packed_code_sizes;)
-    {
-        mz_uint code = packed_code_sizes[packed_code_sizes_index++];
-        MZ_ASSERT(code < TDEFL_MAX_HUFF_SYMBOLS_2);
-        TDEFL_PUT_BITS(d->m_huff_codes[2][code], d->m_huff_code_sizes[2][code]);
-        if (code >= 16)
-            TDEFL_PUT_BITS(packed_code_sizes[packed_code_sizes_index++], "\02\03\07"[code - 16]);
-    }
-}
-
-static void tdefl_start_static_block(tdefl_compressor *d)
-{
-    mz_uint i;
-    mz_uint8 *p = &d->m_huff_code_sizes[0][0];
-
-    for (i = 0; i <= 143; ++i)
-        *p++ = 8;
-    for (; i <= 255; ++i)
-        *p++ = 9;
-    for (; i <= 279; ++i)
-        *p++ = 7;
-    for (; i <= 287; ++i)
-        *p++ = 8;
-
-    memset(d->m_huff_code_sizes[1], 5, 32);
-
-    tdefl_optimize_huffman_table(d, 0, 288, 15, MZ_TRUE);
-    tdefl_optimize_huffman_table(d, 1, 32, 15, MZ_TRUE);
-
-    TDEFL_PUT_BITS(1, 2);
-}
-
-static const mz_uint mz_bitmasks[17] = { 0x0000, 0x0001, 0x0003, 0x0007, 0x000F, 0x001F, 0x003F, 0x007F, 0x00FF, 0x01FF, 0x03FF, 0x07FF, 0x0FFF, 0x1FFF, 0x3FFF, 0x7FFF, 0xFFFF };
+    static const mz_uint mz_bitmasks[17] = { 0x0000, 0x0001, 0x0003, 0x0007, 0x000F, 0x001F, 0x003F, 0x007F, 0x00FF, 0x01FF, 0x03FF, 0x07FF, 0x0FFF, 0x1FFF, 0x3FFF, 0x7FFF, 0xFFFF };
 
 #if MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN && MINIZ_HAS_64BIT_REGISTERS
-static mz_bool tdefl_compress_lz_codes(tdefl_compressor *d)
-{
-    mz_uint flags;
-    mz_uint8 *pLZ_codes;
-    mz_uint8 *pOutput_buf = d->m_pOutput_buf;
-    mz_uint8 *pLZ_code_buf_end = d->m_pLZ_code_buf;
-    mz_uint64 bit_buffer = d->m_bit_buffer;
-    mz_uint bits_in = d->m_bits_in;
+    static mz_bool tdefl_compress_lz_codes(tdefl_compressor *d)
+    {
+        mz_uint flags;
+        mz_uint8 *pLZ_codes;
+        mz_uint8 *pOutput_buf = d->m_pOutput_buf;
+        mz_uint8 *pLZ_code_buf_end = d->m_pLZ_code_buf;
+        mz_uint64 bit_buffer = d->m_bit_buffer;
+        mz_uint bits_in = d->m_bits_in;
 
 #define TDEFL_PUT_BITS_FAST(b, l)                    \
     {                                                \
@@ -1112,45 +1108,38 @@ static mz_bool tdefl_compress_lz_codes(tdefl_compressor *d)
         bits_in += (l);                              \
     }
 
-    flags = 1;
-    for (pLZ_codes = d->m_lz_code_buf; pLZ_codes < pLZ_code_buf_end; flags >>= 1)
-    {
-        if (flags == 1)
-            flags = *pLZ_codes++ | 0x100;
-
-        if (flags & 1)
+        flags = 1;
+        for (pLZ_codes = d->m_lz_code_buf; pLZ_codes < pLZ_code_buf_end; flags >>= 1)
         {
-            mz_uint s0, s1, n0, n1, sym, num_extra_bits;
-            mz_uint match_len = pLZ_codes[0];
-            mz_uint match_dist = (pLZ_codes[1] | (pLZ_codes[2] << 8));
-            pLZ_codes += 3;
+            if (flags == 1)
+                flags = *pLZ_codes++ | 0x100;
 
-            MZ_ASSERT(d->m_huff_code_sizes[0][s_tdefl_len_sym[match_len]]);
-            TDEFL_PUT_BITS_FAST(d->m_huff_codes[0][s_tdefl_len_sym[match_len]], d->m_huff_code_sizes[0][s_tdefl_len_sym[match_len]]);
-            TDEFL_PUT_BITS_FAST(match_len & mz_bitmasks[s_tdefl_len_extra[match_len]], s_tdefl_len_extra[match_len]);
-
-            /* This sequence coaxes MSVC into using cmov's vs. jmp's. */
-            s0 = s_tdefl_small_dist_sym[match_dist & 511];
-            n0 = s_tdefl_small_dist_extra[match_dist & 511];
-            s1 = s_tdefl_large_dist_sym[match_dist >> 8];
-            n1 = s_tdefl_large_dist_extra[match_dist >> 8];
-            sym = (match_dist < 512) ? s0 : s1;
-            num_extra_bits = (match_dist < 512) ? n0 : n1;
-
-            MZ_ASSERT(d->m_huff_code_sizes[1][sym]);
-            TDEFL_PUT_BITS_FAST(d->m_huff_codes[1][sym], d->m_huff_code_sizes[1][sym]);
-            TDEFL_PUT_BITS_FAST(match_dist & mz_bitmasks[num_extra_bits], num_extra_bits);
-        }
-        else
-        {
-            mz_uint lit = *pLZ_codes++;
-            MZ_ASSERT(d->m_huff_code_sizes[0][lit]);
-            TDEFL_PUT_BITS_FAST(d->m_huff_codes[0][lit], d->m_huff_code_sizes[0][lit]);
-
-            if (((flags & 2) == 0) && (pLZ_codes < pLZ_code_buf_end))
+            if (flags & 1)
             {
-                flags >>= 1;
-                lit = *pLZ_codes++;
+                mz_uint s0, s1, n0, n1, sym, num_extra_bits;
+                mz_uint match_len = pLZ_codes[0];
+                mz_uint match_dist = (pLZ_codes[1] | (pLZ_codes[2] << 8));
+                pLZ_codes += 3;
+
+                MZ_ASSERT(d->m_huff_code_sizes[0][s_tdefl_len_sym[match_len]]);
+                TDEFL_PUT_BITS_FAST(d->m_huff_codes[0][s_tdefl_len_sym[match_len]], d->m_huff_code_sizes[0][s_tdefl_len_sym[match_len]]);
+                TDEFL_PUT_BITS_FAST(match_len & mz_bitmasks[s_tdefl_len_extra[match_len]], s_tdefl_len_extra[match_len]);
+
+                /* This sequence coaxes MSVC into using cmov's vs. jmp's. */
+                s0 = s_tdefl_small_dist_sym[match_dist & 511];
+                n0 = s_tdefl_small_dist_extra[match_dist & 511];
+                s1 = s_tdefl_large_dist_sym[match_dist >> 8];
+                n1 = s_tdefl_large_dist_extra[match_dist >> 8];
+                sym = (match_dist < 512) ? s0 : s1;
+                num_extra_bits = (match_dist < 512) ? n0 : n1;
+
+                MZ_ASSERT(d->m_huff_code_sizes[1][sym]);
+                TDEFL_PUT_BITS_FAST(d->m_huff_codes[1][sym], d->m_huff_code_sizes[1][sym]);
+                TDEFL_PUT_BITS_FAST(match_dist & mz_bitmasks[num_extra_bits], num_extra_bits);
+            }
+            else
+            {
+                mz_uint lit = *pLZ_codes++;
                 MZ_ASSERT(d->m_huff_code_sizes[0][lit]);
                 TDEFL_PUT_BITS_FAST(d->m_huff_codes[0][lit], d->m_huff_code_sizes[0][lit]);
 
@@ -1160,37 +1149,44 @@ static mz_bool tdefl_compress_lz_codes(tdefl_compressor *d)
                     lit = *pLZ_codes++;
                     MZ_ASSERT(d->m_huff_code_sizes[0][lit]);
                     TDEFL_PUT_BITS_FAST(d->m_huff_codes[0][lit], d->m_huff_code_sizes[0][lit]);
+
+                    if (((flags & 2) == 0) && (pLZ_codes < pLZ_code_buf_end))
+                    {
+                        flags >>= 1;
+                        lit = *pLZ_codes++;
+                        MZ_ASSERT(d->m_huff_code_sizes[0][lit]);
+                        TDEFL_PUT_BITS_FAST(d->m_huff_codes[0][lit], d->m_huff_code_sizes[0][lit]);
+                    }
                 }
             }
+
+            if (pOutput_buf >= d->m_pOutput_buf_end)
+                return MZ_FALSE;
+
+            memcpy(pOutput_buf, &bit_buffer, sizeof(mz_uint64));
+            pOutput_buf += (bits_in >> 3);
+            bit_buffer >>= (bits_in & ~7);
+            bits_in &= 7;
         }
-
-        if (pOutput_buf >= d->m_pOutput_buf_end)
-            return MZ_FALSE;
-
-        memcpy(pOutput_buf, &bit_buffer, sizeof(mz_uint64));
-        pOutput_buf += (bits_in >> 3);
-        bit_buffer >>= (bits_in & ~7);
-        bits_in &= 7;
-    }
 
 #undef TDEFL_PUT_BITS_FAST
 
-    d->m_pOutput_buf = pOutput_buf;
-    d->m_bits_in = 0;
-    d->m_bit_buffer = 0;
+        d->m_pOutput_buf = pOutput_buf;
+        d->m_bits_in = 0;
+        d->m_bit_buffer = 0;
 
-    while (bits_in)
-    {
-        mz_uint32 n = MZ_MIN(bits_in, 16);
-        TDEFL_PUT_BITS((mz_uint)bit_buffer & mz_bitmasks[n], n);
-        bit_buffer >>= n;
-        bits_in -= n;
+        while (bits_in)
+        {
+            mz_uint32 n = MZ_MIN(bits_in, 16);
+            TDEFL_PUT_BITS((mz_uint)bit_buffer & mz_bitmasks[n], n);
+            bit_buffer >>= n;
+            bits_in -= n;
+        }
+
+        TDEFL_PUT_BITS(d->m_huff_codes[0][256], d->m_huff_code_sizes[0][256]);
+
+        return (d->m_pOutput_buf < d->m_pOutput_buf_end);
     }
-
-    TDEFL_PUT_BITS(d->m_huff_codes[0][256], d->m_huff_code_sizes[0][256]);
-
-    return (d->m_pOutput_buf < d->m_pOutput_buf_end);
-}
 #else
 static mz_bool tdefl_compress_lz_codes(tdefl_compressor *d)
 {
@@ -1240,204 +1236,205 @@ static mz_bool tdefl_compress_lz_codes(tdefl_compressor *d)
 }
 #endif /* MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN && MINIZ_HAS_64BIT_REGISTERS */
 
-static mz_bool tdefl_compress_block(tdefl_compressor *d, mz_bool static_block)
-{
-    if (static_block)
-        tdefl_start_static_block(d);
-    else
-        tdefl_start_dynamic_block(d);
-    return tdefl_compress_lz_codes(d);
-}
-
-static const mz_uint s_tdefl_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
-
-static int tdefl_flush_block(tdefl_compressor *d, int flush)
-{
-    mz_uint saved_bit_buf, saved_bits_in;
-    mz_uint8 *pSaved_output_buf;
-    mz_bool comp_block_succeeded = MZ_FALSE;
-    int n, use_raw_block = ((d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS) != 0) && (d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size;
-    mz_uint8 *pOutput_buf_start = ((d->m_pPut_buf_func == NULL) && ((*d->m_pOut_buf_size - d->m_out_buf_ofs) >= TDEFL_OUT_BUF_SIZE)) ? ((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs) : d->m_output_buf;
-
-    d->m_pOutput_buf = pOutput_buf_start;
-    d->m_pOutput_buf_end = d->m_pOutput_buf + TDEFL_OUT_BUF_SIZE - 16;
-
-    MZ_ASSERT(!d->m_output_flush_remaining);
-    d->m_output_flush_ofs = 0;
-    d->m_output_flush_remaining = 0;
-
-    *d->m_pLZ_flags = (mz_uint8)(*d->m_pLZ_flags >> d->m_num_flags_left);
-    d->m_pLZ_code_buf -= (d->m_num_flags_left == 8);
-
-    if ((d->m_flags & TDEFL_WRITE_ZLIB_HEADER) && (!d->m_block_index))
+    static mz_bool tdefl_compress_block(tdefl_compressor *d, mz_bool static_block)
     {
-        const mz_uint8 cmf = 0x78;
-        mz_uint8 flg, flevel = 3;
-        mz_uint header, i, mz_un = sizeof(s_tdefl_num_probes) / sizeof(mz_uint);
-
-        /* Determine compression level by reversing the process in tdefl_create_comp_flags_from_zip_params() */
-        for (i = 0; i < mz_un; i++)
-            if (s_tdefl_num_probes[i] == (d->m_flags & 0xFFF)) break;
-
-        if (i < 2)
-            flevel = 0;
-        else if (i < 6)
-            flevel = 1;
-        else if (i == 6)
-            flevel = 2;
-
-        header = cmf << 8 | (flevel << 6);
-        header += 31 - (header % 31);
-        flg = header & 0xFF;
-
-        TDEFL_PUT_BITS(cmf, 8);
-        TDEFL_PUT_BITS(flg, 8);
+        if (static_block)
+            tdefl_start_static_block(d);
+        else
+            tdefl_start_dynamic_block(d);
+        return tdefl_compress_lz_codes(d);
     }
 
-    TDEFL_PUT_BITS(flush == TDEFL_FINISH, 1);
+    static const mz_uint s_tdefl_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
 
-    pSaved_output_buf = d->m_pOutput_buf;
-    saved_bit_buf = d->m_bit_buffer;
-    saved_bits_in = d->m_bits_in;
-
-    if (!use_raw_block)
-        comp_block_succeeded = tdefl_compress_block(d, (d->m_flags & TDEFL_FORCE_ALL_STATIC_BLOCKS) || (d->m_total_lz_bytes < 48));
-
-    /* If the block gets expanded, forget the current contents of the output buffer and send a raw block instead. */
-    if (((use_raw_block) || ((d->m_total_lz_bytes) && ((d->m_pOutput_buf - pSaved_output_buf + 1U) >= d->m_total_lz_bytes))) &&
-        ((d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size))
+    static int tdefl_flush_block(tdefl_compressor *d, int flush)
     {
-        mz_uint i;
-        d->m_pOutput_buf = pSaved_output_buf;
-        d->m_bit_buffer = saved_bit_buf, d->m_bits_in = saved_bits_in;
-        TDEFL_PUT_BITS(0, 2);
-        if (d->m_bits_in)
-        {
-            TDEFL_PUT_BITS(0, 8 - d->m_bits_in);
-        }
-        for (i = 2; i; --i, d->m_total_lz_bytes ^= 0xFFFF)
-        {
-            TDEFL_PUT_BITS(d->m_total_lz_bytes & 0xFFFF, 16);
-        }
-        for (i = 0; i < d->m_total_lz_bytes; ++i)
-        {
-            TDEFL_PUT_BITS(d->m_dict[(d->m_lz_code_buf_dict_pos + i) & TDEFL_LZ_DICT_SIZE_MASK], 8);
-        }
-    }
-    /* Check for the extremely unlikely (if not impossible) case of the compressed block not fitting into the output buffer when using dynamic codes. */
-    else if (!comp_block_succeeded)
-    {
-        d->m_pOutput_buf = pSaved_output_buf;
-        d->m_bit_buffer = saved_bit_buf, d->m_bits_in = saved_bits_in;
-        tdefl_compress_block(d, MZ_TRUE);
-    }
+        mz_uint saved_bit_buf, saved_bits_in;
+        mz_uint8 *pSaved_output_buf;
+        mz_bool comp_block_succeeded = MZ_FALSE;
+        int n, use_raw_block = ((d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS) != 0) && (d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size;
+        mz_uint8 *pOutput_buf_start = ((d->m_pPut_buf_func == NULL) && ((*d->m_pOut_buf_size - d->m_out_buf_ofs) >= TDEFL_OUT_BUF_SIZE)) ? ((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs) : d->m_output_buf;
 
-    if (flush)
-    {
-        if (flush == TDEFL_FINISH)
+        d->m_pOutput_buf = pOutput_buf_start;
+        d->m_pOutput_buf_end = d->m_pOutput_buf + TDEFL_OUT_BUF_SIZE - 16;
+
+        MZ_ASSERT(!d->m_output_flush_remaining);
+        d->m_output_flush_ofs = 0;
+        d->m_output_flush_remaining = 0;
+
+        *d->m_pLZ_flags = (mz_uint8)(*d->m_pLZ_flags >> d->m_num_flags_left);
+        d->m_pLZ_code_buf -= (d->m_num_flags_left == 8);
+
+        if ((d->m_flags & TDEFL_WRITE_ZLIB_HEADER) && (!d->m_block_index))
         {
+            const mz_uint8 cmf = 0x78;
+            mz_uint8 flg, flevel = 3;
+            mz_uint header, i, mz_un = sizeof(s_tdefl_num_probes) / sizeof(mz_uint);
+
+            /* Determine compression level by reversing the process in tdefl_create_comp_flags_from_zip_params() */
+            for (i = 0; i < mz_un; i++)
+                if (s_tdefl_num_probes[i] == (d->m_flags & 0xFFF))
+                    break;
+
+            if (i < 2)
+                flevel = 0;
+            else if (i < 6)
+                flevel = 1;
+            else if (i == 6)
+                flevel = 2;
+
+            header = cmf << 8 | (flevel << 6);
+            header += 31 - (header % 31);
+            flg = header & 0xFF;
+
+            TDEFL_PUT_BITS(cmf, 8);
+            TDEFL_PUT_BITS(flg, 8);
+        }
+
+        TDEFL_PUT_BITS(flush == TDEFL_FINISH, 1);
+
+        pSaved_output_buf = d->m_pOutput_buf;
+        saved_bit_buf = d->m_bit_buffer;
+        saved_bits_in = d->m_bits_in;
+
+        if (!use_raw_block)
+            comp_block_succeeded = tdefl_compress_block(d, (d->m_flags & TDEFL_FORCE_ALL_STATIC_BLOCKS) || (d->m_total_lz_bytes < 48));
+
+        /* If the block gets expanded, forget the current contents of the output buffer and send a raw block instead. */
+        if (((use_raw_block) || ((d->m_total_lz_bytes) && ((d->m_pOutput_buf - pSaved_output_buf + 1U) >= d->m_total_lz_bytes))) &&
+            ((d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size))
+        {
+            mz_uint i;
+            d->m_pOutput_buf = pSaved_output_buf;
+            d->m_bit_buffer = saved_bit_buf, d->m_bits_in = saved_bits_in;
+            TDEFL_PUT_BITS(0, 2);
             if (d->m_bits_in)
             {
                 TDEFL_PUT_BITS(0, 8 - d->m_bits_in);
             }
-            if (d->m_flags & TDEFL_WRITE_ZLIB_HEADER)
+            for (i = 2; i; --i, d->m_total_lz_bytes ^= 0xFFFF)
             {
-                mz_uint i, a = d->m_adler32;
-                for (i = 0; i < 4; i++)
+                TDEFL_PUT_BITS(d->m_total_lz_bytes & 0xFFFF, 16);
+            }
+            for (i = 0; i < d->m_total_lz_bytes; ++i)
+            {
+                TDEFL_PUT_BITS(d->m_dict[(d->m_lz_code_buf_dict_pos + i) & TDEFL_LZ_DICT_SIZE_MASK], 8);
+            }
+        }
+        /* Check for the extremely unlikely (if not impossible) case of the compressed block not fitting into the output buffer when using dynamic codes. */
+        else if (!comp_block_succeeded)
+        {
+            d->m_pOutput_buf = pSaved_output_buf;
+            d->m_bit_buffer = saved_bit_buf, d->m_bits_in = saved_bits_in;
+            tdefl_compress_block(d, MZ_TRUE);
+        }
+
+        if (flush)
+        {
+            if (flush == TDEFL_FINISH)
+            {
+                if (d->m_bits_in)
                 {
-                    TDEFL_PUT_BITS((a >> 24) & 0xFF, 8);
-                    a <<= 8;
+                    TDEFL_PUT_BITS(0, 8 - d->m_bits_in);
+                }
+                if (d->m_flags & TDEFL_WRITE_ZLIB_HEADER)
+                {
+                    mz_uint i, a = d->m_adler32;
+                    for (i = 0; i < 4; i++)
+                    {
+                        TDEFL_PUT_BITS((a >> 24) & 0xFF, 8);
+                        a <<= 8;
+                    }
+                }
+            }
+            else
+            {
+                mz_uint i, z = 0;
+                TDEFL_PUT_BITS(0, 3);
+                if (d->m_bits_in)
+                {
+                    TDEFL_PUT_BITS(0, 8 - d->m_bits_in);
+                }
+                for (i = 2; i; --i, z ^= 0xFFFF)
+                {
+                    TDEFL_PUT_BITS(z & 0xFFFF, 16);
                 }
             }
         }
-        else
+
+        MZ_ASSERT(d->m_pOutput_buf < d->m_pOutput_buf_end);
+
+        memset(&d->m_huff_count[0][0], 0, sizeof(d->m_huff_count[0][0]) * TDEFL_MAX_HUFF_SYMBOLS_0);
+        memset(&d->m_huff_count[1][0], 0, sizeof(d->m_huff_count[1][0]) * TDEFL_MAX_HUFF_SYMBOLS_1);
+
+        d->m_pLZ_code_buf = d->m_lz_code_buf + 1;
+        d->m_pLZ_flags = d->m_lz_code_buf;
+        d->m_num_flags_left = 8;
+        d->m_lz_code_buf_dict_pos += d->m_total_lz_bytes;
+        d->m_total_lz_bytes = 0;
+        d->m_block_index++;
+
+        if ((n = (int)(d->m_pOutput_buf - pOutput_buf_start)) != 0)
         {
-            mz_uint i, z = 0;
-            TDEFL_PUT_BITS(0, 3);
-            if (d->m_bits_in)
+            if (d->m_pPut_buf_func)
             {
-                TDEFL_PUT_BITS(0, 8 - d->m_bits_in);
+                *d->m_pIn_buf_size = d->m_pSrc - (const mz_uint8 *)d->m_pIn_buf;
+                if (!(*d->m_pPut_buf_func)(d->m_output_buf, n, d->m_pPut_buf_user))
+                    return (d->m_prev_return_status = TDEFL_STATUS_PUT_BUF_FAILED);
             }
-            for (i = 2; i; --i, z ^= 0xFFFF)
+            else if (pOutput_buf_start == d->m_output_buf)
             {
-                TDEFL_PUT_BITS(z & 0xFFFF, 16);
+                int bytes_to_copy = (int)MZ_MIN((size_t)n, (size_t)(*d->m_pOut_buf_size - d->m_out_buf_ofs));
+                memcpy((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs, d->m_output_buf, bytes_to_copy);
+                d->m_out_buf_ofs += bytes_to_copy;
+                if ((n -= bytes_to_copy) != 0)
+                {
+                    d->m_output_flush_ofs = bytes_to_copy;
+                    d->m_output_flush_remaining = n;
+                }
+            }
+            else
+            {
+                d->m_out_buf_ofs += n;
             }
         }
+
+        return d->m_output_flush_remaining;
     }
-
-    MZ_ASSERT(d->m_pOutput_buf < d->m_pOutput_buf_end);
-
-    memset(&d->m_huff_count[0][0], 0, sizeof(d->m_huff_count[0][0]) * TDEFL_MAX_HUFF_SYMBOLS_0);
-    memset(&d->m_huff_count[1][0], 0, sizeof(d->m_huff_count[1][0]) * TDEFL_MAX_HUFF_SYMBOLS_1);
-
-    d->m_pLZ_code_buf = d->m_lz_code_buf + 1;
-    d->m_pLZ_flags = d->m_lz_code_buf;
-    d->m_num_flags_left = 8;
-    d->m_lz_code_buf_dict_pos += d->m_total_lz_bytes;
-    d->m_total_lz_bytes = 0;
-    d->m_block_index++;
-
-    if ((n = (int)(d->m_pOutput_buf - pOutput_buf_start)) != 0)
-    {
-        if (d->m_pPut_buf_func)
-        {
-            *d->m_pIn_buf_size = d->m_pSrc - (const mz_uint8 *)d->m_pIn_buf;
-            if (!(*d->m_pPut_buf_func)(d->m_output_buf, n, d->m_pPut_buf_user))
-                return (d->m_prev_return_status = TDEFL_STATUS_PUT_BUF_FAILED);
-        }
-        else if (pOutput_buf_start == d->m_output_buf)
-        {
-            int bytes_to_copy = (int)MZ_MIN((size_t)n, (size_t)(*d->m_pOut_buf_size - d->m_out_buf_ofs));
-            memcpy((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs, d->m_output_buf, bytes_to_copy);
-            d->m_out_buf_ofs += bytes_to_copy;
-            if ((n -= bytes_to_copy) != 0)
-            {
-                d->m_output_flush_ofs = bytes_to_copy;
-                d->m_output_flush_remaining = n;
-            }
-        }
-        else
-        {
-            d->m_out_buf_ofs += n;
-        }
-    }
-
-    return d->m_output_flush_remaining;
-}
 
 #if MINIZ_USE_UNALIGNED_LOADS_AND_STORES
 #ifdef MINIZ_UNALIGNED_USE_MEMCPY
-static mz_uint16 TDEFL_READ_UNALIGNED_WORD(const mz_uint8* p)
-{
-	mz_uint16 ret;
-	memcpy(&ret, p, sizeof(mz_uint16));
-	return ret;
-}
-static mz_uint16 TDEFL_READ_UNALIGNED_WORD2(const mz_uint16* p)
-{
-	mz_uint16 ret;
-	memcpy(&ret, p, sizeof(mz_uint16));
-	return ret;
-}
+    static mz_uint16 TDEFL_READ_UNALIGNED_WORD(const mz_uint8 *p)
+    {
+        mz_uint16 ret;
+        memcpy(&ret, p, sizeof(mz_uint16));
+        return ret;
+    }
+    static mz_uint16 TDEFL_READ_UNALIGNED_WORD2(const mz_uint16 *p)
+    {
+        mz_uint16 ret;
+        memcpy(&ret, p, sizeof(mz_uint16));
+        return ret;
+    }
 #else
 #define TDEFL_READ_UNALIGNED_WORD(p) *(const mz_uint16 *)(p)
 #define TDEFL_READ_UNALIGNED_WORD2(p) *(const mz_uint16 *)(p)
 #endif
-static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahead_pos, mz_uint max_dist, mz_uint max_match_len, mz_uint *pMatch_dist, mz_uint *pMatch_len)
-{
-    mz_uint dist, pos = lookahead_pos & TDEFL_LZ_DICT_SIZE_MASK, match_len = *pMatch_len, probe_pos = pos, next_probe_pos, probe_len;
-    mz_uint num_probes_left = d->m_max_probes[match_len >= 32];
-    const mz_uint16 *s = (const mz_uint16 *)(d->m_dict + pos), *p, *q;
-    mz_uint16 c01 = TDEFL_READ_UNALIGNED_WORD(&d->m_dict[pos + match_len - 1]), s01 = TDEFL_READ_UNALIGNED_WORD2(s);
-    MZ_ASSERT(max_match_len <= TDEFL_MAX_MATCH_LEN);
-    if (max_match_len <= match_len)
-        return;
-    for (;;)
+    static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahead_pos, mz_uint max_dist, mz_uint max_match_len, mz_uint *pMatch_dist, mz_uint *pMatch_len)
     {
+        mz_uint dist, pos = lookahead_pos & TDEFL_LZ_DICT_SIZE_MASK, match_len = *pMatch_len, probe_pos = pos, next_probe_pos, probe_len;
+        mz_uint num_probes_left = d->m_max_probes[match_len >= 32];
+        const mz_uint16 *s = (const mz_uint16 *)(d->m_dict + pos), *p, *q;
+        mz_uint16 c01 = TDEFL_READ_UNALIGNED_WORD(&d->m_dict[pos + match_len - 1]), s01 = TDEFL_READ_UNALIGNED_WORD2(s);
+        MZ_ASSERT(max_match_len <= TDEFL_MAX_MATCH_LEN);
+        if (max_match_len <= match_len)
+            return;
         for (;;)
         {
-            if (--num_probes_left == 0)
-                return;
+            for (;;)
+            {
+                if (--num_probes_left == 0)
+                    return;
 #define TDEFL_PROBE                                                                             \
     next_probe_pos = d->m_next[probe_pos];                                                      \
     if ((!next_probe_pos) || ((dist = (mz_uint16)(lookahead_pos - next_probe_pos)) > max_dist)) \
@@ -1445,36 +1442,36 @@ static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahe
     probe_pos = next_probe_pos & TDEFL_LZ_DICT_SIZE_MASK;                                       \
     if (TDEFL_READ_UNALIGNED_WORD(&d->m_dict[probe_pos + match_len - 1]) == c01)                \
         break;
-            TDEFL_PROBE;
-            TDEFL_PROBE;
-            TDEFL_PROBE;
-        }
-        if (!dist)
-            break;
-        q = (const mz_uint16 *)(d->m_dict + probe_pos);
-        if (TDEFL_READ_UNALIGNED_WORD2(q) != s01)
-            continue;
-        p = s;
-        probe_len = 32;
-        do
-        {
-        } while ((TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) &&
-                 (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (--probe_len > 0));
-        if (!probe_len)
-        {
-            *pMatch_dist = dist;
-            *pMatch_len = MZ_MIN(max_match_len, (mz_uint)TDEFL_MAX_MATCH_LEN);
-            break;
-        }
-        else if ((probe_len = ((mz_uint)(p - s) * 2) + (mz_uint)(*(const mz_uint8 *)p == *(const mz_uint8 *)q)) > match_len)
-        {
-            *pMatch_dist = dist;
-            if ((*pMatch_len = match_len = MZ_MIN(max_match_len, probe_len)) == max_match_len)
+                TDEFL_PROBE;
+                TDEFL_PROBE;
+                TDEFL_PROBE;
+            }
+            if (!dist)
                 break;
-            c01 = TDEFL_READ_UNALIGNED_WORD(&d->m_dict[pos + match_len - 1]);
+            q = (const mz_uint16 *)(d->m_dict + probe_pos);
+            if (TDEFL_READ_UNALIGNED_WORD2(q) != s01)
+                continue;
+            p = s;
+            probe_len = 32;
+            do
+            {
+            } while ((TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) &&
+                     (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (--probe_len > 0));
+            if (!probe_len)
+            {
+                *pMatch_dist = dist;
+                *pMatch_len = MZ_MIN(max_match_len, (mz_uint)TDEFL_MAX_MATCH_LEN);
+                break;
+            }
+            else if ((probe_len = ((mz_uint)(p - s) * 2) + (mz_uint)(*(const mz_uint8 *)p == *(const mz_uint8 *)q)) > match_len)
+            {
+                *pMatch_dist = dist;
+                if ((*pMatch_len = match_len = MZ_MIN(max_match_len, probe_len)) == max_match_len)
+                    break;
+                c01 = TDEFL_READ_UNALIGNED_WORD(&d->m_dict[pos + match_len - 1]);
+            }
         }
     }
-}
 #else
 static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahead_pos, mz_uint max_dist, mz_uint max_match_len, mz_uint *pMatch_dist, mz_uint *pMatch_len)
 {
@@ -1523,717 +1520,717 @@ static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahe
 
 #if MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN
 #ifdef MINIZ_UNALIGNED_USE_MEMCPY
-static mz_uint32 TDEFL_READ_UNALIGNED_WORD32(const mz_uint8* p)
-{
-	mz_uint32 ret;
-	memcpy(&ret, p, sizeof(mz_uint32));
-	return ret;
-}
+    static mz_uint32 TDEFL_READ_UNALIGNED_WORD32(const mz_uint8 *p)
+    {
+        mz_uint32 ret;
+        memcpy(&ret, p, sizeof(mz_uint32));
+        return ret;
+    }
 #else
 #define TDEFL_READ_UNALIGNED_WORD32(p) *(const mz_uint32 *)(p)
 #endif
-static mz_bool tdefl_compress_fast(tdefl_compressor *d)
-{
-    /* Faster, minimally featured LZRW1-style match+parse loop with better register utilization. Intended for applications where raw throughput is valued more highly than ratio. */
-    mz_uint lookahead_pos = d->m_lookahead_pos, lookahead_size = d->m_lookahead_size, dict_size = d->m_dict_size, total_lz_bytes = d->m_total_lz_bytes, num_flags_left = d->m_num_flags_left;
-    mz_uint8 *pLZ_code_buf = d->m_pLZ_code_buf, *pLZ_flags = d->m_pLZ_flags;
-    mz_uint cur_pos = lookahead_pos & TDEFL_LZ_DICT_SIZE_MASK;
-
-    while ((d->m_src_buf_left) || ((d->m_flush) && (lookahead_size)))
+    static mz_bool tdefl_compress_fast(tdefl_compressor *d)
     {
-        const mz_uint TDEFL_COMP_FAST_LOOKAHEAD_SIZE = 4096;
-        mz_uint dst_pos = (lookahead_pos + lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK;
-        mz_uint num_bytes_to_process = (mz_uint)MZ_MIN(d->m_src_buf_left, TDEFL_COMP_FAST_LOOKAHEAD_SIZE - lookahead_size);
-        d->m_src_buf_left -= num_bytes_to_process;
-        lookahead_size += num_bytes_to_process;
+        /* Faster, minimally featured LZRW1-style match+parse loop with better register utilization. Intended for applications where raw throughput is valued more highly than ratio. */
+        mz_uint lookahead_pos = d->m_lookahead_pos, lookahead_size = d->m_lookahead_size, dict_size = d->m_dict_size, total_lz_bytes = d->m_total_lz_bytes, num_flags_left = d->m_num_flags_left;
+        mz_uint8 *pLZ_code_buf = d->m_pLZ_code_buf, *pLZ_flags = d->m_pLZ_flags;
+        mz_uint cur_pos = lookahead_pos & TDEFL_LZ_DICT_SIZE_MASK;
 
-        while (num_bytes_to_process)
+        while ((d->m_src_buf_left) || ((d->m_flush) && (lookahead_size)))
         {
-            mz_uint32 n = MZ_MIN(TDEFL_LZ_DICT_SIZE - dst_pos, num_bytes_to_process);
-            memcpy(d->m_dict + dst_pos, d->m_pSrc, n);
-            if (dst_pos < (TDEFL_MAX_MATCH_LEN - 1))
-                memcpy(d->m_dict + TDEFL_LZ_DICT_SIZE + dst_pos, d->m_pSrc, MZ_MIN(n, (TDEFL_MAX_MATCH_LEN - 1) - dst_pos));
-            d->m_pSrc += n;
-            dst_pos = (dst_pos + n) & TDEFL_LZ_DICT_SIZE_MASK;
-            num_bytes_to_process -= n;
-        }
+            const mz_uint TDEFL_COMP_FAST_LOOKAHEAD_SIZE = 4096;
+            mz_uint dst_pos = (lookahead_pos + lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK;
+            mz_uint num_bytes_to_process = (mz_uint)MZ_MIN(d->m_src_buf_left, TDEFL_COMP_FAST_LOOKAHEAD_SIZE - lookahead_size);
+            d->m_src_buf_left -= num_bytes_to_process;
+            lookahead_size += num_bytes_to_process;
 
-        dict_size = MZ_MIN(TDEFL_LZ_DICT_SIZE - lookahead_size, dict_size);
-        if ((!d->m_flush) && (lookahead_size < TDEFL_COMP_FAST_LOOKAHEAD_SIZE))
-            break;
-
-        while (lookahead_size >= 4)
-        {
-            mz_uint cur_match_dist, cur_match_len = 1;
-            mz_uint8 *pCur_dict = d->m_dict + cur_pos;
-            mz_uint first_trigram = TDEFL_READ_UNALIGNED_WORD32(pCur_dict) & 0xFFFFFF;
-            mz_uint hash = (first_trigram ^ (first_trigram >> (24 - (TDEFL_LZ_HASH_BITS - 8)))) & TDEFL_LEVEL1_HASH_SIZE_MASK;
-            mz_uint probe_pos = d->m_hash[hash];
-            d->m_hash[hash] = (mz_uint16)lookahead_pos;
-
-            if (((cur_match_dist = (mz_uint16)(lookahead_pos - probe_pos)) <= dict_size) && ((TDEFL_READ_UNALIGNED_WORD32(d->m_dict + (probe_pos &= TDEFL_LZ_DICT_SIZE_MASK)) & 0xFFFFFF) == first_trigram))
+            while (num_bytes_to_process)
             {
-                const mz_uint16 *p = (const mz_uint16 *)pCur_dict;
-                const mz_uint16 *q = (const mz_uint16 *)(d->m_dict + probe_pos);
-                mz_uint32 probe_len = 32;
-                do
-                {
-                } while ((TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) &&
-                         (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (--probe_len > 0));
-                cur_match_len = ((mz_uint)(p - (const mz_uint16 *)pCur_dict) * 2) + (mz_uint)(*(const mz_uint8 *)p == *(const mz_uint8 *)q);
-                if (!probe_len)
-                    cur_match_len = cur_match_dist ? TDEFL_MAX_MATCH_LEN : 0;
+                mz_uint32 n = MZ_MIN(TDEFL_LZ_DICT_SIZE - dst_pos, num_bytes_to_process);
+                memcpy(d->m_dict + dst_pos, d->m_pSrc, n);
+                if (dst_pos < (TDEFL_MAX_MATCH_LEN - 1))
+                    memcpy(d->m_dict + TDEFL_LZ_DICT_SIZE + dst_pos, d->m_pSrc, MZ_MIN(n, (TDEFL_MAX_MATCH_LEN - 1) - dst_pos));
+                d->m_pSrc += n;
+                dst_pos = (dst_pos + n) & TDEFL_LZ_DICT_SIZE_MASK;
+                num_bytes_to_process -= n;
+            }
 
-                if ((cur_match_len < TDEFL_MIN_MATCH_LEN) || ((cur_match_len == TDEFL_MIN_MATCH_LEN) && (cur_match_dist >= 8U * 1024U)))
+            dict_size = MZ_MIN(TDEFL_LZ_DICT_SIZE - lookahead_size, dict_size);
+            if ((!d->m_flush) && (lookahead_size < TDEFL_COMP_FAST_LOOKAHEAD_SIZE))
+                break;
+
+            while (lookahead_size >= 4)
+            {
+                mz_uint cur_match_dist, cur_match_len = 1;
+                mz_uint8 *pCur_dict = d->m_dict + cur_pos;
+                mz_uint first_trigram = TDEFL_READ_UNALIGNED_WORD32(pCur_dict) & 0xFFFFFF;
+                mz_uint hash = (first_trigram ^ (first_trigram >> (24 - (TDEFL_LZ_HASH_BITS - 8)))) & TDEFL_LEVEL1_HASH_SIZE_MASK;
+                mz_uint probe_pos = d->m_hash[hash];
+                d->m_hash[hash] = (mz_uint16)lookahead_pos;
+
+                if (((cur_match_dist = (mz_uint16)(lookahead_pos - probe_pos)) <= dict_size) && ((TDEFL_READ_UNALIGNED_WORD32(d->m_dict + (probe_pos &= TDEFL_LZ_DICT_SIZE_MASK)) & 0xFFFFFF) == first_trigram))
                 {
-                    cur_match_len = 1;
+                    const mz_uint16 *p = (const mz_uint16 *)pCur_dict;
+                    const mz_uint16 *q = (const mz_uint16 *)(d->m_dict + probe_pos);
+                    mz_uint32 probe_len = 32;
+                    do
+                    {
+                    } while ((TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) &&
+                             (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (TDEFL_READ_UNALIGNED_WORD2(++p) == TDEFL_READ_UNALIGNED_WORD2(++q)) && (--probe_len > 0));
+                    cur_match_len = ((mz_uint)(p - (const mz_uint16 *)pCur_dict) * 2) + (mz_uint)(*(const mz_uint8 *)p == *(const mz_uint8 *)q);
+                    if (!probe_len)
+                        cur_match_len = cur_match_dist ? TDEFL_MAX_MATCH_LEN : 0;
+
+                    if ((cur_match_len < TDEFL_MIN_MATCH_LEN) || ((cur_match_len == TDEFL_MIN_MATCH_LEN) && (cur_match_dist >= 8U * 1024U)))
+                    {
+                        cur_match_len = 1;
+                        *pLZ_code_buf++ = (mz_uint8)first_trigram;
+                        *pLZ_flags = (mz_uint8)(*pLZ_flags >> 1);
+                        d->m_huff_count[0][(mz_uint8)first_trigram]++;
+                    }
+                    else
+                    {
+                        mz_uint32 s0, s1;
+                        cur_match_len = MZ_MIN(cur_match_len, lookahead_size);
+
+                        MZ_ASSERT((cur_match_len >= TDEFL_MIN_MATCH_LEN) && (cur_match_dist >= 1) && (cur_match_dist <= TDEFL_LZ_DICT_SIZE));
+
+                        cur_match_dist--;
+
+                        pLZ_code_buf[0] = (mz_uint8)(cur_match_len - TDEFL_MIN_MATCH_LEN);
+#ifdef MINIZ_UNALIGNED_USE_MEMCPY
+                        memcpy(&pLZ_code_buf[1], &cur_match_dist, sizeof(cur_match_dist));
+#else
+                        *(mz_uint16 *)(&pLZ_code_buf[1]) = (mz_uint16)cur_match_dist;
+#endif
+                        pLZ_code_buf += 3;
+                        *pLZ_flags = (mz_uint8)((*pLZ_flags >> 1) | 0x80);
+
+                        s0 = s_tdefl_small_dist_sym[cur_match_dist & 511];
+                        s1 = s_tdefl_large_dist_sym[cur_match_dist >> 8];
+                        d->m_huff_count[1][(cur_match_dist < 512) ? s0 : s1]++;
+
+                        d->m_huff_count[0][s_tdefl_len_sym[cur_match_len - TDEFL_MIN_MATCH_LEN]]++;
+                    }
+                }
+                else
+                {
                     *pLZ_code_buf++ = (mz_uint8)first_trigram;
                     *pLZ_flags = (mz_uint8)(*pLZ_flags >> 1);
                     d->m_huff_count[0][(mz_uint8)first_trigram]++;
                 }
-                else
+
+                if (--num_flags_left == 0)
                 {
-                    mz_uint32 s0, s1;
-                    cur_match_len = MZ_MIN(cur_match_len, lookahead_size);
+                    num_flags_left = 8;
+                    pLZ_flags = pLZ_code_buf++;
+                }
 
-                    MZ_ASSERT((cur_match_len >= TDEFL_MIN_MATCH_LEN) && (cur_match_dist >= 1) && (cur_match_dist <= TDEFL_LZ_DICT_SIZE));
+                total_lz_bytes += cur_match_len;
+                lookahead_pos += cur_match_len;
+                dict_size = MZ_MIN(dict_size + cur_match_len, (mz_uint)TDEFL_LZ_DICT_SIZE);
+                cur_pos = (cur_pos + cur_match_len) & TDEFL_LZ_DICT_SIZE_MASK;
+                MZ_ASSERT(lookahead_size >= cur_match_len);
+                lookahead_size -= cur_match_len;
 
-                    cur_match_dist--;
-
-                    pLZ_code_buf[0] = (mz_uint8)(cur_match_len - TDEFL_MIN_MATCH_LEN);
-#ifdef MINIZ_UNALIGNED_USE_MEMCPY
-					memcpy(&pLZ_code_buf[1], &cur_match_dist, sizeof(cur_match_dist));
-#else
-                    *(mz_uint16 *)(&pLZ_code_buf[1]) = (mz_uint16)cur_match_dist;
-#endif
-                    pLZ_code_buf += 3;
-                    *pLZ_flags = (mz_uint8)((*pLZ_flags >> 1) | 0x80);
-
-                    s0 = s_tdefl_small_dist_sym[cur_match_dist & 511];
-                    s1 = s_tdefl_large_dist_sym[cur_match_dist >> 8];
-                    d->m_huff_count[1][(cur_match_dist < 512) ? s0 : s1]++;
-
-                    d->m_huff_count[0][s_tdefl_len_sym[cur_match_len - TDEFL_MIN_MATCH_LEN]]++;
+                if (pLZ_code_buf > &d->m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE - 8])
+                {
+                    int n;
+                    d->m_lookahead_pos = lookahead_pos;
+                    d->m_lookahead_size = lookahead_size;
+                    d->m_dict_size = dict_size;
+                    d->m_total_lz_bytes = total_lz_bytes;
+                    d->m_pLZ_code_buf = pLZ_code_buf;
+                    d->m_pLZ_flags = pLZ_flags;
+                    d->m_num_flags_left = num_flags_left;
+                    if ((n = tdefl_flush_block(d, 0)) != 0)
+                        return (n < 0) ? MZ_FALSE : MZ_TRUE;
+                    total_lz_bytes = d->m_total_lz_bytes;
+                    pLZ_code_buf = d->m_pLZ_code_buf;
+                    pLZ_flags = d->m_pLZ_flags;
+                    num_flags_left = d->m_num_flags_left;
                 }
             }
-            else
+
+            while (lookahead_size)
             {
-                *pLZ_code_buf++ = (mz_uint8)first_trigram;
+                mz_uint8 lit = d->m_dict[cur_pos];
+
+                total_lz_bytes++;
+                *pLZ_code_buf++ = lit;
                 *pLZ_flags = (mz_uint8)(*pLZ_flags >> 1);
-                d->m_huff_count[0][(mz_uint8)first_trigram]++;
-            }
+                if (--num_flags_left == 0)
+                {
+                    num_flags_left = 8;
+                    pLZ_flags = pLZ_code_buf++;
+                }
 
-            if (--num_flags_left == 0)
-            {
-                num_flags_left = 8;
-                pLZ_flags = pLZ_code_buf++;
-            }
+                d->m_huff_count[0][lit]++;
 
-            total_lz_bytes += cur_match_len;
-            lookahead_pos += cur_match_len;
-            dict_size = MZ_MIN(dict_size + cur_match_len, (mz_uint)TDEFL_LZ_DICT_SIZE);
-            cur_pos = (cur_pos + cur_match_len) & TDEFL_LZ_DICT_SIZE_MASK;
-            MZ_ASSERT(lookahead_size >= cur_match_len);
-            lookahead_size -= cur_match_len;
+                lookahead_pos++;
+                dict_size = MZ_MIN(dict_size + 1, (mz_uint)TDEFL_LZ_DICT_SIZE);
+                cur_pos = (cur_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK;
+                lookahead_size--;
 
-            if (pLZ_code_buf > &d->m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE - 8])
-            {
-                int n;
-                d->m_lookahead_pos = lookahead_pos;
-                d->m_lookahead_size = lookahead_size;
-                d->m_dict_size = dict_size;
-                d->m_total_lz_bytes = total_lz_bytes;
-                d->m_pLZ_code_buf = pLZ_code_buf;
-                d->m_pLZ_flags = pLZ_flags;
-                d->m_num_flags_left = num_flags_left;
-                if ((n = tdefl_flush_block(d, 0)) != 0)
-                    return (n < 0) ? MZ_FALSE : MZ_TRUE;
-                total_lz_bytes = d->m_total_lz_bytes;
-                pLZ_code_buf = d->m_pLZ_code_buf;
-                pLZ_flags = d->m_pLZ_flags;
-                num_flags_left = d->m_num_flags_left;
+                if (pLZ_code_buf > &d->m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE - 8])
+                {
+                    int n;
+                    d->m_lookahead_pos = lookahead_pos;
+                    d->m_lookahead_size = lookahead_size;
+                    d->m_dict_size = dict_size;
+                    d->m_total_lz_bytes = total_lz_bytes;
+                    d->m_pLZ_code_buf = pLZ_code_buf;
+                    d->m_pLZ_flags = pLZ_flags;
+                    d->m_num_flags_left = num_flags_left;
+                    if ((n = tdefl_flush_block(d, 0)) != 0)
+                        return (n < 0) ? MZ_FALSE : MZ_TRUE;
+                    total_lz_bytes = d->m_total_lz_bytes;
+                    pLZ_code_buf = d->m_pLZ_code_buf;
+                    pLZ_flags = d->m_pLZ_flags;
+                    num_flags_left = d->m_num_flags_left;
+                }
             }
         }
 
-        while (lookahead_size)
-        {
-            mz_uint8 lit = d->m_dict[cur_pos];
-
-            total_lz_bytes++;
-            *pLZ_code_buf++ = lit;
-            *pLZ_flags = (mz_uint8)(*pLZ_flags >> 1);
-            if (--num_flags_left == 0)
-            {
-                num_flags_left = 8;
-                pLZ_flags = pLZ_code_buf++;
-            }
-
-            d->m_huff_count[0][lit]++;
-
-            lookahead_pos++;
-            dict_size = MZ_MIN(dict_size + 1, (mz_uint)TDEFL_LZ_DICT_SIZE);
-            cur_pos = (cur_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK;
-            lookahead_size--;
-
-            if (pLZ_code_buf > &d->m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE - 8])
-            {
-                int n;
-                d->m_lookahead_pos = lookahead_pos;
-                d->m_lookahead_size = lookahead_size;
-                d->m_dict_size = dict_size;
-                d->m_total_lz_bytes = total_lz_bytes;
-                d->m_pLZ_code_buf = pLZ_code_buf;
-                d->m_pLZ_flags = pLZ_flags;
-                d->m_num_flags_left = num_flags_left;
-                if ((n = tdefl_flush_block(d, 0)) != 0)
-                    return (n < 0) ? MZ_FALSE : MZ_TRUE;
-                total_lz_bytes = d->m_total_lz_bytes;
-                pLZ_code_buf = d->m_pLZ_code_buf;
-                pLZ_flags = d->m_pLZ_flags;
-                num_flags_left = d->m_num_flags_left;
-            }
-        }
+        d->m_lookahead_pos = lookahead_pos;
+        d->m_lookahead_size = lookahead_size;
+        d->m_dict_size = dict_size;
+        d->m_total_lz_bytes = total_lz_bytes;
+        d->m_pLZ_code_buf = pLZ_code_buf;
+        d->m_pLZ_flags = pLZ_flags;
+        d->m_num_flags_left = num_flags_left;
+        return MZ_TRUE;
     }
-
-    d->m_lookahead_pos = lookahead_pos;
-    d->m_lookahead_size = lookahead_size;
-    d->m_dict_size = dict_size;
-    d->m_total_lz_bytes = total_lz_bytes;
-    d->m_pLZ_code_buf = pLZ_code_buf;
-    d->m_pLZ_flags = pLZ_flags;
-    d->m_num_flags_left = num_flags_left;
-    return MZ_TRUE;
-}
 #endif /* MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN */
 
-static MZ_FORCEINLINE void tdefl_record_literal(tdefl_compressor *d, mz_uint8 lit)
-{
-    d->m_total_lz_bytes++;
-    *d->m_pLZ_code_buf++ = lit;
-    *d->m_pLZ_flags = (mz_uint8)(*d->m_pLZ_flags >> 1);
-    if (--d->m_num_flags_left == 0)
+    static MZ_FORCEINLINE void tdefl_record_literal(tdefl_compressor *d, mz_uint8 lit)
     {
-        d->m_num_flags_left = 8;
-        d->m_pLZ_flags = d->m_pLZ_code_buf++;
-    }
-    d->m_huff_count[0][lit]++;
-}
-
-static MZ_FORCEINLINE void tdefl_record_match(tdefl_compressor *d, mz_uint match_len, mz_uint match_dist)
-{
-    mz_uint32 s0, s1;
-
-    MZ_ASSERT((match_len >= TDEFL_MIN_MATCH_LEN) && (match_dist >= 1) && (match_dist <= TDEFL_LZ_DICT_SIZE));
-
-    d->m_total_lz_bytes += match_len;
-
-    d->m_pLZ_code_buf[0] = (mz_uint8)(match_len - TDEFL_MIN_MATCH_LEN);
-
-    match_dist -= 1;
-    d->m_pLZ_code_buf[1] = (mz_uint8)(match_dist & 0xFF);
-    d->m_pLZ_code_buf[2] = (mz_uint8)(match_dist >> 8);
-    d->m_pLZ_code_buf += 3;
-
-    *d->m_pLZ_flags = (mz_uint8)((*d->m_pLZ_flags >> 1) | 0x80);
-    if (--d->m_num_flags_left == 0)
-    {
-        d->m_num_flags_left = 8;
-        d->m_pLZ_flags = d->m_pLZ_code_buf++;
-    }
-
-    s0 = s_tdefl_small_dist_sym[match_dist & 511];
-    s1 = s_tdefl_large_dist_sym[(match_dist >> 8) & 127];
-    d->m_huff_count[1][(match_dist < 512) ? s0 : s1]++;
-    d->m_huff_count[0][s_tdefl_len_sym[match_len - TDEFL_MIN_MATCH_LEN]]++;
-}
-
-static mz_bool tdefl_compress_normal(tdefl_compressor *d)
-{
-    const mz_uint8 *pSrc = d->m_pSrc;
-    size_t src_buf_left = d->m_src_buf_left;
-    tdefl_flush flush = d->m_flush;
-
-    while ((src_buf_left) || ((flush) && (d->m_lookahead_size)))
-    {
-        mz_uint len_to_move, cur_match_dist, cur_match_len, cur_pos;
-        /* Update dictionary and hash chains. Keeps the lookahead size equal to TDEFL_MAX_MATCH_LEN. */
-        if ((d->m_lookahead_size + d->m_dict_size) >= (TDEFL_MIN_MATCH_LEN - 1))
+        d->m_total_lz_bytes++;
+        *d->m_pLZ_code_buf++ = lit;
+        *d->m_pLZ_flags = (mz_uint8)(*d->m_pLZ_flags >> 1);
+        if (--d->m_num_flags_left == 0)
         {
-            mz_uint dst_pos = (d->m_lookahead_pos + d->m_lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK, ins_pos = d->m_lookahead_pos + d->m_lookahead_size - 2;
-            mz_uint hash = (d->m_dict[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] << TDEFL_LZ_HASH_SHIFT) ^ d->m_dict[(ins_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK];
-            mz_uint num_bytes_to_process = (mz_uint)MZ_MIN(src_buf_left, TDEFL_MAX_MATCH_LEN - d->m_lookahead_size);
-            const mz_uint8 *pSrc_end = pSrc ? pSrc + num_bytes_to_process : NULL;
-            src_buf_left -= num_bytes_to_process;
-            d->m_lookahead_size += num_bytes_to_process;
-            while (pSrc != pSrc_end)
-            {
-                mz_uint8 c = *pSrc++;
-                d->m_dict[dst_pos] = c;
-                if (dst_pos < (TDEFL_MAX_MATCH_LEN - 1))
-                    d->m_dict[TDEFL_LZ_DICT_SIZE + dst_pos] = c;
-                hash = ((hash << TDEFL_LZ_HASH_SHIFT) ^ c) & (TDEFL_LZ_HASH_SIZE - 1);
-                d->m_next[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] = d->m_hash[hash];
-                d->m_hash[hash] = (mz_uint16)(ins_pos);
-                dst_pos = (dst_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK;
-                ins_pos++;
-            }
+            d->m_num_flags_left = 8;
+            d->m_pLZ_flags = d->m_pLZ_code_buf++;
         }
-        else
+        d->m_huff_count[0][lit]++;
+    }
+
+    static MZ_FORCEINLINE void tdefl_record_match(tdefl_compressor *d, mz_uint match_len, mz_uint match_dist)
+    {
+        mz_uint32 s0, s1;
+
+        MZ_ASSERT((match_len >= TDEFL_MIN_MATCH_LEN) && (match_dist >= 1) && (match_dist <= TDEFL_LZ_DICT_SIZE));
+
+        d->m_total_lz_bytes += match_len;
+
+        d->m_pLZ_code_buf[0] = (mz_uint8)(match_len - TDEFL_MIN_MATCH_LEN);
+
+        match_dist -= 1;
+        d->m_pLZ_code_buf[1] = (mz_uint8)(match_dist & 0xFF);
+        d->m_pLZ_code_buf[2] = (mz_uint8)(match_dist >> 8);
+        d->m_pLZ_code_buf += 3;
+
+        *d->m_pLZ_flags = (mz_uint8)((*d->m_pLZ_flags >> 1) | 0x80);
+        if (--d->m_num_flags_left == 0)
         {
-            while ((src_buf_left) && (d->m_lookahead_size < TDEFL_MAX_MATCH_LEN))
+            d->m_num_flags_left = 8;
+            d->m_pLZ_flags = d->m_pLZ_code_buf++;
+        }
+
+        s0 = s_tdefl_small_dist_sym[match_dist & 511];
+        s1 = s_tdefl_large_dist_sym[(match_dist >> 8) & 127];
+        d->m_huff_count[1][(match_dist < 512) ? s0 : s1]++;
+        d->m_huff_count[0][s_tdefl_len_sym[match_len - TDEFL_MIN_MATCH_LEN]]++;
+    }
+
+    static mz_bool tdefl_compress_normal(tdefl_compressor *d)
+    {
+        const mz_uint8 *pSrc = d->m_pSrc;
+        size_t src_buf_left = d->m_src_buf_left;
+        tdefl_flush flush = d->m_flush;
+
+        while ((src_buf_left) || ((flush) && (d->m_lookahead_size)))
+        {
+            mz_uint len_to_move, cur_match_dist, cur_match_len, cur_pos;
+            /* Update dictionary and hash chains. Keeps the lookahead size equal to TDEFL_MAX_MATCH_LEN. */
+            if ((d->m_lookahead_size + d->m_dict_size) >= (TDEFL_MIN_MATCH_LEN - 1))
             {
-                mz_uint8 c = *pSrc++;
-                mz_uint dst_pos = (d->m_lookahead_pos + d->m_lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK;
-                src_buf_left--;
-                d->m_dict[dst_pos] = c;
-                if (dst_pos < (TDEFL_MAX_MATCH_LEN - 1))
-                    d->m_dict[TDEFL_LZ_DICT_SIZE + dst_pos] = c;
-                if ((++d->m_lookahead_size + d->m_dict_size) >= TDEFL_MIN_MATCH_LEN)
+                mz_uint dst_pos = (d->m_lookahead_pos + d->m_lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK, ins_pos = d->m_lookahead_pos + d->m_lookahead_size - 2;
+                mz_uint hash = (d->m_dict[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] << TDEFL_LZ_HASH_SHIFT) ^ d->m_dict[(ins_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK];
+                mz_uint num_bytes_to_process = (mz_uint)MZ_MIN(src_buf_left, TDEFL_MAX_MATCH_LEN - d->m_lookahead_size);
+                const mz_uint8 *pSrc_end = pSrc ? pSrc + num_bytes_to_process : NULL;
+                src_buf_left -= num_bytes_to_process;
+                d->m_lookahead_size += num_bytes_to_process;
+                while (pSrc != pSrc_end)
                 {
-                    mz_uint ins_pos = d->m_lookahead_pos + (d->m_lookahead_size - 1) - 2;
-                    mz_uint hash = ((d->m_dict[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] << (TDEFL_LZ_HASH_SHIFT * 2)) ^ (d->m_dict[(ins_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK] << TDEFL_LZ_HASH_SHIFT) ^ c) & (TDEFL_LZ_HASH_SIZE - 1);
+                    mz_uint8 c = *pSrc++;
+                    d->m_dict[dst_pos] = c;
+                    if (dst_pos < (TDEFL_MAX_MATCH_LEN - 1))
+                        d->m_dict[TDEFL_LZ_DICT_SIZE + dst_pos] = c;
+                    hash = ((hash << TDEFL_LZ_HASH_SHIFT) ^ c) & (TDEFL_LZ_HASH_SIZE - 1);
                     d->m_next[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] = d->m_hash[hash];
                     d->m_hash[hash] = (mz_uint16)(ins_pos);
-                }
-            }
-        }
-        d->m_dict_size = MZ_MIN(TDEFL_LZ_DICT_SIZE - d->m_lookahead_size, d->m_dict_size);
-        if ((!flush) && (d->m_lookahead_size < TDEFL_MAX_MATCH_LEN))
-            break;
-
-        /* Simple lazy/greedy parsing state machine. */
-        len_to_move = 1;
-        cur_match_dist = 0;
-        cur_match_len = d->m_saved_match_len ? d->m_saved_match_len : (TDEFL_MIN_MATCH_LEN - 1);
-        cur_pos = d->m_lookahead_pos & TDEFL_LZ_DICT_SIZE_MASK;
-        if (d->m_flags & (TDEFL_RLE_MATCHES | TDEFL_FORCE_ALL_RAW_BLOCKS))
-        {
-            if ((d->m_dict_size) && (!(d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS)))
-            {
-                mz_uint8 c = d->m_dict[(cur_pos - 1) & TDEFL_LZ_DICT_SIZE_MASK];
-                cur_match_len = 0;
-                while (cur_match_len < d->m_lookahead_size)
-                {
-                    if (d->m_dict[cur_pos + cur_match_len] != c)
-                        break;
-                    cur_match_len++;
-                }
-                if (cur_match_len < TDEFL_MIN_MATCH_LEN)
-                    cur_match_len = 0;
-                else
-                    cur_match_dist = 1;
-            }
-        }
-        else
-        {
-            tdefl_find_match(d, d->m_lookahead_pos, d->m_dict_size, d->m_lookahead_size, &cur_match_dist, &cur_match_len);
-        }
-        if (((cur_match_len == TDEFL_MIN_MATCH_LEN) && (cur_match_dist >= 8U * 1024U)) || (cur_pos == cur_match_dist) || ((d->m_flags & TDEFL_FILTER_MATCHES) && (cur_match_len <= 5)))
-        {
-            cur_match_dist = cur_match_len = 0;
-        }
-        if (d->m_saved_match_len)
-        {
-            if (cur_match_len > d->m_saved_match_len)
-            {
-                tdefl_record_literal(d, (mz_uint8)d->m_saved_lit);
-                if (cur_match_len >= 128)
-                {
-                    tdefl_record_match(d, cur_match_len, cur_match_dist);
-                    d->m_saved_match_len = 0;
-                    len_to_move = cur_match_len;
-                }
-                else
-                {
-                    d->m_saved_lit = d->m_dict[cur_pos];
-                    d->m_saved_match_dist = cur_match_dist;
-                    d->m_saved_match_len = cur_match_len;
+                    dst_pos = (dst_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK;
+                    ins_pos++;
                 }
             }
             else
             {
-                tdefl_record_match(d, d->m_saved_match_len, d->m_saved_match_dist);
-                len_to_move = d->m_saved_match_len - 1;
-                d->m_saved_match_len = 0;
+                while ((src_buf_left) && (d->m_lookahead_size < TDEFL_MAX_MATCH_LEN))
+                {
+                    mz_uint8 c = *pSrc++;
+                    mz_uint dst_pos = (d->m_lookahead_pos + d->m_lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK;
+                    src_buf_left--;
+                    d->m_dict[dst_pos] = c;
+                    if (dst_pos < (TDEFL_MAX_MATCH_LEN - 1))
+                        d->m_dict[TDEFL_LZ_DICT_SIZE + dst_pos] = c;
+                    if ((++d->m_lookahead_size + d->m_dict_size) >= TDEFL_MIN_MATCH_LEN)
+                    {
+                        mz_uint ins_pos = d->m_lookahead_pos + (d->m_lookahead_size - 1) - 2;
+                        mz_uint hash = ((d->m_dict[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] << (TDEFL_LZ_HASH_SHIFT * 2)) ^ (d->m_dict[(ins_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK] << TDEFL_LZ_HASH_SHIFT) ^ c) & (TDEFL_LZ_HASH_SIZE - 1);
+                        d->m_next[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] = d->m_hash[hash];
+                        d->m_hash[hash] = (mz_uint16)(ins_pos);
+                    }
+                }
+            }
+            d->m_dict_size = MZ_MIN(TDEFL_LZ_DICT_SIZE - d->m_lookahead_size, d->m_dict_size);
+            if ((!flush) && (d->m_lookahead_size < TDEFL_MAX_MATCH_LEN))
+                break;
+
+            /* Simple lazy/greedy parsing state machine. */
+            len_to_move = 1;
+            cur_match_dist = 0;
+            cur_match_len = d->m_saved_match_len ? d->m_saved_match_len : (TDEFL_MIN_MATCH_LEN - 1);
+            cur_pos = d->m_lookahead_pos & TDEFL_LZ_DICT_SIZE_MASK;
+            if (d->m_flags & (TDEFL_RLE_MATCHES | TDEFL_FORCE_ALL_RAW_BLOCKS))
+            {
+                if ((d->m_dict_size) && (!(d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS)))
+                {
+                    mz_uint8 c = d->m_dict[(cur_pos - 1) & TDEFL_LZ_DICT_SIZE_MASK];
+                    cur_match_len = 0;
+                    while (cur_match_len < d->m_lookahead_size)
+                    {
+                        if (d->m_dict[cur_pos + cur_match_len] != c)
+                            break;
+                        cur_match_len++;
+                    }
+                    if (cur_match_len < TDEFL_MIN_MATCH_LEN)
+                        cur_match_len = 0;
+                    else
+                        cur_match_dist = 1;
+                }
+            }
+            else
+            {
+                tdefl_find_match(d, d->m_lookahead_pos, d->m_dict_size, d->m_lookahead_size, &cur_match_dist, &cur_match_len);
+            }
+            if (((cur_match_len == TDEFL_MIN_MATCH_LEN) && (cur_match_dist >= 8U * 1024U)) || (cur_pos == cur_match_dist) || ((d->m_flags & TDEFL_FILTER_MATCHES) && (cur_match_len <= 5)))
+            {
+                cur_match_dist = cur_match_len = 0;
+            }
+            if (d->m_saved_match_len)
+            {
+                if (cur_match_len > d->m_saved_match_len)
+                {
+                    tdefl_record_literal(d, (mz_uint8)d->m_saved_lit);
+                    if (cur_match_len >= 128)
+                    {
+                        tdefl_record_match(d, cur_match_len, cur_match_dist);
+                        d->m_saved_match_len = 0;
+                        len_to_move = cur_match_len;
+                    }
+                    else
+                    {
+                        d->m_saved_lit = d->m_dict[cur_pos];
+                        d->m_saved_match_dist = cur_match_dist;
+                        d->m_saved_match_len = cur_match_len;
+                    }
+                }
+                else
+                {
+                    tdefl_record_match(d, d->m_saved_match_len, d->m_saved_match_dist);
+                    len_to_move = d->m_saved_match_len - 1;
+                    d->m_saved_match_len = 0;
+                }
+            }
+            else if (!cur_match_dist)
+                tdefl_record_literal(d, d->m_dict[MZ_MIN(cur_pos, sizeof(d->m_dict) - 1)]);
+            else if ((d->m_greedy_parsing) || (d->m_flags & TDEFL_RLE_MATCHES) || (cur_match_len >= 128))
+            {
+                tdefl_record_match(d, cur_match_len, cur_match_dist);
+                len_to_move = cur_match_len;
+            }
+            else
+            {
+                d->m_saved_lit = d->m_dict[MZ_MIN(cur_pos, sizeof(d->m_dict) - 1)];
+                d->m_saved_match_dist = cur_match_dist;
+                d->m_saved_match_len = cur_match_len;
+            }
+            /* Move the lookahead forward by len_to_move bytes. */
+            d->m_lookahead_pos += len_to_move;
+            MZ_ASSERT(d->m_lookahead_size >= len_to_move);
+            d->m_lookahead_size -= len_to_move;
+            d->m_dict_size = MZ_MIN(d->m_dict_size + len_to_move, (mz_uint)TDEFL_LZ_DICT_SIZE);
+            /* Check if it's time to flush the current LZ codes to the internal output buffer. */
+            if ((d->m_pLZ_code_buf > &d->m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE - 8]) ||
+                ((d->m_total_lz_bytes > 31 * 1024) && (((((mz_uint)(d->m_pLZ_code_buf - d->m_lz_code_buf) * 115) >> 7) >= d->m_total_lz_bytes) || (d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS))))
+            {
+                int n;
+                d->m_pSrc = pSrc;
+                d->m_src_buf_left = src_buf_left;
+                if ((n = tdefl_flush_block(d, 0)) != 0)
+                    return (n < 0) ? MZ_FALSE : MZ_TRUE;
             }
         }
-        else if (!cur_match_dist)
-            tdefl_record_literal(d, d->m_dict[MZ_MIN(cur_pos, sizeof(d->m_dict) - 1)]);
-        else if ((d->m_greedy_parsing) || (d->m_flags & TDEFL_RLE_MATCHES) || (cur_match_len >= 128))
+
+        d->m_pSrc = pSrc;
+        d->m_src_buf_left = src_buf_left;
+        return MZ_TRUE;
+    }
+
+    static tdefl_status tdefl_flush_output_buffer(tdefl_compressor *d)
+    {
+        if (d->m_pIn_buf_size)
         {
-            tdefl_record_match(d, cur_match_len, cur_match_dist);
-            len_to_move = cur_match_len;
+            *d->m_pIn_buf_size = d->m_pSrc - (const mz_uint8 *)d->m_pIn_buf;
         }
-        else
+
+        if (d->m_pOut_buf_size)
         {
-            d->m_saved_lit = d->m_dict[MZ_MIN(cur_pos, sizeof(d->m_dict) - 1)];
-            d->m_saved_match_dist = cur_match_dist;
-            d->m_saved_match_len = cur_match_len;
+            size_t n = MZ_MIN(*d->m_pOut_buf_size - d->m_out_buf_ofs, d->m_output_flush_remaining);
+            memcpy((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs, d->m_output_buf + d->m_output_flush_ofs, n);
+            d->m_output_flush_ofs += (mz_uint)n;
+            d->m_output_flush_remaining -= (mz_uint)n;
+            d->m_out_buf_ofs += n;
+
+            *d->m_pOut_buf_size = d->m_out_buf_ofs;
         }
-        /* Move the lookahead forward by len_to_move bytes. */
-        d->m_lookahead_pos += len_to_move;
-        MZ_ASSERT(d->m_lookahead_size >= len_to_move);
-        d->m_lookahead_size -= len_to_move;
-        d->m_dict_size = MZ_MIN(d->m_dict_size + len_to_move, (mz_uint)TDEFL_LZ_DICT_SIZE);
-        /* Check if it's time to flush the current LZ codes to the internal output buffer. */
-        if ((d->m_pLZ_code_buf > &d->m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE - 8]) ||
-            ((d->m_total_lz_bytes > 31 * 1024) && (((((mz_uint)(d->m_pLZ_code_buf - d->m_lz_code_buf) * 115) >> 7) >= d->m_total_lz_bytes) || (d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS))))
+
+        return (d->m_finished && !d->m_output_flush_remaining) ? TDEFL_STATUS_DONE : TDEFL_STATUS_OKAY;
+    }
+
+    tdefl_status tdefl_compress(tdefl_compressor *d, const void *pIn_buf, size_t *pIn_buf_size, void *pOut_buf, size_t *pOut_buf_size, tdefl_flush flush)
+    {
+        if (!d)
         {
-            int n;
-            d->m_pSrc = pSrc;
-            d->m_src_buf_left = src_buf_left;
-            if ((n = tdefl_flush_block(d, 0)) != 0)
-                return (n < 0) ? MZ_FALSE : MZ_TRUE;
+            if (pIn_buf_size)
+                *pIn_buf_size = 0;
+            if (pOut_buf_size)
+                *pOut_buf_size = 0;
+            return TDEFL_STATUS_BAD_PARAM;
         }
-    }
 
-    d->m_pSrc = pSrc;
-    d->m_src_buf_left = src_buf_left;
-    return MZ_TRUE;
-}
+        d->m_pIn_buf = pIn_buf;
+        d->m_pIn_buf_size = pIn_buf_size;
+        d->m_pOut_buf = pOut_buf;
+        d->m_pOut_buf_size = pOut_buf_size;
+        d->m_pSrc = (const mz_uint8 *)(pIn_buf);
+        d->m_src_buf_left = pIn_buf_size ? *pIn_buf_size : 0;
+        d->m_out_buf_ofs = 0;
+        d->m_flush = flush;
 
-static tdefl_status tdefl_flush_output_buffer(tdefl_compressor *d)
-{
-    if (d->m_pIn_buf_size)
-    {
-        *d->m_pIn_buf_size = d->m_pSrc - (const mz_uint8 *)d->m_pIn_buf;
-    }
+        if (((d->m_pPut_buf_func != NULL) == ((pOut_buf != NULL) || (pOut_buf_size != NULL))) || (d->m_prev_return_status != TDEFL_STATUS_OKAY) ||
+            (d->m_wants_to_finish && (flush != TDEFL_FINISH)) || (pIn_buf_size && *pIn_buf_size && !pIn_buf) || (pOut_buf_size && *pOut_buf_size && !pOut_buf))
+        {
+            if (pIn_buf_size)
+                *pIn_buf_size = 0;
+            if (pOut_buf_size)
+                *pOut_buf_size = 0;
+            return (d->m_prev_return_status = TDEFL_STATUS_BAD_PARAM);
+        }
+        d->m_wants_to_finish |= (flush == TDEFL_FINISH);
 
-    if (d->m_pOut_buf_size)
-    {
-        size_t n = MZ_MIN(*d->m_pOut_buf_size - d->m_out_buf_ofs, d->m_output_flush_remaining);
-        memcpy((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs, d->m_output_buf + d->m_output_flush_ofs, n);
-        d->m_output_flush_ofs += (mz_uint)n;
-        d->m_output_flush_remaining -= (mz_uint)n;
-        d->m_out_buf_ofs += n;
-
-        *d->m_pOut_buf_size = d->m_out_buf_ofs;
-    }
-
-    return (d->m_finished && !d->m_output_flush_remaining) ? TDEFL_STATUS_DONE : TDEFL_STATUS_OKAY;
-}
-
-tdefl_status tdefl_compress(tdefl_compressor *d, const void *pIn_buf, size_t *pIn_buf_size, void *pOut_buf, size_t *pOut_buf_size, tdefl_flush flush)
-{
-    if (!d)
-    {
-        if (pIn_buf_size)
-            *pIn_buf_size = 0;
-        if (pOut_buf_size)
-            *pOut_buf_size = 0;
-        return TDEFL_STATUS_BAD_PARAM;
-    }
-
-    d->m_pIn_buf = pIn_buf;
-    d->m_pIn_buf_size = pIn_buf_size;
-    d->m_pOut_buf = pOut_buf;
-    d->m_pOut_buf_size = pOut_buf_size;
-    d->m_pSrc = (const mz_uint8 *)(pIn_buf);
-    d->m_src_buf_left = pIn_buf_size ? *pIn_buf_size : 0;
-    d->m_out_buf_ofs = 0;
-    d->m_flush = flush;
-
-    if (((d->m_pPut_buf_func != NULL) == ((pOut_buf != NULL) || (pOut_buf_size != NULL))) || (d->m_prev_return_status != TDEFL_STATUS_OKAY) ||
-        (d->m_wants_to_finish && (flush != TDEFL_FINISH)) || (pIn_buf_size && *pIn_buf_size && !pIn_buf) || (pOut_buf_size && *pOut_buf_size && !pOut_buf))
-    {
-        if (pIn_buf_size)
-            *pIn_buf_size = 0;
-        if (pOut_buf_size)
-            *pOut_buf_size = 0;
-        return (d->m_prev_return_status = TDEFL_STATUS_BAD_PARAM);
-    }
-    d->m_wants_to_finish |= (flush == TDEFL_FINISH);
-
-    if ((d->m_output_flush_remaining) || (d->m_finished))
-        return (d->m_prev_return_status = tdefl_flush_output_buffer(d));
+        if ((d->m_output_flush_remaining) || (d->m_finished))
+            return (d->m_prev_return_status = tdefl_flush_output_buffer(d));
 
 #if MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN
-    if (((d->m_flags & TDEFL_MAX_PROBES_MASK) == 1) &&
-        ((d->m_flags & TDEFL_GREEDY_PARSING_FLAG) != 0) &&
-        ((d->m_flags & (TDEFL_FILTER_MATCHES | TDEFL_FORCE_ALL_RAW_BLOCKS | TDEFL_RLE_MATCHES)) == 0))
-    {
-        if (!tdefl_compress_fast(d))
-            return d->m_prev_return_status;
-    }
-    else
-#endif /* #if MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN */
-    {
-        if (!tdefl_compress_normal(d))
-            return d->m_prev_return_status;
-    }
-
-    if ((d->m_flags & (TDEFL_WRITE_ZLIB_HEADER | TDEFL_COMPUTE_ADLER32)) && (pIn_buf))
-        d->m_adler32 = (mz_uint32)mz_adler32(d->m_adler32, (const mz_uint8 *)pIn_buf, d->m_pSrc - (const mz_uint8 *)pIn_buf);
-
-    if ((flush) && (!d->m_lookahead_size) && (!d->m_src_buf_left) && (!d->m_output_flush_remaining))
-    {
-        if (tdefl_flush_block(d, flush) < 0)
-            return d->m_prev_return_status;
-        d->m_finished = (flush == TDEFL_FINISH);
-        if (flush == TDEFL_FULL_FLUSH)
+        if (((d->m_flags & TDEFL_MAX_PROBES_MASK) == 1) &&
+            ((d->m_flags & TDEFL_GREEDY_PARSING_FLAG) != 0) &&
+            ((d->m_flags & (TDEFL_FILTER_MATCHES | TDEFL_FORCE_ALL_RAW_BLOCKS | TDEFL_RLE_MATCHES)) == 0))
         {
-            MZ_CLEAR_ARR(d->m_hash);
-            MZ_CLEAR_ARR(d->m_next);
-            d->m_dict_size = 0;
+            if (!tdefl_compress_fast(d))
+                return d->m_prev_return_status;
         }
-    }
-
-    return (d->m_prev_return_status = tdefl_flush_output_buffer(d));
-}
-
-tdefl_status tdefl_compress_buffer(tdefl_compressor *d, const void *pIn_buf, size_t in_buf_size, tdefl_flush flush)
-{
-    MZ_ASSERT(d->m_pPut_buf_func);
-    return tdefl_compress(d, pIn_buf, &in_buf_size, NULL, NULL, flush);
-}
-
-tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
-{
-    d->m_pPut_buf_func = pPut_buf_func;
-    d->m_pPut_buf_user = pPut_buf_user;
-    d->m_flags = (mz_uint)(flags);
-    d->m_max_probes[0] = 1 + ((flags & 0xFFF) + 2) / 3;
-    d->m_greedy_parsing = (flags & TDEFL_GREEDY_PARSING_FLAG) != 0;
-    d->m_max_probes[1] = 1 + (((flags & 0xFFF) >> 2) + 2) / 3;
-    if (!(flags & TDEFL_NONDETERMINISTIC_PARSING_FLAG))
-        MZ_CLEAR_ARR(d->m_hash);
-    d->m_lookahead_pos = d->m_lookahead_size = d->m_dict_size = d->m_total_lz_bytes = d->m_lz_code_buf_dict_pos = d->m_bits_in = 0;
-    d->m_output_flush_ofs = d->m_output_flush_remaining = d->m_finished = d->m_block_index = d->m_bit_buffer = d->m_wants_to_finish = 0;
-    d->m_pLZ_code_buf = d->m_lz_code_buf + 1;
-    d->m_pLZ_flags = d->m_lz_code_buf;
-    *d->m_pLZ_flags = 0;
-    d->m_num_flags_left = 8;
-    d->m_pOutput_buf = d->m_output_buf;
-    d->m_pOutput_buf_end = d->m_output_buf;
-    d->m_prev_return_status = TDEFL_STATUS_OKAY;
-    d->m_saved_match_dist = d->m_saved_match_len = d->m_saved_lit = 0;
-    d->m_adler32 = 1;
-    d->m_pIn_buf = NULL;
-    d->m_pOut_buf = NULL;
-    d->m_pIn_buf_size = NULL;
-    d->m_pOut_buf_size = NULL;
-    d->m_flush = TDEFL_NO_FLUSH;
-    d->m_pSrc = NULL;
-    d->m_src_buf_left = 0;
-    d->m_out_buf_ofs = 0;
-    if (!(flags & TDEFL_NONDETERMINISTIC_PARSING_FLAG))
-        MZ_CLEAR_ARR(d->m_dict);
-    memset(&d->m_huff_count[0][0], 0, sizeof(d->m_huff_count[0][0]) * TDEFL_MAX_HUFF_SYMBOLS_0);
-    memset(&d->m_huff_count[1][0], 0, sizeof(d->m_huff_count[1][0]) * TDEFL_MAX_HUFF_SYMBOLS_1);
-    return TDEFL_STATUS_OKAY;
-}
-
-tdefl_status tdefl_get_prev_return_status(tdefl_compressor *d)
-{
-    return d->m_prev_return_status;
-}
-
-mz_uint32 tdefl_get_adler32(tdefl_compressor *d)
-{
-    return d->m_adler32;
-}
-
-mz_bool tdefl_compress_mem_to_output(const void *pBuf, size_t buf_len, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
-{
-    tdefl_compressor *pComp;
-    mz_bool succeeded;
-    if (((buf_len) && (!pBuf)) || (!pPut_buf_func))
-        return MZ_FALSE;
-    pComp = (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
-    if (!pComp)
-        return MZ_FALSE;
-    succeeded = (tdefl_init(pComp, pPut_buf_func, pPut_buf_user, flags) == TDEFL_STATUS_OKAY);
-    succeeded = succeeded && (tdefl_compress_buffer(pComp, pBuf, buf_len, TDEFL_FINISH) == TDEFL_STATUS_DONE);
-    MZ_FREE(pComp);
-    return succeeded;
-}
-
-typedef struct
-{
-    size_t m_size, m_capacity;
-    mz_uint8 *m_pBuf;
-    mz_bool m_expandable;
-} tdefl_output_buffer;
-
-static mz_bool tdefl_output_buffer_putter(const void *pBuf, int len, void *pUser)
-{
-    tdefl_output_buffer *p = (tdefl_output_buffer *)pUser;
-    size_t new_size = p->m_size + len;
-    if (new_size > p->m_capacity)
-    {
-        size_t new_capacity = p->m_capacity;
-        mz_uint8 *pNew_buf;
-        if (!p->m_expandable)
-            return MZ_FALSE;
-        do
+        else
+#endif /* #if MINIZ_USE_UNALIGNED_LOADS_AND_STORES && MINIZ_LITTLE_ENDIAN */
         {
-            new_capacity = MZ_MAX(128U, new_capacity << 1U);
-        } while (new_size > new_capacity);
-        pNew_buf = (mz_uint8 *)MZ_REALLOC(p->m_pBuf, new_capacity);
-        if (!pNew_buf)
-            return MZ_FALSE;
-        p->m_pBuf = pNew_buf;
-        p->m_capacity = new_capacity;
+            if (!tdefl_compress_normal(d))
+                return d->m_prev_return_status;
+        }
+
+        if ((d->m_flags & (TDEFL_WRITE_ZLIB_HEADER | TDEFL_COMPUTE_ADLER32)) && (pIn_buf))
+            d->m_adler32 = (mz_uint32)mz_adler32(d->m_adler32, (const mz_uint8 *)pIn_buf, d->m_pSrc - (const mz_uint8 *)pIn_buf);
+
+        if ((flush) && (!d->m_lookahead_size) && (!d->m_src_buf_left) && (!d->m_output_flush_remaining))
+        {
+            if (tdefl_flush_block(d, flush) < 0)
+                return d->m_prev_return_status;
+            d->m_finished = (flush == TDEFL_FINISH);
+            if (flush == TDEFL_FULL_FLUSH)
+            {
+                MZ_CLEAR_ARR(d->m_hash);
+                MZ_CLEAR_ARR(d->m_next);
+                d->m_dict_size = 0;
+            }
+        }
+
+        return (d->m_prev_return_status = tdefl_flush_output_buffer(d));
     }
-    memcpy((mz_uint8 *)p->m_pBuf + p->m_size, pBuf, len);
-    p->m_size = new_size;
-    return MZ_TRUE;
-}
 
-void *tdefl_compress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags)
-{
-    tdefl_output_buffer out_buf;
-    MZ_CLEAR_OBJ(out_buf);
-    if (!pOut_len)
-        return MZ_FALSE;
-    else
-        *pOut_len = 0;
-    out_buf.m_expandable = MZ_TRUE;
-    if (!tdefl_compress_mem_to_output(pSrc_buf, src_buf_len, tdefl_output_buffer_putter, &out_buf, flags))
-        return NULL;
-    *pOut_len = out_buf.m_size;
-    return out_buf.m_pBuf;
-}
+    tdefl_status tdefl_compress_buffer(tdefl_compressor *d, const void *pIn_buf, size_t in_buf_size, tdefl_flush flush)
+    {
+        MZ_ASSERT(d->m_pPut_buf_func);
+        return tdefl_compress(d, pIn_buf, &in_buf_size, NULL, NULL, flush);
+    }
 
-size_t tdefl_compress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags)
-{
-    tdefl_output_buffer out_buf;
-    MZ_CLEAR_OBJ(out_buf);
-    if (!pOut_buf)
-        return 0;
-    out_buf.m_pBuf = (mz_uint8 *)pOut_buf;
-    out_buf.m_capacity = out_buf_len;
-    if (!tdefl_compress_mem_to_output(pSrc_buf, src_buf_len, tdefl_output_buffer_putter, &out_buf, flags))
-        return 0;
-    return out_buf.m_size;
-}
+    tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
+    {
+        d->m_pPut_buf_func = pPut_buf_func;
+        d->m_pPut_buf_user = pPut_buf_user;
+        d->m_flags = (mz_uint)(flags);
+        d->m_max_probes[0] = 1 + ((flags & 0xFFF) + 2) / 3;
+        d->m_greedy_parsing = (flags & TDEFL_GREEDY_PARSING_FLAG) != 0;
+        d->m_max_probes[1] = 1 + (((flags & 0xFFF) >> 2) + 2) / 3;
+        if (!(flags & TDEFL_NONDETERMINISTIC_PARSING_FLAG))
+            MZ_CLEAR_ARR(d->m_hash);
+        d->m_lookahead_pos = d->m_lookahead_size = d->m_dict_size = d->m_total_lz_bytes = d->m_lz_code_buf_dict_pos = d->m_bits_in = 0;
+        d->m_output_flush_ofs = d->m_output_flush_remaining = d->m_finished = d->m_block_index = d->m_bit_buffer = d->m_wants_to_finish = 0;
+        d->m_pLZ_code_buf = d->m_lz_code_buf + 1;
+        d->m_pLZ_flags = d->m_lz_code_buf;
+        *d->m_pLZ_flags = 0;
+        d->m_num_flags_left = 8;
+        d->m_pOutput_buf = d->m_output_buf;
+        d->m_pOutput_buf_end = d->m_output_buf;
+        d->m_prev_return_status = TDEFL_STATUS_OKAY;
+        d->m_saved_match_dist = d->m_saved_match_len = d->m_saved_lit = 0;
+        d->m_adler32 = 1;
+        d->m_pIn_buf = NULL;
+        d->m_pOut_buf = NULL;
+        d->m_pIn_buf_size = NULL;
+        d->m_pOut_buf_size = NULL;
+        d->m_flush = TDEFL_NO_FLUSH;
+        d->m_pSrc = NULL;
+        d->m_src_buf_left = 0;
+        d->m_out_buf_ofs = 0;
+        if (!(flags & TDEFL_NONDETERMINISTIC_PARSING_FLAG))
+            MZ_CLEAR_ARR(d->m_dict);
+        memset(&d->m_huff_count[0][0], 0, sizeof(d->m_huff_count[0][0]) * TDEFL_MAX_HUFF_SYMBOLS_0);
+        memset(&d->m_huff_count[1][0], 0, sizeof(d->m_huff_count[1][0]) * TDEFL_MAX_HUFF_SYMBOLS_1);
+        return TDEFL_STATUS_OKAY;
+    }
 
-/* level may actually range from [0,10] (10 is a "hidden" max level, where we want a bit more compression and it's fine if throughput to fall off a cliff on some files). */
-mz_uint tdefl_create_comp_flags_from_zip_params(int level, int window_bits, int strategy)
-{
-    mz_uint comp_flags = s_tdefl_num_probes[(level >= 0) ? MZ_MIN(10, level) : MZ_DEFAULT_LEVEL] | ((level <= 3) ? TDEFL_GREEDY_PARSING_FLAG : 0);
-    if (window_bits > 0)
-        comp_flags |= TDEFL_WRITE_ZLIB_HEADER;
+    tdefl_status tdefl_get_prev_return_status(tdefl_compressor *d)
+    {
+        return d->m_prev_return_status;
+    }
 
-    if (!level)
-        comp_flags |= TDEFL_FORCE_ALL_RAW_BLOCKS;
-    else if (strategy == MZ_FILTERED)
-        comp_flags |= TDEFL_FILTER_MATCHES;
-    else if (strategy == MZ_HUFFMAN_ONLY)
-        comp_flags &= ~TDEFL_MAX_PROBES_MASK;
-    else if (strategy == MZ_FIXED)
-        comp_flags |= TDEFL_FORCE_ALL_STATIC_BLOCKS;
-    else if (strategy == MZ_RLE)
-        comp_flags |= TDEFL_RLE_MATCHES;
+    mz_uint32 tdefl_get_adler32(tdefl_compressor *d)
+    {
+        return d->m_adler32;
+    }
 
-    return comp_flags;
-}
+    mz_bool tdefl_compress_mem_to_output(const void *pBuf, size_t buf_len, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
+    {
+        tdefl_compressor *pComp;
+        mz_bool succeeded;
+        if (((buf_len) && (!pBuf)) || (!pPut_buf_func))
+            return MZ_FALSE;
+        pComp = (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
+        if (!pComp)
+            return MZ_FALSE;
+        succeeded = (tdefl_init(pComp, pPut_buf_func, pPut_buf_user, flags) == TDEFL_STATUS_OKAY);
+        succeeded = succeeded && (tdefl_compress_buffer(pComp, pBuf, buf_len, TDEFL_FINISH) == TDEFL_STATUS_DONE);
+        MZ_FREE(pComp);
+        return succeeded;
+    }
+
+    typedef struct
+    {
+        size_t m_size, m_capacity;
+        mz_uint8 *m_pBuf;
+        mz_bool m_expandable;
+    } tdefl_output_buffer;
+
+    static mz_bool tdefl_output_buffer_putter(const void *pBuf, int len, void *pUser)
+    {
+        tdefl_output_buffer *p = (tdefl_output_buffer *)pUser;
+        size_t new_size = p->m_size + len;
+        if (new_size > p->m_capacity)
+        {
+            size_t new_capacity = p->m_capacity;
+            mz_uint8 *pNew_buf;
+            if (!p->m_expandable)
+                return MZ_FALSE;
+            do
+            {
+                new_capacity = MZ_MAX(128U, new_capacity << 1U);
+            } while (new_size > new_capacity);
+            pNew_buf = (mz_uint8 *)MZ_REALLOC(p->m_pBuf, new_capacity);
+            if (!pNew_buf)
+                return MZ_FALSE;
+            p->m_pBuf = pNew_buf;
+            p->m_capacity = new_capacity;
+        }
+        memcpy((mz_uint8 *)p->m_pBuf + p->m_size, pBuf, len);
+        p->m_size = new_size;
+        return MZ_TRUE;
+    }
+
+    void *tdefl_compress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags)
+    {
+        tdefl_output_buffer out_buf;
+        MZ_CLEAR_OBJ(out_buf);
+        if (!pOut_len)
+            return MZ_FALSE;
+        else
+            *pOut_len = 0;
+        out_buf.m_expandable = MZ_TRUE;
+        if (!tdefl_compress_mem_to_output(pSrc_buf, src_buf_len, tdefl_output_buffer_putter, &out_buf, flags))
+            return NULL;
+        *pOut_len = out_buf.m_size;
+        return out_buf.m_pBuf;
+    }
+
+    size_t tdefl_compress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags)
+    {
+        tdefl_output_buffer out_buf;
+        MZ_CLEAR_OBJ(out_buf);
+        if (!pOut_buf)
+            return 0;
+        out_buf.m_pBuf = (mz_uint8 *)pOut_buf;
+        out_buf.m_capacity = out_buf_len;
+        if (!tdefl_compress_mem_to_output(pSrc_buf, src_buf_len, tdefl_output_buffer_putter, &out_buf, flags))
+            return 0;
+        return out_buf.m_size;
+    }
+
+    /* level may actually range from [0,10] (10 is a "hidden" max level, where we want a bit more compression and it's fine if throughput to fall off a cliff on some files). */
+    mz_uint tdefl_create_comp_flags_from_zip_params(int level, int window_bits, int strategy)
+    {
+        mz_uint comp_flags = s_tdefl_num_probes[(level >= 0) ? MZ_MIN(10, level) : MZ_DEFAULT_LEVEL] | ((level <= 3) ? TDEFL_GREEDY_PARSING_FLAG : 0);
+        if (window_bits > 0)
+            comp_flags |= TDEFL_WRITE_ZLIB_HEADER;
+
+        if (!level)
+            comp_flags |= TDEFL_FORCE_ALL_RAW_BLOCKS;
+        else if (strategy == MZ_FILTERED)
+            comp_flags |= TDEFL_FILTER_MATCHES;
+        else if (strategy == MZ_HUFFMAN_ONLY)
+            comp_flags &= ~TDEFL_MAX_PROBES_MASK;
+        else if (strategy == MZ_FIXED)
+            comp_flags |= TDEFL_FORCE_ALL_STATIC_BLOCKS;
+        else if (strategy == MZ_RLE)
+            comp_flags |= TDEFL_RLE_MATCHES;
+
+        return comp_flags;
+    }
 
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4204) /* nonstandard extension used : non-constant aggregate initializer (also supported by GNU C and C99, so no big deal) */
 #endif
 
-/* Simple PNG writer function by Alex Evans, 2011. Released into the public domain: https://gist.github.com/908299, more context at
- http://altdevblogaday.org/2011/04/06/a-smaller-jpg-encoder/.
- This is actually a modification of Alex's original code so PNG files generated by this function pass pngcheck. */
-void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int h, int num_chans, size_t *pLen_out, mz_uint level, mz_bool flip)
-{
-    /* Using a local copy of this array here in case MINIZ_NO_ZLIB_APIS was defined. */
-    static const mz_uint s_tdefl_png_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
-    tdefl_compressor *pComp = (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
-    tdefl_output_buffer out_buf;
-    int i, bpl = w * num_chans, y, z;
-    mz_uint32 c;
-    *pLen_out = 0;
-    if (!pComp)
-        return NULL;
-    MZ_CLEAR_OBJ(out_buf);
-    out_buf.m_expandable = MZ_TRUE;
-    out_buf.m_capacity = 57 + MZ_MAX(64, (1 + bpl) * h);
-    if (NULL == (out_buf.m_pBuf = (mz_uint8 *)MZ_MALLOC(out_buf.m_capacity)))
+    /* Simple PNG writer function by Alex Evans, 2011. Released into the public domain: https://gist.github.com/908299, more context at
+     http://altdevblogaday.org/2011/04/06/a-smaller-jpg-encoder/.
+     This is actually a modification of Alex's original code so PNG files generated by this function pass pngcheck. */
+    void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int h, int num_chans, size_t *pLen_out, mz_uint level, mz_bool flip)
     {
-        MZ_FREE(pComp);
-        return NULL;
-    }
-    /* write dummy header */
-    for (z = 41; z; --z)
-        tdefl_output_buffer_putter(&z, 1, &out_buf);
-    /* compress image data */
-    tdefl_init(pComp, tdefl_output_buffer_putter, &out_buf, s_tdefl_png_num_probes[MZ_MIN(10, level)] | TDEFL_WRITE_ZLIB_HEADER);
-    for (y = 0; y < h; ++y)
-    {
-        tdefl_compress_buffer(pComp, &z, 1, TDEFL_NO_FLUSH);
-        tdefl_compress_buffer(pComp, (mz_uint8 *)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH);
-    }
-    if (tdefl_compress_buffer(pComp, NULL, 0, TDEFL_FINISH) != TDEFL_STATUS_DONE)
-    {
-        MZ_FREE(pComp);
-        MZ_FREE(out_buf.m_pBuf);
-        return NULL;
-    }
-    /* write real header */
-    *pLen_out = out_buf.m_size - 41;
-    {
-        static const mz_uint8 chans[] = { 0x00, 0x00, 0x04, 0x02, 0x06 };
-        mz_uint8 pnghdr[41] = { 0x89, 0x50, 0x4e, 0x47, 0x0d,
-                                0x0a, 0x1a, 0x0a, 0x00, 0x00,
-                                0x00, 0x0d, 0x49, 0x48, 0x44,
-                                0x52, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x08,
-                                0x00, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x49, 0x44, 0x41,
-                                0x54 };
-        pnghdr[18] = (mz_uint8)(w >> 8);
-        pnghdr[19] = (mz_uint8)w;
-        pnghdr[22] = (mz_uint8)(h >> 8);
-        pnghdr[23] = (mz_uint8)h;
-        pnghdr[25] = chans[num_chans];
-        pnghdr[33] = (mz_uint8)(*pLen_out >> 24);
-        pnghdr[34] = (mz_uint8)(*pLen_out >> 16);
-        pnghdr[35] = (mz_uint8)(*pLen_out >> 8);
-        pnghdr[36] = (mz_uint8)*pLen_out;
-        c = (mz_uint32)mz_crc32(MZ_CRC32_INIT, pnghdr + 12, 17);
-        for (i = 0; i < 4; ++i, c <<= 8)
-            ((mz_uint8 *)(pnghdr + 29))[i] = (mz_uint8)(c >> 24);
-        memcpy(out_buf.m_pBuf, pnghdr, 41);
-    }
-    /* write footer (IDAT CRC-32, followed by IEND chunk) */
-    if (!tdefl_output_buffer_putter("\0\0\0\0\0\0\0\0\x49\x45\x4e\x44\xae\x42\x60\x82", 16, &out_buf))
-    {
+        /* Using a local copy of this array here in case MINIZ_NO_ZLIB_APIS was defined. */
+        static const mz_uint s_tdefl_png_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
+        tdefl_compressor *pComp = (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
+        tdefl_output_buffer out_buf;
+        int i, bpl = w * num_chans, y, z;
+        mz_uint32 c;
         *pLen_out = 0;
+        if (!pComp)
+            return NULL;
+        MZ_CLEAR_OBJ(out_buf);
+        out_buf.m_expandable = MZ_TRUE;
+        out_buf.m_capacity = 57 + MZ_MAX(64, (1 + bpl) * h);
+        if (NULL == (out_buf.m_pBuf = (mz_uint8 *)MZ_MALLOC(out_buf.m_capacity)))
+        {
+            MZ_FREE(pComp);
+            return NULL;
+        }
+        /* write dummy header */
+        for (z = 41; z; --z)
+            tdefl_output_buffer_putter(&z, 1, &out_buf);
+        /* compress image data */
+        tdefl_init(pComp, tdefl_output_buffer_putter, &out_buf, s_tdefl_png_num_probes[MZ_MIN(10, level)] | TDEFL_WRITE_ZLIB_HEADER);
+        for (y = 0; y < h; ++y)
+        {
+            tdefl_compress_buffer(pComp, &z, 1, TDEFL_NO_FLUSH);
+            tdefl_compress_buffer(pComp, (mz_uint8 *)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH);
+        }
+        if (tdefl_compress_buffer(pComp, NULL, 0, TDEFL_FINISH) != TDEFL_STATUS_DONE)
+        {
+            MZ_FREE(pComp);
+            MZ_FREE(out_buf.m_pBuf);
+            return NULL;
+        }
+        /* write real header */
+        *pLen_out = out_buf.m_size - 41;
+        {
+            static const mz_uint8 chans[] = { 0x00, 0x00, 0x04, 0x02, 0x06 };
+            mz_uint8 pnghdr[41] = { 0x89, 0x50, 0x4e, 0x47, 0x0d,
+                                    0x0a, 0x1a, 0x0a, 0x00, 0x00,
+                                    0x00, 0x0d, 0x49, 0x48, 0x44,
+                                    0x52, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x08,
+                                    0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x49, 0x44, 0x41,
+                                    0x54 };
+            pnghdr[18] = (mz_uint8)(w >> 8);
+            pnghdr[19] = (mz_uint8)w;
+            pnghdr[22] = (mz_uint8)(h >> 8);
+            pnghdr[23] = (mz_uint8)h;
+            pnghdr[25] = chans[num_chans];
+            pnghdr[33] = (mz_uint8)(*pLen_out >> 24);
+            pnghdr[34] = (mz_uint8)(*pLen_out >> 16);
+            pnghdr[35] = (mz_uint8)(*pLen_out >> 8);
+            pnghdr[36] = (mz_uint8)*pLen_out;
+            c = (mz_uint32)mz_crc32(MZ_CRC32_INIT, pnghdr + 12, 17);
+            for (i = 0; i < 4; ++i, c <<= 8)
+                ((mz_uint8 *)(pnghdr + 29))[i] = (mz_uint8)(c >> 24);
+            memcpy(out_buf.m_pBuf, pnghdr, 41);
+        }
+        /* write footer (IDAT CRC-32, followed by IEND chunk) */
+        if (!tdefl_output_buffer_putter("\0\0\0\0\0\0\0\0\x49\x45\x4e\x44\xae\x42\x60\x82", 16, &out_buf))
+        {
+            *pLen_out = 0;
+            MZ_FREE(pComp);
+            MZ_FREE(out_buf.m_pBuf);
+            return NULL;
+        }
+        c = (mz_uint32)mz_crc32(MZ_CRC32_INIT, out_buf.m_pBuf + 41 - 4, *pLen_out + 4);
+        for (i = 0; i < 4; ++i, c <<= 8)
+            (out_buf.m_pBuf + out_buf.m_size - 16)[i] = (mz_uint8)(c >> 24);
+        /* compute final size of file, grab compressed data buffer and return */
+        *pLen_out += 57;
         MZ_FREE(pComp);
-        MZ_FREE(out_buf.m_pBuf);
-        return NULL;
+        return out_buf.m_pBuf;
     }
-    c = (mz_uint32)mz_crc32(MZ_CRC32_INIT, out_buf.m_pBuf + 41 - 4, *pLen_out + 4);
-    for (i = 0; i < 4; ++i, c <<= 8)
-        (out_buf.m_pBuf + out_buf.m_size - 16)[i] = (mz_uint8)(c >> 24);
-    /* compute final size of file, grab compressed data buffer and return */
-    *pLen_out += 57;
-    MZ_FREE(pComp);
-    return out_buf.m_pBuf;
-}
-void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, int num_chans, size_t *pLen_out)
-{
-    /* Level 6 corresponds to TDEFL_DEFAULT_MAX_PROBES or MZ_DEFAULT_LEVEL (but we can't depend on MZ_DEFAULT_LEVEL being available in case the zlib API's where #defined out) */
-    return tdefl_write_image_to_png_file_in_memory_ex(pImage, w, h, num_chans, pLen_out, 6, MZ_FALSE);
-}
+    void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, int num_chans, size_t *pLen_out)
+    {
+        /* Level 6 corresponds to TDEFL_DEFAULT_MAX_PROBES or MZ_DEFAULT_LEVEL (but we can't depend on MZ_DEFAULT_LEVEL being available in case the zlib API's where #defined out) */
+        return tdefl_write_image_to_png_file_in_memory_ex(pImage, w, h, num_chans, pLen_out, 6, MZ_FALSE);
+    }
 
 #ifndef MINIZ_NO_MALLOC
-/* Allocate the tdefl_compressor and tinfl_decompressor structures in C so that */
-/* non-C language bindings to tdefL_ and tinfl_ API don't need to worry about */
-/* structure size and allocation mechanism. */
-tdefl_compressor *tdefl_compressor_alloc(void)
-{
-    return (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
-}
+    /* Allocate the tdefl_compressor and tinfl_decompressor structures in C so that */
+    /* non-C language bindings to tdefL_ and tinfl_ API don't need to worry about */
+    /* structure size and allocation mechanism. */
+    tdefl_compressor *tdefl_compressor_alloc(void)
+    {
+        return (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
+    }
 
-void tdefl_compressor_free(tdefl_compressor *pComp)
-{
-    MZ_FREE(pComp);
-}
+    void tdefl_compressor_free(tdefl_compressor *pComp)
+    {
+        MZ_FREE(pComp);
+    }
 #endif
 
 #ifdef _MSC_VER
@@ -2245,7 +2242,7 @@ void tdefl_compressor_free(tdefl_compressor *pComp)
 #endif
 
 #endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
-/**************************************************************************
+ /**************************************************************************
  *
  * Copyright 2013-2014 RAD Game Tools and Valve Software
  * Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
@@ -2272,13 +2269,15 @@ void tdefl_compressor_free(tdefl_compressor *pComp)
  **************************************************************************/
 
 
+
 #ifndef MINIZ_NO_INFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* ------------------- Low-level Decompression (completely independent from all compression API's) */
+    /* ------------------- Low-level Decompression (completely independent from all compression API's) */
 
 #define TINFL_MEMCPY(d, s, l) memcpy(d, s, l)
 #define TINFL_MEMSET(p, c, l) memset(p, c, l)
@@ -2354,29 +2353,29 @@ extern "C" {
 /* It reads just enough bytes from the input stream that are needed to decode the next Huffman code (and absolutely no more). It works by trying to fully decode a */
 /* Huffman code by using whatever bits are currently present in the bit buffer. If this fails, it reads another byte, and tries again until it succeeds or until the */
 /* bit buffer contains >=15 bits (deflate's max. Huffman code size). */
-#define TINFL_HUFF_BITBUF_FILL(state_index, pLookUp, pTree)                    \
-    do                                                                         \
-    {                                                                          \
-        temp = pLookUp[bit_buf & (TINFL_FAST_LOOKUP_SIZE - 1)];                \
-        if (temp >= 0)                                                         \
-        {                                                                      \
-            code_len = temp >> 9;                                              \
-            if ((code_len) && (num_bits >= code_len))                          \
-                break;                                                         \
-        }                                                                      \
-        else if (num_bits > TINFL_FAST_LOOKUP_BITS)                            \
-        {                                                                      \
-            code_len = TINFL_FAST_LOOKUP_BITS;                                 \
-            do                                                                 \
-            {                                                                  \
-                temp = pTree[~temp + ((bit_buf >> code_len++) & 1)];           \
-            } while ((temp < 0) && (num_bits >= (code_len + 1)));              \
-            if (temp >= 0)                                                     \
-                break;                                                         \
-        }                                                                      \
-        TINFL_GET_BYTE(state_index, c);                                        \
-        bit_buf |= (((tinfl_bit_buf_t)c) << num_bits);                         \
-        num_bits += 8;                                                         \
+#define TINFL_HUFF_BITBUF_FILL(state_index, pLookUp, pTree)          \
+    do                                                               \
+    {                                                                \
+        temp = pLookUp[bit_buf & (TINFL_FAST_LOOKUP_SIZE - 1)];      \
+        if (temp >= 0)                                               \
+        {                                                            \
+            code_len = temp >> 9;                                    \
+            if ((code_len) && (num_bits >= code_len))                \
+                break;                                               \
+        }                                                            \
+        else if (num_bits > TINFL_FAST_LOOKUP_BITS)                  \
+        {                                                            \
+            code_len = TINFL_FAST_LOOKUP_BITS;                       \
+            do                                                       \
+            {                                                        \
+                temp = pTree[~temp + ((bit_buf >> code_len++) & 1)]; \
+            } while ((temp < 0) && (num_bits >= (code_len + 1)));    \
+            if (temp >= 0)                                           \
+                break;                                               \
+        }                                                            \
+        TINFL_GET_BYTE(state_index, c);                              \
+        bit_buf |= (((tinfl_bit_buf_t)c) << num_bits);               \
+        num_bits += 8;                                               \
     } while (num_bits < 15);
 
 /* TINFL_HUFF_DECODE() decodes the next Huffman coded symbol. It's more complex than you would initially expect because the zlib API expects the decompressor to never read */
@@ -2419,278 +2418,278 @@ extern "C" {
     }                                                                                                                               \
     MZ_MACRO_END
 
-static void tinfl_clear_tree(tinfl_decompressor *r)
-{
-    if (r->m_type == 0)
-        MZ_CLEAR_ARR(r->m_tree_0);
-    else if (r->m_type == 1)
-        MZ_CLEAR_ARR(r->m_tree_1);
-    else
-        MZ_CLEAR_ARR(r->m_tree_2);
-}
-
-tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_next, size_t *pIn_buf_size, mz_uint8 *pOut_buf_start, mz_uint8 *pOut_buf_next, size_t *pOut_buf_size, const mz_uint32 decomp_flags)
-{
-    static const mz_uint16 s_length_base[31] = { 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0 };
-    static const mz_uint8 s_length_extra[31] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0 };
-    static const mz_uint16 s_dist_base[32] = { 1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577, 0, 0 };
-    static const mz_uint8 s_dist_extra[32] = { 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13 };
-    static const mz_uint8 s_length_dezigzag[19] = { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
-    static const mz_uint16 s_min_table_sizes[3] = { 257, 1, 4 };
-
-    mz_int16 *pTrees[3];
-    mz_uint8 *pCode_sizes[3];
-
-    tinfl_status status = TINFL_STATUS_FAILED;
-    mz_uint32 num_bits, dist, counter, num_extra;
-    tinfl_bit_buf_t bit_buf;
-    const mz_uint8 *pIn_buf_cur = pIn_buf_next, *const pIn_buf_end = pIn_buf_next + *pIn_buf_size;
-    mz_uint8 *pOut_buf_cur = pOut_buf_next, *const pOut_buf_end = pOut_buf_next ? pOut_buf_next + *pOut_buf_size : NULL;
-    size_t out_buf_size_mask = (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF) ? (size_t)-1 : ((pOut_buf_next - pOut_buf_start) + *pOut_buf_size) - 1, dist_from_out_buf_start;
-
-    /* Ensure the output buffer's size is a power of 2, unless the output buffer is large enough to hold the entire output file (in which case it doesn't matter). */
-    if (((out_buf_size_mask + 1) & out_buf_size_mask) || (pOut_buf_next < pOut_buf_start))
+    static void tinfl_clear_tree(tinfl_decompressor *r)
     {
-        *pIn_buf_size = *pOut_buf_size = 0;
-        return TINFL_STATUS_BAD_PARAM;
-    }
-
-    pTrees[0] = r->m_tree_0;
-    pTrees[1] = r->m_tree_1;
-    pTrees[2] = r->m_tree_2;
-    pCode_sizes[0] = r->m_code_size_0;
-    pCode_sizes[1] = r->m_code_size_1;
-    pCode_sizes[2] = r->m_code_size_2;
-
-    num_bits = r->m_num_bits;
-    bit_buf = r->m_bit_buf;
-    dist = r->m_dist;
-    counter = r->m_counter;
-    num_extra = r->m_num_extra;
-    dist_from_out_buf_start = r->m_dist_from_out_buf_start;
-    TINFL_CR_BEGIN
-
-    bit_buf = num_bits = dist = counter = num_extra = r->m_zhdr0 = r->m_zhdr1 = 0;
-    r->m_z_adler32 = r->m_check_adler32 = 1;
-    if (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER)
-    {
-        TINFL_GET_BYTE(1, r->m_zhdr0);
-        TINFL_GET_BYTE(2, r->m_zhdr1);
-        counter = (((r->m_zhdr0 * 256 + r->m_zhdr1) % 31 != 0) || (r->m_zhdr1 & 32) || ((r->m_zhdr0 & 15) != 8));
-        if (!(decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
-            counter |= (((1U << (8U + (r->m_zhdr0 >> 4))) > 32768U) || ((out_buf_size_mask + 1) < (size_t)((size_t)1 << (8U + (r->m_zhdr0 >> 4)))));
-        if (counter)
-        {
-            TINFL_CR_RETURN_FOREVER(36, TINFL_STATUS_FAILED);
-        }
-    }
-
-    do
-    {
-        TINFL_GET_BITS(3, r->m_final, 3);
-        r->m_type = r->m_final >> 1;
         if (r->m_type == 0)
-        {
-            TINFL_SKIP_BITS(5, num_bits & 7);
-            for (counter = 0; counter < 4; ++counter)
-            {
-                if (num_bits)
-                    TINFL_GET_BITS(6, r->m_raw_header[counter], 8);
-                else
-                    TINFL_GET_BYTE(7, r->m_raw_header[counter]);
-            }
-            if ((counter = (r->m_raw_header[0] | (r->m_raw_header[1] << 8))) != (mz_uint)(0xFFFF ^ (r->m_raw_header[2] | (r->m_raw_header[3] << 8))))
-            {
-                TINFL_CR_RETURN_FOREVER(39, TINFL_STATUS_FAILED);
-            }
-            while ((counter) && (num_bits))
-            {
-                TINFL_GET_BITS(51, dist, 8);
-                while (pOut_buf_cur >= pOut_buf_end)
-                {
-                    TINFL_CR_RETURN(52, TINFL_STATUS_HAS_MORE_OUTPUT);
-                }
-                *pOut_buf_cur++ = (mz_uint8)dist;
-                counter--;
-            }
-            while (counter)
-            {
-                size_t n;
-                while (pOut_buf_cur >= pOut_buf_end)
-                {
-                    TINFL_CR_RETURN(9, TINFL_STATUS_HAS_MORE_OUTPUT);
-                }
-                while (pIn_buf_cur >= pIn_buf_end)
-                {
-                    TINFL_CR_RETURN(38, (decomp_flags & TINFL_FLAG_HAS_MORE_INPUT) ? TINFL_STATUS_NEEDS_MORE_INPUT : TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS);
-                }
-                n = MZ_MIN(MZ_MIN((size_t)(pOut_buf_end - pOut_buf_cur), (size_t)(pIn_buf_end - pIn_buf_cur)), counter);
-                TINFL_MEMCPY(pOut_buf_cur, pIn_buf_cur, n);
-                pIn_buf_cur += n;
-                pOut_buf_cur += n;
-                counter -= (mz_uint)n;
-            }
-        }
-        else if (r->m_type == 3)
-        {
-            TINFL_CR_RETURN_FOREVER(10, TINFL_STATUS_FAILED);
-        }
+            MZ_CLEAR_ARR(r->m_tree_0);
+        else if (r->m_type == 1)
+            MZ_CLEAR_ARR(r->m_tree_1);
         else
+            MZ_CLEAR_ARR(r->m_tree_2);
+    }
+
+    tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_next, size_t *pIn_buf_size, mz_uint8 *pOut_buf_start, mz_uint8 *pOut_buf_next, size_t *pOut_buf_size, const mz_uint32 decomp_flags)
+    {
+        static const mz_uint16 s_length_base[31] = { 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0 };
+        static const mz_uint8 s_length_extra[31] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0 };
+        static const mz_uint16 s_dist_base[32] = { 1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577, 0, 0 };
+        static const mz_uint8 s_dist_extra[32] = { 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13 };
+        static const mz_uint8 s_length_dezigzag[19] = { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
+        static const mz_uint16 s_min_table_sizes[3] = { 257, 1, 4 };
+
+        mz_int16 *pTrees[3];
+        mz_uint8 *pCode_sizes[3];
+
+        tinfl_status status = TINFL_STATUS_FAILED;
+        mz_uint32 num_bits, dist, counter, num_extra;
+        tinfl_bit_buf_t bit_buf;
+        const mz_uint8 *pIn_buf_cur = pIn_buf_next, *const pIn_buf_end = pIn_buf_next + *pIn_buf_size;
+        mz_uint8 *pOut_buf_cur = pOut_buf_next, *const pOut_buf_end = pOut_buf_next ? pOut_buf_next + *pOut_buf_size : NULL;
+        size_t out_buf_size_mask = (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF) ? (size_t)-1 : ((pOut_buf_next - pOut_buf_start) + *pOut_buf_size) - 1, dist_from_out_buf_start;
+
+        /* Ensure the output buffer's size is a power of 2, unless the output buffer is large enough to hold the entire output file (in which case it doesn't matter). */
+        if (((out_buf_size_mask + 1) & out_buf_size_mask) || (pOut_buf_next < pOut_buf_start))
         {
-            if (r->m_type == 1)
+            *pIn_buf_size = *pOut_buf_size = 0;
+            return TINFL_STATUS_BAD_PARAM;
+        }
+
+        pTrees[0] = r->m_tree_0;
+        pTrees[1] = r->m_tree_1;
+        pTrees[2] = r->m_tree_2;
+        pCode_sizes[0] = r->m_code_size_0;
+        pCode_sizes[1] = r->m_code_size_1;
+        pCode_sizes[2] = r->m_code_size_2;
+
+        num_bits = r->m_num_bits;
+        bit_buf = r->m_bit_buf;
+        dist = r->m_dist;
+        counter = r->m_counter;
+        num_extra = r->m_num_extra;
+        dist_from_out_buf_start = r->m_dist_from_out_buf_start;
+        TINFL_CR_BEGIN
+
+        bit_buf = num_bits = dist = counter = num_extra = r->m_zhdr0 = r->m_zhdr1 = 0;
+        r->m_z_adler32 = r->m_check_adler32 = 1;
+        if (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER)
+        {
+            TINFL_GET_BYTE(1, r->m_zhdr0);
+            TINFL_GET_BYTE(2, r->m_zhdr1);
+            counter = (((r->m_zhdr0 * 256 + r->m_zhdr1) % 31 != 0) || (r->m_zhdr1 & 32) || ((r->m_zhdr0 & 15) != 8));
+            if (!(decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
+                counter |= (((1U << (8U + (r->m_zhdr0 >> 4))) > 32768U) || ((out_buf_size_mask + 1) < (size_t)((size_t)1 << (8U + (r->m_zhdr0 >> 4)))));
+            if (counter)
             {
-                mz_uint8 *p = r->m_code_size_0;
-                mz_uint i;
-                r->m_table_sizes[0] = 288;
-                r->m_table_sizes[1] = 32;
-                TINFL_MEMSET(r->m_code_size_1, 5, 32);
-                for (i = 0; i <= 143; ++i)
-                    *p++ = 8;
-                for (; i <= 255; ++i)
-                    *p++ = 9;
-                for (; i <= 279; ++i)
-                    *p++ = 7;
-                for (; i <= 287; ++i)
-                    *p++ = 8;
+                TINFL_CR_RETURN_FOREVER(36, TINFL_STATUS_FAILED);
+            }
+        }
+
+        do
+        {
+            TINFL_GET_BITS(3, r->m_final, 3);
+            r->m_type = r->m_final >> 1;
+            if (r->m_type == 0)
+            {
+                TINFL_SKIP_BITS(5, num_bits & 7);
+                for (counter = 0; counter < 4; ++counter)
+                {
+                    if (num_bits)
+                        TINFL_GET_BITS(6, r->m_raw_header[counter], 8);
+                    else
+                        TINFL_GET_BYTE(7, r->m_raw_header[counter]);
+                }
+                if ((counter = (r->m_raw_header[0] | (r->m_raw_header[1] << 8))) != (mz_uint)(0xFFFF ^ (r->m_raw_header[2] | (r->m_raw_header[3] << 8))))
+                {
+                    TINFL_CR_RETURN_FOREVER(39, TINFL_STATUS_FAILED);
+                }
+                while ((counter) && (num_bits))
+                {
+                    TINFL_GET_BITS(51, dist, 8);
+                    while (pOut_buf_cur >= pOut_buf_end)
+                    {
+                        TINFL_CR_RETURN(52, TINFL_STATUS_HAS_MORE_OUTPUT);
+                    }
+                    *pOut_buf_cur++ = (mz_uint8)dist;
+                    counter--;
+                }
+                while (counter)
+                {
+                    size_t n;
+                    while (pOut_buf_cur >= pOut_buf_end)
+                    {
+                        TINFL_CR_RETURN(9, TINFL_STATUS_HAS_MORE_OUTPUT);
+                    }
+                    while (pIn_buf_cur >= pIn_buf_end)
+                    {
+                        TINFL_CR_RETURN(38, (decomp_flags & TINFL_FLAG_HAS_MORE_INPUT) ? TINFL_STATUS_NEEDS_MORE_INPUT : TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS);
+                    }
+                    n = MZ_MIN(MZ_MIN((size_t)(pOut_buf_end - pOut_buf_cur), (size_t)(pIn_buf_end - pIn_buf_cur)), counter);
+                    TINFL_MEMCPY(pOut_buf_cur, pIn_buf_cur, n);
+                    pIn_buf_cur += n;
+                    pOut_buf_cur += n;
+                    counter -= (mz_uint)n;
+                }
+            }
+            else if (r->m_type == 3)
+            {
+                TINFL_CR_RETURN_FOREVER(10, TINFL_STATUS_FAILED);
             }
             else
             {
-                for (counter = 0; counter < 3; counter++)
+                if (r->m_type == 1)
                 {
-                    TINFL_GET_BITS(11, r->m_table_sizes[counter], "\05\05\04"[counter]);
-                    r->m_table_sizes[counter] += s_min_table_sizes[counter];
+                    mz_uint8 *p = r->m_code_size_0;
+                    mz_uint i;
+                    r->m_table_sizes[0] = 288;
+                    r->m_table_sizes[1] = 32;
+                    TINFL_MEMSET(r->m_code_size_1, 5, 32);
+                    for (i = 0; i <= 143; ++i)
+                        *p++ = 8;
+                    for (; i <= 255; ++i)
+                        *p++ = 9;
+                    for (; i <= 279; ++i)
+                        *p++ = 7;
+                    for (; i <= 287; ++i)
+                        *p++ = 8;
                 }
-                MZ_CLEAR_ARR(r->m_code_size_2);
-                for (counter = 0; counter < r->m_table_sizes[2]; counter++)
+                else
                 {
-                    mz_uint s;
-                    TINFL_GET_BITS(14, s, 3);
-                    r->m_code_size_2[s_length_dezigzag[counter]] = (mz_uint8)s;
-                }
-                r->m_table_sizes[2] = 19;
-            }
-            for (; (int)r->m_type >= 0; r->m_type--)
-            {
-                int tree_next, tree_cur;
-                mz_int16 *pLookUp;
-                mz_int16 *pTree;
-                mz_uint8 *pCode_size;
-                mz_uint i, j, used_syms, total, sym_index, next_code[17], total_syms[16];
-                pLookUp = r->m_look_up[r->m_type];
-                pTree = pTrees[r->m_type];
-                pCode_size = pCode_sizes[r->m_type];
-                MZ_CLEAR_ARR(total_syms);
-                TINFL_MEMSET(pLookUp, 0, sizeof(r->m_look_up[0]));
-                tinfl_clear_tree(r);
-                for (i = 0; i < r->m_table_sizes[r->m_type]; ++i)
-                    total_syms[pCode_size[i]]++;
-                used_syms = 0, total = 0;
-                next_code[0] = next_code[1] = 0;
-                for (i = 1; i <= 15; ++i)
-                {
-                    used_syms += total_syms[i];
-                    next_code[i + 1] = (total = ((total + total_syms[i]) << 1));
-                }
-                if ((65536 != total) && (used_syms > 1))
-                {
-                    TINFL_CR_RETURN_FOREVER(35, TINFL_STATUS_FAILED);
-                }
-                for (tree_next = -1, sym_index = 0; sym_index < r->m_table_sizes[r->m_type]; ++sym_index)
-                {
-                    mz_uint rev_code = 0, l, cur_code, code_size = pCode_size[sym_index];
-                    if (!code_size)
-                        continue;
-                    cur_code = next_code[code_size]++;
-                    for (l = code_size; l > 0; l--, cur_code >>= 1)
-                        rev_code = (rev_code << 1) | (cur_code & 1);
-                    if (code_size <= TINFL_FAST_LOOKUP_BITS)
+                    for (counter = 0; counter < 3; counter++)
                     {
-                        mz_int16 k = (mz_int16)((code_size << 9) | sym_index);
-                        while (rev_code < TINFL_FAST_LOOKUP_SIZE)
+                        TINFL_GET_BITS(11, r->m_table_sizes[counter], "\05\05\04"[counter]);
+                        r->m_table_sizes[counter] += s_min_table_sizes[counter];
+                    }
+                    MZ_CLEAR_ARR(r->m_code_size_2);
+                    for (counter = 0; counter < r->m_table_sizes[2]; counter++)
+                    {
+                        mz_uint s;
+                        TINFL_GET_BITS(14, s, 3);
+                        r->m_code_size_2[s_length_dezigzag[counter]] = (mz_uint8)s;
+                    }
+                    r->m_table_sizes[2] = 19;
+                }
+                for (; (int)r->m_type >= 0; r->m_type--)
+                {
+                    int tree_next, tree_cur;
+                    mz_int16 *pLookUp;
+                    mz_int16 *pTree;
+                    mz_uint8 *pCode_size;
+                    mz_uint i, j, used_syms, total, sym_index, next_code[17], total_syms[16];
+                    pLookUp = r->m_look_up[r->m_type];
+                    pTree = pTrees[r->m_type];
+                    pCode_size = pCode_sizes[r->m_type];
+                    MZ_CLEAR_ARR(total_syms);
+                    TINFL_MEMSET(pLookUp, 0, sizeof(r->m_look_up[0]));
+                    tinfl_clear_tree(r);
+                    for (i = 0; i < r->m_table_sizes[r->m_type]; ++i)
+                        total_syms[pCode_size[i]]++;
+                    used_syms = 0, total = 0;
+                    next_code[0] = next_code[1] = 0;
+                    for (i = 1; i <= 15; ++i)
+                    {
+                        used_syms += total_syms[i];
+                        next_code[i + 1] = (total = ((total + total_syms[i]) << 1));
+                    }
+                    if ((65536 != total) && (used_syms > 1))
+                    {
+                        TINFL_CR_RETURN_FOREVER(35, TINFL_STATUS_FAILED);
+                    }
+                    for (tree_next = -1, sym_index = 0; sym_index < r->m_table_sizes[r->m_type]; ++sym_index)
+                    {
+                        mz_uint rev_code = 0, l, cur_code, code_size = pCode_size[sym_index];
+                        if (!code_size)
+                            continue;
+                        cur_code = next_code[code_size]++;
+                        for (l = code_size; l > 0; l--, cur_code >>= 1)
+                            rev_code = (rev_code << 1) | (cur_code & 1);
+                        if (code_size <= TINFL_FAST_LOOKUP_BITS)
                         {
-                            pLookUp[rev_code] = k;
-                            rev_code += (1 << code_size);
+                            mz_int16 k = (mz_int16)((code_size << 9) | sym_index);
+                            while (rev_code < TINFL_FAST_LOOKUP_SIZE)
+                            {
+                                pLookUp[rev_code] = k;
+                                rev_code += (1 << code_size);
+                            }
+                            continue;
                         }
-                        continue;
-                    }
-                    if (0 == (tree_cur = pLookUp[rev_code & (TINFL_FAST_LOOKUP_SIZE - 1)]))
-                    {
-                        pLookUp[rev_code & (TINFL_FAST_LOOKUP_SIZE - 1)] = (mz_int16)tree_next;
-                        tree_cur = tree_next;
-                        tree_next -= 2;
-                    }
-                    rev_code >>= (TINFL_FAST_LOOKUP_BITS - 1);
-                    for (j = code_size; j > (TINFL_FAST_LOOKUP_BITS + 1); j--)
-                    {
-                        tree_cur -= ((rev_code >>= 1) & 1);
-                        if (!pTree[-tree_cur - 1])
+                        if (0 == (tree_cur = pLookUp[rev_code & (TINFL_FAST_LOOKUP_SIZE - 1)]))
                         {
-                            pTree[-tree_cur - 1] = (mz_int16)tree_next;
+                            pLookUp[rev_code & (TINFL_FAST_LOOKUP_SIZE - 1)] = (mz_int16)tree_next;
                             tree_cur = tree_next;
                             tree_next -= 2;
                         }
-                        else
-                            tree_cur = pTree[-tree_cur - 1];
-                    }
-                    tree_cur -= ((rev_code >>= 1) & 1);
-                    pTree[-tree_cur - 1] = (mz_int16)sym_index;
-                }
-                if (r->m_type == 2)
-                {
-                    for (counter = 0; counter < (r->m_table_sizes[0] + r->m_table_sizes[1]);)
-                    {
-                        mz_uint s;
-                        TINFL_HUFF_DECODE(16, dist, r->m_look_up[2], r->m_tree_2);
-                        if (dist < 16)
+                        rev_code >>= (TINFL_FAST_LOOKUP_BITS - 1);
+                        for (j = code_size; j > (TINFL_FAST_LOOKUP_BITS + 1); j--)
                         {
-                            r->m_len_codes[counter++] = (mz_uint8)dist;
-                            continue;
+                            tree_cur -= ((rev_code >>= 1) & 1);
+                            if (!pTree[-tree_cur - 1])
+                            {
+                                pTree[-tree_cur - 1] = (mz_int16)tree_next;
+                                tree_cur = tree_next;
+                                tree_next -= 2;
+                            }
+                            else
+                                tree_cur = pTree[-tree_cur - 1];
                         }
-                        if ((dist == 16) && (!counter))
-                        {
-                            TINFL_CR_RETURN_FOREVER(17, TINFL_STATUS_FAILED);
-                        }
-                        num_extra = "\02\03\07"[dist - 16];
-                        TINFL_GET_BITS(18, s, num_extra);
-                        s += "\03\03\013"[dist - 16];
-                        TINFL_MEMSET(r->m_len_codes + counter, (dist == 16) ? r->m_len_codes[counter - 1] : 0, s);
-                        counter += s;
+                        tree_cur -= ((rev_code >>= 1) & 1);
+                        pTree[-tree_cur - 1] = (mz_int16)sym_index;
                     }
-                    if ((r->m_table_sizes[0] + r->m_table_sizes[1]) != counter)
+                    if (r->m_type == 2)
                     {
-                        TINFL_CR_RETURN_FOREVER(21, TINFL_STATUS_FAILED);
+                        for (counter = 0; counter < (r->m_table_sizes[0] + r->m_table_sizes[1]);)
+                        {
+                            mz_uint s;
+                            TINFL_HUFF_DECODE(16, dist, r->m_look_up[2], r->m_tree_2);
+                            if (dist < 16)
+                            {
+                                r->m_len_codes[counter++] = (mz_uint8)dist;
+                                continue;
+                            }
+                            if ((dist == 16) && (!counter))
+                            {
+                                TINFL_CR_RETURN_FOREVER(17, TINFL_STATUS_FAILED);
+                            }
+                            num_extra = "\02\03\07"[dist - 16];
+                            TINFL_GET_BITS(18, s, num_extra);
+                            s += "\03\03\013"[dist - 16];
+                            TINFL_MEMSET(r->m_len_codes + counter, (dist == 16) ? r->m_len_codes[counter - 1] : 0, s);
+                            counter += s;
+                        }
+                        if ((r->m_table_sizes[0] + r->m_table_sizes[1]) != counter)
+                        {
+                            TINFL_CR_RETURN_FOREVER(21, TINFL_STATUS_FAILED);
+                        }
+                        TINFL_MEMCPY(r->m_code_size_0, r->m_len_codes, r->m_table_sizes[0]);
+                        TINFL_MEMCPY(r->m_code_size_1, r->m_len_codes + r->m_table_sizes[0], r->m_table_sizes[1]);
                     }
-                    TINFL_MEMCPY(r->m_code_size_0, r->m_len_codes, r->m_table_sizes[0]);
-                    TINFL_MEMCPY(r->m_code_size_1, r->m_len_codes + r->m_table_sizes[0], r->m_table_sizes[1]);
                 }
-            }
-            for (;;)
-            {
-                mz_uint8 *pSrc;
                 for (;;)
                 {
-                    if (((pIn_buf_end - pIn_buf_cur) < 4) || ((pOut_buf_end - pOut_buf_cur) < 2))
+                    mz_uint8 *pSrc;
+                    for (;;)
                     {
-                        TINFL_HUFF_DECODE(23, counter, r->m_look_up[0], r->m_tree_0);
-                        if (counter >= 256)
-                            break;
-                        while (pOut_buf_cur >= pOut_buf_end)
+                        if (((pIn_buf_end - pIn_buf_cur) < 4) || ((pOut_buf_end - pOut_buf_cur) < 2))
                         {
-                            TINFL_CR_RETURN(24, TINFL_STATUS_HAS_MORE_OUTPUT);
+                            TINFL_HUFF_DECODE(23, counter, r->m_look_up[0], r->m_tree_0);
+                            if (counter >= 256)
+                                break;
+                            while (pOut_buf_cur >= pOut_buf_end)
+                            {
+                                TINFL_CR_RETURN(24, TINFL_STATUS_HAS_MORE_OUTPUT);
+                            }
+                            *pOut_buf_cur++ = (mz_uint8)counter;
                         }
-                        *pOut_buf_cur++ = (mz_uint8)counter;
-                    }
-                    else
-                    {
-                        int sym2;
-                        mz_uint code_len;
+                        else
+                        {
+                            int sym2;
+                            mz_uint code_len;
 #if TINFL_USE_64BIT_BITBUF
-                        if (num_bits < 30)
-                        {
-                            bit_buf |= (((tinfl_bit_buf_t)MZ_READ_LE32(pIn_buf_cur)) << num_bits);
-                            pIn_buf_cur += 4;
-                            num_bits += 32;
-                        }
+                            if (num_bits < 30)
+                            {
+                                bit_buf |= (((tinfl_bit_buf_t)MZ_READ_LE32(pIn_buf_cur)) << num_bits);
+                                pIn_buf_cur += 4;
+                                num_bits += 32;
+                            }
 #else
                         if (num_bits < 15)
                         {
@@ -2699,313 +2698,313 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                             num_bits += 16;
                         }
 #endif
-                        if ((sym2 = r->m_look_up[0][bit_buf & (TINFL_FAST_LOOKUP_SIZE - 1)]) >= 0)
-                            code_len = sym2 >> 9;
-                        else
-                        {
-                            code_len = TINFL_FAST_LOOKUP_BITS;
-                            do
+                            if ((sym2 = r->m_look_up[0][bit_buf & (TINFL_FAST_LOOKUP_SIZE - 1)]) >= 0)
+                                code_len = sym2 >> 9;
+                            else
                             {
-                                sym2 = r->m_tree_0[~sym2 + ((bit_buf >> code_len++) & 1)];
-                            } while (sym2 < 0);
-                        }
-                        counter = sym2;
-                        bit_buf >>= code_len;
-                        num_bits -= code_len;
-                        if (counter & 256)
-                            break;
+                                code_len = TINFL_FAST_LOOKUP_BITS;
+                                do
+                                {
+                                    sym2 = r->m_tree_0[~sym2 + ((bit_buf >> code_len++) & 1)];
+                                } while (sym2 < 0);
+                            }
+                            counter = sym2;
+                            bit_buf >>= code_len;
+                            num_bits -= code_len;
+                            if (counter & 256)
+                                break;
 
 #if !TINFL_USE_64BIT_BITBUF
-                        if (num_bits < 15)
-                        {
-                            bit_buf |= (((tinfl_bit_buf_t)MZ_READ_LE16(pIn_buf_cur)) << num_bits);
-                            pIn_buf_cur += 2;
-                            num_bits += 16;
-                        }
-#endif
-                        if ((sym2 = r->m_look_up[0][bit_buf & (TINFL_FAST_LOOKUP_SIZE - 1)]) >= 0)
-                            code_len = sym2 >> 9;
-                        else
-                        {
-                            code_len = TINFL_FAST_LOOKUP_BITS;
-                            do
+                            if (num_bits < 15)
                             {
-                                sym2 = r->m_tree_0[~sym2 + ((bit_buf >> code_len++) & 1)];
-                            } while (sym2 < 0);
-                        }
-                        bit_buf >>= code_len;
-                        num_bits -= code_len;
-
-                        pOut_buf_cur[0] = (mz_uint8)counter;
-                        if (sym2 & 256)
-                        {
-                            pOut_buf_cur++;
-                            counter = sym2;
-                            break;
-                        }
-                        pOut_buf_cur[1] = (mz_uint8)sym2;
-                        pOut_buf_cur += 2;
-                    }
-                }
-                if ((counter &= 511) == 256)
-                    break;
-
-                num_extra = s_length_extra[counter - 257];
-                counter = s_length_base[counter - 257];
-                if (num_extra)
-                {
-                    mz_uint extra_bits;
-                    TINFL_GET_BITS(25, extra_bits, num_extra);
-                    counter += extra_bits;
-                }
-
-                TINFL_HUFF_DECODE(26, dist, r->m_look_up[1], r->m_tree_1);
-                num_extra = s_dist_extra[dist];
-                dist = s_dist_base[dist];
-                if (num_extra)
-                {
-                    mz_uint extra_bits;
-                    TINFL_GET_BITS(27, extra_bits, num_extra);
-                    dist += extra_bits;
-                }
-
-                dist_from_out_buf_start = pOut_buf_cur - pOut_buf_start;
-                if ((dist == 0 || dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
-                {
-                    TINFL_CR_RETURN_FOREVER(37, TINFL_STATUS_FAILED);
-                }
-
-                pSrc = pOut_buf_start + ((dist_from_out_buf_start - dist) & out_buf_size_mask);
-
-                if ((MZ_MAX(pOut_buf_cur, pSrc) + counter) > pOut_buf_end)
-                {
-                    while (counter--)
-                    {
-                        while (pOut_buf_cur >= pOut_buf_end)
-                        {
-                            TINFL_CR_RETURN(53, TINFL_STATUS_HAS_MORE_OUTPUT);
-                        }
-                        *pOut_buf_cur++ = pOut_buf_start[(dist_from_out_buf_start++ - dist) & out_buf_size_mask];
-                    }
-                    continue;
-                }
-#if MINIZ_USE_UNALIGNED_LOADS_AND_STORES
-                else if ((counter >= 9) && (counter <= dist))
-                {
-                    const mz_uint8 *pSrc_end = pSrc + (counter & ~7);
-                    do
-                    {
-#ifdef MINIZ_UNALIGNED_USE_MEMCPY
-						memcpy(pOut_buf_cur, pSrc, sizeof(mz_uint32)*2);
-#else
-                        ((mz_uint32 *)pOut_buf_cur)[0] = ((const mz_uint32 *)pSrc)[0];
-                        ((mz_uint32 *)pOut_buf_cur)[1] = ((const mz_uint32 *)pSrc)[1];
+                                bit_buf |= (((tinfl_bit_buf_t)MZ_READ_LE16(pIn_buf_cur)) << num_bits);
+                                pIn_buf_cur += 2;
+                                num_bits += 16;
+                            }
 #endif
-                        pOut_buf_cur += 8;
-                    } while ((pSrc += 8) < pSrc_end);
-                    if ((counter &= 7) < 3)
+                            if ((sym2 = r->m_look_up[0][bit_buf & (TINFL_FAST_LOOKUP_SIZE - 1)]) >= 0)
+                                code_len = sym2 >> 9;
+                            else
+                            {
+                                code_len = TINFL_FAST_LOOKUP_BITS;
+                                do
+                                {
+                                    sym2 = r->m_tree_0[~sym2 + ((bit_buf >> code_len++) & 1)];
+                                } while (sym2 < 0);
+                            }
+                            bit_buf >>= code_len;
+                            num_bits -= code_len;
+
+                            pOut_buf_cur[0] = (mz_uint8)counter;
+                            if (sym2 & 256)
+                            {
+                                pOut_buf_cur++;
+                                counter = sym2;
+                                break;
+                            }
+                            pOut_buf_cur[1] = (mz_uint8)sym2;
+                            pOut_buf_cur += 2;
+                        }
+                    }
+                    if ((counter &= 511) == 256)
+                        break;
+
+                    num_extra = s_length_extra[counter - 257];
+                    counter = s_length_base[counter - 257];
+                    if (num_extra)
                     {
-                        if (counter)
+                        mz_uint extra_bits;
+                        TINFL_GET_BITS(25, extra_bits, num_extra);
+                        counter += extra_bits;
+                    }
+
+                    TINFL_HUFF_DECODE(26, dist, r->m_look_up[1], r->m_tree_1);
+                    num_extra = s_dist_extra[dist];
+                    dist = s_dist_base[dist];
+                    if (num_extra)
+                    {
+                        mz_uint extra_bits;
+                        TINFL_GET_BITS(27, extra_bits, num_extra);
+                        dist += extra_bits;
+                    }
+
+                    dist_from_out_buf_start = pOut_buf_cur - pOut_buf_start;
+                    if ((dist == 0 || dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
+                    {
+                        TINFL_CR_RETURN_FOREVER(37, TINFL_STATUS_FAILED);
+                    }
+
+                    pSrc = pOut_buf_start + ((dist_from_out_buf_start - dist) & out_buf_size_mask);
+
+                    if ((MZ_MAX(pOut_buf_cur, pSrc) + counter) > pOut_buf_end)
+                    {
+                        while (counter--)
                         {
-                            pOut_buf_cur[0] = pSrc[0];
-                            if (counter > 1)
-                                pOut_buf_cur[1] = pSrc[1];
-                            pOut_buf_cur += counter;
+                            while (pOut_buf_cur >= pOut_buf_end)
+                            {
+                                TINFL_CR_RETURN(53, TINFL_STATUS_HAS_MORE_OUTPUT);
+                            }
+                            *pOut_buf_cur++ = pOut_buf_start[(dist_from_out_buf_start++ - dist) & out_buf_size_mask];
                         }
                         continue;
                     }
-                }
+#if MINIZ_USE_UNALIGNED_LOADS_AND_STORES
+                    else if ((counter >= 9) && (counter <= dist))
+                    {
+                        const mz_uint8 *pSrc_end = pSrc + (counter & ~7);
+                        do
+                        {
+#ifdef MINIZ_UNALIGNED_USE_MEMCPY
+                            memcpy(pOut_buf_cur, pSrc, sizeof(mz_uint32) * 2);
+#else
+                            ((mz_uint32 *)pOut_buf_cur)[0] = ((const mz_uint32 *)pSrc)[0];
+                            ((mz_uint32 *)pOut_buf_cur)[1] = ((const mz_uint32 *)pSrc)[1];
 #endif
-                while(counter>2)
-                {
-                    pOut_buf_cur[0] = pSrc[0];
-                    pOut_buf_cur[1] = pSrc[1];
-                    pOut_buf_cur[2] = pSrc[2];
-                    pOut_buf_cur += 3;
-                    pSrc += 3;
-					counter -= 3;
-                }
-                if (counter > 0)
-                {
-                    pOut_buf_cur[0] = pSrc[0];
-                    if (counter > 1)
+                            pOut_buf_cur += 8;
+                        } while ((pSrc += 8) < pSrc_end);
+                        if ((counter &= 7) < 3)
+                        {
+                            if (counter)
+                            {
+                                pOut_buf_cur[0] = pSrc[0];
+                                if (counter > 1)
+                                    pOut_buf_cur[1] = pSrc[1];
+                                pOut_buf_cur += counter;
+                            }
+                            continue;
+                        }
+                    }
+#endif
+                    while (counter > 2)
+                    {
+                        pOut_buf_cur[0] = pSrc[0];
                         pOut_buf_cur[1] = pSrc[1];
-                    pOut_buf_cur += counter;
+                        pOut_buf_cur[2] = pSrc[2];
+                        pOut_buf_cur += 3;
+                        pSrc += 3;
+                        counter -= 3;
+                    }
+                    if (counter > 0)
+                    {
+                        pOut_buf_cur[0] = pSrc[0];
+                        if (counter > 1)
+                            pOut_buf_cur[1] = pSrc[1];
+                        pOut_buf_cur += counter;
+                    }
                 }
             }
-        }
-    } while (!(r->m_final & 1));
+        } while (!(r->m_final & 1));
 
-    /* Ensure byte alignment and put back any bytes from the bitbuf if we've looked ahead too far on gzip, or other Deflate streams followed by arbitrary data. */
-    /* I'm being super conservative here. A number of simplifications can be made to the byte alignment part, and the Adler32 check shouldn't ever need to worry about reading from the bitbuf now. */
-    TINFL_SKIP_BITS(32, num_bits & 7);
-    while ((pIn_buf_cur > pIn_buf_next) && (num_bits >= 8))
-    {
-        --pIn_buf_cur;
-        num_bits -= 8;
-    }
-    bit_buf &= ~(~(tinfl_bit_buf_t)0 << num_bits);
-    MZ_ASSERT(!num_bits); /* if this assert fires then we've read beyond the end of non-deflate/zlib streams with following data (such as gzip streams). */
-
-    if (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER)
-    {
-        for (counter = 0; counter < 4; ++counter)
-        {
-            mz_uint s;
-            if (num_bits)
-                TINFL_GET_BITS(41, s, 8);
-            else
-                TINFL_GET_BYTE(42, s);
-            r->m_z_adler32 = (r->m_z_adler32 << 8) | s;
-        }
-    }
-    TINFL_CR_RETURN_FOREVER(34, TINFL_STATUS_DONE);
-
-    TINFL_CR_FINISH
-
-common_exit:
-    /* As long as we aren't telling the caller that we NEED more input to make forward progress: */
-    /* Put back any bytes from the bitbuf in case we've looked ahead too far on gzip, or other Deflate streams followed by arbitrary data. */
-    /* We need to be very careful here to NOT push back any bytes we definitely know we need to make forward progress, though, or we'll lock the caller up into an inf loop. */
-    if ((status != TINFL_STATUS_NEEDS_MORE_INPUT) && (status != TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS))
-    {
+        /* Ensure byte alignment and put back any bytes from the bitbuf if we've looked ahead too far on gzip, or other Deflate streams followed by arbitrary data. */
+        /* I'm being super conservative here. A number of simplifications can be made to the byte alignment part, and the Adler32 check shouldn't ever need to worry about reading from the bitbuf now. */
+        TINFL_SKIP_BITS(32, num_bits & 7);
         while ((pIn_buf_cur > pIn_buf_next) && (num_bits >= 8))
         {
             --pIn_buf_cur;
             num_bits -= 8;
         }
-    }
-    r->m_num_bits = num_bits;
-    r->m_bit_buf = bit_buf & ~(~(tinfl_bit_buf_t)0 << num_bits);
-    r->m_dist = dist;
-    r->m_counter = counter;
-    r->m_num_extra = num_extra;
-    r->m_dist_from_out_buf_start = dist_from_out_buf_start;
-    *pIn_buf_size = pIn_buf_cur - pIn_buf_next;
-    *pOut_buf_size = pOut_buf_cur - pOut_buf_next;
-    if ((decomp_flags & (TINFL_FLAG_PARSE_ZLIB_HEADER | TINFL_FLAG_COMPUTE_ADLER32)) && (status >= 0))
-    {
-        const mz_uint8 *ptr = pOut_buf_next;
-        size_t buf_len = *pOut_buf_size;
-        mz_uint32 i, s1 = r->m_check_adler32 & 0xffff, s2 = r->m_check_adler32 >> 16;
-        size_t block_len = buf_len % 5552;
-        while (buf_len)
+        bit_buf &= ~(~(tinfl_bit_buf_t)0 << num_bits);
+        MZ_ASSERT(!num_bits); /* if this assert fires then we've read beyond the end of non-deflate/zlib streams with following data (such as gzip streams). */
+
+        if (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER)
         {
-            for (i = 0; i + 7 < block_len; i += 8, ptr += 8)
+            for (counter = 0; counter < 4; ++counter)
             {
-                s1 += ptr[0], s2 += s1;
-                s1 += ptr[1], s2 += s1;
-                s1 += ptr[2], s2 += s1;
-                s1 += ptr[3], s2 += s1;
-                s1 += ptr[4], s2 += s1;
-                s1 += ptr[5], s2 += s1;
-                s1 += ptr[6], s2 += s1;
-                s1 += ptr[7], s2 += s1;
+                mz_uint s;
+                if (num_bits)
+                    TINFL_GET_BITS(41, s, 8);
+                else
+                    TINFL_GET_BYTE(42, s);
+                r->m_z_adler32 = (r->m_z_adler32 << 8) | s;
             }
-            for (; i < block_len; ++i)
-                s1 += *ptr++, s2 += s1;
-            s1 %= 65521U, s2 %= 65521U;
-            buf_len -= block_len;
-            block_len = 5552;
         }
-        r->m_check_adler32 = (s2 << 16) + s1;
-        if ((status == TINFL_STATUS_DONE) && (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER) && (r->m_check_adler32 != r->m_z_adler32))
-            status = TINFL_STATUS_ADLER32_MISMATCH;
-    }
-    return status;
-}
+        TINFL_CR_RETURN_FOREVER(34, TINFL_STATUS_DONE);
 
-/* Higher level helper functions. */
-void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags)
-{
-    tinfl_decompressor decomp;
-    void *pBuf = NULL, *pNew_buf;
-    size_t src_buf_ofs = 0, out_buf_capacity = 0;
-    *pOut_len = 0;
-    tinfl_init(&decomp);
-    for (;;)
+        TINFL_CR_FINISH
+
+    common_exit:
+        /* As long as we aren't telling the caller that we NEED more input to make forward progress: */
+        /* Put back any bytes from the bitbuf in case we've looked ahead too far on gzip, or other Deflate streams followed by arbitrary data. */
+        /* We need to be very careful here to NOT push back any bytes we definitely know we need to make forward progress, though, or we'll lock the caller up into an inf loop. */
+        if ((status != TINFL_STATUS_NEEDS_MORE_INPUT) && (status != TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS))
+        {
+            while ((pIn_buf_cur > pIn_buf_next) && (num_bits >= 8))
+            {
+                --pIn_buf_cur;
+                num_bits -= 8;
+            }
+        }
+        r->m_num_bits = num_bits;
+        r->m_bit_buf = bit_buf & ~(~(tinfl_bit_buf_t)0 << num_bits);
+        r->m_dist = dist;
+        r->m_counter = counter;
+        r->m_num_extra = num_extra;
+        r->m_dist_from_out_buf_start = dist_from_out_buf_start;
+        *pIn_buf_size = pIn_buf_cur - pIn_buf_next;
+        *pOut_buf_size = pOut_buf_cur - pOut_buf_next;
+        if ((decomp_flags & (TINFL_FLAG_PARSE_ZLIB_HEADER | TINFL_FLAG_COMPUTE_ADLER32)) && (status >= 0))
+        {
+            const mz_uint8 *ptr = pOut_buf_next;
+            size_t buf_len = *pOut_buf_size;
+            mz_uint32 i, s1 = r->m_check_adler32 & 0xffff, s2 = r->m_check_adler32 >> 16;
+            size_t block_len = buf_len % 5552;
+            while (buf_len)
+            {
+                for (i = 0; i + 7 < block_len; i += 8, ptr += 8)
+                {
+                    s1 += ptr[0], s2 += s1;
+                    s1 += ptr[1], s2 += s1;
+                    s1 += ptr[2], s2 += s1;
+                    s1 += ptr[3], s2 += s1;
+                    s1 += ptr[4], s2 += s1;
+                    s1 += ptr[5], s2 += s1;
+                    s1 += ptr[6], s2 += s1;
+                    s1 += ptr[7], s2 += s1;
+                }
+                for (; i < block_len; ++i)
+                    s1 += *ptr++, s2 += s1;
+                s1 %= 65521U, s2 %= 65521U;
+                buf_len -= block_len;
+                block_len = 5552;
+            }
+            r->m_check_adler32 = (s2 << 16) + s1;
+            if ((status == TINFL_STATUS_DONE) && (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER) && (r->m_check_adler32 != r->m_z_adler32))
+                status = TINFL_STATUS_ADLER32_MISMATCH;
+        }
+        return status;
+    }
+
+    /* Higher level helper functions. */
+    void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags)
     {
-        size_t src_buf_size = src_buf_len - src_buf_ofs, dst_buf_size = out_buf_capacity - *pOut_len, new_out_buf_capacity;
-        tinfl_status status = tinfl_decompress(&decomp, (const mz_uint8 *)pSrc_buf + src_buf_ofs, &src_buf_size, (mz_uint8 *)pBuf, pBuf ? (mz_uint8 *)pBuf + *pOut_len : NULL, &dst_buf_size,
-                                               (flags & ~TINFL_FLAG_HAS_MORE_INPUT) | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
-        if ((status < 0) || (status == TINFL_STATUS_NEEDS_MORE_INPUT))
+        tinfl_decompressor decomp;
+        void *pBuf = NULL, *pNew_buf;
+        size_t src_buf_ofs = 0, out_buf_capacity = 0;
+        *pOut_len = 0;
+        tinfl_init(&decomp);
+        for (;;)
         {
-            MZ_FREE(pBuf);
-            *pOut_len = 0;
-            return NULL;
+            size_t src_buf_size = src_buf_len - src_buf_ofs, dst_buf_size = out_buf_capacity - *pOut_len, new_out_buf_capacity;
+            tinfl_status status = tinfl_decompress(&decomp, (const mz_uint8 *)pSrc_buf + src_buf_ofs, &src_buf_size, (mz_uint8 *)pBuf, pBuf ? (mz_uint8 *)pBuf + *pOut_len : NULL, &dst_buf_size,
+                                                   (flags & ~TINFL_FLAG_HAS_MORE_INPUT) | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
+            if ((status < 0) || (status == TINFL_STATUS_NEEDS_MORE_INPUT))
+            {
+                MZ_FREE(pBuf);
+                *pOut_len = 0;
+                return NULL;
+            }
+            src_buf_ofs += src_buf_size;
+            *pOut_len += dst_buf_size;
+            if (status == TINFL_STATUS_DONE)
+                break;
+            new_out_buf_capacity = out_buf_capacity * 2;
+            if (new_out_buf_capacity < 128)
+                new_out_buf_capacity = 128;
+            pNew_buf = MZ_REALLOC(pBuf, new_out_buf_capacity);
+            if (!pNew_buf)
+            {
+                MZ_FREE(pBuf);
+                *pOut_len = 0;
+                return NULL;
+            }
+            pBuf = pNew_buf;
+            out_buf_capacity = new_out_buf_capacity;
         }
-        src_buf_ofs += src_buf_size;
-        *pOut_len += dst_buf_size;
-        if (status == TINFL_STATUS_DONE)
-            break;
-        new_out_buf_capacity = out_buf_capacity * 2;
-        if (new_out_buf_capacity < 128)
-            new_out_buf_capacity = 128;
-        pNew_buf = MZ_REALLOC(pBuf, new_out_buf_capacity);
-        if (!pNew_buf)
-        {
-            MZ_FREE(pBuf);
-            *pOut_len = 0;
-            return NULL;
-        }
-        pBuf = pNew_buf;
-        out_buf_capacity = new_out_buf_capacity;
+        return pBuf;
     }
-    return pBuf;
-}
 
-size_t tinfl_decompress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags)
-{
-    tinfl_decompressor decomp;
-    tinfl_status status;
-    tinfl_init(&decomp);
-    status = tinfl_decompress(&decomp, (const mz_uint8 *)pSrc_buf, &src_buf_len, (mz_uint8 *)pOut_buf, (mz_uint8 *)pOut_buf, &out_buf_len, (flags & ~TINFL_FLAG_HAS_MORE_INPUT) | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
-    return (status != TINFL_STATUS_DONE) ? TINFL_DECOMPRESS_MEM_TO_MEM_FAILED : out_buf_len;
-}
-
-int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, tinfl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
-{
-    int result = 0;
-    tinfl_decompressor decomp;
-    mz_uint8 *pDict = (mz_uint8 *)MZ_MALLOC(TINFL_LZ_DICT_SIZE);
-    size_t in_buf_ofs = 0, dict_ofs = 0;
-    if (!pDict)
-        return TINFL_STATUS_FAILED;
-    memset(pDict,0,TINFL_LZ_DICT_SIZE);
-    tinfl_init(&decomp);
-    for (;;)
+    size_t tinfl_decompress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags)
     {
-        size_t in_buf_size = *pIn_buf_size - in_buf_ofs, dst_buf_size = TINFL_LZ_DICT_SIZE - dict_ofs;
-        tinfl_status status = tinfl_decompress(&decomp, (const mz_uint8 *)pIn_buf + in_buf_ofs, &in_buf_size, pDict, pDict + dict_ofs, &dst_buf_size,
-                                               (flags & ~(TINFL_FLAG_HAS_MORE_INPUT | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF)));
-        in_buf_ofs += in_buf_size;
-        if ((dst_buf_size) && (!(*pPut_buf_func)(pDict + dict_ofs, (int)dst_buf_size, pPut_buf_user)))
-            break;
-        if (status != TINFL_STATUS_HAS_MORE_OUTPUT)
-        {
-            result = (status == TINFL_STATUS_DONE);
-            break;
-        }
-        dict_ofs = (dict_ofs + dst_buf_size) & (TINFL_LZ_DICT_SIZE - 1);
+        tinfl_decompressor decomp;
+        tinfl_status status;
+        tinfl_init(&decomp);
+        status = tinfl_decompress(&decomp, (const mz_uint8 *)pSrc_buf, &src_buf_len, (mz_uint8 *)pOut_buf, (mz_uint8 *)pOut_buf, &out_buf_len, (flags & ~TINFL_FLAG_HAS_MORE_INPUT) | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
+        return (status != TINFL_STATUS_DONE) ? TINFL_DECOMPRESS_MEM_TO_MEM_FAILED : out_buf_len;
     }
-    MZ_FREE(pDict);
-    *pIn_buf_size = in_buf_ofs;
-    return result;
-}
+
+    int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, tinfl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
+    {
+        int result = 0;
+        tinfl_decompressor decomp;
+        mz_uint8 *pDict = (mz_uint8 *)MZ_MALLOC(TINFL_LZ_DICT_SIZE);
+        size_t in_buf_ofs = 0, dict_ofs = 0;
+        if (!pDict)
+            return TINFL_STATUS_FAILED;
+        memset(pDict, 0, TINFL_LZ_DICT_SIZE);
+        tinfl_init(&decomp);
+        for (;;)
+        {
+            size_t in_buf_size = *pIn_buf_size - in_buf_ofs, dst_buf_size = TINFL_LZ_DICT_SIZE - dict_ofs;
+            tinfl_status status = tinfl_decompress(&decomp, (const mz_uint8 *)pIn_buf + in_buf_ofs, &in_buf_size, pDict, pDict + dict_ofs, &dst_buf_size,
+                                                   (flags & ~(TINFL_FLAG_HAS_MORE_INPUT | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF)));
+            in_buf_ofs += in_buf_size;
+            if ((dst_buf_size) && (!(*pPut_buf_func)(pDict + dict_ofs, (int)dst_buf_size, pPut_buf_user)))
+                break;
+            if (status != TINFL_STATUS_HAS_MORE_OUTPUT)
+            {
+                result = (status == TINFL_STATUS_DONE);
+                break;
+            }
+            dict_ofs = (dict_ofs + dst_buf_size) & (TINFL_LZ_DICT_SIZE - 1);
+        }
+        MZ_FREE(pDict);
+        *pIn_buf_size = in_buf_ofs;
+        return result;
+    }
 
 #ifndef MINIZ_NO_MALLOC
-tinfl_decompressor *tinfl_decompressor_alloc(void)
-{
-    tinfl_decompressor *pDecomp = (tinfl_decompressor *)MZ_MALLOC(sizeof(tinfl_decompressor));
-    if (pDecomp)
-        tinfl_init(pDecomp);
-    return pDecomp;
-}
+    tinfl_decompressor *tinfl_decompressor_alloc(void)
+    {
+        tinfl_decompressor *pDecomp = (tinfl_decompressor *)MZ_MALLOC(sizeof(tinfl_decompressor));
+        if (pDecomp)
+            tinfl_init(pDecomp);
+        return pDecomp;
+    }
 
-void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
-{
-    MZ_FREE(pDecomp);
-}
+    void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
+    {
+        MZ_FREE(pDecomp);
+    }
 #endif
 
 #ifdef __cplusplus
@@ -3013,7 +3012,7 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
 #endif
 
 #endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
-/**************************************************************************
+ /**************************************************************************
  *
  * Copyright 2013-2014 RAD Game Tools and Valve Software
  * Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
@@ -3040,61 +3039,81 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
  *
  **************************************************************************/
 
+
 #ifndef MINIZ_NO_ARCHIVE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* ------------------- .ZIP archive reading */
+    /* ------------------- .ZIP archive reading */
 
 #ifdef MINIZ_NO_STDIO
 #define MZ_FILE void *
 #else
 #include <sys/stat.h>
 
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#if defined(_MSC_VER) || defined(__MINGW64__) || defined(__MINGW32__)
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef __cplusplus
+#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 
-static WCHAR* mz_utf8z_to_widechar(const char* str)
+static WCHAR *mz_utf8z_to_widechar(const char *str)
 {
-  int reqChars = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
-  WCHAR* wStr = (WCHAR*)malloc(reqChars * sizeof(WCHAR));
-  MultiByteToWideChar(CP_UTF8, 0, str, -1, wStr, reqChars);
-  return wStr;
+    int reqChars = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+    WCHAR *wStr = (WCHAR *)malloc(reqChars * sizeof(WCHAR));
+    MultiByteToWideChar(CP_UTF8, 0, str, -1, wStr, reqChars);
+    return wStr;
 }
 
 static FILE *mz_fopen(const char *pFilename, const char *pMode)
 {
-  WCHAR* wFilename = mz_utf8z_to_widechar(pFilename);
-  WCHAR* wMode = mz_utf8z_to_widechar(pMode);
-  FILE* pFile = NULL;
-  errno_t err = _wfopen_s(&pFile, wFilename, wMode);
-  free(wFilename);
-  free(wMode);
-  return err ? NULL : pFile;
+    WCHAR *wFilename = mz_utf8z_to_widechar(pFilename);
+    WCHAR *wMode = mz_utf8z_to_widechar(pMode);
+    FILE *pFile = NULL;
+    errno_t err = _wfopen_s(&pFile, wFilename, wMode);
+    free(wFilename);
+    free(wMode);
+    return err ? NULL : pFile;
 }
 
 static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 {
-  WCHAR* wPath = mz_utf8z_to_widechar(pPath);
-  WCHAR* wMode = mz_utf8z_to_widechar(pMode);
-  FILE* pFile = NULL;
-  errno_t err = _wfreopen_s(&pFile, wPath, wMode, pStream);
-  free(wPath);
-  free(wMode);
-  return err ? NULL : pFile;
+    WCHAR *wPath = mz_utf8z_to_widechar(pPath);
+    WCHAR *wMode = mz_utf8z_to_widechar(pMode);
+    FILE *pFile = NULL;
+    errno_t err = _wfreopen_s(&pFile, wPath, wMode, pStream);
+    free(wPath);
+    free(wMode);
+    return err ? NULL : pFile;
 }
 
+#if defined(__MINGW32__)
+static int mz_stat(const char *path, struct _stat *buffer)
+{
+    WCHAR *wPath = mz_utf8z_to_widechar(path);
+    int res = _wstat(wPath, buffer);
+    free(wPath);
+    return res;
+}
+#else
 static int mz_stat64(const char *path, struct __stat64 *buffer)
 {
-  WCHAR* wPath = mz_utf8z_to_widechar(path);
-  int res = _wstat64(wPath, buffer);
-  free(wPath);
-  return res;
+    WCHAR *wPath = mz_utf8z_to_widechar(path);
+    int res = _wstat64(wPath, buffer);
+    free(wPath);
+    return res;
 }
+#endif
 
 #ifndef MINIZ_NO_TIME
 #include <sys/utime.h>
@@ -3105,13 +3124,18 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
 #define MZ_FWRITE fwrite
 #define MZ_FTELL64 _ftelli64
 #define MZ_FSEEK64 _fseeki64
+#if defined(__MINGW32__)
+#define MZ_FILE_STAT_STRUCT _stat
+#define MZ_FILE_STAT mz_stat
+#else
 #define MZ_FILE_STAT_STRUCT _stat64
-#define MZ_FILE_STAT mz_stat64 
+#define MZ_FILE_STAT mz_stat64
+#endif
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN mz_freopen
 #define MZ_DELETE_FILE remove
 
-#elif defined(__MINGW32__) || defined(__WATCOMC__)
+#elif defined(__WATCOMC__)
 #ifndef MINIZ_NO_TIME
 #include <sys/utime.h>
 #endif
@@ -3159,7 +3183,7 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
 #define MZ_FREOPEN(p, m, s) freopen64(p, m, s)
 #define MZ_DELETE_FILE remove
 
-#elif defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || (defined(__linux__) && defined(__x86_64__))
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif
@@ -3201,333 +3225,333 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
 
 #define MZ_TOLOWER(c) ((((c) >= 'A') && ((c) <= 'Z')) ? ((c) - 'A' + 'a') : (c))
 
-/* Various ZIP archive enums. To completely avoid cross platform compiler alignment and platform endian issues, miniz.c doesn't use structs for any of this stuff. */
-enum
-{
-    /* ZIP archive identifiers and record sizes */
-    MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG = 0x06054b50,
-    MZ_ZIP_CENTRAL_DIR_HEADER_SIG = 0x02014b50,
-    MZ_ZIP_LOCAL_DIR_HEADER_SIG = 0x04034b50,
-    MZ_ZIP_LOCAL_DIR_HEADER_SIZE = 30,
-    MZ_ZIP_CENTRAL_DIR_HEADER_SIZE = 46,
-    MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE = 22,
+    /* Various ZIP archive enums. To completely avoid cross platform compiler alignment and platform endian issues, miniz.c doesn't use structs for any of this stuff. */
+    enum
+    {
+        /* ZIP archive identifiers and record sizes */
+        MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG = 0x06054b50,
+        MZ_ZIP_CENTRAL_DIR_HEADER_SIG = 0x02014b50,
+        MZ_ZIP_LOCAL_DIR_HEADER_SIG = 0x04034b50,
+        MZ_ZIP_LOCAL_DIR_HEADER_SIZE = 30,
+        MZ_ZIP_CENTRAL_DIR_HEADER_SIZE = 46,
+        MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE = 22,
 
-    /* ZIP64 archive identifier and record sizes */
-    MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIG = 0x06064b50,
-    MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIG = 0x07064b50,
-    MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE = 56,
-    MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE = 20,
-    MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID = 0x0001,
-    MZ_ZIP_DATA_DESCRIPTOR_ID = 0x08074b50,
-    MZ_ZIP_DATA_DESCRIPTER_SIZE64 = 24,
-    MZ_ZIP_DATA_DESCRIPTER_SIZE32 = 16,
+        /* ZIP64 archive identifier and record sizes */
+        MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIG = 0x06064b50,
+        MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIG = 0x07064b50,
+        MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE = 56,
+        MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE = 20,
+        MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID = 0x0001,
+        MZ_ZIP_DATA_DESCRIPTOR_ID = 0x08074b50,
+        MZ_ZIP_DATA_DESCRIPTER_SIZE64 = 24,
+        MZ_ZIP_DATA_DESCRIPTER_SIZE32 = 16,
 
-    /* Central directory header record offsets */
-    MZ_ZIP_CDH_SIG_OFS = 0,
-    MZ_ZIP_CDH_VERSION_MADE_BY_OFS = 4,
-    MZ_ZIP_CDH_VERSION_NEEDED_OFS = 6,
-    MZ_ZIP_CDH_BIT_FLAG_OFS = 8,
-    MZ_ZIP_CDH_METHOD_OFS = 10,
-    MZ_ZIP_CDH_FILE_TIME_OFS = 12,
-    MZ_ZIP_CDH_FILE_DATE_OFS = 14,
-    MZ_ZIP_CDH_CRC32_OFS = 16,
-    MZ_ZIP_CDH_COMPRESSED_SIZE_OFS = 20,
-    MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS = 24,
-    MZ_ZIP_CDH_FILENAME_LEN_OFS = 28,
-    MZ_ZIP_CDH_EXTRA_LEN_OFS = 30,
-    MZ_ZIP_CDH_COMMENT_LEN_OFS = 32,
-    MZ_ZIP_CDH_DISK_START_OFS = 34,
-    MZ_ZIP_CDH_INTERNAL_ATTR_OFS = 36,
-    MZ_ZIP_CDH_EXTERNAL_ATTR_OFS = 38,
-    MZ_ZIP_CDH_LOCAL_HEADER_OFS = 42,
+        /* Central directory header record offsets */
+        MZ_ZIP_CDH_SIG_OFS = 0,
+        MZ_ZIP_CDH_VERSION_MADE_BY_OFS = 4,
+        MZ_ZIP_CDH_VERSION_NEEDED_OFS = 6,
+        MZ_ZIP_CDH_BIT_FLAG_OFS = 8,
+        MZ_ZIP_CDH_METHOD_OFS = 10,
+        MZ_ZIP_CDH_FILE_TIME_OFS = 12,
+        MZ_ZIP_CDH_FILE_DATE_OFS = 14,
+        MZ_ZIP_CDH_CRC32_OFS = 16,
+        MZ_ZIP_CDH_COMPRESSED_SIZE_OFS = 20,
+        MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS = 24,
+        MZ_ZIP_CDH_FILENAME_LEN_OFS = 28,
+        MZ_ZIP_CDH_EXTRA_LEN_OFS = 30,
+        MZ_ZIP_CDH_COMMENT_LEN_OFS = 32,
+        MZ_ZIP_CDH_DISK_START_OFS = 34,
+        MZ_ZIP_CDH_INTERNAL_ATTR_OFS = 36,
+        MZ_ZIP_CDH_EXTERNAL_ATTR_OFS = 38,
+        MZ_ZIP_CDH_LOCAL_HEADER_OFS = 42,
 
-    /* Local directory header offsets */
-    MZ_ZIP_LDH_SIG_OFS = 0,
-    MZ_ZIP_LDH_VERSION_NEEDED_OFS = 4,
-    MZ_ZIP_LDH_BIT_FLAG_OFS = 6,
-    MZ_ZIP_LDH_METHOD_OFS = 8,
-    MZ_ZIP_LDH_FILE_TIME_OFS = 10,
-    MZ_ZIP_LDH_FILE_DATE_OFS = 12,
-    MZ_ZIP_LDH_CRC32_OFS = 14,
-    MZ_ZIP_LDH_COMPRESSED_SIZE_OFS = 18,
-    MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS = 22,
-    MZ_ZIP_LDH_FILENAME_LEN_OFS = 26,
-    MZ_ZIP_LDH_EXTRA_LEN_OFS = 28,
-    MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR = 1 << 3,
+        /* Local directory header offsets */
+        MZ_ZIP_LDH_SIG_OFS = 0,
+        MZ_ZIP_LDH_VERSION_NEEDED_OFS = 4,
+        MZ_ZIP_LDH_BIT_FLAG_OFS = 6,
+        MZ_ZIP_LDH_METHOD_OFS = 8,
+        MZ_ZIP_LDH_FILE_TIME_OFS = 10,
+        MZ_ZIP_LDH_FILE_DATE_OFS = 12,
+        MZ_ZIP_LDH_CRC32_OFS = 14,
+        MZ_ZIP_LDH_COMPRESSED_SIZE_OFS = 18,
+        MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS = 22,
+        MZ_ZIP_LDH_FILENAME_LEN_OFS = 26,
+        MZ_ZIP_LDH_EXTRA_LEN_OFS = 28,
+        MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR = 1 << 3,
 
-    /* End of central directory offsets */
-    MZ_ZIP_ECDH_SIG_OFS = 0,
-    MZ_ZIP_ECDH_NUM_THIS_DISK_OFS = 4,
-    MZ_ZIP_ECDH_NUM_DISK_CDIR_OFS = 6,
-    MZ_ZIP_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS = 8,
-    MZ_ZIP_ECDH_CDIR_TOTAL_ENTRIES_OFS = 10,
-    MZ_ZIP_ECDH_CDIR_SIZE_OFS = 12,
-    MZ_ZIP_ECDH_CDIR_OFS_OFS = 16,
-    MZ_ZIP_ECDH_COMMENT_SIZE_OFS = 20,
+        /* End of central directory offsets */
+        MZ_ZIP_ECDH_SIG_OFS = 0,
+        MZ_ZIP_ECDH_NUM_THIS_DISK_OFS = 4,
+        MZ_ZIP_ECDH_NUM_DISK_CDIR_OFS = 6,
+        MZ_ZIP_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS = 8,
+        MZ_ZIP_ECDH_CDIR_TOTAL_ENTRIES_OFS = 10,
+        MZ_ZIP_ECDH_CDIR_SIZE_OFS = 12,
+        MZ_ZIP_ECDH_CDIR_OFS_OFS = 16,
+        MZ_ZIP_ECDH_COMMENT_SIZE_OFS = 20,
 
-    /* ZIP64 End of central directory locator offsets */
-    MZ_ZIP64_ECDL_SIG_OFS = 0,                    /* 4 bytes */
-    MZ_ZIP64_ECDL_NUM_DISK_CDIR_OFS = 4,          /* 4 bytes */
-    MZ_ZIP64_ECDL_REL_OFS_TO_ZIP64_ECDR_OFS = 8,  /* 8 bytes */
-    MZ_ZIP64_ECDL_TOTAL_NUMBER_OF_DISKS_OFS = 16, /* 4 bytes */
+        /* ZIP64 End of central directory locator offsets */
+        MZ_ZIP64_ECDL_SIG_OFS = 0,                    /* 4 bytes */
+        MZ_ZIP64_ECDL_NUM_DISK_CDIR_OFS = 4,          /* 4 bytes */
+        MZ_ZIP64_ECDL_REL_OFS_TO_ZIP64_ECDR_OFS = 8,  /* 8 bytes */
+        MZ_ZIP64_ECDL_TOTAL_NUMBER_OF_DISKS_OFS = 16, /* 4 bytes */
 
-    /* ZIP64 End of central directory header offsets */
-    MZ_ZIP64_ECDH_SIG_OFS = 0,                       /* 4 bytes */
-    MZ_ZIP64_ECDH_SIZE_OF_RECORD_OFS = 4,            /* 8 bytes */
-    MZ_ZIP64_ECDH_VERSION_MADE_BY_OFS = 12,          /* 2 bytes */
-    MZ_ZIP64_ECDH_VERSION_NEEDED_OFS = 14,           /* 2 bytes */
-    MZ_ZIP64_ECDH_NUM_THIS_DISK_OFS = 16,            /* 4 bytes */
-    MZ_ZIP64_ECDH_NUM_DISK_CDIR_OFS = 20,            /* 4 bytes */
-    MZ_ZIP64_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS = 24, /* 8 bytes */
-    MZ_ZIP64_ECDH_CDIR_TOTAL_ENTRIES_OFS = 32,       /* 8 bytes */
-    MZ_ZIP64_ECDH_CDIR_SIZE_OFS = 40,                /* 8 bytes */
-    MZ_ZIP64_ECDH_CDIR_OFS_OFS = 48,                 /* 8 bytes */
-    MZ_ZIP_VERSION_MADE_BY_DOS_FILESYSTEM_ID = 0,
-    MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG = 0x10,
-    MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED = 1,
-    MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG = 32,
-    MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION = 64,
-    MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_LOCAL_DIR_IS_MASKED = 8192,
-    MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8 = 1 << 11
-};
+        /* ZIP64 End of central directory header offsets */
+        MZ_ZIP64_ECDH_SIG_OFS = 0,                       /* 4 bytes */
+        MZ_ZIP64_ECDH_SIZE_OF_RECORD_OFS = 4,            /* 8 bytes */
+        MZ_ZIP64_ECDH_VERSION_MADE_BY_OFS = 12,          /* 2 bytes */
+        MZ_ZIP64_ECDH_VERSION_NEEDED_OFS = 14,           /* 2 bytes */
+        MZ_ZIP64_ECDH_NUM_THIS_DISK_OFS = 16,            /* 4 bytes */
+        MZ_ZIP64_ECDH_NUM_DISK_CDIR_OFS = 20,            /* 4 bytes */
+        MZ_ZIP64_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS = 24, /* 8 bytes */
+        MZ_ZIP64_ECDH_CDIR_TOTAL_ENTRIES_OFS = 32,       /* 8 bytes */
+        MZ_ZIP64_ECDH_CDIR_SIZE_OFS = 40,                /* 8 bytes */
+        MZ_ZIP64_ECDH_CDIR_OFS_OFS = 48,                 /* 8 bytes */
+        MZ_ZIP_VERSION_MADE_BY_DOS_FILESYSTEM_ID = 0,
+        MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG = 0x10,
+        MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED = 1,
+        MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG = 32,
+        MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION = 64,
+        MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_LOCAL_DIR_IS_MASKED = 8192,
+        MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8 = 1 << 11
+    };
 
-typedef struct
-{
-    void *m_p;
-    size_t m_size, m_capacity;
-    mz_uint m_element_size;
-} mz_zip_array;
+    typedef struct
+    {
+        void *m_p;
+        size_t m_size, m_capacity;
+        mz_uint m_element_size;
+    } mz_zip_array;
 
-struct mz_zip_internal_state_tag
-{
-    mz_zip_array m_central_dir;
-    mz_zip_array m_central_dir_offsets;
-    mz_zip_array m_sorted_central_dir_offsets;
+    struct mz_zip_internal_state_tag
+    {
+        mz_zip_array m_central_dir;
+        mz_zip_array m_central_dir_offsets;
+        mz_zip_array m_sorted_central_dir_offsets;
 
-    /* The flags passed in when the archive is initially opened. */
-    mz_uint32 m_init_flags;
+        /* The flags passed in when the archive is initially opened. */
+        mz_uint32 m_init_flags;
 
-    /* MZ_TRUE if the archive has a zip64 end of central directory headers, etc. */
-    mz_bool m_zip64;
+        /* MZ_TRUE if the archive has a zip64 end of central directory headers, etc. */
+        mz_bool m_zip64;
 
-    /* MZ_TRUE if we found zip64 extended info in the central directory (m_zip64 will also be slammed to true too, even if we didn't find a zip64 end of central dir header, etc.) */
-    mz_bool m_zip64_has_extended_info_fields;
+        /* MZ_TRUE if we found zip64 extended info in the central directory (m_zip64 will also be slammed to true too, even if we didn't find a zip64 end of central dir header, etc.) */
+        mz_bool m_zip64_has_extended_info_fields;
 
-    /* These fields are used by the file, FILE, memory, and memory/heap read/write helpers. */
-    MZ_FILE *m_pFile;
-    mz_uint64 m_file_archive_start_ofs;
+        /* These fields are used by the file, FILE, memory, and memory/heap read/write helpers. */
+        MZ_FILE *m_pFile;
+        mz_uint64 m_file_archive_start_ofs;
 
-    void *m_pMem;
-    size_t m_mem_size;
-    size_t m_mem_capacity;
-};
+        void *m_pMem;
+        size_t m_mem_size;
+        size_t m_mem_capacity;
+    };
 
 #define MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(array_ptr, element_size) (array_ptr)->m_element_size = element_size
 
 #if defined(DEBUG) || defined(_DEBUG)
-static MZ_FORCEINLINE mz_uint mz_zip_array_range_check(const mz_zip_array *pArray, mz_uint index)
-{
-    MZ_ASSERT(index < pArray->m_size);
-    return index;
-}
+    static MZ_FORCEINLINE mz_uint mz_zip_array_range_check(const mz_zip_array *pArray, mz_uint index)
+    {
+        MZ_ASSERT(index < pArray->m_size);
+        return index;
+    }
 #define MZ_ZIP_ARRAY_ELEMENT(array_ptr, element_type, index) ((element_type *)((array_ptr)->m_p))[mz_zip_array_range_check(array_ptr, index)]
 #else
 #define MZ_ZIP_ARRAY_ELEMENT(array_ptr, element_type, index) ((element_type *)((array_ptr)->m_p))[index]
 #endif
 
-static MZ_FORCEINLINE void mz_zip_array_init(mz_zip_array *pArray, mz_uint32 element_size)
-{
-    memset(pArray, 0, sizeof(mz_zip_array));
-    pArray->m_element_size = element_size;
-}
+    static MZ_FORCEINLINE void mz_zip_array_init(mz_zip_array *pArray, mz_uint32 element_size)
+    {
+        memset(pArray, 0, sizeof(mz_zip_array));
+        pArray->m_element_size = element_size;
+    }
 
-static MZ_FORCEINLINE void mz_zip_array_clear(mz_zip_archive *pZip, mz_zip_array *pArray)
-{
-    pZip->m_pFree(pZip->m_pAlloc_opaque, pArray->m_p);
-    memset(pArray, 0, sizeof(mz_zip_array));
-}
+    static MZ_FORCEINLINE void mz_zip_array_clear(mz_zip_archive *pZip, mz_zip_array *pArray)
+    {
+        pZip->m_pFree(pZip->m_pAlloc_opaque, pArray->m_p);
+        memset(pArray, 0, sizeof(mz_zip_array));
+    }
 
-static mz_bool mz_zip_array_ensure_capacity(mz_zip_archive *pZip, mz_zip_array *pArray, size_t min_new_capacity, mz_uint growing)
-{
-    void *pNew_p;
-    size_t new_capacity = min_new_capacity;
-    MZ_ASSERT(pArray->m_element_size);
-    if (pArray->m_capacity >= min_new_capacity)
+    static mz_bool mz_zip_array_ensure_capacity(mz_zip_archive *pZip, mz_zip_array *pArray, size_t min_new_capacity, mz_uint growing)
+    {
+        void *pNew_p;
+        size_t new_capacity = min_new_capacity;
+        MZ_ASSERT(pArray->m_element_size);
+        if (pArray->m_capacity >= min_new_capacity)
+            return MZ_TRUE;
+        if (growing)
+        {
+            new_capacity = MZ_MAX(1, pArray->m_capacity);
+            while (new_capacity < min_new_capacity)
+                new_capacity *= 2;
+        }
+        if (NULL == (pNew_p = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pArray->m_p, pArray->m_element_size, new_capacity)))
+            return MZ_FALSE;
+        pArray->m_p = pNew_p;
+        pArray->m_capacity = new_capacity;
         return MZ_TRUE;
-    if (growing)
-    {
-        new_capacity = MZ_MAX(1, pArray->m_capacity);
-        while (new_capacity < min_new_capacity)
-            new_capacity *= 2;
     }
-    if (NULL == (pNew_p = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pArray->m_p, pArray->m_element_size, new_capacity)))
-        return MZ_FALSE;
-    pArray->m_p = pNew_p;
-    pArray->m_capacity = new_capacity;
-    return MZ_TRUE;
-}
 
-static MZ_FORCEINLINE mz_bool mz_zip_array_reserve(mz_zip_archive *pZip, mz_zip_array *pArray, size_t new_capacity, mz_uint growing)
-{
-    if (new_capacity > pArray->m_capacity)
+    static MZ_FORCEINLINE mz_bool mz_zip_array_reserve(mz_zip_archive *pZip, mz_zip_array *pArray, size_t new_capacity, mz_uint growing)
     {
-        if (!mz_zip_array_ensure_capacity(pZip, pArray, new_capacity, growing))
+        if (new_capacity > pArray->m_capacity)
+        {
+            if (!mz_zip_array_ensure_capacity(pZip, pArray, new_capacity, growing))
+                return MZ_FALSE;
+        }
+        return MZ_TRUE;
+    }
+
+    static MZ_FORCEINLINE mz_bool mz_zip_array_resize(mz_zip_archive *pZip, mz_zip_array *pArray, size_t new_size, mz_uint growing)
+    {
+        if (new_size > pArray->m_capacity)
+        {
+            if (!mz_zip_array_ensure_capacity(pZip, pArray, new_size, growing))
+                return MZ_FALSE;
+        }
+        pArray->m_size = new_size;
+        return MZ_TRUE;
+    }
+
+    static MZ_FORCEINLINE mz_bool mz_zip_array_ensure_room(mz_zip_archive *pZip, mz_zip_array *pArray, size_t n)
+    {
+        return mz_zip_array_reserve(pZip, pArray, pArray->m_size + n, MZ_TRUE);
+    }
+
+    static MZ_FORCEINLINE mz_bool mz_zip_array_push_back(mz_zip_archive *pZip, mz_zip_array *pArray, const void *pElements, size_t n)
+    {
+        size_t orig_size = pArray->m_size;
+        if (!mz_zip_array_resize(pZip, pArray, orig_size + n, MZ_TRUE))
             return MZ_FALSE;
+        if (n > 0)
+            memcpy((mz_uint8 *)pArray->m_p + orig_size * pArray->m_element_size, pElements, n * pArray->m_element_size);
+        return MZ_TRUE;
     }
-    return MZ_TRUE;
-}
-
-static MZ_FORCEINLINE mz_bool mz_zip_array_resize(mz_zip_archive *pZip, mz_zip_array *pArray, size_t new_size, mz_uint growing)
-{
-    if (new_size > pArray->m_capacity)
-    {
-        if (!mz_zip_array_ensure_capacity(pZip, pArray, new_size, growing))
-            return MZ_FALSE;
-    }
-    pArray->m_size = new_size;
-    return MZ_TRUE;
-}
-
-static MZ_FORCEINLINE mz_bool mz_zip_array_ensure_room(mz_zip_archive *pZip, mz_zip_array *pArray, size_t n)
-{
-    return mz_zip_array_reserve(pZip, pArray, pArray->m_size + n, MZ_TRUE);
-}
-
-static MZ_FORCEINLINE mz_bool mz_zip_array_push_back(mz_zip_archive *pZip, mz_zip_array *pArray, const void *pElements, size_t n)
-{
-    size_t orig_size = pArray->m_size;
-    if (!mz_zip_array_resize(pZip, pArray, orig_size + n, MZ_TRUE))
-        return MZ_FALSE;
-    if (n > 0)
-        memcpy((mz_uint8 *)pArray->m_p + orig_size * pArray->m_element_size, pElements, n * pArray->m_element_size);
-    return MZ_TRUE;
-}
 
 #ifndef MINIZ_NO_TIME
-static MZ_TIME_T mz_zip_dos_to_time_t(int dos_time, int dos_date)
-{
-    struct tm tm;
-    memset(&tm, 0, sizeof(tm));
-    tm.tm_isdst = -1;
-    tm.tm_year = ((dos_date >> 9) & 127) + 1980 - 1900;
-    tm.tm_mon = ((dos_date >> 5) & 15) - 1;
-    tm.tm_mday = dos_date & 31;
-    tm.tm_hour = (dos_time >> 11) & 31;
-    tm.tm_min = (dos_time >> 5) & 63;
-    tm.tm_sec = (dos_time << 1) & 62;
-    return mktime(&tm);
-}
+    static MZ_TIME_T mz_zip_dos_to_time_t(int dos_time, int dos_date)
+    {
+        struct tm tm;
+        memset(&tm, 0, sizeof(tm));
+        tm.tm_isdst = -1;
+        tm.tm_year = ((dos_date >> 9) & 127) + 1980 - 1900;
+        tm.tm_mon = ((dos_date >> 5) & 15) - 1;
+        tm.tm_mday = dos_date & 31;
+        tm.tm_hour = (dos_time >> 11) & 31;
+        tm.tm_min = (dos_time >> 5) & 63;
+        tm.tm_sec = (dos_time << 1) & 62;
+        return mktime(&tm);
+    }
 
 #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
-static void mz_zip_time_t_to_dos_time(MZ_TIME_T time, mz_uint16 *pDOS_time, mz_uint16 *pDOS_date)
-{
-#ifdef _MSC_VER
-    struct tm tm_struct;
-    struct tm *tm = &tm_struct;
-    errno_t err = localtime_s(tm, &time);
-    if (err)
+    static void mz_zip_time_t_to_dos_time(MZ_TIME_T time, mz_uint16 *pDOS_time, mz_uint16 *pDOS_date)
     {
-        *pDOS_date = 0;
-        *pDOS_time = 0;
-        return;
-    }
+#ifdef _MSC_VER
+        struct tm tm_struct;
+        struct tm *tm = &tm_struct;
+        errno_t err = localtime_s(tm, &time);
+        if (err)
+        {
+            *pDOS_date = 0;
+            *pDOS_time = 0;
+            return;
+        }
 #else
-    struct tm *tm = localtime(&time);
+        struct tm *tm = localtime(&time);
 #endif /* #ifdef _MSC_VER */
 
-    *pDOS_time = (mz_uint16)(((tm->tm_hour) << 11) + ((tm->tm_min) << 5) + ((tm->tm_sec) >> 1));
-    *pDOS_date = (mz_uint16)(((tm->tm_year + 1900 - 1980) << 9) + ((tm->tm_mon + 1) << 5) + tm->tm_mday);
-}
+        *pDOS_time = (mz_uint16)(((tm->tm_hour) << 11) + ((tm->tm_min) << 5) + ((tm->tm_sec) >> 1));
+        *pDOS_date = (mz_uint16)(((tm->tm_year + 1900 - 1980) << 9) + ((tm->tm_mon + 1) << 5) + tm->tm_mday);
+    }
 #endif /* MINIZ_NO_ARCHIVE_WRITING_APIS */
 
 #ifndef MINIZ_NO_STDIO
 #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
-static mz_bool mz_zip_get_file_modified_time(const char *pFilename, MZ_TIME_T *pTime)
-{
-    struct MZ_FILE_STAT_STRUCT file_stat;
+    static mz_bool mz_zip_get_file_modified_time(const char *pFilename, MZ_TIME_T *pTime)
+    {
+        struct MZ_FILE_STAT_STRUCT file_stat;
 
-    /* On Linux with x86 glibc, this call will fail on large files (I think >= 0x80000000 bytes) unless you compiled with _LARGEFILE64_SOURCE. Argh. */
-    if (MZ_FILE_STAT(pFilename, &file_stat) != 0)
-        return MZ_FALSE;
+        /* On Linux with x86 glibc, this call will fail on large files (I think >= 0x80000000 bytes) unless you compiled with _LARGEFILE64_SOURCE. Argh. */
+        if (MZ_FILE_STAT(pFilename, &file_stat) != 0)
+            return MZ_FALSE;
 
-    *pTime = file_stat.st_mtime;
+        *pTime = file_stat.st_mtime;
 
-    return MZ_TRUE;
-}
+        return MZ_TRUE;
+    }
 #endif /* #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS*/
 
-static mz_bool mz_zip_set_file_times(const char *pFilename, MZ_TIME_T access_time, MZ_TIME_T modified_time)
-{
-    struct utimbuf t;
+    static mz_bool mz_zip_set_file_times(const char *pFilename, MZ_TIME_T access_time, MZ_TIME_T modified_time)
+    {
+        struct utimbuf t;
 
-    memset(&t, 0, sizeof(t));
-    t.actime = access_time;
-    t.modtime = modified_time;
+        memset(&t, 0, sizeof(t));
+        t.actime = access_time;
+        t.modtime = modified_time;
 
-    return !utime(pFilename, &t);
-}
+        return !utime(pFilename, &t);
+    }
 #endif /* #ifndef MINIZ_NO_STDIO */
 #endif /* #ifndef MINIZ_NO_TIME */
 
-static MZ_FORCEINLINE mz_bool mz_zip_set_error(mz_zip_archive *pZip, mz_zip_error err_num)
-{
-    if (pZip)
-        pZip->m_last_error = err_num;
-    return MZ_FALSE;
-}
-
-static mz_bool mz_zip_reader_init_internal(mz_zip_archive *pZip, mz_uint flags)
-{
-    (void)flags;
-    if ((!pZip) || (pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_INVALID))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (!pZip->m_pAlloc)
-        pZip->m_pAlloc = miniz_def_alloc_func;
-    if (!pZip->m_pFree)
-        pZip->m_pFree = miniz_def_free_func;
-    if (!pZip->m_pRealloc)
-        pZip->m_pRealloc = miniz_def_realloc_func;
-
-    pZip->m_archive_size = 0;
-    pZip->m_central_directory_file_ofs = 0;
-    pZip->m_total_files = 0;
-    pZip->m_last_error = MZ_ZIP_NO_ERROR;
-
-    if (NULL == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-    memset(pZip->m_pState, 0, sizeof(mz_zip_internal_state));
-    MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir, sizeof(mz_uint8));
-    MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir_offsets, sizeof(mz_uint32));
-    MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_sorted_central_dir_offsets, sizeof(mz_uint32));
-    pZip->m_pState->m_init_flags = flags;
-    pZip->m_pState->m_zip64 = MZ_FALSE;
-    pZip->m_pState->m_zip64_has_extended_info_fields = MZ_FALSE;
-
-    pZip->m_zip_mode = MZ_ZIP_MODE_READING;
-
-    return MZ_TRUE;
-}
-
-static MZ_FORCEINLINE mz_bool mz_zip_reader_filename_less(const mz_zip_array *pCentral_dir_array, const mz_zip_array *pCentral_dir_offsets, mz_uint l_index, mz_uint r_index)
-{
-    const mz_uint8 *pL = &MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_array, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_offsets, mz_uint32, l_index)), *pE;
-    const mz_uint8 *pR = &MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_array, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_offsets, mz_uint32, r_index));
-    mz_uint l_len = MZ_READ_LE16(pL + MZ_ZIP_CDH_FILENAME_LEN_OFS), r_len = MZ_READ_LE16(pR + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-    mz_uint8 l = 0, r = 0;
-    pL += MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
-    pR += MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
-    pE = pL + MZ_MIN(l_len, r_len);
-    while (pL < pE)
+    static MZ_FORCEINLINE mz_bool mz_zip_set_error(mz_zip_archive *pZip, mz_zip_error err_num)
     {
-        if ((l = MZ_TOLOWER(*pL)) != (r = MZ_TOLOWER(*pR)))
-            break;
-        pL++;
-        pR++;
+        if (pZip)
+            pZip->m_last_error = err_num;
+        return MZ_FALSE;
     }
-    return (pL == pE) ? (l_len < r_len) : (l < r);
-}
+
+    static mz_bool mz_zip_reader_init_internal(mz_zip_archive *pZip, mz_uint flags)
+    {
+        (void)flags;
+        if ((!pZip) || (pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_INVALID))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (!pZip->m_pAlloc)
+            pZip->m_pAlloc = miniz_def_alloc_func;
+        if (!pZip->m_pFree)
+            pZip->m_pFree = miniz_def_free_func;
+        if (!pZip->m_pRealloc)
+            pZip->m_pRealloc = miniz_def_realloc_func;
+
+        pZip->m_archive_size = 0;
+        pZip->m_central_directory_file_ofs = 0;
+        pZip->m_total_files = 0;
+        pZip->m_last_error = MZ_ZIP_NO_ERROR;
+
+        if (NULL == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
+            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+        memset(pZip->m_pState, 0, sizeof(mz_zip_internal_state));
+        MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir, sizeof(mz_uint8));
+        MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir_offsets, sizeof(mz_uint32));
+        MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_sorted_central_dir_offsets, sizeof(mz_uint32));
+        pZip->m_pState->m_init_flags = flags;
+        pZip->m_pState->m_zip64 = MZ_FALSE;
+        pZip->m_pState->m_zip64_has_extended_info_fields = MZ_FALSE;
+
+        pZip->m_zip_mode = MZ_ZIP_MODE_READING;
+
+        return MZ_TRUE;
+    }
+
+    static MZ_FORCEINLINE mz_bool mz_zip_reader_filename_less(const mz_zip_array *pCentral_dir_array, const mz_zip_array *pCentral_dir_offsets, mz_uint l_index, mz_uint r_index)
+    {
+        const mz_uint8 *pL = &MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_array, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_offsets, mz_uint32, l_index)), *pE;
+        const mz_uint8 *pR = &MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_array, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_offsets, mz_uint32, r_index));
+        mz_uint l_len = MZ_READ_LE16(pL + MZ_ZIP_CDH_FILENAME_LEN_OFS), r_len = MZ_READ_LE16(pR + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+        mz_uint8 l = 0, r = 0;
+        pL += MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
+        pR += MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
+        pE = pL + MZ_MIN(l_len, r_len);
+        while (pL < pE)
+        {
+            if ((l = MZ_TOLOWER(*pL)) != (r = MZ_TOLOWER(*pR)))
+                break;
+            pL++;
+            pR++;
+        }
+        return (pL == pE) ? (l_len < r_len) : (l < r);
+    }
 
 #define MZ_SWAP_UINT32(a, b) \
     do                       \
@@ -3538,383 +3562,2233 @@ static MZ_FORCEINLINE mz_bool mz_zip_reader_filename_less(const mz_zip_array *pC
     }                        \
     MZ_MACRO_END
 
-/* Heap sort of lowercased filenames, used to help accelerate plain central directory searches by mz_zip_reader_locate_file(). (Could also use qsort(), but it could allocate memory.) */
-static void mz_zip_reader_sort_central_dir_offsets_by_filename(mz_zip_archive *pZip)
-{
-    mz_zip_internal_state *pState = pZip->m_pState;
-    const mz_zip_array *pCentral_dir_offsets = &pState->m_central_dir_offsets;
-    const mz_zip_array *pCentral_dir = &pState->m_central_dir;
-    mz_uint32 *pIndices;
-    mz_uint32 start, end;
-    const mz_uint32 size = pZip->m_total_files;
-
-    if (size <= 1U)
-        return;
-
-    pIndices = &MZ_ZIP_ARRAY_ELEMENT(&pState->m_sorted_central_dir_offsets, mz_uint32, 0);
-
-    start = (size - 2U) >> 1U;
-    for (;;)
+    /* Heap sort of lowercased filenames, used to help accelerate plain central directory searches by mz_zip_reader_locate_file(). (Could also use qsort(), but it could allocate memory.) */
+    static void mz_zip_reader_sort_central_dir_offsets_by_filename(mz_zip_archive *pZip)
     {
-        mz_uint64 child, root = start;
+        mz_zip_internal_state *pState = pZip->m_pState;
+        const mz_zip_array *pCentral_dir_offsets = &pState->m_central_dir_offsets;
+        const mz_zip_array *pCentral_dir = &pState->m_central_dir;
+        mz_uint32 *pIndices;
+        mz_uint32 start, end;
+        const mz_uint32 size = pZip->m_total_files;
+
+        if (size <= 1U)
+            return;
+
+        pIndices = &MZ_ZIP_ARRAY_ELEMENT(&pState->m_sorted_central_dir_offsets, mz_uint32, 0);
+
+        start = (size - 2U) >> 1U;
         for (;;)
         {
-            if ((child = (root << 1U) + 1U) >= size)
+            mz_uint64 child, root = start;
+            for (;;)
+            {
+                if ((child = (root << 1U) + 1U) >= size)
+                    break;
+                child += (((child + 1U) < size) && (mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[child], pIndices[child + 1U])));
+                if (!mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[root], pIndices[child]))
+                    break;
+                MZ_SWAP_UINT32(pIndices[root], pIndices[child]);
+                root = child;
+            }
+            if (!start)
                 break;
-            child += (((child + 1U) < size) && (mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[child], pIndices[child + 1U])));
-            if (!mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[root], pIndices[child]))
-                break;
-            MZ_SWAP_UINT32(pIndices[root], pIndices[child]);
-            root = child;
+            start--;
         }
-        if (!start)
-            break;
-        start--;
-    }
 
-    end = size - 1;
-    while (end > 0)
-    {
-        mz_uint64 child, root = 0;
-        MZ_SWAP_UINT32(pIndices[end], pIndices[0]);
-        for (;;)
+        end = size - 1;
+        while (end > 0)
         {
-            if ((child = (root << 1U) + 1U) >= end)
-                break;
-            child += (((child + 1U) < end) && mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[child], pIndices[child + 1U]));
-            if (!mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[root], pIndices[child]))
-                break;
-            MZ_SWAP_UINT32(pIndices[root], pIndices[child]);
-            root = child;
+            mz_uint64 child, root = 0;
+            MZ_SWAP_UINT32(pIndices[end], pIndices[0]);
+            for (;;)
+            {
+                if ((child = (root << 1U) + 1U) >= end)
+                    break;
+                child += (((child + 1U) < end) && mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[child], pIndices[child + 1U]));
+                if (!mz_zip_reader_filename_less(pCentral_dir, pCentral_dir_offsets, pIndices[root], pIndices[child]))
+                    break;
+                MZ_SWAP_UINT32(pIndices[root], pIndices[child]);
+                root = child;
+            }
+            end--;
         }
-        end--;
     }
-}
 
-static mz_bool mz_zip_reader_locate_header_sig(mz_zip_archive *pZip, mz_uint32 record_sig, mz_uint32 record_size, mz_int64 *pOfs)
-{
-    mz_int64 cur_file_ofs;
-    mz_uint32 buf_u32[4096 / sizeof(mz_uint32)];
-    mz_uint8 *pBuf = (mz_uint8 *)buf_u32;
-
-    /* Basic sanity checks - reject files which are too small */
-    if (pZip->m_archive_size < record_size)
-        return MZ_FALSE;
-
-    /* Find the record by scanning the file from the end towards the beginning. */
-    cur_file_ofs = MZ_MAX((mz_int64)pZip->m_archive_size - (mz_int64)sizeof(buf_u32), 0);
-    for (;;)
+    static mz_bool mz_zip_reader_locate_header_sig(mz_zip_archive *pZip, mz_uint32 record_sig, mz_uint32 record_size, mz_int64 *pOfs)
     {
-        int i, n = (int)MZ_MIN(sizeof(buf_u32), pZip->m_archive_size - cur_file_ofs);
+        mz_int64 cur_file_ofs;
+        mz_uint32 buf_u32[4096 / sizeof(mz_uint32)];
+        mz_uint8 *pBuf = (mz_uint8 *)buf_u32;
 
-        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pBuf, n) != (mz_uint)n)
+        /* Basic sanity checks - reject files which are too small */
+        if (pZip->m_archive_size < record_size)
             return MZ_FALSE;
 
-        for (i = n - 4; i >= 0; --i)
+        /* Find the record by scanning the file from the end towards the beginning. */
+        cur_file_ofs = MZ_MAX((mz_int64)pZip->m_archive_size - (mz_int64)sizeof(buf_u32), 0);
+        for (;;)
         {
-            mz_uint s = MZ_READ_LE32(pBuf + i);
-            if (s == record_sig)
+            int i, n = (int)MZ_MIN(sizeof(buf_u32), pZip->m_archive_size - cur_file_ofs);
+
+            if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pBuf, n) != (mz_uint)n)
+                return MZ_FALSE;
+
+            for (i = n - 4; i >= 0; --i)
             {
-                if ((pZip->m_archive_size - (cur_file_ofs + i)) >= record_size)
-                    break;
+                mz_uint s = MZ_READ_LE32(pBuf + i);
+                if (s == record_sig)
+                {
+                    if ((pZip->m_archive_size - (cur_file_ofs + i)) >= record_size)
+                        break;
+                }
+            }
+
+            if (i >= 0)
+            {
+                cur_file_ofs += i;
+                break;
+            }
+
+            /* Give up if we've searched the entire file, or we've gone back "too far" (~64kb) */
+            if ((!cur_file_ofs) || ((pZip->m_archive_size - cur_file_ofs) >= ((mz_uint64)(MZ_UINT16_MAX) + record_size)))
+                return MZ_FALSE;
+
+            cur_file_ofs = MZ_MAX(cur_file_ofs - (sizeof(buf_u32) - 3), 0);
+        }
+
+        *pOfs = cur_file_ofs;
+        return MZ_TRUE;
+    }
+
+    static mz_bool mz_zip_reader_eocd64_valid(mz_zip_archive *pZip, uint64_t offset, uint8_t *buf)
+    {
+        if (pZip->m_pRead(pZip->m_pIO_opaque, offset, buf, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE) == MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE)
+        {
+            if (MZ_READ_LE32(buf + MZ_ZIP64_ECDH_SIG_OFS) == MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIG)
+            {
+                return MZ_TRUE;
             }
         }
 
-        if (i >= 0)
-        {
-            cur_file_ofs += i;
-            break;
-        }
-
-        /* Give up if we've searched the entire file, or we've gone back "too far" (~64kb) */
-        if ((!cur_file_ofs) || ((pZip->m_archive_size - cur_file_ofs) >= (MZ_UINT16_MAX + record_size)))
-            return MZ_FALSE;
-
-        cur_file_ofs = MZ_MAX(cur_file_ofs - (sizeof(buf_u32) - 3), 0);
+        return MZ_FALSE;
     }
 
-    *pOfs = cur_file_ofs;
-    return MZ_TRUE;
-}
-
-static mz_bool mz_zip_reader_read_central_dir(mz_zip_archive *pZip, mz_uint flags)
-{
-    mz_uint cdir_size = 0, cdir_entries_on_this_disk = 0, num_this_disk = 0, cdir_disk_index = 0;
-    mz_uint64 cdir_ofs = 0;
-    mz_int64 cur_file_ofs = 0;
-    const mz_uint8 *p;
-
-    mz_uint32 buf_u32[4096 / sizeof(mz_uint32)];
-    mz_uint8 *pBuf = (mz_uint8 *)buf_u32;
-    mz_bool sort_central_dir = ((flags & MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY) == 0);
-    mz_uint32 zip64_end_of_central_dir_locator_u32[(MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pZip64_locator = (mz_uint8 *)zip64_end_of_central_dir_locator_u32;
-
-    mz_uint32 zip64_end_of_central_dir_header_u32[(MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pZip64_end_of_central_dir = (mz_uint8 *)zip64_end_of_central_dir_header_u32;
-
-    mz_uint64 zip64_end_of_central_dir_ofs = 0;
-
-    /* Basic sanity checks - reject files which are too small, and check the first 4 bytes of the file to make sure a local header is there. */
-    if (pZip->m_archive_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
-
-    if (!mz_zip_reader_locate_header_sig(pZip, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE, &cur_file_ofs))
-        return mz_zip_set_error(pZip, MZ_ZIP_FAILED_FINDING_CENTRAL_DIR);
-
-    /* Read and verify the end of central directory record. */
-    if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pBuf, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE) != MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-
-    if (MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_SIG_OFS) != MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG)
-        return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
-
-    if (cur_file_ofs >= (MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE + MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE))
+    static mz_bool mz_zip_reader_read_central_dir(mz_zip_archive *pZip, mz_uint flags)
     {
-        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs - MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE, pZip64_locator, MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE) == MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE)
-        {
-            if (MZ_READ_LE32(pZip64_locator + MZ_ZIP64_ECDL_SIG_OFS) == MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIG)
-            {
-                zip64_end_of_central_dir_ofs = MZ_READ_LE64(pZip64_locator + MZ_ZIP64_ECDL_REL_OFS_TO_ZIP64_ECDR_OFS);
-                if (zip64_end_of_central_dir_ofs > (pZip->m_archive_size - MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE))
-                    return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+        mz_uint cdir_size = 0, cdir_entries_on_this_disk = 0, num_this_disk = 0, cdir_disk_index = 0;
+        mz_uint64 cdir_ofs = 0, eocd_ofs = 0, archive_ofs = 0;
+        mz_int64 cur_file_ofs = 0;
+        const mz_uint8 *p;
 
-                if (pZip->m_pRead(pZip->m_pIO_opaque, zip64_end_of_central_dir_ofs, pZip64_end_of_central_dir, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE) == MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE)
+        mz_uint32 buf_u32[4096 / sizeof(mz_uint32)];
+        mz_uint8 *pBuf = (mz_uint8 *)buf_u32;
+        mz_bool sort_central_dir = ((flags & MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY) == 0);
+        mz_uint32 zip64_end_of_central_dir_locator_u32[(MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pZip64_locator = (mz_uint8 *)zip64_end_of_central_dir_locator_u32;
+
+        mz_uint32 zip64_end_of_central_dir_header_u32[(MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pZip64_end_of_central_dir = (mz_uint8 *)zip64_end_of_central_dir_header_u32;
+
+        mz_uint64 zip64_end_of_central_dir_ofs = 0;
+
+        /* Basic sanity checks - reject files which are too small, and check the first 4 bytes of the file to make sure a local header is there. */
+        if (pZip->m_archive_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+
+        if (!mz_zip_reader_locate_header_sig(pZip, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE, &cur_file_ofs))
+            return mz_zip_set_error(pZip, MZ_ZIP_FAILED_FINDING_CENTRAL_DIR);
+
+        eocd_ofs = cur_file_ofs;
+        /* Read and verify the end of central directory record. */
+        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pBuf, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE) != MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+
+        if (MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_SIG_OFS) != MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG)
+            return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+
+        if (cur_file_ofs >= (MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE + MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE))
+        {
+            if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs - MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE, pZip64_locator, MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE) == MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE)
+            {
+                if (MZ_READ_LE32(pZip64_locator + MZ_ZIP64_ECDL_SIG_OFS) == MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIG)
                 {
-                    if (MZ_READ_LE32(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_SIG_OFS) == MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIG)
-                    {
-                        pZip->m_pState->m_zip64 = MZ_TRUE;
-                    }
+                    pZip->m_pState->m_zip64 = MZ_TRUE;
                 }
             }
         }
-    }
 
-    pZip->m_total_files = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_CDIR_TOTAL_ENTRIES_OFS);
-    cdir_entries_on_this_disk = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS);
-    num_this_disk = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_THIS_DISK_OFS);
-    cdir_disk_index = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_DISK_CDIR_OFS);
-    cdir_size = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_SIZE_OFS);
-    cdir_ofs = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_OFS_OFS);
-
-    if (pZip->m_pState->m_zip64)
-    {
-        mz_uint32 zip64_total_num_of_disks = MZ_READ_LE32(pZip64_locator + MZ_ZIP64_ECDL_TOTAL_NUMBER_OF_DISKS_OFS);
-        mz_uint64 zip64_cdir_total_entries = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_TOTAL_ENTRIES_OFS);
-        mz_uint64 zip64_cdir_total_entries_on_this_disk = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS);
-        mz_uint64 zip64_size_of_end_of_central_dir_record = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_SIZE_OF_RECORD_OFS);
-        mz_uint64 zip64_size_of_central_directory = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_SIZE_OFS);
-
-        if (zip64_size_of_end_of_central_dir_record < (MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE - 12))
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-        if (zip64_total_num_of_disks != 1U)
-            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
-
-        /* Check for miniz's practical limits */
-        if (zip64_cdir_total_entries > MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-
-        pZip->m_total_files = (mz_uint32)zip64_cdir_total_entries;
-
-        if (zip64_cdir_total_entries_on_this_disk > MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-
-        cdir_entries_on_this_disk = (mz_uint32)zip64_cdir_total_entries_on_this_disk;
-
-        /* Check for miniz's current practical limits (sorry, this should be enough for millions of files) */
-        if (zip64_size_of_central_directory > MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
-
-        cdir_size = (mz_uint32)zip64_size_of_central_directory;
-
-        num_this_disk = MZ_READ_LE32(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_NUM_THIS_DISK_OFS);
-
-        cdir_disk_index = MZ_READ_LE32(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_NUM_DISK_CDIR_OFS);
-
-        cdir_ofs = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_OFS_OFS);
-    }
-
-    if (pZip->m_total_files != cdir_entries_on_this_disk)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
-
-    if (((num_this_disk | cdir_disk_index) != 0) && ((num_this_disk != 1) || (cdir_disk_index != 1)))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
-
-    if (cdir_size < (mz_uint64)pZip->m_total_files * MZ_ZIP_CENTRAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    if ((cdir_ofs + (mz_uint64)cdir_size) > pZip->m_archive_size)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    pZip->m_central_directory_file_ofs = cdir_ofs;
-
-    if (pZip->m_total_files)
-    {
-        mz_uint i, n;
-        /* Read the entire central directory into a heap block, and allocate another heap block to hold the unsorted central dir file record offsets, and possibly another to hold the sorted indices. */
-        if ((!mz_zip_array_resize(pZip, &pZip->m_pState->m_central_dir, cdir_size, MZ_FALSE)) ||
-            (!mz_zip_array_resize(pZip, &pZip->m_pState->m_central_dir_offsets, pZip->m_total_files, MZ_FALSE)))
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-        if (sort_central_dir)
+        if (pZip->m_pState->m_zip64)
         {
-            if (!mz_zip_array_resize(pZip, &pZip->m_pState->m_sorted_central_dir_offsets, pZip->m_total_files, MZ_FALSE))
-                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            /* Try locating the EOCD64 right before the EOCD64 locator. This works even
+             * when the effective start of the zip header is not yet known. */
+            if (cur_file_ofs < MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE +
+                                   MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE)
+                return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+
+            zip64_end_of_central_dir_ofs = cur_file_ofs -
+                                           MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE -
+                                           MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE;
+
+            if (!mz_zip_reader_eocd64_valid(pZip, zip64_end_of_central_dir_ofs,
+                                            pZip64_end_of_central_dir))
+            {
+                /* That failed, try reading where the locator tells us to. */
+                zip64_end_of_central_dir_ofs = MZ_READ_LE64(
+                    pZip64_locator + MZ_ZIP64_ECDL_REL_OFS_TO_ZIP64_ECDR_OFS);
+
+                if (zip64_end_of_central_dir_ofs >
+                    (pZip->m_archive_size - MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE))
+                    return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+
+                if (!mz_zip_reader_eocd64_valid(pZip, zip64_end_of_central_dir_ofs,
+                                                pZip64_end_of_central_dir))
+                    return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+            }
         }
 
-        if (pZip->m_pRead(pZip->m_pIO_opaque, cdir_ofs, pZip->m_pState->m_central_dir.m_p, cdir_size) != cdir_size)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+        pZip->m_total_files = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_CDIR_TOTAL_ENTRIES_OFS);
+        cdir_entries_on_this_disk = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS);
+        num_this_disk = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_THIS_DISK_OFS);
+        cdir_disk_index = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_DISK_CDIR_OFS);
+        cdir_size = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_SIZE_OFS);
+        cdir_ofs = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_OFS_OFS);
 
-        /* Now create an index into the central directory file records, do some basic sanity checking on each record */
-        p = (const mz_uint8 *)pZip->m_pState->m_central_dir.m_p;
-        for (n = cdir_size, i = 0; i < pZip->m_total_files; ++i)
+        if (pZip->m_pState->m_zip64)
         {
-            mz_uint total_header_size, disk_index, bit_flags, filename_size, ext_data_size;
-            mz_uint64 comp_size, decomp_size, local_header_ofs;
+            mz_uint32 zip64_total_num_of_disks = MZ_READ_LE32(pZip64_locator + MZ_ZIP64_ECDL_TOTAL_NUMBER_OF_DISKS_OFS);
+            mz_uint64 zip64_cdir_total_entries = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_TOTAL_ENTRIES_OFS);
+            mz_uint64 zip64_cdir_total_entries_on_this_disk = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS);
+            mz_uint64 zip64_size_of_end_of_central_dir_record = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_SIZE_OF_RECORD_OFS);
+            mz_uint64 zip64_size_of_central_directory = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_SIZE_OFS);
 
-            if ((n < MZ_ZIP_CENTRAL_DIR_HEADER_SIZE) || (MZ_READ_LE32(p) != MZ_ZIP_CENTRAL_DIR_HEADER_SIG))
+            if (zip64_size_of_end_of_central_dir_record < (MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE - 12))
                 return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
 
-            MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, i) = (mz_uint32)(p - (const mz_uint8 *)pZip->m_pState->m_central_dir.m_p);
+            if (zip64_total_num_of_disks != 1U)
+                return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
+
+            /* Check for miniz's practical limits */
+            if (zip64_cdir_total_entries > MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+
+            pZip->m_total_files = (mz_uint32)zip64_cdir_total_entries;
+
+            if (zip64_cdir_total_entries_on_this_disk > MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+
+            cdir_entries_on_this_disk = (mz_uint32)zip64_cdir_total_entries_on_this_disk;
+
+            /* Check for miniz's current practical limits (sorry, this should be enough for millions of files) */
+            if (zip64_size_of_central_directory > MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
+
+            cdir_size = (mz_uint32)zip64_size_of_central_directory;
+
+            num_this_disk = MZ_READ_LE32(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_NUM_THIS_DISK_OFS);
+
+            cdir_disk_index = MZ_READ_LE32(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_NUM_DISK_CDIR_OFS);
+
+            cdir_ofs = MZ_READ_LE64(pZip64_end_of_central_dir + MZ_ZIP64_ECDH_CDIR_OFS_OFS);
+        }
+
+        if (pZip->m_total_files != cdir_entries_on_this_disk)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
+
+        if (((num_this_disk | cdir_disk_index) != 0) && ((num_this_disk != 1) || (cdir_disk_index != 1)))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
+
+        if (cdir_size < (mz_uint64)pZip->m_total_files * MZ_ZIP_CENTRAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        if ((cdir_ofs + (mz_uint64)cdir_size) > pZip->m_archive_size)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        if (eocd_ofs < cdir_ofs + cdir_size)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        /* The end of central dir follows the central dir, unless the zip file has
+         * some trailing data (e.g. it is appended to an executable file). */
+        archive_ofs = eocd_ofs - (cdir_ofs + cdir_size);
+        if (pZip->m_pState->m_zip64)
+        {
+            if (archive_ofs < MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE +
+                                  MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE)
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+            archive_ofs -= MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE +
+                           MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE;
+        }
+
+        /* Update the archive start position, but only if not specified. */
+        if ((pZip->m_zip_type == MZ_ZIP_TYPE_FILE || pZip->m_zip_type == MZ_ZIP_TYPE_CFILE ||
+            pZip->m_zip_type == MZ_ZIP_TYPE_USER) && pZip->m_pState->m_file_archive_start_ofs == 0)
+        {
+            pZip->m_pState->m_file_archive_start_ofs = archive_ofs;
+            pZip->m_archive_size -= archive_ofs;
+        }
+
+        pZip->m_central_directory_file_ofs = cdir_ofs;
+
+        if (pZip->m_total_files)
+        {
+            mz_uint i, n;
+            /* Read the entire central directory into a heap block, and allocate another heap block to hold the unsorted central dir file record offsets, and possibly another to hold the sorted indices. */
+            if ((!mz_zip_array_resize(pZip, &pZip->m_pState->m_central_dir, cdir_size, MZ_FALSE)) ||
+                (!mz_zip_array_resize(pZip, &pZip->m_pState->m_central_dir_offsets, pZip->m_total_files, MZ_FALSE)))
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
             if (sort_central_dir)
-                MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_sorted_central_dir_offsets, mz_uint32, i) = i;
-
-            comp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS);
-            decomp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS);
-            local_header_ofs = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
-            filename_size = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-            ext_data_size = MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS);
-
-            if ((!pZip->m_pState->m_zip64_has_extended_info_fields) &&
-                (ext_data_size) &&
-                (MZ_MAX(MZ_MAX(comp_size, decomp_size), local_header_ofs) == MZ_UINT32_MAX))
             {
-                /* Attempt to find zip64 extended information field in the entry's extra data */
-                mz_uint32 extra_size_remaining = ext_data_size;
+                if (!mz_zip_array_resize(pZip, &pZip->m_pState->m_sorted_central_dir_offsets, pZip->m_total_files, MZ_FALSE))
+                    return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
 
-                if (extra_size_remaining)
+            if (pZip->m_pRead(pZip->m_pIO_opaque, cdir_ofs, pZip->m_pState->m_central_dir.m_p, cdir_size) != cdir_size)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+
+            /* Now create an index into the central directory file records, do some basic sanity checking on each record */
+            p = (const mz_uint8 *)pZip->m_pState->m_central_dir.m_p;
+            for (n = cdir_size, i = 0; i < pZip->m_total_files; ++i)
+            {
+                mz_uint total_header_size, disk_index, bit_flags, filename_size, ext_data_size;
+                mz_uint64 comp_size, decomp_size, local_header_ofs;
+
+                if ((n < MZ_ZIP_CENTRAL_DIR_HEADER_SIZE) || (MZ_READ_LE32(p) != MZ_ZIP_CENTRAL_DIR_HEADER_SIG))
+                    return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, i) = (mz_uint32)(p - (const mz_uint8 *)pZip->m_pState->m_central_dir.m_p);
+
+                if (sort_central_dir)
+                    MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_sorted_central_dir_offsets, mz_uint32, i) = i;
+
+                comp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS);
+                decomp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS);
+                local_header_ofs = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
+                filename_size = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+                ext_data_size = MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS);
+
+                if ((!pZip->m_pState->m_zip64_has_extended_info_fields) &&
+                    (ext_data_size) &&
+                    (MZ_MAX(MZ_MAX(comp_size, decomp_size), local_header_ofs) == MZ_UINT32_MAX))
                 {
-					const mz_uint8 *pExtra_data;
-					void* buf = NULL;
+                    /* Attempt to find zip64 extended information field in the entry's extra data */
+                    mz_uint32 extra_size_remaining = ext_data_size;
 
-					if (MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size + ext_data_size > n)
-					{
-						buf = MZ_MALLOC(ext_data_size);
-						if(buf==NULL)
-							return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-						if (pZip->m_pRead(pZip->m_pIO_opaque, cdir_ofs + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size, buf, ext_data_size) != ext_data_size)
-						{
-							MZ_FREE(buf);
-							return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-						}
-
-						pExtra_data = (mz_uint8*)buf;
-					}
-					else
-					{
-						pExtra_data = p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size;
-					}
-
-                    do
+                    if (extra_size_remaining)
                     {
-                        mz_uint32 field_id;
-                        mz_uint32 field_data_size;
+                        const mz_uint8 *pExtra_data;
+                        void *buf = NULL;
 
-						if (extra_size_remaining < (sizeof(mz_uint16) * 2))
-						{
-							MZ_FREE(buf);
-							return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-						}
-
-                        field_id = MZ_READ_LE16(pExtra_data);
-                        field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
-
-						if ((field_data_size + sizeof(mz_uint16) * 2) > extra_size_remaining)
-						{
-							MZ_FREE(buf);
-							return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-						}
-
-                        if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
+                        if (MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size + ext_data_size > n)
                         {
-                            /* Ok, the archive didn't have any zip64 headers but it uses a zip64 extended information field so mark it as zip64 anyway (this can occur with infozip's zip util when it reads compresses files from stdin). */
-                            pZip->m_pState->m_zip64 = MZ_TRUE;
-                            pZip->m_pState->m_zip64_has_extended_info_fields = MZ_TRUE;
+                            buf = MZ_MALLOC(ext_data_size);
+                            if (buf == NULL)
+                                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+                            if (pZip->m_pRead(pZip->m_pIO_opaque, cdir_ofs + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size, buf, ext_data_size) != ext_data_size)
+                            {
+                                MZ_FREE(buf);
+                                return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                            }
+
+                            pExtra_data = (mz_uint8 *)buf;
+                        }
+                        else
+                        {
+                            pExtra_data = p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size;
+                        }
+
+                        do
+                        {
+                            mz_uint32 field_id;
+                            mz_uint32 field_data_size;
+
+                            if (extra_size_remaining < (sizeof(mz_uint16) * 2))
+                            {
+                                MZ_FREE(buf);
+                                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                            }
+
+                            field_id = MZ_READ_LE16(pExtra_data);
+                            field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
+
+                            if ((field_data_size + sizeof(mz_uint16) * 2) > extra_size_remaining)
+                            {
+                                MZ_FREE(buf);
+                                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                            }
+
+                            if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
+                            {
+                                /* Ok, the archive didn't have any zip64 headers but it uses a zip64 extended information field so mark it as zip64 anyway (this can occur with infozip's zip util when it reads compresses files from stdin). */
+                                pZip->m_pState->m_zip64 = MZ_TRUE;
+                                pZip->m_pState->m_zip64_has_extended_info_fields = MZ_TRUE;
+                                break;
+                            }
+
+                            pExtra_data += sizeof(mz_uint16) * 2 + field_data_size;
+                            extra_size_remaining = extra_size_remaining - sizeof(mz_uint16) * 2 - field_data_size;
+                        } while (extra_size_remaining);
+
+                        MZ_FREE(buf);
+                    }
+                }
+
+                /* I've seen archives that aren't marked as zip64 that uses zip64 ext data, argh */
+                if ((comp_size != MZ_UINT32_MAX) && (decomp_size != MZ_UINT32_MAX))
+                {
+                    if (((!MZ_READ_LE32(p + MZ_ZIP_CDH_METHOD_OFS)) && (decomp_size != comp_size)) || (decomp_size && !comp_size))
+                        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                }
+
+                disk_index = MZ_READ_LE16(p + MZ_ZIP_CDH_DISK_START_OFS);
+                if ((disk_index == MZ_UINT16_MAX) || ((disk_index != num_this_disk) && (disk_index != 1)))
+                    return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
+
+                if (comp_size != MZ_UINT32_MAX)
+                {
+                    if (((mz_uint64)MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS) + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + comp_size) > pZip->m_archive_size)
+                        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                }
+
+                bit_flags = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
+                if (bit_flags & MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_LOCAL_DIR_IS_MASKED)
+                    return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
+
+                if ((total_header_size = MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS) + MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS) + MZ_READ_LE16(p + MZ_ZIP_CDH_COMMENT_LEN_OFS)) > n)
+                    return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                n -= total_header_size;
+                p += total_header_size;
+            }
+        }
+
+        if (sort_central_dir)
+            mz_zip_reader_sort_central_dir_offsets_by_filename(pZip);
+
+        return MZ_TRUE;
+    }
+
+    void mz_zip_zero_struct(mz_zip_archive *pZip)
+    {
+        if (pZip)
+            MZ_CLEAR_PTR(pZip);
+    }
+
+    static mz_bool mz_zip_reader_end_internal(mz_zip_archive *pZip, mz_bool set_last_error)
+    {
+        mz_bool status = MZ_TRUE;
+
+        if (!pZip)
+            return MZ_FALSE;
+
+        if ((!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || (pZip->m_zip_mode != MZ_ZIP_MODE_READING))
+        {
+            if (set_last_error)
+                pZip->m_last_error = MZ_ZIP_INVALID_PARAMETER;
+
+            return MZ_FALSE;
+        }
+
+        if (pZip->m_pState)
+        {
+            mz_zip_internal_state *pState = pZip->m_pState;
+            pZip->m_pState = NULL;
+
+            mz_zip_array_clear(pZip, &pState->m_central_dir);
+            mz_zip_array_clear(pZip, &pState->m_central_dir_offsets);
+            mz_zip_array_clear(pZip, &pState->m_sorted_central_dir_offsets);
+
+#ifndef MINIZ_NO_STDIO
+            if (pState->m_pFile)
+            {
+                if (pZip->m_zip_type == MZ_ZIP_TYPE_FILE)
+                {
+                    if (MZ_FCLOSE(pState->m_pFile) == EOF)
+                    {
+                        if (set_last_error)
+                            pZip->m_last_error = MZ_ZIP_FILE_CLOSE_FAILED;
+                        status = MZ_FALSE;
+                    }
+                }
+                pState->m_pFile = NULL;
+            }
+#endif /* #ifndef MINIZ_NO_STDIO */
+
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+        }
+        pZip->m_zip_mode = MZ_ZIP_MODE_INVALID;
+
+        return status;
+    }
+
+    mz_bool mz_zip_reader_end(mz_zip_archive *pZip)
+    {
+        return mz_zip_reader_end_internal(pZip, MZ_TRUE);
+    }
+    mz_bool mz_zip_reader_init(mz_zip_archive *pZip, mz_uint64 size, mz_uint flags)
+    {
+        if ((!pZip) || (!pZip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (!mz_zip_reader_init_internal(pZip, flags))
+            return MZ_FALSE;
+
+        pZip->m_zip_type = MZ_ZIP_TYPE_USER;
+        pZip->m_archive_size = size;
+
+        if (!mz_zip_reader_read_central_dir(pZip, flags))
+        {
+            mz_zip_reader_end_internal(pZip, MZ_FALSE);
+            return MZ_FALSE;
+        }
+
+        return MZ_TRUE;
+    }
+
+    static size_t mz_zip_mem_read_func(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
+    {
+        mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
+        size_t s = (file_ofs >= pZip->m_archive_size) ? 0 : (size_t)MZ_MIN(pZip->m_archive_size - file_ofs, n);
+        memcpy(pBuf, (const mz_uint8 *)pZip->m_pState->m_pMem + file_ofs, s);
+        return s;
+    }
+
+    mz_bool mz_zip_reader_init_mem(mz_zip_archive *pZip, const void *pMem, size_t size, mz_uint flags)
+    {
+        if (!pMem)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+
+        if (!mz_zip_reader_init_internal(pZip, flags))
+            return MZ_FALSE;
+
+        pZip->m_zip_type = MZ_ZIP_TYPE_MEMORY;
+        pZip->m_archive_size = size;
+        pZip->m_pRead = mz_zip_mem_read_func;
+        pZip->m_pIO_opaque = pZip;
+        pZip->m_pNeeds_keepalive = NULL;
+
+#ifdef __cplusplus
+        pZip->m_pState->m_pMem = const_cast<void *>(pMem);
+#else
+    pZip->m_pState->m_pMem = (void *)pMem;
+#endif
+
+        pZip->m_pState->m_mem_size = size;
+
+        if (!mz_zip_reader_read_central_dir(pZip, flags))
+        {
+            mz_zip_reader_end_internal(pZip, MZ_FALSE);
+            return MZ_FALSE;
+        }
+
+        return MZ_TRUE;
+    }
+
+#ifndef MINIZ_NO_STDIO
+    static size_t mz_zip_file_read_func(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
+    {
+        mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
+        mz_int64 cur_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
+
+        file_ofs += pZip->m_pState->m_file_archive_start_ofs;
+
+        if (((mz_int64)file_ofs < 0) || (((cur_ofs != (mz_int64)file_ofs)) && (MZ_FSEEK64(pZip->m_pState->m_pFile, (mz_int64)file_ofs, SEEK_SET))))
+            return 0;
+
+        return MZ_FREAD(pBuf, 1, n, pZip->m_pState->m_pFile);
+    }
+
+    mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint32 flags)
+    {
+        return mz_zip_reader_init_file_v2(pZip, pFilename, flags, 0, 0);
+    }
+
+    mz_bool mz_zip_reader_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags, mz_uint64 file_start_ofs, mz_uint64 archive_size)
+    {
+        mz_uint64 file_size;
+        MZ_FILE *pFile;
+
+        if ((!pZip) || (!pFilename) || ((archive_size) && (archive_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pFile = MZ_FOPEN(pFilename, (flags & MZ_ZIP_FLAG_READ_ALLOW_WRITING ) ? "r+b" : "rb");
+        if (!pFile)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+
+        file_size = archive_size;
+        if (!file_size)
+        {
+            if (MZ_FSEEK64(pFile, 0, SEEK_END))
+            {
+                MZ_FCLOSE(pFile);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
+            }
+
+            file_size = MZ_FTELL64(pFile);
+        }
+
+        /* TODO: Better sanity check archive_size and the # of actual remaining bytes */
+
+        if (file_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
+        {
+            MZ_FCLOSE(pFile);
+            return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+        }
+
+        if (!mz_zip_reader_init_internal(pZip, flags))
+        {
+            MZ_FCLOSE(pFile);
+            return MZ_FALSE;
+        }
+
+        pZip->m_zip_type = MZ_ZIP_TYPE_FILE;
+        pZip->m_pRead = mz_zip_file_read_func;
+        pZip->m_pIO_opaque = pZip;
+        pZip->m_pState->m_pFile = pFile;
+        pZip->m_archive_size = file_size;
+        pZip->m_pState->m_file_archive_start_ofs = file_start_ofs;
+
+        if (!mz_zip_reader_read_central_dir(pZip, flags))
+        {
+            mz_zip_reader_end_internal(pZip, MZ_FALSE);
+            return MZ_FALSE;
+        }
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_reader_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint64 archive_size, mz_uint flags)
+    {
+        mz_uint64 cur_file_ofs;
+
+        if ((!pZip) || (!pFile))
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+
+        cur_file_ofs = MZ_FTELL64(pFile);
+
+        if (!archive_size)
+        {
+            if (MZ_FSEEK64(pFile, 0, SEEK_END))
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
+
+            archive_size = MZ_FTELL64(pFile) - cur_file_ofs;
+
+            if (archive_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
+                return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
+        }
+
+        if (!mz_zip_reader_init_internal(pZip, flags))
+            return MZ_FALSE;
+
+        pZip->m_zip_type = MZ_ZIP_TYPE_CFILE;
+        pZip->m_pRead = mz_zip_file_read_func;
+
+        pZip->m_pIO_opaque = pZip;
+        pZip->m_pState->m_pFile = pFile;
+        pZip->m_archive_size = archive_size;
+        pZip->m_pState->m_file_archive_start_ofs = cur_file_ofs;
+
+        if (!mz_zip_reader_read_central_dir(pZip, flags))
+        {
+            mz_zip_reader_end_internal(pZip, MZ_FALSE);
+            return MZ_FALSE;
+        }
+
+        return MZ_TRUE;
+    }
+
+#endif /* #ifndef MINIZ_NO_STDIO */
+
+    static MZ_FORCEINLINE const mz_uint8 *mz_zip_get_cdh(mz_zip_archive *pZip, mz_uint file_index)
+    {
+        if ((!pZip) || (!pZip->m_pState) || (file_index >= pZip->m_total_files))
+            return NULL;
+        return &MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index));
+    }
+
+    mz_bool mz_zip_reader_is_file_encrypted(mz_zip_archive *pZip, mz_uint file_index)
+    {
+        mz_uint m_bit_flag;
+        const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
+        if (!p)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+            return MZ_FALSE;
+        }
+
+        m_bit_flag = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
+        return (m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION)) != 0;
+    }
+
+    mz_bool mz_zip_reader_is_file_supported(mz_zip_archive *pZip, mz_uint file_index)
+    {
+        mz_uint bit_flag;
+        mz_uint method;
+
+        const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
+        if (!p)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+            return MZ_FALSE;
+        }
+
+        method = MZ_READ_LE16(p + MZ_ZIP_CDH_METHOD_OFS);
+        bit_flag = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
+
+        if ((method != 0) && (method != MZ_DEFLATED))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
+            return MZ_FALSE;
+        }
+
+        if (bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
+            return MZ_FALSE;
+        }
+
+        if (bit_flag & MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
+            return MZ_FALSE;
+        }
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_reader_is_file_a_directory(mz_zip_archive *pZip, mz_uint file_index)
+    {
+        mz_uint filename_len, attribute_mapping_id, external_attr;
+        const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
+        if (!p)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+            return MZ_FALSE;
+        }
+
+        filename_len = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+        if (filename_len)
+        {
+            if (*(p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_len - 1) == '/')
+                return MZ_TRUE;
+        }
+
+        /* Bugfix: This code was also checking if the internal attribute was non-zero, which wasn't correct. */
+        /* Most/all zip writers (hopefully) set DOS file/directory attributes in the low 16-bits, so check for the DOS directory flag and ignore the source OS ID in the created by field. */
+        /* FIXME: Remove this check? Is it necessary - we already check the filename. */
+        attribute_mapping_id = MZ_READ_LE16(p + MZ_ZIP_CDH_VERSION_MADE_BY_OFS) >> 8;
+        (void)attribute_mapping_id;
+
+        external_attr = MZ_READ_LE32(p + MZ_ZIP_CDH_EXTERNAL_ATTR_OFS);
+        if ((external_attr & MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG) != 0)
+        {
+            return MZ_TRUE;
+        }
+
+        return MZ_FALSE;
+    }
+
+    static mz_bool mz_zip_file_stat_internal(mz_zip_archive *pZip, mz_uint file_index, const mz_uint8 *pCentral_dir_header, mz_zip_archive_file_stat *pStat, mz_bool *pFound_zip64_extra_data)
+    {
+        mz_uint n;
+        const mz_uint8 *p = pCentral_dir_header;
+
+        if (pFound_zip64_extra_data)
+            *pFound_zip64_extra_data = MZ_FALSE;
+
+        if ((!p) || (!pStat))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        /* Extract fields from the central directory record. */
+        pStat->m_file_index = file_index;
+        pStat->m_central_dir_ofs = MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index);
+        pStat->m_version_made_by = MZ_READ_LE16(p + MZ_ZIP_CDH_VERSION_MADE_BY_OFS);
+        pStat->m_version_needed = MZ_READ_LE16(p + MZ_ZIP_CDH_VERSION_NEEDED_OFS);
+        pStat->m_bit_flag = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
+        pStat->m_method = MZ_READ_LE16(p + MZ_ZIP_CDH_METHOD_OFS);
+#ifndef MINIZ_NO_TIME
+        pStat->m_time = mz_zip_dos_to_time_t(MZ_READ_LE16(p + MZ_ZIP_CDH_FILE_TIME_OFS), MZ_READ_LE16(p + MZ_ZIP_CDH_FILE_DATE_OFS));
+#endif
+        pStat->m_crc32 = MZ_READ_LE32(p + MZ_ZIP_CDH_CRC32_OFS);
+        pStat->m_comp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS);
+        pStat->m_uncomp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS);
+        pStat->m_internal_attr = MZ_READ_LE16(p + MZ_ZIP_CDH_INTERNAL_ATTR_OFS);
+        pStat->m_external_attr = MZ_READ_LE32(p + MZ_ZIP_CDH_EXTERNAL_ATTR_OFS);
+        pStat->m_local_header_ofs = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
+
+        /* Copy as much of the filename and comment as possible. */
+        n = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+        n = MZ_MIN(n, MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE - 1);
+        memcpy(pStat->m_filename, p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, n);
+        pStat->m_filename[n] = '\0';
+
+        n = MZ_READ_LE16(p + MZ_ZIP_CDH_COMMENT_LEN_OFS);
+        n = MZ_MIN(n, MZ_ZIP_MAX_ARCHIVE_FILE_COMMENT_SIZE - 1);
+        pStat->m_comment_size = n;
+        memcpy(pStat->m_comment, p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS) + MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS), n);
+        pStat->m_comment[n] = '\0';
+
+        /* Set some flags for convienance */
+        pStat->m_is_directory = mz_zip_reader_is_file_a_directory(pZip, file_index);
+        pStat->m_is_encrypted = mz_zip_reader_is_file_encrypted(pZip, file_index);
+        pStat->m_is_supported = mz_zip_reader_is_file_supported(pZip, file_index);
+
+        /* See if we need to read any zip64 extended information fields. */
+        /* Confusingly, these zip64 fields can be present even on non-zip64 archives (Debian zip on a huge files from stdin piped to stdout creates them). */
+        if (MZ_MAX(MZ_MAX(pStat->m_comp_size, pStat->m_uncomp_size), pStat->m_local_header_ofs) == MZ_UINT32_MAX)
+        {
+            /* Attempt to find zip64 extended information field in the entry's extra data */
+            mz_uint32 extra_size_remaining = MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS);
+
+            if (extra_size_remaining)
+            {
+                const mz_uint8 *pExtra_data = p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+
+                do
+                {
+                    mz_uint32 field_id;
+                    mz_uint32 field_data_size;
+
+                    if (extra_size_remaining < (sizeof(mz_uint16) * 2))
+                        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                    field_id = MZ_READ_LE16(pExtra_data);
+                    field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
+
+                    if ((field_data_size + sizeof(mz_uint16) * 2) > extra_size_remaining)
+                        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                    if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
+                    {
+                        const mz_uint8 *pField_data = pExtra_data + sizeof(mz_uint16) * 2;
+                        mz_uint32 field_data_remaining = field_data_size;
+
+                        if (pFound_zip64_extra_data)
+                            *pFound_zip64_extra_data = MZ_TRUE;
+
+                        if (pStat->m_uncomp_size == MZ_UINT32_MAX)
+                        {
+                            if (field_data_remaining < sizeof(mz_uint64))
+                                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                            pStat->m_uncomp_size = MZ_READ_LE64(pField_data);
+                            pField_data += sizeof(mz_uint64);
+                            field_data_remaining -= sizeof(mz_uint64);
+                        }
+
+                        if (pStat->m_comp_size == MZ_UINT32_MAX)
+                        {
+                            if (field_data_remaining < sizeof(mz_uint64))
+                                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                            pStat->m_comp_size = MZ_READ_LE64(pField_data);
+                            pField_data += sizeof(mz_uint64);
+                            field_data_remaining -= sizeof(mz_uint64);
+                        }
+
+                        if (pStat->m_local_header_ofs == MZ_UINT32_MAX)
+                        {
+                            if (field_data_remaining < sizeof(mz_uint64))
+                                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+                            pStat->m_local_header_ofs = MZ_READ_LE64(pField_data);
+                            pField_data += sizeof(mz_uint64);
+                            field_data_remaining -= sizeof(mz_uint64);
+                        }
+
+                        break;
+                    }
+
+                    pExtra_data += sizeof(mz_uint16) * 2 + field_data_size;
+                    extra_size_remaining = extra_size_remaining - sizeof(mz_uint16) * 2 - field_data_size;
+                } while (extra_size_remaining);
+            }
+        }
+
+        return MZ_TRUE;
+    }
+
+    static MZ_FORCEINLINE mz_bool mz_zip_string_equal(const char *pA, const char *pB, mz_uint len, mz_uint flags)
+    {
+        mz_uint i;
+        if (flags & MZ_ZIP_FLAG_CASE_SENSITIVE)
+            return 0 == memcmp(pA, pB, len);
+        for (i = 0; i < len; ++i)
+            if (MZ_TOLOWER(pA[i]) != MZ_TOLOWER(pB[i]))
+                return MZ_FALSE;
+        return MZ_TRUE;
+    }
+
+    static MZ_FORCEINLINE int mz_zip_filename_compare(const mz_zip_array *pCentral_dir_array, const mz_zip_array *pCentral_dir_offsets, mz_uint l_index, const char *pR, mz_uint r_len)
+    {
+        const mz_uint8 *pL = &MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_array, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_offsets, mz_uint32, l_index)), *pE;
+        mz_uint l_len = MZ_READ_LE16(pL + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+        mz_uint8 l = 0, r = 0;
+        pL += MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
+        pE = pL + MZ_MIN(l_len, r_len);
+        while (pL < pE)
+        {
+            if ((l = MZ_TOLOWER(*pL)) != (r = MZ_TOLOWER(*pR)))
+                break;
+            pL++;
+            pR++;
+        }
+        return (pL == pE) ? (int)(l_len - r_len) : (l - r);
+    }
+
+    static mz_bool mz_zip_locate_file_binary_search(mz_zip_archive *pZip, const char *pFilename, mz_uint32 *pIndex)
+    {
+        mz_zip_internal_state *pState = pZip->m_pState;
+        const mz_zip_array *pCentral_dir_offsets = &pState->m_central_dir_offsets;
+        const mz_zip_array *pCentral_dir = &pState->m_central_dir;
+        mz_uint32 *pIndices = &MZ_ZIP_ARRAY_ELEMENT(&pState->m_sorted_central_dir_offsets, mz_uint32, 0);
+        const mz_uint32 size = pZip->m_total_files;
+        const mz_uint filename_len = (mz_uint)strlen(pFilename);
+
+        if (pIndex)
+            *pIndex = 0;
+
+        if (size)
+        {
+            /* yes I could use uint32_t's, but then we would have to add some special case checks in the loop, argh, and */
+            /* honestly the major expense here on 32-bit CPU's will still be the filename compare */
+            mz_int64 l = 0, h = (mz_int64)size - 1;
+
+            while (l <= h)
+            {
+                mz_int64 m = l + ((h - l) >> 1);
+                mz_uint32 file_index = pIndices[(mz_uint32)m];
+
+                int comp = mz_zip_filename_compare(pCentral_dir, pCentral_dir_offsets, file_index, pFilename, filename_len);
+                if (!comp)
+                {
+                    if (pIndex)
+                        *pIndex = file_index;
+                    return MZ_TRUE;
+                }
+                else if (comp < 0)
+                    l = m + 1;
+                else
+                    h = m - 1;
+            }
+        }
+
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_NOT_FOUND);
+    }
+
+    int mz_zip_reader_locate_file(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags)
+    {
+        mz_uint32 index;
+        if (!mz_zip_reader_locate_file_v2(pZip, pName, pComment, flags, &index))
+            return -1;
+        else
+            return (int)index;
+    }
+
+    mz_bool mz_zip_reader_locate_file_v2(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags, mz_uint32 *pIndex)
+    {
+        mz_uint file_index;
+        size_t name_len, comment_len;
+
+        if (pIndex)
+            *pIndex = 0;
+
+        if ((!pZip) || (!pZip->m_pState) || (!pName))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        /* See if we can use a binary search */
+        if (((pZip->m_pState->m_init_flags & MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY) == 0) &&
+            (pZip->m_zip_mode == MZ_ZIP_MODE_READING) &&
+            ((flags & (MZ_ZIP_FLAG_IGNORE_PATH | MZ_ZIP_FLAG_CASE_SENSITIVE)) == 0) && (!pComment) && (pZip->m_pState->m_sorted_central_dir_offsets.m_size))
+        {
+            return mz_zip_locate_file_binary_search(pZip, pName, pIndex);
+        }
+
+        /* Locate the entry by scanning the entire central directory */
+        name_len = strlen(pName);
+        if (name_len > MZ_UINT16_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        comment_len = pComment ? strlen(pComment) : 0;
+        if (comment_len > MZ_UINT16_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        for (file_index = 0; file_index < pZip->m_total_files; file_index++)
+        {
+            const mz_uint8 *pHeader = &MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index));
+            mz_uint filename_len = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+            const char *pFilename = (const char *)pHeader + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
+            if (filename_len < name_len)
+                continue;
+            if (comment_len)
+            {
+                mz_uint file_extra_len = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_EXTRA_LEN_OFS), file_comment_len = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_COMMENT_LEN_OFS);
+                const char *pFile_comment = pFilename + filename_len + file_extra_len;
+                if ((file_comment_len != comment_len) || (!mz_zip_string_equal(pComment, pFile_comment, file_comment_len, flags)))
+                    continue;
+            }
+            if ((flags & MZ_ZIP_FLAG_IGNORE_PATH) && (filename_len))
+            {
+                int ofs = filename_len - 1;
+                do
+                {
+                    if ((pFilename[ofs] == '/') || (pFilename[ofs] == '\\') || (pFilename[ofs] == ':'))
+                        break;
+                } while (--ofs >= 0);
+                ofs++;
+                pFilename += ofs;
+                filename_len -= ofs;
+            }
+            if ((filename_len == name_len) && (mz_zip_string_equal(pName, pFilename, filename_len, flags)))
+            {
+                if (pIndex)
+                    *pIndex = file_index;
+                return MZ_TRUE;
+            }
+        }
+
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_NOT_FOUND);
+    }
+
+    static mz_bool mz_zip_reader_extract_to_mem_no_alloc1(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size, const mz_zip_archive_file_stat *st)
+    {
+        int status = TINFL_STATUS_DONE;
+        mz_uint64 needed_size, cur_file_ofs, comp_remaining, out_buf_ofs = 0, read_buf_size, read_buf_ofs = 0, read_buf_avail;
+        mz_zip_archive_file_stat file_stat;
+        void *pRead_buf;
+        mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
+        tinfl_decompressor inflator;
+
+        if ((!pZip) || (!pZip->m_pState) || ((buf_size) && (!pBuf)) || ((user_read_buf_size) && (!pUser_read_buf)) || (!pZip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (st)
+        {
+            file_stat = *st;
+        }
+        else if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
+            return MZ_FALSE;
+
+        /* A directory or zero length file */
+        if ((file_stat.m_is_directory) || (!file_stat.m_comp_size))
+            return MZ_TRUE;
+
+        /* Encryption and patch files are not supported. */
+        if (file_stat.m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
+
+        /* This function only supports decompressing stored and deflate. */
+        if ((!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (file_stat.m_method != 0) && (file_stat.m_method != MZ_DEFLATED))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
+
+        /* Ensure supplied output buffer is large enough. */
+        needed_size = (flags & MZ_ZIP_FLAG_COMPRESSED_DATA) ? file_stat.m_comp_size : file_stat.m_uncomp_size;
+        if (buf_size < needed_size)
+            return mz_zip_set_error(pZip, MZ_ZIP_BUF_TOO_SMALL);
+
+        /* Read and parse the local directory entry. */
+        cur_file_ofs = file_stat.m_local_header_ofs;
+        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+
+        if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        cur_file_ofs += (mz_uint64)(MZ_ZIP_LOCAL_DIR_HEADER_SIZE) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
+        if ((cur_file_ofs + file_stat.m_comp_size) > pZip->m_archive_size)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        if ((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!file_stat.m_method))
+        {
+            /* The file is stored or the caller has requested the compressed data. */
+            if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pBuf, (size_t)needed_size) != needed_size)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+            if ((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) == 0)
+            {
+                if (mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)pBuf, (size_t)file_stat.m_uncomp_size) != file_stat.m_crc32)
+                    return mz_zip_set_error(pZip, MZ_ZIP_CRC_CHECK_FAILED);
+            }
+#endif
+
+            return MZ_TRUE;
+        }
+
+        /* Decompress the file either directly from memory or from a file input buffer. */
+        tinfl_init(&inflator);
+
+        if (pZip->m_pState->m_pMem)
+        {
+            /* Read directly from the archive in memory. */
+            pRead_buf = (mz_uint8 *)pZip->m_pState->m_pMem + cur_file_ofs;
+            read_buf_size = read_buf_avail = file_stat.m_comp_size;
+            comp_remaining = 0;
+        }
+        else if (pUser_read_buf)
+        {
+            /* Use a user provided read buffer. */
+            if (!user_read_buf_size)
+                return MZ_FALSE;
+            pRead_buf = (mz_uint8 *)pUser_read_buf;
+            read_buf_size = user_read_buf_size;
+            read_buf_avail = 0;
+            comp_remaining = file_stat.m_comp_size;
+        }
+        else
+        {
+            /* Temporarily allocate a read buffer. */
+            read_buf_size = MZ_MIN(file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
+            if (((sizeof(size_t) == sizeof(mz_uint32))) && (read_buf_size > 0x7FFFFFFF))
+                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+            if (NULL == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+            read_buf_avail = 0;
+            comp_remaining = file_stat.m_comp_size;
+        }
+
+        do
+        {
+            /* The size_t cast here should be OK because we've verified that the output buffer is >= file_stat.m_uncomp_size above */
+            size_t in_buf_size, out_buf_size = (size_t)(file_stat.m_uncomp_size - out_buf_ofs);
+            if ((!read_buf_avail) && (!pZip->m_pState->m_pMem))
+            {
+                read_buf_avail = MZ_MIN(read_buf_size, comp_remaining);
+                if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
+                {
+                    status = TINFL_STATUS_FAILED;
+                    mz_zip_set_error(pZip, MZ_ZIP_DECOMPRESSION_FAILED);
+                    break;
+                }
+                cur_file_ofs += read_buf_avail;
+                comp_remaining -= read_buf_avail;
+                read_buf_ofs = 0;
+            }
+            in_buf_size = (size_t)read_buf_avail;
+            status = tinfl_decompress(&inflator, (mz_uint8 *)pRead_buf + read_buf_ofs, &in_buf_size, (mz_uint8 *)pBuf, (mz_uint8 *)pBuf + out_buf_ofs, &out_buf_size, TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF | (comp_remaining ? TINFL_FLAG_HAS_MORE_INPUT : 0));
+            read_buf_avail -= in_buf_size;
+            read_buf_ofs += in_buf_size;
+            out_buf_ofs += out_buf_size;
+        } while (status == TINFL_STATUS_NEEDS_MORE_INPUT);
+
+        if (status == TINFL_STATUS_DONE)
+        {
+            /* Make sure the entire file was decompressed, and check its CRC. */
+            if (out_buf_ofs != file_stat.m_uncomp_size)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE);
+                status = TINFL_STATUS_FAILED;
+            }
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+            else if (mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)pBuf, (size_t)file_stat.m_uncomp_size) != file_stat.m_crc32)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_CRC_CHECK_FAILED);
+                status = TINFL_STATUS_FAILED;
+            }
+#endif
+        }
+
+        if ((!pZip->m_pState->m_pMem) && (!pUser_read_buf))
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+
+        return status == TINFL_STATUS_DONE;
+    }
+
+    mz_bool mz_zip_reader_extract_to_mem_no_alloc(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size)
+    {
+        return mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, buf_size, flags, pUser_read_buf, user_read_buf_size, NULL);
+    }
+
+    mz_bool mz_zip_reader_extract_file_to_mem_no_alloc(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size)
+    {
+        mz_uint32 file_index;
+        if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+            return MZ_FALSE;
+        return mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, buf_size, flags, pUser_read_buf, user_read_buf_size, NULL);
+    }
+
+    mz_bool mz_zip_reader_extract_to_mem(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags)
+    {
+        return mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, buf_size, flags, NULL, 0, NULL);
+    }
+
+    mz_bool mz_zip_reader_extract_file_to_mem(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags)
+    {
+        return mz_zip_reader_extract_file_to_mem_no_alloc(pZip, pFilename, pBuf, buf_size, flags, NULL, 0);
+    }
+
+    void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, size_t *pSize, mz_uint flags)
+    {
+        mz_zip_archive_file_stat file_stat;
+        mz_uint64 alloc_size;
+        void *pBuf;
+
+        if (pSize)
+            *pSize = 0;
+
+        if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
+            return NULL;
+
+        alloc_size = (flags & MZ_ZIP_FLAG_COMPRESSED_DATA) ? file_stat.m_comp_size : file_stat.m_uncomp_size;
+        if (((sizeof(size_t) == sizeof(mz_uint32))) && (alloc_size > 0x7FFFFFFF))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+            return NULL;
+        }
+
+        if (NULL == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)alloc_size)))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            return NULL;
+        }
+
+        if (!mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, (size_t)alloc_size, flags, NULL, 0, &file_stat))
+        {
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
+            return NULL;
+        }
+
+        if (pSize)
+            *pSize = (size_t)alloc_size;
+        return pBuf;
+    }
+
+    void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFilename, size_t *pSize, mz_uint flags)
+    {
+        mz_uint32 file_index;
+        if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+        {
+            if (pSize)
+                *pSize = 0;
+            return MZ_FALSE;
+        }
+        return mz_zip_reader_extract_to_heap(pZip, file_index, pSize, flags);
+    }
+
+    mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_index, mz_file_write_func pCallback, void *pOpaque, mz_uint flags)
+    {
+        int status = TINFL_STATUS_DONE;
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+        mz_uint file_crc32 = MZ_CRC32_INIT;
+#endif
+        mz_uint64 read_buf_size, read_buf_ofs = 0, read_buf_avail, comp_remaining, out_buf_ofs = 0, cur_file_ofs;
+        mz_zip_archive_file_stat file_stat;
+        void *pRead_buf = NULL;
+        void *pWrite_buf = NULL;
+        mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
+
+        if ((!pZip) || (!pZip->m_pState) || (!pCallback) || (!pZip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
+            return MZ_FALSE;
+
+        /* A directory or zero length file */
+        if ((file_stat.m_is_directory) || (!file_stat.m_comp_size))
+            return MZ_TRUE;
+
+        /* Encryption and patch files are not supported. */
+        if (file_stat.m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
+
+        /* This function only supports decompressing stored and deflate. */
+        if ((!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (file_stat.m_method != 0) && (file_stat.m_method != MZ_DEFLATED))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
+
+        /* Read and do some minimal validation of the local directory entry (this doesn't crack the zip64 stuff, which we already have from the central dir) */
+        cur_file_ofs = file_stat.m_local_header_ofs;
+        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+
+        if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        cur_file_ofs += (mz_uint64)(MZ_ZIP_LOCAL_DIR_HEADER_SIZE) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
+        if ((cur_file_ofs + file_stat.m_comp_size) > pZip->m_archive_size)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        /* Decompress the file either directly from memory or from a file input buffer. */
+        if (pZip->m_pState->m_pMem)
+        {
+            pRead_buf = (mz_uint8 *)pZip->m_pState->m_pMem + cur_file_ofs;
+            read_buf_size = read_buf_avail = file_stat.m_comp_size;
+            comp_remaining = 0;
+        }
+        else
+        {
+            read_buf_size = MZ_MIN(file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
+            if (NULL == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+            read_buf_avail = 0;
+            comp_remaining = file_stat.m_comp_size;
+        }
+
+        if ((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!file_stat.m_method))
+        {
+            /* The file is stored or the caller has requested the compressed data. */
+            if (pZip->m_pState->m_pMem)
+            {
+                if (((sizeof(size_t) == sizeof(mz_uint32))) && (file_stat.m_comp_size > MZ_UINT32_MAX))
+                    return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+                if (pCallback(pOpaque, out_buf_ofs, pRead_buf, (size_t)file_stat.m_comp_size) != file_stat.m_comp_size)
+                {
+                    mz_zip_set_error(pZip, MZ_ZIP_WRITE_CALLBACK_FAILED);
+                    status = TINFL_STATUS_FAILED;
+                }
+                else if (!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
+                {
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+                    file_crc32 = (mz_uint32)mz_crc32(file_crc32, (const mz_uint8 *)pRead_buf, (size_t)file_stat.m_comp_size);
+#endif
+                }
+
+                cur_file_ofs += file_stat.m_comp_size;
+                out_buf_ofs += file_stat.m_comp_size;
+                comp_remaining = 0;
+            }
+            else
+            {
+                while (comp_remaining)
+                {
+                    read_buf_avail = MZ_MIN(read_buf_size, comp_remaining);
+                    if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
+                    {
+                        mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                        status = TINFL_STATUS_FAILED;
+                        break;
+                    }
+
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+                    if (!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
+                    {
+                        file_crc32 = (mz_uint32)mz_crc32(file_crc32, (const mz_uint8 *)pRead_buf, (size_t)read_buf_avail);
+                    }
+#endif
+
+                    if (pCallback(pOpaque, out_buf_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
+                    {
+                        mz_zip_set_error(pZip, MZ_ZIP_WRITE_CALLBACK_FAILED);
+                        status = TINFL_STATUS_FAILED;
+                        break;
+                    }
+
+                    cur_file_ofs += read_buf_avail;
+                    out_buf_ofs += read_buf_avail;
+                    comp_remaining -= read_buf_avail;
+                }
+            }
+        }
+        else
+        {
+            tinfl_decompressor inflator;
+            tinfl_init(&inflator);
+
+            if (NULL == (pWrite_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, TINFL_LZ_DICT_SIZE)))
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+                status = TINFL_STATUS_FAILED;
+            }
+            else
+            {
+                do
+                {
+                    mz_uint8 *pWrite_buf_cur = (mz_uint8 *)pWrite_buf + (out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
+                    size_t in_buf_size, out_buf_size = TINFL_LZ_DICT_SIZE - (out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
+                    if ((!read_buf_avail) && (!pZip->m_pState->m_pMem))
+                    {
+                        read_buf_avail = MZ_MIN(read_buf_size, comp_remaining);
+                        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
+                        {
+                            mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                            status = TINFL_STATUS_FAILED;
+                            break;
+                        }
+                        cur_file_ofs += read_buf_avail;
+                        comp_remaining -= read_buf_avail;
+                        read_buf_ofs = 0;
+                    }
+
+                    in_buf_size = (size_t)read_buf_avail;
+                    status = tinfl_decompress(&inflator, (const mz_uint8 *)pRead_buf + read_buf_ofs, &in_buf_size, (mz_uint8 *)pWrite_buf, pWrite_buf_cur, &out_buf_size, comp_remaining ? TINFL_FLAG_HAS_MORE_INPUT : 0);
+                    read_buf_avail -= in_buf_size;
+                    read_buf_ofs += in_buf_size;
+
+                    if (out_buf_size)
+                    {
+                        if (pCallback(pOpaque, out_buf_ofs, pWrite_buf_cur, out_buf_size) != out_buf_size)
+                        {
+                            mz_zip_set_error(pZip, MZ_ZIP_WRITE_CALLBACK_FAILED);
+                            status = TINFL_STATUS_FAILED;
                             break;
                         }
 
-                        pExtra_data += sizeof(mz_uint16) * 2 + field_data_size;
-                        extra_size_remaining = extra_size_remaining - sizeof(mz_uint16) * 2 - field_data_size;
-                    } while (extra_size_remaining);
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+                        file_crc32 = (mz_uint32)mz_crc32(file_crc32, pWrite_buf_cur, out_buf_size);
+#endif
+                        if ((out_buf_ofs += out_buf_size) > file_stat.m_uncomp_size)
+                        {
+                            mz_zip_set_error(pZip, MZ_ZIP_DECOMPRESSION_FAILED);
+                            status = TINFL_STATUS_FAILED;
+                            break;
+                        }
+                    }
+                } while ((status == TINFL_STATUS_NEEDS_MORE_INPUT) || (status == TINFL_STATUS_HAS_MORE_OUTPUT));
+            }
+        }
 
-					MZ_FREE(buf);
+        if ((status == TINFL_STATUS_DONE) && (!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
+        {
+            /* Make sure the entire file was decompressed, and check its CRC. */
+            if (out_buf_ofs != file_stat.m_uncomp_size)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE);
+                status = TINFL_STATUS_FAILED;
+            }
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+            else if (file_crc32 != file_stat.m_crc32)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_DECOMPRESSION_FAILED);
+                status = TINFL_STATUS_FAILED;
+            }
+#endif
+        }
+
+        if (!pZip->m_pState->m_pMem)
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+
+        if (pWrite_buf)
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pWrite_buf);
+
+        return status == TINFL_STATUS_DONE;
+    }
+
+    mz_bool mz_zip_reader_extract_file_to_callback(mz_zip_archive *pZip, const char *pFilename, mz_file_write_func pCallback, void *pOpaque, mz_uint flags)
+    {
+        mz_uint32 file_index;
+        if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+            return MZ_FALSE;
+
+        return mz_zip_reader_extract_to_callback(pZip, file_index, pCallback, pOpaque, flags);
+    }
+
+    mz_zip_reader_extract_iter_state *mz_zip_reader_extract_iter_new(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags)
+    {
+        mz_zip_reader_extract_iter_state *pState;
+        mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
+
+        /* Argument sanity check */
+        if ((!pZip) || (!pZip->m_pState))
+            return NULL;
+
+        /* Allocate an iterator status structure */
+        pState = (mz_zip_reader_extract_iter_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_reader_extract_iter_state));
+        if (!pState)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            return NULL;
+        }
+
+        /* Fetch file details */
+        if (!mz_zip_reader_file_stat(pZip, file_index, &pState->file_stat))
+        {
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+            return NULL;
+        }
+
+        /* Encryption and patch files are not supported. */
+        if (pState->file_stat.m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+            return NULL;
+        }
+
+        /* This function only supports decompressing stored and deflate. */
+        if ((!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (pState->file_stat.m_method != 0) && (pState->file_stat.m_method != MZ_DEFLATED))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+            return NULL;
+        }
+
+        /* Init state - save args */
+        pState->pZip = pZip;
+        pState->flags = flags;
+
+        /* Init state - reset variables to defaults */
+        pState->status = TINFL_STATUS_DONE;
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+        pState->file_crc32 = MZ_CRC32_INIT;
+#endif
+        pState->read_buf_ofs = 0;
+        pState->out_buf_ofs = 0;
+        pState->pRead_buf = NULL;
+        pState->pWrite_buf = NULL;
+        pState->out_blk_remain = 0;
+
+        /* Read and parse the local directory entry. */
+        pState->cur_file_ofs = pState->file_stat.m_local_header_ofs;
+        if (pZip->m_pRead(pZip->m_pIO_opaque, pState->cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+            return NULL;
+        }
+
+        if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+            return NULL;
+        }
+
+        pState->cur_file_ofs += (mz_uint64)(MZ_ZIP_LOCAL_DIR_HEADER_SIZE) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
+        if ((pState->cur_file_ofs + pState->file_stat.m_comp_size) > pZip->m_archive_size)
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+            return NULL;
+        }
+
+        /* Decompress the file either directly from memory or from a file input buffer. */
+        if (pZip->m_pState->m_pMem)
+        {
+            pState->pRead_buf = (mz_uint8 *)pZip->m_pState->m_pMem + pState->cur_file_ofs;
+            pState->read_buf_size = pState->read_buf_avail = pState->file_stat.m_comp_size;
+            pState->comp_remaining = pState->file_stat.m_comp_size;
+        }
+        else
+        {
+            if (!((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method)))
+            {
+                /* Decompression required, therefore intermediate read buffer required */
+                pState->read_buf_size = MZ_MIN(pState->file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
+                if (NULL == (pState->pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)pState->read_buf_size)))
+                {
+                    mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+                    return NULL;
+                }
+            }
+            else
+            {
+                /* Decompression not required - we will be reading directly into user buffer, no temp buf required */
+                pState->read_buf_size = 0;
+            }
+            pState->read_buf_avail = 0;
+            pState->comp_remaining = pState->file_stat.m_comp_size;
+        }
+
+        if (!((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method)))
+        {
+            /* Decompression required, init decompressor */
+            tinfl_init(&pState->inflator);
+
+            /* Allocate write buffer */
+            if (NULL == (pState->pWrite_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, TINFL_LZ_DICT_SIZE)))
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+                if (pState->pRead_buf)
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pState->pRead_buf);
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+                return NULL;
+            }
+        }
+
+        return pState;
+    }
+
+    mz_zip_reader_extract_iter_state *mz_zip_reader_extract_file_iter_new(mz_zip_archive *pZip, const char *pFilename, mz_uint flags)
+    {
+        mz_uint32 file_index;
+
+        /* Locate file index by name */
+        if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+            return NULL;
+
+        /* Construct iterator */
+        return mz_zip_reader_extract_iter_new(pZip, file_index, flags);
+    }
+
+    size_t mz_zip_reader_extract_iter_read(mz_zip_reader_extract_iter_state *pState, void *pvBuf, size_t buf_size)
+    {
+        size_t copied_to_caller = 0;
+
+        /* Argument sanity check */
+        if ((!pState) || (!pState->pZip) || (!pState->pZip->m_pState) || (!pvBuf))
+            return 0;
+
+        if ((pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method))
+        {
+            /* The file is stored or the caller has requested the compressed data, calc amount to return. */
+            copied_to_caller = (size_t)MZ_MIN(buf_size, pState->comp_remaining);
+
+            /* Zip is in memory....or requires reading from a file? */
+            if (pState->pZip->m_pState->m_pMem)
+            {
+                /* Copy data to caller's buffer */
+                memcpy(pvBuf, pState->pRead_buf, copied_to_caller);
+                pState->pRead_buf = ((mz_uint8 *)pState->pRead_buf) + copied_to_caller;
+            }
+            else
+            {
+                /* Read directly into caller's buffer */
+                if (pState->pZip->m_pRead(pState->pZip->m_pIO_opaque, pState->cur_file_ofs, pvBuf, copied_to_caller) != copied_to_caller)
+                {
+                    /* Failed to read all that was asked for, flag failure and alert user */
+                    mz_zip_set_error(pState->pZip, MZ_ZIP_FILE_READ_FAILED);
+                    pState->status = TINFL_STATUS_FAILED;
+                    copied_to_caller = 0;
                 }
             }
 
-            /* I've seen archives that aren't marked as zip64 that uses zip64 ext data, argh */
-            if ((comp_size != MZ_UINT32_MAX) && (decomp_size != MZ_UINT32_MAX))
-            {
-                if (((!MZ_READ_LE32(p + MZ_ZIP_CDH_METHOD_OFS)) && (decomp_size != comp_size)) || (decomp_size && !comp_size))
-                    return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-            }
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+            /* Compute CRC if not returning compressed data only */
+            if (!(pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
+                pState->file_crc32 = (mz_uint32)mz_crc32(pState->file_crc32, (const mz_uint8 *)pvBuf, copied_to_caller);
+#endif
 
-            disk_index = MZ_READ_LE16(p + MZ_ZIP_CDH_DISK_START_OFS);
-            if ((disk_index == MZ_UINT16_MAX) || ((disk_index != num_this_disk) && (disk_index != 1)))
-                return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
-
-            if (comp_size != MZ_UINT32_MAX)
-            {
-                if (((mz_uint64)MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS) + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + comp_size) > pZip->m_archive_size)
-                    return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-            }
-
-            bit_flags = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
-            if (bit_flags & MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_LOCAL_DIR_IS_MASKED)
-                return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
-
-            if ((total_header_size = MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS) + MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS) + MZ_READ_LE16(p + MZ_ZIP_CDH_COMMENT_LEN_OFS)) > n)
-                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-            n -= total_header_size;
-            p += total_header_size;
+            /* Advance offsets, dec counters */
+            pState->cur_file_ofs += copied_to_caller;
+            pState->out_buf_ofs += copied_to_caller;
+            pState->comp_remaining -= copied_to_caller;
         }
+        else
+        {
+            do
+            {
+                /* Calc ptr to write buffer - given current output pos and block size */
+                mz_uint8 *pWrite_buf_cur = (mz_uint8 *)pState->pWrite_buf + (pState->out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
+
+                /* Calc max output size - given current output pos and block size */
+                size_t in_buf_size, out_buf_size = TINFL_LZ_DICT_SIZE - (pState->out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
+
+                if (!pState->out_blk_remain)
+                {
+                    /* Read more data from file if none available (and reading from file) */
+                    if ((!pState->read_buf_avail) && (!pState->pZip->m_pState->m_pMem))
+                    {
+                        /* Calc read size */
+                        pState->read_buf_avail = MZ_MIN(pState->read_buf_size, pState->comp_remaining);
+                        if (pState->pZip->m_pRead(pState->pZip->m_pIO_opaque, pState->cur_file_ofs, pState->pRead_buf, (size_t)pState->read_buf_avail) != pState->read_buf_avail)
+                        {
+                            mz_zip_set_error(pState->pZip, MZ_ZIP_FILE_READ_FAILED);
+                            pState->status = TINFL_STATUS_FAILED;
+                            break;
+                        }
+
+                        /* Advance offsets, dec counters */
+                        pState->cur_file_ofs += pState->read_buf_avail;
+                        pState->comp_remaining -= pState->read_buf_avail;
+                        pState->read_buf_ofs = 0;
+                    }
+
+                    /* Perform decompression */
+                    in_buf_size = (size_t)pState->read_buf_avail;
+                    pState->status = tinfl_decompress(&pState->inflator, (const mz_uint8 *)pState->pRead_buf + pState->read_buf_ofs, &in_buf_size, (mz_uint8 *)pState->pWrite_buf, pWrite_buf_cur, &out_buf_size, pState->comp_remaining ? TINFL_FLAG_HAS_MORE_INPUT : 0);
+                    pState->read_buf_avail -= in_buf_size;
+                    pState->read_buf_ofs += in_buf_size;
+
+                    /* Update current output block size remaining */
+                    pState->out_blk_remain = out_buf_size;
+                }
+
+                if (pState->out_blk_remain)
+                {
+                    /* Calc amount to return. */
+                    size_t to_copy = MZ_MIN((buf_size - copied_to_caller), pState->out_blk_remain);
+
+                    /* Copy data to caller's buffer */
+                    memcpy((mz_uint8 *)pvBuf + copied_to_caller, pWrite_buf_cur, to_copy);
+
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+                    /* Perform CRC */
+                    pState->file_crc32 = (mz_uint32)mz_crc32(pState->file_crc32, pWrite_buf_cur, to_copy);
+#endif
+
+                    /* Decrement data consumed from block */
+                    pState->out_blk_remain -= to_copy;
+
+                    /* Inc output offset, while performing sanity check */
+                    if ((pState->out_buf_ofs += to_copy) > pState->file_stat.m_uncomp_size)
+                    {
+                        mz_zip_set_error(pState->pZip, MZ_ZIP_DECOMPRESSION_FAILED);
+                        pState->status = TINFL_STATUS_FAILED;
+                        break;
+                    }
+
+                    /* Increment counter of data copied to caller */
+                    copied_to_caller += to_copy;
+                }
+            } while ((copied_to_caller < buf_size) && ((pState->status == TINFL_STATUS_NEEDS_MORE_INPUT) || (pState->status == TINFL_STATUS_HAS_MORE_OUTPUT)));
+        }
+
+        /* Return how many bytes were copied into user buffer */
+        return copied_to_caller;
     }
 
-    if (sort_central_dir)
-        mz_zip_reader_sort_central_dir_offsets_by_filename(pZip);
-
-    return MZ_TRUE;
-}
-
-void mz_zip_zero_struct(mz_zip_archive *pZip)
-{
-    if (pZip)
-        MZ_CLEAR_PTR(pZip);
-}
-
-static mz_bool mz_zip_reader_end_internal(mz_zip_archive *pZip, mz_bool set_last_error)
-{
-    mz_bool status = MZ_TRUE;
-
-    if (!pZip)
-        return MZ_FALSE;
-
-    if ((!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || (pZip->m_zip_mode != MZ_ZIP_MODE_READING))
+    mz_bool mz_zip_reader_extract_iter_free(mz_zip_reader_extract_iter_state *pState)
     {
-        if (set_last_error)
-            pZip->m_last_error = MZ_ZIP_INVALID_PARAMETER;
+        int status;
 
+        /* Argument sanity check */
+        if ((!pState) || (!pState->pZip) || (!pState->pZip->m_pState))
+            return MZ_FALSE;
+
+        /* Was decompression completed and requested? */
+        if ((pState->status == TINFL_STATUS_DONE) && (!(pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
+        {
+            /* Make sure the entire file was decompressed, and check its CRC. */
+            if (pState->out_buf_ofs != pState->file_stat.m_uncomp_size)
+            {
+                mz_zip_set_error(pState->pZip, MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE);
+                pState->status = TINFL_STATUS_FAILED;
+            }
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+            else if (pState->file_crc32 != pState->file_stat.m_crc32)
+            {
+                mz_zip_set_error(pState->pZip, MZ_ZIP_DECOMPRESSION_FAILED);
+                pState->status = TINFL_STATUS_FAILED;
+            }
+#endif
+        }
+
+        /* Free buffers */
+        if (!pState->pZip->m_pState->m_pMem)
+            pState->pZip->m_pFree(pState->pZip->m_pAlloc_opaque, pState->pRead_buf);
+        if (pState->pWrite_buf)
+            pState->pZip->m_pFree(pState->pZip->m_pAlloc_opaque, pState->pWrite_buf);
+
+        /* Save status */
+        status = pState->status;
+
+        /* Free context */
+        pState->pZip->m_pFree(pState->pZip->m_pAlloc_opaque, pState);
+
+        return status == TINFL_STATUS_DONE;
+    }
+
+#ifndef MINIZ_NO_STDIO
+    static size_t mz_zip_file_write_callback(void *pOpaque, mz_uint64 ofs, const void *pBuf, size_t n)
+    {
+        (void)ofs;
+
+        return MZ_FWRITE(pBuf, 1, n, (MZ_FILE *)pOpaque);
+    }
+
+    mz_bool mz_zip_reader_extract_to_file(mz_zip_archive *pZip, mz_uint file_index, const char *pDst_filename, mz_uint flags)
+    {
+        mz_bool status;
+        mz_zip_archive_file_stat file_stat;
+        MZ_FILE *pFile;
+
+        if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
+            return MZ_FALSE;
+
+        if ((file_stat.m_is_directory) || (!file_stat.m_is_supported))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
+
+        pFile = MZ_FOPEN(pDst_filename, "wb");
+        if (!pFile)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+
+        status = mz_zip_reader_extract_to_callback(pZip, file_index, mz_zip_file_write_callback, pFile, flags);
+
+        if (MZ_FCLOSE(pFile) == EOF)
+        {
+            if (status)
+                mz_zip_set_error(pZip, MZ_ZIP_FILE_CLOSE_FAILED);
+
+            status = MZ_FALSE;
+        }
+
+#if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_STDIO)
+        if (status)
+            mz_zip_set_file_times(pDst_filename, file_stat.m_time, file_stat.m_time);
+#endif
+
+        return status;
+    }
+
+    mz_bool mz_zip_reader_extract_file_to_file(mz_zip_archive *pZip, const char *pArchive_filename, const char *pDst_filename, mz_uint flags)
+    {
+        mz_uint32 file_index;
+        if (!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, NULL, flags, &file_index))
+            return MZ_FALSE;
+
+        return mz_zip_reader_extract_to_file(pZip, file_index, pDst_filename, flags);
+    }
+
+    mz_bool mz_zip_reader_extract_to_cfile(mz_zip_archive *pZip, mz_uint file_index, MZ_FILE *pFile, mz_uint flags)
+    {
+        mz_zip_archive_file_stat file_stat;
+
+        if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
+            return MZ_FALSE;
+
+        if ((file_stat.m_is_directory) || (!file_stat.m_is_supported))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
+
+        return mz_zip_reader_extract_to_callback(pZip, file_index, mz_zip_file_write_callback, pFile, flags);
+    }
+
+    mz_bool mz_zip_reader_extract_file_to_cfile(mz_zip_archive *pZip, const char *pArchive_filename, MZ_FILE *pFile, mz_uint flags)
+    {
+        mz_uint32 file_index;
+        if (!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, NULL, flags, &file_index))
+            return MZ_FALSE;
+
+        return mz_zip_reader_extract_to_cfile(pZip, file_index, pFile, flags);
+    }
+#endif /* #ifndef MINIZ_NO_STDIO */
+
+    static size_t mz_zip_compute_crc32_callback(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n)
+    {
+        mz_uint32 *p = (mz_uint32 *)pOpaque;
+        (void)file_ofs;
+        *p = (mz_uint32)mz_crc32(*p, (const mz_uint8 *)pBuf, n);
+        return n;
+    }
+
+    mz_bool mz_zip_validate_file(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags)
+    {
+        mz_zip_archive_file_stat file_stat;
+        mz_zip_internal_state *pState;
+        const mz_uint8 *pCentral_dir_header;
+        mz_bool found_zip64_ext_data_in_cdir = MZ_FALSE;
+        mz_bool found_zip64_ext_data_in_ldir = MZ_FALSE;
+        mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
+        mz_uint64 local_header_ofs = 0;
+        mz_uint32 local_header_filename_len, local_header_extra_len, local_header_crc32;
+        mz_uint64 local_header_comp_size, local_header_uncomp_size;
+        mz_uint32 uncomp_crc32 = MZ_CRC32_INIT;
+        mz_bool has_data_descriptor;
+        mz_uint32 local_header_bit_flags;
+
+        mz_zip_array file_data_array;
+        mz_zip_array_init(&file_data_array, 1);
+
+        if ((!pZip) || (!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || (!pZip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (file_index > pZip->m_total_files)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pState = pZip->m_pState;
+
+        pCentral_dir_header = mz_zip_get_cdh(pZip, file_index);
+
+        if (!mz_zip_file_stat_internal(pZip, file_index, pCentral_dir_header, &file_stat, &found_zip64_ext_data_in_cdir))
+            return MZ_FALSE;
+
+        /* A directory or zero length file */
+        if ((file_stat.m_is_directory) || (!file_stat.m_uncomp_size))
+            return MZ_TRUE;
+
+        /* Encryption and patch files are not supported. */
+        if (file_stat.m_is_encrypted)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
+
+        /* This function only supports stored and deflate. */
+        if ((file_stat.m_method != 0) && (file_stat.m_method != MZ_DEFLATED))
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
+
+        if (!file_stat.m_is_supported)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
+
+        /* Read and parse the local directory entry. */
+        local_header_ofs = file_stat.m_local_header_ofs;
+        if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+
+        if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        local_header_filename_len = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS);
+        local_header_extra_len = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
+        local_header_comp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS);
+        local_header_uncomp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS);
+        local_header_crc32 = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_CRC32_OFS);
+        local_header_bit_flags = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_BIT_FLAG_OFS);
+        has_data_descriptor = (local_header_bit_flags & 8) != 0;
+
+        if (local_header_filename_len != strlen(file_stat.m_filename))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        if ((local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_len + local_header_extra_len + file_stat.m_comp_size) > pZip->m_archive_size)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        if (!mz_zip_array_resize(pZip, &file_data_array, MZ_MAX(local_header_filename_len, local_header_extra_len), MZ_FALSE))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            goto handle_failure;
+        }
+
+        if (local_header_filename_len)
+        {
+            if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE, file_data_array.m_p, local_header_filename_len) != local_header_filename_len)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                goto handle_failure;
+            }
+
+            /* I've seen 1 archive that had the same pathname, but used backslashes in the local dir and forward slashes in the central dir. Do we care about this? For now, this case will fail validation. */
+            if (memcmp(file_stat.m_filename, file_data_array.m_p, local_header_filename_len) != 0)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
+                goto handle_failure;
+            }
+        }
+
+        if ((local_header_extra_len) && ((local_header_comp_size == MZ_UINT32_MAX) || (local_header_uncomp_size == MZ_UINT32_MAX)))
+        {
+            mz_uint32 extra_size_remaining = local_header_extra_len;
+            const mz_uint8 *pExtra_data = (const mz_uint8 *)file_data_array.m_p;
+
+            if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_len, file_data_array.m_p, local_header_extra_len) != local_header_extra_len)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                goto handle_failure;
+            }
+
+            do
+            {
+                mz_uint32 field_id, field_data_size, field_total_size;
+
+                if (extra_size_remaining < (sizeof(mz_uint16) * 2))
+                {
+                    mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                    goto handle_failure;
+                }
+
+                field_id = MZ_READ_LE16(pExtra_data);
+                field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
+                field_total_size = field_data_size + sizeof(mz_uint16) * 2;
+
+                if (field_total_size > extra_size_remaining)
+                {
+                    mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                    goto handle_failure;
+                }
+
+                if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
+                {
+                    const mz_uint8 *pSrc_field_data = pExtra_data + sizeof(mz_uint32);
+
+                    if (field_data_size < sizeof(mz_uint64) * 2)
+                    {
+                        mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                        goto handle_failure;
+                    }
+
+                    local_header_uncomp_size = MZ_READ_LE64(pSrc_field_data);
+                    local_header_comp_size = MZ_READ_LE64(pSrc_field_data + sizeof(mz_uint64));
+
+                    found_zip64_ext_data_in_ldir = MZ_TRUE;
+                    break;
+                }
+
+                pExtra_data += field_total_size;
+                extra_size_remaining -= field_total_size;
+            } while (extra_size_remaining);
+        }
+
+        /* TODO: parse local header extra data when local_header_comp_size is 0xFFFFFFFF! (big_descriptor.zip) */
+        /* I've seen zips in the wild with the data descriptor bit set, but proper local header values and bogus data descriptors */
+        if ((has_data_descriptor) && (!local_header_comp_size) && (!local_header_crc32))
+        {
+            mz_uint8 descriptor_buf[32];
+            mz_bool has_id;
+            const mz_uint8 *pSrc;
+            mz_uint32 file_crc32;
+            mz_uint64 comp_size = 0, uncomp_size = 0;
+
+            mz_uint32 num_descriptor_uint32s = ((pState->m_zip64) || (found_zip64_ext_data_in_ldir)) ? 6 : 4;
+
+            if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_len + local_header_extra_len + file_stat.m_comp_size, descriptor_buf, sizeof(mz_uint32) * num_descriptor_uint32s) != (sizeof(mz_uint32) * num_descriptor_uint32s))
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                goto handle_failure;
+            }
+
+            has_id = (MZ_READ_LE32(descriptor_buf) == MZ_ZIP_DATA_DESCRIPTOR_ID);
+            pSrc = has_id ? (descriptor_buf + sizeof(mz_uint32)) : descriptor_buf;
+
+            file_crc32 = MZ_READ_LE32(pSrc);
+
+            if ((pState->m_zip64) || (found_zip64_ext_data_in_ldir))
+            {
+                comp_size = MZ_READ_LE64(pSrc + sizeof(mz_uint32));
+                uncomp_size = MZ_READ_LE64(pSrc + sizeof(mz_uint32) + sizeof(mz_uint64));
+            }
+            else
+            {
+                comp_size = MZ_READ_LE32(pSrc + sizeof(mz_uint32));
+                uncomp_size = MZ_READ_LE32(pSrc + sizeof(mz_uint32) + sizeof(mz_uint32));
+            }
+
+            if ((file_crc32 != file_stat.m_crc32) || (comp_size != file_stat.m_comp_size) || (uncomp_size != file_stat.m_uncomp_size))
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
+                goto handle_failure;
+            }
+        }
+        else
+        {
+            if ((local_header_crc32 != file_stat.m_crc32) || (local_header_comp_size != file_stat.m_comp_size) || (local_header_uncomp_size != file_stat.m_uncomp_size))
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
+                goto handle_failure;
+            }
+        }
+
+        mz_zip_array_clear(pZip, &file_data_array);
+
+        if ((flags & MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY) == 0)
+        {
+            if (!mz_zip_reader_extract_to_callback(pZip, file_index, mz_zip_compute_crc32_callback, &uncomp_crc32, 0))
+                return MZ_FALSE;
+
+            /* 1 more check to be sure, although the extract checks too. */
+            if (uncomp_crc32 != file_stat.m_crc32)
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
+                return MZ_FALSE;
+            }
+        }
+
+        return MZ_TRUE;
+
+    handle_failure:
+        mz_zip_array_clear(pZip, &file_data_array);
         return MZ_FALSE;
     }
 
-    if (pZip->m_pState)
+    mz_bool mz_zip_validate_archive(mz_zip_archive *pZip, mz_uint flags)
     {
+        mz_zip_internal_state *pState;
+        mz_uint32 i;
+
+        if ((!pZip) || (!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || (!pZip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pState = pZip->m_pState;
+
+        /* Basic sanity checks */
+        if (!pState->m_zip64)
+        {
+            if (pZip->m_total_files > MZ_UINT16_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+
+            if (pZip->m_archive_size > MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+        }
+        else
+        {
+            if (pState->m_central_dir.m_size >= MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+        }
+
+        for (i = 0; i < pZip->m_total_files; i++)
+        {
+            if (MZ_ZIP_FLAG_VALIDATE_LOCATE_FILE_FLAG & flags)
+            {
+                mz_uint32 found_index;
+                mz_zip_archive_file_stat stat;
+
+                if (!mz_zip_reader_file_stat(pZip, i, &stat))
+                    return MZ_FALSE;
+
+                if (!mz_zip_reader_locate_file_v2(pZip, stat.m_filename, NULL, 0, &found_index))
+                    return MZ_FALSE;
+
+                /* This check can fail if there are duplicate filenames in the archive (which we don't check for when writing - that's up to the user) */
+                if (found_index != i)
+                    return mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
+            }
+
+            if (!mz_zip_validate_file(pZip, i, flags))
+                return MZ_FALSE;
+        }
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_validate_mem_archive(const void *pMem, size_t size, mz_uint flags, mz_zip_error *pErr)
+    {
+        mz_bool success = MZ_TRUE;
+        mz_zip_archive zip;
+        mz_zip_error actual_err = MZ_ZIP_NO_ERROR;
+
+        if ((!pMem) || (!size))
+        {
+            if (pErr)
+                *pErr = MZ_ZIP_INVALID_PARAMETER;
+            return MZ_FALSE;
+        }
+
+        mz_zip_zero_struct(&zip);
+
+        if (!mz_zip_reader_init_mem(&zip, pMem, size, flags))
+        {
+            if (pErr)
+                *pErr = zip.m_last_error;
+            return MZ_FALSE;
+        }
+
+        if (!mz_zip_validate_archive(&zip, flags))
+        {
+            actual_err = zip.m_last_error;
+            success = MZ_FALSE;
+        }
+
+        if (!mz_zip_reader_end_internal(&zip, success))
+        {
+            if (!actual_err)
+                actual_err = zip.m_last_error;
+            success = MZ_FALSE;
+        }
+
+        if (pErr)
+            *pErr = actual_err;
+
+        return success;
+    }
+
+#ifndef MINIZ_NO_STDIO
+    mz_bool mz_zip_validate_file_archive(const char *pFilename, mz_uint flags, mz_zip_error *pErr)
+    {
+        mz_bool success = MZ_TRUE;
+        mz_zip_archive zip;
+        mz_zip_error actual_err = MZ_ZIP_NO_ERROR;
+
+        if (!pFilename)
+        {
+            if (pErr)
+                *pErr = MZ_ZIP_INVALID_PARAMETER;
+            return MZ_FALSE;
+        }
+
+        mz_zip_zero_struct(&zip);
+
+        if (!mz_zip_reader_init_file_v2(&zip, pFilename, flags, 0, 0))
+        {
+            if (pErr)
+                *pErr = zip.m_last_error;
+            return MZ_FALSE;
+        }
+
+        if (!mz_zip_validate_archive(&zip, flags))
+        {
+            actual_err = zip.m_last_error;
+            success = MZ_FALSE;
+        }
+
+        if (!mz_zip_reader_end_internal(&zip, success))
+        {
+            if (!actual_err)
+                actual_err = zip.m_last_error;
+            success = MZ_FALSE;
+        }
+
+        if (pErr)
+            *pErr = actual_err;
+
+        return success;
+    }
+#endif /* #ifndef MINIZ_NO_STDIO */
+
+    /* ------------------- .ZIP archive writing */
+
+#ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
+
+    static MZ_FORCEINLINE void mz_write_le16(mz_uint8 *p, mz_uint16 v)
+    {
+        p[0] = (mz_uint8)v;
+        p[1] = (mz_uint8)(v >> 8);
+    }
+    static MZ_FORCEINLINE void mz_write_le32(mz_uint8 *p, mz_uint32 v)
+    {
+        p[0] = (mz_uint8)v;
+        p[1] = (mz_uint8)(v >> 8);
+        p[2] = (mz_uint8)(v >> 16);
+        p[3] = (mz_uint8)(v >> 24);
+    }
+    static MZ_FORCEINLINE void mz_write_le64(mz_uint8 *p, mz_uint64 v)
+    {
+        mz_write_le32(p, (mz_uint32)v);
+        mz_write_le32(p + sizeof(mz_uint32), (mz_uint32)(v >> 32));
+    }
+
+#define MZ_WRITE_LE16(p, v) mz_write_le16((mz_uint8 *)(p), (mz_uint16)(v))
+#define MZ_WRITE_LE32(p, v) mz_write_le32((mz_uint8 *)(p), (mz_uint32)(v))
+#define MZ_WRITE_LE64(p, v) mz_write_le64((mz_uint8 *)(p), (mz_uint64)(v))
+
+    static size_t mz_zip_heap_write_func(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n)
+    {
+        mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
         mz_zip_internal_state *pState = pZip->m_pState;
-        pZip->m_pState = NULL;
+        mz_uint64 new_size = MZ_MAX(file_ofs + n, pState->m_mem_size);
 
+        if (!n)
+            return 0;
+
+        /* An allocation this big is likely to just fail on 32-bit systems, so don't even go there. */
+        if ((sizeof(size_t) == sizeof(mz_uint32)) && (new_size > 0x7FFFFFFF))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_FILE_TOO_LARGE);
+            return 0;
+        }
+
+        if (new_size > pState->m_mem_capacity)
+        {
+            void *pNew_block;
+            size_t new_capacity = MZ_MAX(64, pState->m_mem_capacity);
+
+            while (new_capacity < new_size)
+                new_capacity *= 2;
+
+            if (NULL == (pNew_block = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pState->m_pMem, 1, new_capacity)))
+            {
+                mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+                return 0;
+            }
+
+            pState->m_pMem = pNew_block;
+            pState->m_mem_capacity = new_capacity;
+        }
+        memcpy((mz_uint8 *)pState->m_pMem + file_ofs, pBuf, n);
+        pState->m_mem_size = (size_t)new_size;
+        return n;
+    }
+
+    static mz_bool mz_zip_writer_end_internal(mz_zip_archive *pZip, mz_bool set_last_error)
+    {
+        mz_zip_internal_state *pState;
+        mz_bool status = MZ_TRUE;
+
+        if ((!pZip) || (!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || ((pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) && (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED)))
+        {
+            if (set_last_error)
+                mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+            return MZ_FALSE;
+        }
+
+        pState = pZip->m_pState;
+        pZip->m_pState = NULL;
         mz_zip_array_clear(pZip, &pState->m_central_dir);
         mz_zip_array_clear(pZip, &pState->m_central_dir_offsets);
         mz_zip_array_clear(pZip, &pState->m_sorted_central_dir_offsets);
@@ -3927,3898 +5801,2106 @@ static mz_bool mz_zip_reader_end_internal(mz_zip_archive *pZip, mz_bool set_last
                 if (MZ_FCLOSE(pState->m_pFile) == EOF)
                 {
                     if (set_last_error)
-                        pZip->m_last_error = MZ_ZIP_FILE_CLOSE_FAILED;
+                        mz_zip_set_error(pZip, MZ_ZIP_FILE_CLOSE_FAILED);
                     status = MZ_FALSE;
                 }
             }
+
             pState->m_pFile = NULL;
         }
 #endif /* #ifndef MINIZ_NO_STDIO */
 
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-    }
-    pZip->m_zip_mode = MZ_ZIP_MODE_INVALID;
-
-    return status;
-}
-
-mz_bool mz_zip_reader_end(mz_zip_archive *pZip)
-{
-    return mz_zip_reader_end_internal(pZip, MZ_TRUE);
-}
-mz_bool mz_zip_reader_init(mz_zip_archive *pZip, mz_uint64 size, mz_uint flags)
-{
-    if ((!pZip) || (!pZip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (!mz_zip_reader_init_internal(pZip, flags))
-        return MZ_FALSE;
-
-    pZip->m_zip_type = MZ_ZIP_TYPE_USER;
-    pZip->m_archive_size = size;
-
-    if (!mz_zip_reader_read_central_dir(pZip, flags))
-    {
-        mz_zip_reader_end_internal(pZip, MZ_FALSE);
-        return MZ_FALSE;
-    }
-
-    return MZ_TRUE;
-}
-
-static size_t mz_zip_mem_read_func(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
-{
-    mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
-    size_t s = (file_ofs >= pZip->m_archive_size) ? 0 : (size_t)MZ_MIN(pZip->m_archive_size - file_ofs, n);
-    memcpy(pBuf, (const mz_uint8 *)pZip->m_pState->m_pMem + file_ofs, s);
-    return s;
-}
-
-mz_bool mz_zip_reader_init_mem(mz_zip_archive *pZip, const void *pMem, size_t size, mz_uint flags)
-{
-    if (!pMem)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
-
-    if (!mz_zip_reader_init_internal(pZip, flags))
-        return MZ_FALSE;
-
-    pZip->m_zip_type = MZ_ZIP_TYPE_MEMORY;
-    pZip->m_archive_size = size;
-    pZip->m_pRead = mz_zip_mem_read_func;
-    pZip->m_pIO_opaque = pZip;
-    pZip->m_pNeeds_keepalive = NULL;
-
-#ifdef __cplusplus
-    pZip->m_pState->m_pMem = const_cast<void *>(pMem);
-#else
-    pZip->m_pState->m_pMem = (void *)pMem;
-#endif
-
-    pZip->m_pState->m_mem_size = size;
-
-    if (!mz_zip_reader_read_central_dir(pZip, flags))
-    {
-        mz_zip_reader_end_internal(pZip, MZ_FALSE);
-        return MZ_FALSE;
-    }
-
-    return MZ_TRUE;
-}
-
-#ifndef MINIZ_NO_STDIO
-static size_t mz_zip_file_read_func(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
-{
-    mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
-    mz_int64 cur_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
-
-    file_ofs += pZip->m_pState->m_file_archive_start_ofs;
-
-    if (((mz_int64)file_ofs < 0) || (((cur_ofs != (mz_int64)file_ofs)) && (MZ_FSEEK64(pZip->m_pState->m_pFile, (mz_int64)file_ofs, SEEK_SET))))
-        return 0;
-
-    return MZ_FREAD(pBuf, 1, n, pZip->m_pState->m_pFile);
-}
-
-mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint32 flags)
-{
-    return mz_zip_reader_init_file_v2(pZip, pFilename, flags, 0, 0);
-}
-
-mz_bool mz_zip_reader_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags, mz_uint64 file_start_ofs, mz_uint64 archive_size)
-{
-    mz_uint64 file_size;
-    MZ_FILE *pFile;
-
-    if ((!pZip) || (!pFilename) || ((archive_size) && (archive_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pFile = MZ_FOPEN(pFilename, "rb");
-    if (!pFile)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
-
-    file_size = archive_size;
-    if (!file_size)
-    {
-        if (MZ_FSEEK64(pFile, 0, SEEK_END))
+        if ((pZip->m_pWrite == mz_zip_heap_write_func) && (pState->m_pMem))
         {
-            MZ_FCLOSE(pFile);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pState->m_pMem);
+            pState->m_pMem = NULL;
         }
 
-        file_size = MZ_FTELL64(pFile);
+        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
+        pZip->m_zip_mode = MZ_ZIP_MODE_INVALID;
+        return status;
     }
 
-    /* TODO: Better sanity check archive_size and the # of actual remaining bytes */
-
-    if (file_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
+    mz_bool mz_zip_writer_init_v2(mz_zip_archive *pZip, mz_uint64 existing_size, mz_uint flags)
     {
-	MZ_FCLOSE(pFile);
-        return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
-    }
+        mz_bool zip64 = (flags & MZ_ZIP_FLAG_WRITE_ZIP64) != 0;
 
-    if (!mz_zip_reader_init_internal(pZip, flags))
-    {
-        MZ_FCLOSE(pFile);
-        return MZ_FALSE;
-    }
+        if ((!pZip) || (pZip->m_pState) || (!pZip->m_pWrite) || (pZip->m_zip_mode != MZ_ZIP_MODE_INVALID))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
-    pZip->m_zip_type = MZ_ZIP_TYPE_FILE;
-    pZip->m_pRead = mz_zip_file_read_func;
-    pZip->m_pIO_opaque = pZip;
-    pZip->m_pState->m_pFile = pFile;
-    pZip->m_archive_size = file_size;
-    pZip->m_pState->m_file_archive_start_ofs = file_start_ofs;
+        if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
+        {
+            if (!pZip->m_pRead)
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+        }
 
-    if (!mz_zip_reader_read_central_dir(pZip, flags))
-    {
-        mz_zip_reader_end_internal(pZip, MZ_FALSE);
-        return MZ_FALSE;
-    }
+        if (pZip->m_file_offset_alignment)
+        {
+            /* Ensure user specified file offset alignment is a power of 2. */
+            if (pZip->m_file_offset_alignment & (pZip->m_file_offset_alignment - 1))
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+        }
 
-    return MZ_TRUE;
-}
+        if (!pZip->m_pAlloc)
+            pZip->m_pAlloc = miniz_def_alloc_func;
+        if (!pZip->m_pFree)
+            pZip->m_pFree = miniz_def_free_func;
+        if (!pZip->m_pRealloc)
+            pZip->m_pRealloc = miniz_def_realloc_func;
 
-mz_bool mz_zip_reader_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint64 archive_size, mz_uint flags)
-{
-    mz_uint64 cur_file_ofs;
+        pZip->m_archive_size = existing_size;
+        pZip->m_central_directory_file_ofs = 0;
+        pZip->m_total_files = 0;
 
-    if ((!pZip) || (!pFile))
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+        if (NULL == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
+            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
-    cur_file_ofs = MZ_FTELL64(pFile);
+        memset(pZip->m_pState, 0, sizeof(mz_zip_internal_state));
 
-    if (!archive_size)
-    {
-        if (MZ_FSEEK64(pFile, 0, SEEK_END))
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
+        MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir, sizeof(mz_uint8));
+        MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir_offsets, sizeof(mz_uint32));
+        MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_sorted_central_dir_offsets, sizeof(mz_uint32));
 
-        archive_size = MZ_FTELL64(pFile) - cur_file_ofs;
+        pZip->m_pState->m_zip64 = zip64;
+        pZip->m_pState->m_zip64_has_extended_info_fields = zip64;
 
-        if (archive_size < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
-            return mz_zip_set_error(pZip, MZ_ZIP_NOT_AN_ARCHIVE);
-    }
+        pZip->m_zip_type = MZ_ZIP_TYPE_USER;
+        pZip->m_zip_mode = MZ_ZIP_MODE_WRITING;
 
-    if (!mz_zip_reader_init_internal(pZip, flags))
-        return MZ_FALSE;
-
-    pZip->m_zip_type = MZ_ZIP_TYPE_CFILE;
-    pZip->m_pRead = mz_zip_file_read_func;
-
-    pZip->m_pIO_opaque = pZip;
-    pZip->m_pState->m_pFile = pFile;
-    pZip->m_archive_size = archive_size;
-    pZip->m_pState->m_file_archive_start_ofs = cur_file_ofs;
-
-    if (!mz_zip_reader_read_central_dir(pZip, flags))
-    {
-        mz_zip_reader_end_internal(pZip, MZ_FALSE);
-        return MZ_FALSE;
-    }
-
-    return MZ_TRUE;
-}
-
-#endif /* #ifndef MINIZ_NO_STDIO */
-
-static MZ_FORCEINLINE const mz_uint8 *mz_zip_get_cdh(mz_zip_archive *pZip, mz_uint file_index)
-{
-    if ((!pZip) || (!pZip->m_pState) || (file_index >= pZip->m_total_files))
-        return NULL;
-    return &MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index));
-}
-
-mz_bool mz_zip_reader_is_file_encrypted(mz_zip_archive *pZip, mz_uint file_index)
-{
-    mz_uint m_bit_flag;
-    const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
-    if (!p)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-        return MZ_FALSE;
-    }
-
-    m_bit_flag = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
-    return (m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION)) != 0;
-}
-
-mz_bool mz_zip_reader_is_file_supported(mz_zip_archive *pZip, mz_uint file_index)
-{
-    mz_uint bit_flag;
-    mz_uint method;
-
-    const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
-    if (!p)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-        return MZ_FALSE;
-    }
-
-    method = MZ_READ_LE16(p + MZ_ZIP_CDH_METHOD_OFS);
-    bit_flag = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
-
-    if ((method != 0) && (method != MZ_DEFLATED))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
-        return MZ_FALSE;
-    }
-
-    if (bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
-        return MZ_FALSE;
-    }
-
-    if (bit_flag & MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
-        return MZ_FALSE;
-    }
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_reader_is_file_a_directory(mz_zip_archive *pZip, mz_uint file_index)
-{
-    mz_uint filename_len, attribute_mapping_id, external_attr;
-    const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
-    if (!p)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-        return MZ_FALSE;
-    }
-
-    filename_len = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-    if (filename_len)
-    {
-        if (*(p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_len - 1) == '/')
-            return MZ_TRUE;
-    }
-
-    /* Bugfix: This code was also checking if the internal attribute was non-zero, which wasn't correct. */
-    /* Most/all zip writers (hopefully) set DOS file/directory attributes in the low 16-bits, so check for the DOS directory flag and ignore the source OS ID in the created by field. */
-    /* FIXME: Remove this check? Is it necessary - we already check the filename. */
-    attribute_mapping_id = MZ_READ_LE16(p + MZ_ZIP_CDH_VERSION_MADE_BY_OFS) >> 8;
-    (void)attribute_mapping_id;
-
-    external_attr = MZ_READ_LE32(p + MZ_ZIP_CDH_EXTERNAL_ATTR_OFS);
-    if ((external_attr & MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG) != 0)
-    {
         return MZ_TRUE;
     }
 
-    return MZ_FALSE;
-}
-
-static mz_bool mz_zip_file_stat_internal(mz_zip_archive *pZip, mz_uint file_index, const mz_uint8 *pCentral_dir_header, mz_zip_archive_file_stat *pStat, mz_bool *pFound_zip64_extra_data)
-{
-    mz_uint n;
-    const mz_uint8 *p = pCentral_dir_header;
-
-    if (pFound_zip64_extra_data)
-        *pFound_zip64_extra_data = MZ_FALSE;
-
-    if ((!p) || (!pStat))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    /* Extract fields from the central directory record. */
-    pStat->m_file_index = file_index;
-    pStat->m_central_dir_ofs = MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index);
-    pStat->m_version_made_by = MZ_READ_LE16(p + MZ_ZIP_CDH_VERSION_MADE_BY_OFS);
-    pStat->m_version_needed = MZ_READ_LE16(p + MZ_ZIP_CDH_VERSION_NEEDED_OFS);
-    pStat->m_bit_flag = MZ_READ_LE16(p + MZ_ZIP_CDH_BIT_FLAG_OFS);
-    pStat->m_method = MZ_READ_LE16(p + MZ_ZIP_CDH_METHOD_OFS);
-#ifndef MINIZ_NO_TIME
-    pStat->m_time = mz_zip_dos_to_time_t(MZ_READ_LE16(p + MZ_ZIP_CDH_FILE_TIME_OFS), MZ_READ_LE16(p + MZ_ZIP_CDH_FILE_DATE_OFS));
-#endif
-    pStat->m_crc32 = MZ_READ_LE32(p + MZ_ZIP_CDH_CRC32_OFS);
-    pStat->m_comp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS);
-    pStat->m_uncomp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS);
-    pStat->m_internal_attr = MZ_READ_LE16(p + MZ_ZIP_CDH_INTERNAL_ATTR_OFS);
-    pStat->m_external_attr = MZ_READ_LE32(p + MZ_ZIP_CDH_EXTERNAL_ATTR_OFS);
-    pStat->m_local_header_ofs = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
-
-    /* Copy as much of the filename and comment as possible. */
-    n = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-    n = MZ_MIN(n, MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE - 1);
-    memcpy(pStat->m_filename, p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, n);
-    pStat->m_filename[n] = '\0';
-
-    n = MZ_READ_LE16(p + MZ_ZIP_CDH_COMMENT_LEN_OFS);
-    n = MZ_MIN(n, MZ_ZIP_MAX_ARCHIVE_FILE_COMMENT_SIZE - 1);
-    pStat->m_comment_size = n;
-    memcpy(pStat->m_comment, p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS) + MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS), n);
-    pStat->m_comment[n] = '\0';
-
-    /* Set some flags for convienance */
-    pStat->m_is_directory = mz_zip_reader_is_file_a_directory(pZip, file_index);
-    pStat->m_is_encrypted = mz_zip_reader_is_file_encrypted(pZip, file_index);
-    pStat->m_is_supported = mz_zip_reader_is_file_supported(pZip, file_index);
-
-    /* See if we need to read any zip64 extended information fields. */
-    /* Confusingly, these zip64 fields can be present even on non-zip64 archives (Debian zip on a huge files from stdin piped to stdout creates them). */
-    if (MZ_MAX(MZ_MAX(pStat->m_comp_size, pStat->m_uncomp_size), pStat->m_local_header_ofs) == MZ_UINT32_MAX)
+    mz_bool mz_zip_writer_init(mz_zip_archive *pZip, mz_uint64 existing_size)
     {
-        /* Attempt to find zip64 extended information field in the entry's extra data */
-        mz_uint32 extra_size_remaining = MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS);
+        return mz_zip_writer_init_v2(pZip, existing_size, 0);
+    }
 
-        if (extra_size_remaining)
+    mz_bool mz_zip_writer_init_heap_v2(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size, mz_uint flags)
+    {
+        pZip->m_pWrite = mz_zip_heap_write_func;
+        pZip->m_pNeeds_keepalive = NULL;
+
+        if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
+            pZip->m_pRead = mz_zip_mem_read_func;
+
+        pZip->m_pIO_opaque = pZip;
+
+        if (!mz_zip_writer_init_v2(pZip, size_to_reserve_at_beginning, flags))
+            return MZ_FALSE;
+
+        pZip->m_zip_type = MZ_ZIP_TYPE_HEAP;
+
+        if (0 != (initial_allocation_size = MZ_MAX(initial_allocation_size, size_to_reserve_at_beginning)))
         {
-            const mz_uint8 *pExtra_data = p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+            if (NULL == (pZip->m_pState->m_pMem = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, initial_allocation_size)))
+            {
+                mz_zip_writer_end_internal(pZip, MZ_FALSE);
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
+            pZip->m_pState->m_mem_capacity = initial_allocation_size;
+        }
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_writer_init_heap(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size)
+    {
+        return mz_zip_writer_init_heap_v2(pZip, size_to_reserve_at_beginning, initial_allocation_size, 0);
+    }
+
+#ifndef MINIZ_NO_STDIO
+    static size_t mz_zip_file_write_func(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n)
+    {
+        mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
+        mz_int64 cur_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
+
+        file_ofs += pZip->m_pState->m_file_archive_start_ofs;
+
+        if (((mz_int64)file_ofs < 0) || (((cur_ofs != (mz_int64)file_ofs)) && (MZ_FSEEK64(pZip->m_pState->m_pFile, (mz_int64)file_ofs, SEEK_SET))))
+        {
+            mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
+            return 0;
+        }
+
+        return MZ_FWRITE(pBuf, 1, n, pZip->m_pState->m_pFile);
+    }
+
+    mz_bool mz_zip_writer_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning)
+    {
+        return mz_zip_writer_init_file_v2(pZip, pFilename, size_to_reserve_at_beginning, 0);
+    }
+
+    mz_bool mz_zip_writer_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning, mz_uint flags)
+    {
+        MZ_FILE *pFile;
+
+        pZip->m_pWrite = mz_zip_file_write_func;
+        pZip->m_pNeeds_keepalive = NULL;
+
+        if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
+            pZip->m_pRead = mz_zip_file_read_func;
+
+        pZip->m_pIO_opaque = pZip;
+
+        if (!mz_zip_writer_init_v2(pZip, size_to_reserve_at_beginning, flags))
+            return MZ_FALSE;
+
+        if (NULL == (pFile = MZ_FOPEN(pFilename, (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING) ? "w+b" : "wb")))
+        {
+            mz_zip_writer_end(pZip);
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+        }
+
+        pZip->m_pState->m_pFile = pFile;
+        pZip->m_zip_type = MZ_ZIP_TYPE_FILE;
+
+        if (size_to_reserve_at_beginning)
+        {
+            mz_uint64 cur_ofs = 0;
+            char buf[4096];
+
+            MZ_CLEAR_ARR(buf);
 
             do
             {
-                mz_uint32 field_id;
-                mz_uint32 field_data_size;
+                size_t n = (size_t)MZ_MIN(sizeof(buf), size_to_reserve_at_beginning);
+                if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_ofs, buf, n) != n)
+                {
+                    mz_zip_writer_end(pZip);
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+                }
+                cur_ofs += n;
+                size_to_reserve_at_beginning -= n;
+            } while (size_to_reserve_at_beginning);
+        }
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_writer_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint flags)
+    {
+        pZip->m_pWrite = mz_zip_file_write_func;
+        pZip->m_pNeeds_keepalive = NULL;
+
+        if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
+            pZip->m_pRead = mz_zip_file_read_func;
+
+        pZip->m_pIO_opaque = pZip;
+
+        if (!mz_zip_writer_init_v2(pZip, 0, flags))
+            return MZ_FALSE;
+
+        pZip->m_pState->m_pFile = pFile;
+        pZip->m_pState->m_file_archive_start_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
+        pZip->m_zip_type = MZ_ZIP_TYPE_CFILE;
+
+        return MZ_TRUE;
+    }
+#endif /* #ifndef MINIZ_NO_STDIO */
+
+    mz_bool mz_zip_writer_init_from_reader_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags)
+    {
+        mz_zip_internal_state *pState;
+
+        if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_READING))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (flags & MZ_ZIP_FLAG_WRITE_ZIP64)
+        {
+            /* We don't support converting a non-zip64 file to zip64 - this seems like more trouble than it's worth. (What about the existing 32-bit data descriptors that could follow the compressed data?) */
+            if (!pZip->m_pState->m_zip64)
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+        }
+
+        /* No sense in trying to write to an archive that's already at the support max size */
+        if (pZip->m_pState->m_zip64)
+        {
+            if (pZip->m_total_files == MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+        }
+        else
+        {
+            if (pZip->m_total_files == MZ_UINT16_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+
+            if ((pZip->m_archive_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_ZIP_LOCAL_DIR_HEADER_SIZE) > MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_TOO_LARGE);
+        }
+
+        pState = pZip->m_pState;
+
+        if (pState->m_pFile)
+        {
+#ifdef MINIZ_NO_STDIO
+            (void)pFilename;
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+#else
+            if (pZip->m_pIO_opaque != pZip)
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+            if (pZip->m_zip_type == MZ_ZIP_TYPE_FILE &&
+                !(flags & MZ_ZIP_FLAG_READ_ALLOW_WRITING) )
+            {
+                if (!pFilename)
+                    return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+                /* Archive is being read from stdio and was originally opened only for reading. Try to reopen as writable. */
+                if (NULL == (pState->m_pFile = MZ_FREOPEN(pFilename, "r+b", pState->m_pFile)))
+                {
+                    /* The mz_zip_archive is now in a bogus state because pState->m_pFile is NULL, so just close it. */
+                    mz_zip_reader_end_internal(pZip, MZ_FALSE);
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+                }
+            }
+
+            pZip->m_pWrite = mz_zip_file_write_func;
+            pZip->m_pNeeds_keepalive = NULL;
+#endif /* #ifdef MINIZ_NO_STDIO */
+        }
+        else if (pState->m_pMem)
+        {
+            /* Archive lives in a memory block. Assume it's from the heap that we can resize using the realloc callback. */
+            if (pZip->m_pIO_opaque != pZip)
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+            pState->m_mem_capacity = pState->m_mem_size;
+            pZip->m_pWrite = mz_zip_heap_write_func;
+            pZip->m_pNeeds_keepalive = NULL;
+        }
+        /* Archive is being read via a user provided read function - make sure the user has specified a write function too. */
+        else if (!pZip->m_pWrite)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        /* Start writing new files at the archive's current central directory location. */
+        /* TODO: We could add a flag that lets the user start writing immediately AFTER the existing central dir - this would be safer. */
+        pZip->m_archive_size = pZip->m_central_directory_file_ofs;
+        pZip->m_central_directory_file_ofs = 0;
+
+        /* Clear the sorted central dir offsets, they aren't useful or maintained now. */
+        /* Even though we're now in write mode, files can still be extracted and verified, but file locates will be slow. */
+        /* TODO: We could easily maintain the sorted central directory offsets. */
+        mz_zip_array_clear(pZip, &pZip->m_pState->m_sorted_central_dir_offsets);
+
+        pZip->m_zip_mode = MZ_ZIP_MODE_WRITING;
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_writer_init_from_reader(mz_zip_archive *pZip, const char *pFilename)
+    {
+        return mz_zip_writer_init_from_reader_v2(pZip, pFilename, 0);
+    }
+
+    /* TODO: pArchive_name is a terrible name here! */
+    mz_bool mz_zip_writer_add_mem(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, mz_uint level_and_flags)
+    {
+        return mz_zip_writer_add_mem_ex(pZip, pArchive_name, pBuf, buf_size, NULL, 0, level_and_flags, 0, 0);
+    }
+
+    typedef struct
+    {
+        mz_zip_archive *m_pZip;
+        mz_uint64 m_cur_archive_file_ofs;
+        mz_uint64 m_comp_size;
+    } mz_zip_writer_add_state;
+
+    static mz_bool mz_zip_writer_add_put_buf_callback(const void *pBuf, int len, void *pUser)
+    {
+        mz_zip_writer_add_state *pState = (mz_zip_writer_add_state *)pUser;
+        if ((int)pState->m_pZip->m_pWrite(pState->m_pZip->m_pIO_opaque, pState->m_cur_archive_file_ofs, pBuf, len) != len)
+            return MZ_FALSE;
+
+        pState->m_cur_archive_file_ofs += len;
+        pState->m_comp_size += len;
+        return MZ_TRUE;
+    }
+
+#define MZ_ZIP64_MAX_LOCAL_EXTRA_FIELD_SIZE (sizeof(mz_uint16) * 2 + sizeof(mz_uint64) * 2)
+#define MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE (sizeof(mz_uint16) * 2 + sizeof(mz_uint64) * 3)
+    static mz_uint32 mz_zip_writer_create_zip64_extra_data(mz_uint8 *pBuf, mz_uint64 *pUncomp_size, mz_uint64 *pComp_size, mz_uint64 *pLocal_header_ofs)
+    {
+        mz_uint8 *pDst = pBuf;
+        mz_uint32 field_size = 0;
+
+        MZ_WRITE_LE16(pDst + 0, MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID);
+        MZ_WRITE_LE16(pDst + 2, 0);
+        pDst += sizeof(mz_uint16) * 2;
+
+        if (pUncomp_size)
+        {
+            MZ_WRITE_LE64(pDst, *pUncomp_size);
+            pDst += sizeof(mz_uint64);
+            field_size += sizeof(mz_uint64);
+        }
+
+        if (pComp_size)
+        {
+            MZ_WRITE_LE64(pDst, *pComp_size);
+            pDst += sizeof(mz_uint64);
+            field_size += sizeof(mz_uint64);
+        }
+
+        if (pLocal_header_ofs)
+        {
+            MZ_WRITE_LE64(pDst, *pLocal_header_ofs);
+            pDst += sizeof(mz_uint64);
+            field_size += sizeof(mz_uint64);
+        }
+
+        MZ_WRITE_LE16(pBuf + 2, field_size);
+
+        return (mz_uint32)(pDst - pBuf);
+    }
+
+    static mz_bool mz_zip_writer_create_local_dir_header(mz_zip_archive *pZip, mz_uint8 *pDst, mz_uint16 filename_size, mz_uint16 extra_size, mz_uint64 uncomp_size, mz_uint64 comp_size, mz_uint32 uncomp_crc32, mz_uint16 method, mz_uint16 bit_flags, mz_uint16 dos_time, mz_uint16 dos_date)
+    {
+        (void)pZip;
+        memset(pDst, 0, MZ_ZIP_LOCAL_DIR_HEADER_SIZE);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_SIG_OFS, MZ_ZIP_LOCAL_DIR_HEADER_SIG);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_VERSION_NEEDED_OFS, method ? 20 : 0);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_BIT_FLAG_OFS, bit_flags);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_METHOD_OFS, method);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, dos_time);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, dos_date);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_CRC32_OFS, uncomp_crc32);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
+        MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILENAME_LEN_OFS, filename_size);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_EXTRA_LEN_OFS, extra_size);
+        return MZ_TRUE;
+    }
+
+    static mz_bool mz_zip_writer_create_central_dir_header(mz_zip_archive *pZip, mz_uint8 *pDst,
+                                                           mz_uint16 filename_size, mz_uint16 extra_size, mz_uint16 comment_size,
+                                                           mz_uint64 uncomp_size, mz_uint64 comp_size, mz_uint32 uncomp_crc32,
+                                                           mz_uint16 method, mz_uint16 bit_flags, mz_uint16 dos_time, mz_uint16 dos_date,
+                                                           mz_uint64 local_header_ofs, mz_uint32 ext_attributes)
+    {
+        (void)pZip;
+        memset(pDst, 0, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_SIG_OFS, MZ_ZIP_CENTRAL_DIR_HEADER_SIG);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_NEEDED_OFS, method ? 20 : 0);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_BIT_FLAG_OFS, bit_flags);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_METHOD_OFS, method);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_TIME_OFS, dos_time);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_DATE_OFS, dos_date);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_CRC32_OFS, uncomp_crc32);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
+        MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILENAME_LEN_OFS, filename_size);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_EXTRA_LEN_OFS, extra_size);
+        MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_COMMENT_LEN_OFS, comment_size);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_EXTERNAL_ATTR_OFS, ext_attributes);
+        MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_LOCAL_HEADER_OFS, MZ_MIN(local_header_ofs, MZ_UINT32_MAX));
+        return MZ_TRUE;
+    }
+
+    static mz_bool mz_zip_writer_add_to_central_dir(mz_zip_archive *pZip, const char *pFilename, mz_uint16 filename_size,
+                                                    const void *pExtra, mz_uint16 extra_size, const void *pComment, mz_uint16 comment_size,
+                                                    mz_uint64 uncomp_size, mz_uint64 comp_size, mz_uint32 uncomp_crc32,
+                                                    mz_uint16 method, mz_uint16 bit_flags, mz_uint16 dos_time, mz_uint16 dos_date,
+                                                    mz_uint64 local_header_ofs, mz_uint32 ext_attributes,
+                                                    const char *user_extra_data, mz_uint user_extra_data_len)
+    {
+        mz_zip_internal_state *pState = pZip->m_pState;
+        mz_uint32 central_dir_ofs = (mz_uint32)pState->m_central_dir.m_size;
+        size_t orig_central_dir_size = pState->m_central_dir.m_size;
+        mz_uint8 central_dir_header[MZ_ZIP_CENTRAL_DIR_HEADER_SIZE];
+
+        if (!pZip->m_pState->m_zip64)
+        {
+            if (local_header_ofs > 0xFFFFFFFF)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_TOO_LARGE);
+        }
+
+        /* miniz doesn't support central dirs >= MZ_UINT32_MAX bytes yet */
+        if (((mz_uint64)pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size + extra_size + user_extra_data_len + comment_size) >= MZ_UINT32_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
+
+        if (!mz_zip_writer_create_central_dir_header(pZip, central_dir_header, filename_size, (mz_uint16)(extra_size + user_extra_data_len), comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_header_ofs, ext_attributes))
+            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+        if ((!mz_zip_array_push_back(pZip, &pState->m_central_dir, central_dir_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE)) ||
+            (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pFilename, filename_size)) ||
+            (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pExtra, extra_size)) ||
+            (!mz_zip_array_push_back(pZip, &pState->m_central_dir, user_extra_data, user_extra_data_len)) ||
+            (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pComment, comment_size)) ||
+            (!mz_zip_array_push_back(pZip, &pState->m_central_dir_offsets, &central_dir_ofs, 1)))
+        {
+            /* Try to resize the central directory array back into its original state. */
+            mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
+            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+        }
+
+        return MZ_TRUE;
+    }
+
+    static mz_bool mz_zip_writer_validate_archive_name(const char *pArchive_name)
+    {
+        /* Basic ZIP archive filename validity checks: Valid filenames cannot start with a forward slash, cannot contain a drive letter, and cannot use DOS-style backward slashes. */
+        if (*pArchive_name == '/')
+            return MZ_FALSE;
+
+        /* Making sure the name does not contain drive letters or DOS style backward slashes is the responsibility of the program using miniz*/
+
+        return MZ_TRUE;
+    }
+
+    static mz_uint mz_zip_writer_compute_padding_needed_for_file_alignment(mz_zip_archive *pZip)
+    {
+        mz_uint32 n;
+        if (!pZip->m_file_offset_alignment)
+            return 0;
+        n = (mz_uint32)(pZip->m_archive_size & (pZip->m_file_offset_alignment - 1));
+        return (mz_uint)((pZip->m_file_offset_alignment - n) & (pZip->m_file_offset_alignment - 1));
+    }
+
+    static mz_bool mz_zip_writer_write_zeros(mz_zip_archive *pZip, mz_uint64 cur_file_ofs, mz_uint32 n)
+    {
+        char buf[4096];
+        memset(buf, 0, MZ_MIN(sizeof(buf), n));
+        while (n)
+        {
+            mz_uint32 s = MZ_MIN(sizeof(buf), n);
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_file_ofs, buf, s) != s)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_file_ofs += s;
+            n -= s;
+        }
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
+                                     mz_uint64 uncomp_size, mz_uint32 uncomp_crc32)
+    {
+        return mz_zip_writer_add_mem_ex_v2(pZip, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, uncomp_size, uncomp_crc32, NULL, NULL, 0, NULL, 0);
+    }
+
+    mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size,
+                                        mz_uint level_and_flags, mz_uint64 uncomp_size, mz_uint32 uncomp_crc32, MZ_TIME_T *last_modified,
+                                        const char *user_extra_data, mz_uint user_extra_data_len, const char *user_extra_data_central, mz_uint user_extra_data_central_len)
+    {
+        mz_uint16 method = 0, dos_time = 0, dos_date = 0;
+        mz_uint level, ext_attributes = 0, num_alignment_padding_bytes;
+        mz_uint64 local_dir_header_ofs = pZip->m_archive_size, cur_archive_file_ofs = pZip->m_archive_size, comp_size = 0;
+        size_t archive_name_size;
+        mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
+        tdefl_compressor *pComp = NULL;
+        mz_bool store_data_uncompressed;
+        mz_zip_internal_state *pState;
+        mz_uint8 *pExtra_data = NULL;
+        mz_uint32 extra_size = 0;
+        mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
+        mz_uint16 bit_flags = 0;
+
+        if ((int)level_and_flags < 0)
+            level_and_flags = MZ_DEFAULT_LEVEL;
+
+        if (uncomp_size || (buf_size && !(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
+            bit_flags |= MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR;
+
+        if (!(level_and_flags & MZ_ZIP_FLAG_ASCII_FILENAME))
+            bit_flags |= MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8;
+
+        level = level_and_flags & 0xF;
+        store_data_uncompressed = ((!level) || (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA));
+
+        if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || ((buf_size) && (!pBuf)) || (!pArchive_name) || ((comment_size) && (!pComment)) || (level > MZ_UBER_COMPRESSION))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pState = pZip->m_pState;
+
+        if (pState->m_zip64)
+        {
+            if (pZip->m_total_files == MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+        }
+        else
+        {
+            if (pZip->m_total_files == MZ_UINT16_MAX)
+            {
+                pState->m_zip64 = MZ_TRUE;
+                /*return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES); */
+            }
+            if (((mz_uint64)buf_size > 0xFFFFFFFF) || (uncomp_size > 0xFFFFFFFF))
+            {
+                pState->m_zip64 = MZ_TRUE;
+                /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
+            }
+        }
+
+        if ((!(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (uncomp_size))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (!mz_zip_writer_validate_archive_name(pArchive_name))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
+
+#ifndef MINIZ_NO_TIME
+        if (last_modified != NULL)
+        {
+            mz_zip_time_t_to_dos_time(*last_modified, &dos_time, &dos_date);
+        }
+        else
+        {
+            MZ_TIME_T cur_time;
+            time(&cur_time);
+            mz_zip_time_t_to_dos_time(cur_time, &dos_time, &dos_date);
+        }
+#else
+        (void)last_modified;
+#endif /* #ifndef MINIZ_NO_TIME */
+
+        if (!(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
+        {
+            uncomp_crc32 = (mz_uint32)mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)pBuf, buf_size);
+            uncomp_size = buf_size;
+            if (uncomp_size <= 3)
+            {
+                level = 0;
+                store_data_uncompressed = MZ_TRUE;
+            }
+        }
+
+        archive_name_size = strlen(pArchive_name);
+        if (archive_name_size > MZ_UINT16_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
+
+        num_alignment_padding_bytes = mz_zip_writer_compute_padding_needed_for_file_alignment(pZip);
+
+        /* miniz doesn't support central dirs >= MZ_UINT32_MAX bytes yet */
+        if (((mz_uint64)pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE + comment_size) >= MZ_UINT32_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
+
+        if (!pState->m_zip64)
+        {
+            /* Bail early if the archive would obviously become too large */
+            if ((pZip->m_archive_size + num_alignment_padding_bytes + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + comment_size + user_extra_data_len +
+                 pState->m_central_dir.m_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE + user_extra_data_central_len + MZ_ZIP_DATA_DESCRIPTER_SIZE32) > 0xFFFFFFFF)
+            {
+                pState->m_zip64 = MZ_TRUE;
+                /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
+            }
+        }
+
+        if ((archive_name_size) && (pArchive_name[archive_name_size - 1] == '/'))
+        {
+            /* Set DOS Subdirectory attribute bit. */
+            ext_attributes |= MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG;
+
+            /* Subdirectories cannot contain data. */
+            if ((buf_size) || (uncomp_size))
+                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+        }
+
+        /* Try to do any allocations before writing to the archive, so if an allocation fails the file remains unmodified. (A good idea if we're doing an in-place modification.) */
+        if ((!mz_zip_array_ensure_room(pZip, &pState->m_central_dir, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + comment_size + (pState->m_zip64 ? MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE : 0))) || (!mz_zip_array_ensure_room(pZip, &pState->m_central_dir_offsets, 1)))
+            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+        if ((!store_data_uncompressed) && (buf_size))
+        {
+            if (NULL == (pComp = (tdefl_compressor *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(tdefl_compressor))))
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+        }
+
+        if (!mz_zip_writer_write_zeros(pZip, cur_archive_file_ofs, num_alignment_padding_bytes))
+        {
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+            return MZ_FALSE;
+        }
+
+        local_dir_header_ofs += num_alignment_padding_bytes;
+        if (pZip->m_file_offset_alignment)
+        {
+            MZ_ASSERT((local_dir_header_ofs & (pZip->m_file_offset_alignment - 1)) == 0);
+        }
+        cur_archive_file_ofs += num_alignment_padding_bytes;
+
+        MZ_CLEAR_ARR(local_dir_header);
+
+        if (!store_data_uncompressed || (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
+        {
+            method = MZ_DEFLATED;
+        }
+
+        if (pState->m_zip64)
+        {
+            if (uncomp_size >= MZ_UINT32_MAX || local_dir_header_ofs >= MZ_UINT32_MAX)
+            {
+                pExtra_data = extra_data;
+                extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
+                                                                   (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+            }
+
+            if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)(extra_size + user_extra_data_len), 0, 0, 0, method, bit_flags, dos_time, dos_date))
+                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, local_dir_header_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += sizeof(local_dir_header);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
+            {
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            }
+            cur_archive_file_ofs += archive_name_size;
+
+            if (pExtra_data != NULL)
+            {
+                if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, extra_data, extra_size) != extra_size)
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+                cur_archive_file_ofs += extra_size;
+            }
+        }
+        else
+        {
+            if ((comp_size > MZ_UINT32_MAX) || (cur_archive_file_ofs > MZ_UINT32_MAX))
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+            if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)user_extra_data_len, 0, 0, 0, method, bit_flags, dos_time, dos_date))
+                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, local_dir_header_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += sizeof(local_dir_header);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
+            {
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            }
+            cur_archive_file_ofs += archive_name_size;
+        }
+
+        if (user_extra_data_len > 0)
+        {
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, user_extra_data, user_extra_data_len) != user_extra_data_len)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += user_extra_data_len;
+        }
+
+        if (store_data_uncompressed)
+        {
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pBuf, buf_size) != buf_size)
+            {
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            }
+
+            cur_archive_file_ofs += buf_size;
+            comp_size = buf_size;
+        }
+        else if (buf_size)
+        {
+            mz_zip_writer_add_state state;
+
+            state.m_pZip = pZip;
+            state.m_cur_archive_file_ofs = cur_archive_file_ofs;
+            state.m_comp_size = 0;
+
+            if ((tdefl_init(pComp, mz_zip_writer_add_put_buf_callback, &state, tdefl_create_comp_flags_from_zip_params(level, -15, MZ_DEFAULT_STRATEGY)) != TDEFL_STATUS_OKAY) ||
+                (tdefl_compress_buffer(pComp, pBuf, buf_size, TDEFL_FINISH) != TDEFL_STATUS_DONE))
+            {
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+                return mz_zip_set_error(pZip, MZ_ZIP_COMPRESSION_FAILED);
+            }
+
+            comp_size = state.m_comp_size;
+            cur_archive_file_ofs = state.m_cur_archive_file_ofs;
+        }
+
+        pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+        pComp = NULL;
+
+        if (uncomp_size)
+        {
+            mz_uint8 local_dir_footer[MZ_ZIP_DATA_DESCRIPTER_SIZE64];
+            mz_uint32 local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE32;
+
+            MZ_ASSERT(bit_flags & MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR);
+
+            MZ_WRITE_LE32(local_dir_footer + 0, MZ_ZIP_DATA_DESCRIPTOR_ID);
+            MZ_WRITE_LE32(local_dir_footer + 4, uncomp_crc32);
+            if (pExtra_data == NULL)
+            {
+                if (comp_size > MZ_UINT32_MAX)
+                    return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+
+                MZ_WRITE_LE32(local_dir_footer + 8, comp_size);
+                MZ_WRITE_LE32(local_dir_footer + 12, uncomp_size);
+            }
+            else
+            {
+                MZ_WRITE_LE64(local_dir_footer + 8, comp_size);
+                MZ_WRITE_LE64(local_dir_footer + 16, uncomp_size);
+                local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE64;
+            }
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_footer, local_dir_footer_size) != local_dir_footer_size)
+                return MZ_FALSE;
+
+            cur_archive_file_ofs += local_dir_footer_size;
+        }
+
+        if (pExtra_data != NULL)
+        {
+            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
+                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+        }
+
+        if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
+                                              comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
+                                              user_extra_data_central, user_extra_data_central_len))
+            return MZ_FALSE;
+
+        pZip->m_total_files++;
+        pZip->m_archive_size = cur_archive_file_ofs;
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_writer_add_read_buf_callback(mz_zip_archive *pZip, const char *pArchive_name, mz_file_read_func read_callback, void *callback_opaque, mz_uint64 max_size, const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
+                                                const char *user_extra_data, mz_uint user_extra_data_len, const char *user_extra_data_central, mz_uint user_extra_data_central_len)
+    {
+        mz_uint16 gen_flags;
+        mz_uint uncomp_crc32 = MZ_CRC32_INIT, level, num_alignment_padding_bytes;
+        mz_uint16 method = 0, dos_time = 0, dos_date = 0, ext_attributes = 0;
+        mz_uint64 local_dir_header_ofs, cur_archive_file_ofs = pZip->m_archive_size, uncomp_size = 0, comp_size = 0;
+        size_t archive_name_size;
+        mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
+        mz_uint8 *pExtra_data = NULL;
+        mz_uint32 extra_size = 0;
+        mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
+        mz_zip_internal_state *pState;
+        mz_uint64 file_ofs = 0, cur_archive_header_file_ofs;
+
+        if ((int)level_and_flags < 0)
+            level_and_flags = MZ_DEFAULT_LEVEL;
+        level = level_and_flags & 0xF;
+
+        gen_flags = (level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE) ? 0 : MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR;
+
+        if (!(level_and_flags & MZ_ZIP_FLAG_ASCII_FILENAME))
+            gen_flags |= MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8;
+
+        /* Sanity checks */
+        if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || (!pArchive_name) || ((comment_size) && (!pComment)) || (level > MZ_UBER_COMPRESSION))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pState = pZip->m_pState;
+
+        if ((!pState->m_zip64) && (max_size > MZ_UINT32_MAX))
+        {
+            /* Source file is too large for non-zip64 */
+            /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
+            pState->m_zip64 = MZ_TRUE;
+        }
+
+        /* We could support this, but why? */
+        if (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (!mz_zip_writer_validate_archive_name(pArchive_name))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
+
+        if (pState->m_zip64)
+        {
+            if (pZip->m_total_files == MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+        }
+        else
+        {
+            if (pZip->m_total_files == MZ_UINT16_MAX)
+            {
+                pState->m_zip64 = MZ_TRUE;
+                /*return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES); */
+            }
+        }
+
+        archive_name_size = strlen(pArchive_name);
+        if (archive_name_size > MZ_UINT16_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
+
+        num_alignment_padding_bytes = mz_zip_writer_compute_padding_needed_for_file_alignment(pZip);
+
+        /* miniz doesn't support central dirs >= MZ_UINT32_MAX bytes yet */
+        if (((mz_uint64)pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE + comment_size) >= MZ_UINT32_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
+
+        if (!pState->m_zip64)
+        {
+            /* Bail early if the archive would obviously become too large */
+            if ((pZip->m_archive_size + num_alignment_padding_bytes + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + comment_size + user_extra_data_len + pState->m_central_dir.m_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE + 1024 + MZ_ZIP_DATA_DESCRIPTER_SIZE32 + user_extra_data_central_len) > 0xFFFFFFFF)
+            {
+                pState->m_zip64 = MZ_TRUE;
+                /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
+            }
+        }
+
+#ifndef MINIZ_NO_TIME
+        if (pFile_time)
+        {
+            mz_zip_time_t_to_dos_time(*pFile_time, &dos_time, &dos_date);
+        }
+#else
+        (void)pFile_time;
+#endif
+
+        if (max_size <= 3)
+            level = 0;
+
+        if (!mz_zip_writer_write_zeros(pZip, cur_archive_file_ofs, num_alignment_padding_bytes))
+        {
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+        }
+
+        cur_archive_file_ofs += num_alignment_padding_bytes;
+        local_dir_header_ofs = cur_archive_file_ofs;
+
+        if (pZip->m_file_offset_alignment)
+        {
+            MZ_ASSERT((cur_archive_file_ofs & (pZip->m_file_offset_alignment - 1)) == 0);
+        }
+
+        if (max_size && level)
+        {
+            method = MZ_DEFLATED;
+        }
+
+        MZ_CLEAR_ARR(local_dir_header);
+        if (pState->m_zip64)
+        {
+            if (max_size >= MZ_UINT32_MAX || local_dir_header_ofs >= MZ_UINT32_MAX)
+            {
+                pExtra_data = extra_data;
+                if (level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE)
+                    extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (max_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
+                                                                       (max_size >= MZ_UINT32_MAX) ? &comp_size : NULL,
+                                                                       (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+                else
+                    extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, NULL,
+                                                                       NULL,
+                                                                       (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+            }
+
+            if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)(extra_size + user_extra_data_len), 0, 0, 0, method, gen_flags, dos_time, dos_date))
+                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += sizeof(local_dir_header);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
+            {
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            }
+
+            cur_archive_file_ofs += archive_name_size;
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, extra_data, extra_size) != extra_size)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += extra_size;
+        }
+        else
+        {
+            if ((comp_size > MZ_UINT32_MAX) || (cur_archive_file_ofs > MZ_UINT32_MAX))
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+            if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)user_extra_data_len, 0, 0, 0, method, gen_flags, dos_time, dos_date))
+                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += sizeof(local_dir_header);
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
+            {
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            }
+
+            cur_archive_file_ofs += archive_name_size;
+        }
+
+        if (user_extra_data_len > 0)
+        {
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, user_extra_data, user_extra_data_len) != user_extra_data_len)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            cur_archive_file_ofs += user_extra_data_len;
+        }
+
+        if (max_size)
+        {
+            void *pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, MZ_ZIP_MAX_IO_BUF_SIZE);
+            if (!pRead_buf)
+            {
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
+
+            if (!level)
+            {
+                while (1)
+                {
+                    size_t n = read_callback(callback_opaque, file_ofs, pRead_buf, MZ_ZIP_MAX_IO_BUF_SIZE);
+                    if (n == 0)
+                        break;
+
+                    if ((n > MZ_ZIP_MAX_IO_BUF_SIZE) || (file_ofs + n > max_size))
+                    {
+                        pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+                        return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                    }
+                    if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pRead_buf, n) != n)
+                    {
+                        pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+                        return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+                    }
+                    file_ofs += n;
+                    uncomp_crc32 = (mz_uint32)mz_crc32(uncomp_crc32, (const mz_uint8 *)pRead_buf, n);
+                    cur_archive_file_ofs += n;
+                }
+                uncomp_size = file_ofs;
+                comp_size = uncomp_size;
+            }
+            else
+            {
+                mz_bool result = MZ_FALSE;
+                mz_zip_writer_add_state state;
+                tdefl_compressor *pComp = (tdefl_compressor *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(tdefl_compressor));
+                if (!pComp)
+                {
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+                    return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+                }
+
+                state.m_pZip = pZip;
+                state.m_cur_archive_file_ofs = cur_archive_file_ofs;
+                state.m_comp_size = 0;
+
+                if (tdefl_init(pComp, mz_zip_writer_add_put_buf_callback, &state, tdefl_create_comp_flags_from_zip_params(level, -15, MZ_DEFAULT_STRATEGY)) != TDEFL_STATUS_OKAY)
+                {
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+                    return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+                }
+
+                for (;;)
+                {
+                    tdefl_status status;
+                    tdefl_flush flush = TDEFL_NO_FLUSH;
+
+                    size_t n = read_callback(callback_opaque, file_ofs, pRead_buf, MZ_ZIP_MAX_IO_BUF_SIZE);
+                    if ((n > MZ_ZIP_MAX_IO_BUF_SIZE) || (file_ofs + n > max_size))
+                    {
+                        mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                        break;
+                    }
+
+                    file_ofs += n;
+                    uncomp_crc32 = (mz_uint32)mz_crc32(uncomp_crc32, (const mz_uint8 *)pRead_buf, n);
+
+                    if (pZip->m_pNeeds_keepalive != NULL && pZip->m_pNeeds_keepalive(pZip->m_pIO_opaque))
+                        flush = TDEFL_FULL_FLUSH;
+
+                    if (n == 0)
+                        flush = TDEFL_FINISH;
+
+                    status = tdefl_compress_buffer(pComp, pRead_buf, n, flush);
+                    if (status == TDEFL_STATUS_DONE)
+                    {
+                        result = MZ_TRUE;
+                        break;
+                    }
+                    else if (status != TDEFL_STATUS_OKAY)
+                    {
+                        mz_zip_set_error(pZip, MZ_ZIP_COMPRESSION_FAILED);
+                        break;
+                    }
+                }
+
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
+
+                if (!result)
+                {
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+                    return MZ_FALSE;
+                }
+
+                uncomp_size = file_ofs;
+                comp_size = state.m_comp_size;
+                cur_archive_file_ofs = state.m_cur_archive_file_ofs;
+            }
+
+            pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
+        }
+
+        if (!(level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE))
+        {
+            mz_uint8 local_dir_footer[MZ_ZIP_DATA_DESCRIPTER_SIZE64];
+            mz_uint32 local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE32;
+
+            MZ_WRITE_LE32(local_dir_footer + 0, MZ_ZIP_DATA_DESCRIPTOR_ID);
+            MZ_WRITE_LE32(local_dir_footer + 4, uncomp_crc32);
+            if (pExtra_data == NULL)
+            {
+                if (comp_size > MZ_UINT32_MAX)
+                    return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+
+                MZ_WRITE_LE32(local_dir_footer + 8, comp_size);
+                MZ_WRITE_LE32(local_dir_footer + 12, uncomp_size);
+            }
+            else
+            {
+                MZ_WRITE_LE64(local_dir_footer + 8, comp_size);
+                MZ_WRITE_LE64(local_dir_footer + 16, uncomp_size);
+                local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE64;
+            }
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_footer, local_dir_footer_size) != local_dir_footer_size)
+                return MZ_FALSE;
+
+            cur_archive_file_ofs += local_dir_footer_size;
+        }
+
+        if (level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE)
+        {
+            if (pExtra_data != NULL)
+            {
+                extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (max_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
+                                                                   (max_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+            }
+
+            if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header,
+                                                       (mz_uint16)archive_name_size, (mz_uint16)(extra_size + user_extra_data_len),
+                                                       (max_size >= MZ_UINT32_MAX) ? MZ_UINT32_MAX : uncomp_size,
+                                                       (max_size >= MZ_UINT32_MAX) ? MZ_UINT32_MAX : comp_size,
+                                                       uncomp_crc32, method, gen_flags, dos_time, dos_date))
+                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
+
+            cur_archive_header_file_ofs = local_dir_header_ofs;
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_header_file_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            if (pExtra_data != NULL)
+            {
+                cur_archive_header_file_ofs += sizeof(local_dir_header);
+
+                if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_header_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
+                {
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+                }
+
+                cur_archive_header_file_ofs += archive_name_size;
+
+                if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_header_file_ofs, extra_data, extra_size) != extra_size)
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+                cur_archive_header_file_ofs += extra_size;
+            }
+        }
+
+        if (pExtra_data != NULL)
+        {
+            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
+                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+        }
+
+        if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment, comment_size,
+                                              uncomp_size, comp_size, uncomp_crc32, method, gen_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
+                                              user_extra_data_central, user_extra_data_central_len))
+            return MZ_FALSE;
+
+        pZip->m_total_files++;
+        pZip->m_archive_size = cur_archive_file_ofs;
+
+        return MZ_TRUE;
+    }
+
+#ifndef MINIZ_NO_STDIO
+
+    static size_t mz_file_read_func_stdio(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
+    {
+        MZ_FILE *pSrc_file = (MZ_FILE *)pOpaque;
+        mz_int64 cur_ofs = MZ_FTELL64(pSrc_file);
+
+        if (((mz_int64)file_ofs < 0) || (((cur_ofs != (mz_int64)file_ofs)) && (MZ_FSEEK64(pSrc_file, (mz_int64)file_ofs, SEEK_SET))))
+            return 0;
+
+        return MZ_FREAD(pBuf, 1, n, pSrc_file);
+    }
+
+    mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name, MZ_FILE *pSrc_file, mz_uint64 max_size, const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
+                                    const char *user_extra_data, mz_uint user_extra_data_len, const char *user_extra_data_central, mz_uint user_extra_data_central_len)
+    {
+        return mz_zip_writer_add_read_buf_callback(pZip, pArchive_name, mz_file_read_func_stdio, pSrc_file, max_size, pFile_time, pComment, comment_size, level_and_flags,
+                                                   user_extra_data, user_extra_data_len, user_extra_data_central, user_extra_data_central_len);
+    }
+
+    mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, const char *pSrc_filename, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags)
+    {
+        MZ_FILE *pSrc_file = NULL;
+        mz_uint64 uncomp_size = 0;
+        MZ_TIME_T file_modified_time;
+        MZ_TIME_T *pFile_time = NULL;
+        mz_bool status;
+
+        memset(&file_modified_time, 0, sizeof(file_modified_time));
+
+#if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_STDIO)
+        pFile_time = &file_modified_time;
+        if (!mz_zip_get_file_modified_time(pSrc_filename, &file_modified_time))
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_STAT_FAILED);
+#endif
+
+        pSrc_file = MZ_FOPEN(pSrc_filename, "rb");
+        if (!pSrc_file)
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+
+        MZ_FSEEK64(pSrc_file, 0, SEEK_END);
+        uncomp_size = MZ_FTELL64(pSrc_file);
+        MZ_FSEEK64(pSrc_file, 0, SEEK_SET);
+
+        status = mz_zip_writer_add_cfile(pZip, pArchive_name, pSrc_file, uncomp_size, pFile_time, pComment, comment_size, level_and_flags, NULL, 0, NULL, 0);
+
+        MZ_FCLOSE(pSrc_file);
+
+        return status;
+    }
+#endif /* #ifndef MINIZ_NO_STDIO */
+
+    static mz_bool mz_zip_writer_update_zip64_extension_block(mz_zip_array *pNew_ext, mz_zip_archive *pZip, const mz_uint8 *pExt, mz_uint32 ext_len, mz_uint64 *pComp_size, mz_uint64 *pUncomp_size, mz_uint64 *pLocal_header_ofs, mz_uint32 *pDisk_start)
+    {
+        /* + 64 should be enough for any new zip64 data */
+        if (!mz_zip_array_reserve(pZip, pNew_ext, ext_len + 64, MZ_FALSE))
+            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+        mz_zip_array_resize(pZip, pNew_ext, 0, MZ_FALSE);
+
+        if ((pUncomp_size) || (pComp_size) || (pLocal_header_ofs) || (pDisk_start))
+        {
+            mz_uint8 new_ext_block[64];
+            mz_uint8 *pDst = new_ext_block;
+            mz_write_le16(pDst, MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID);
+            mz_write_le16(pDst + sizeof(mz_uint16), 0);
+            pDst += sizeof(mz_uint16) * 2;
+
+            if (pUncomp_size)
+            {
+                mz_write_le64(pDst, *pUncomp_size);
+                pDst += sizeof(mz_uint64);
+            }
+
+            if (pComp_size)
+            {
+                mz_write_le64(pDst, *pComp_size);
+                pDst += sizeof(mz_uint64);
+            }
+
+            if (pLocal_header_ofs)
+            {
+                mz_write_le64(pDst, *pLocal_header_ofs);
+                pDst += sizeof(mz_uint64);
+            }
+
+            if (pDisk_start)
+            {
+                mz_write_le32(pDst, *pDisk_start);
+                pDst += sizeof(mz_uint32);
+            }
+
+            mz_write_le16(new_ext_block + sizeof(mz_uint16), (mz_uint16)((pDst - new_ext_block) - sizeof(mz_uint16) * 2));
+
+            if (!mz_zip_array_push_back(pZip, pNew_ext, new_ext_block, pDst - new_ext_block))
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+        }
+
+        if ((pExt) && (ext_len))
+        {
+            mz_uint32 extra_size_remaining = ext_len;
+            const mz_uint8 *pExtra_data = pExt;
+
+            do
+            {
+                mz_uint32 field_id, field_data_size, field_total_size;
 
                 if (extra_size_remaining < (sizeof(mz_uint16) * 2))
                     return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
 
                 field_id = MZ_READ_LE16(pExtra_data);
                 field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
+                field_total_size = field_data_size + sizeof(mz_uint16) * 2;
 
-                if ((field_data_size + sizeof(mz_uint16) * 2) > extra_size_remaining)
+                if (field_total_size > extra_size_remaining)
                     return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
 
-                if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
+                if (field_id != MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
                 {
-                    const mz_uint8 *pField_data = pExtra_data + sizeof(mz_uint16) * 2;
-                    mz_uint32 field_data_remaining = field_data_size;
-
-                    if (pFound_zip64_extra_data)
-                        *pFound_zip64_extra_data = MZ_TRUE;
-
-                    if (pStat->m_uncomp_size == MZ_UINT32_MAX)
-                    {
-                        if (field_data_remaining < sizeof(mz_uint64))
-                            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-                        pStat->m_uncomp_size = MZ_READ_LE64(pField_data);
-                        pField_data += sizeof(mz_uint64);
-                        field_data_remaining -= sizeof(mz_uint64);
-                    }
-
-                    if (pStat->m_comp_size == MZ_UINT32_MAX)
-                    {
-                        if (field_data_remaining < sizeof(mz_uint64))
-                            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-                        pStat->m_comp_size = MZ_READ_LE64(pField_data);
-                        pField_data += sizeof(mz_uint64);
-                        field_data_remaining -= sizeof(mz_uint64);
-                    }
-
-                    if (pStat->m_local_header_ofs == MZ_UINT32_MAX)
-                    {
-                        if (field_data_remaining < sizeof(mz_uint64))
-                            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-                        pStat->m_local_header_ofs = MZ_READ_LE64(pField_data);
-                        pField_data += sizeof(mz_uint64);
-                        field_data_remaining -= sizeof(mz_uint64);
-                    }
-
-                    break;
+                    if (!mz_zip_array_push_back(pZip, pNew_ext, pExtra_data, field_total_size))
+                        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
                 }
 
-                pExtra_data += sizeof(mz_uint16) * 2 + field_data_size;
-                extra_size_remaining = extra_size_remaining - sizeof(mz_uint16) * 2 - field_data_size;
+                pExtra_data += field_total_size;
+                extra_size_remaining -= field_total_size;
             } while (extra_size_remaining);
         }
-    }
 
-    return MZ_TRUE;
-}
-
-static MZ_FORCEINLINE mz_bool mz_zip_string_equal(const char *pA, const char *pB, mz_uint len, mz_uint flags)
-{
-    mz_uint i;
-    if (flags & MZ_ZIP_FLAG_CASE_SENSITIVE)
-        return 0 == memcmp(pA, pB, len);
-    for (i = 0; i < len; ++i)
-        if (MZ_TOLOWER(pA[i]) != MZ_TOLOWER(pB[i]))
-            return MZ_FALSE;
-    return MZ_TRUE;
-}
-
-static MZ_FORCEINLINE int mz_zip_filename_compare(const mz_zip_array *pCentral_dir_array, const mz_zip_array *pCentral_dir_offsets, mz_uint l_index, const char *pR, mz_uint r_len)
-{
-    const mz_uint8 *pL = &MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_array, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(pCentral_dir_offsets, mz_uint32, l_index)), *pE;
-    mz_uint l_len = MZ_READ_LE16(pL + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-    mz_uint8 l = 0, r = 0;
-    pL += MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
-    pE = pL + MZ_MIN(l_len, r_len);
-    while (pL < pE)
-    {
-        if ((l = MZ_TOLOWER(*pL)) != (r = MZ_TOLOWER(*pR)))
-            break;
-        pL++;
-        pR++;
-    }
-    return (pL == pE) ? (int)(l_len - r_len) : (l - r);
-}
-
-static mz_bool mz_zip_locate_file_binary_search(mz_zip_archive *pZip, const char *pFilename, mz_uint32 *pIndex)
-{
-    mz_zip_internal_state *pState = pZip->m_pState;
-    const mz_zip_array *pCentral_dir_offsets = &pState->m_central_dir_offsets;
-    const mz_zip_array *pCentral_dir = &pState->m_central_dir;
-    mz_uint32 *pIndices = &MZ_ZIP_ARRAY_ELEMENT(&pState->m_sorted_central_dir_offsets, mz_uint32, 0);
-    const mz_uint32 size = pZip->m_total_files;
-    const mz_uint filename_len = (mz_uint)strlen(pFilename);
-
-    if (pIndex)
-        *pIndex = 0;
-
-    if (size)
-    {
-        /* yes I could use uint32_t's, but then we would have to add some special case checks in the loop, argh, and */
-        /* honestly the major expense here on 32-bit CPU's will still be the filename compare */
-        mz_int64 l = 0, h = (mz_int64)size - 1;
-
-        while (l <= h)
-        {
-            mz_int64 m = l + ((h - l) >> 1);
-            mz_uint32 file_index = pIndices[(mz_uint32)m];
-
-            int comp = mz_zip_filename_compare(pCentral_dir, pCentral_dir_offsets, file_index, pFilename, filename_len);
-            if (!comp)
-            {
-                if (pIndex)
-                    *pIndex = file_index;
-                return MZ_TRUE;
-            }
-            else if (comp < 0)
-                l = m + 1;
-            else
-                h = m - 1;
-        }
-    }
-
-    return mz_zip_set_error(pZip, MZ_ZIP_FILE_NOT_FOUND);
-}
-
-int mz_zip_reader_locate_file(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags)
-{
-    mz_uint32 index;
-    if (!mz_zip_reader_locate_file_v2(pZip, pName, pComment, flags, &index))
-        return -1;
-    else
-        return (int)index;
-}
-
-mz_bool mz_zip_reader_locate_file_v2(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags, mz_uint32 *pIndex)
-{
-    mz_uint file_index;
-    size_t name_len, comment_len;
-
-    if (pIndex)
-        *pIndex = 0;
-
-    if ((!pZip) || (!pZip->m_pState) || (!pName))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    /* See if we can use a binary search */
-    if (((pZip->m_pState->m_init_flags & MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY) == 0) &&
-        (pZip->m_zip_mode == MZ_ZIP_MODE_READING) &&
-        ((flags & (MZ_ZIP_FLAG_IGNORE_PATH | MZ_ZIP_FLAG_CASE_SENSITIVE)) == 0) && (!pComment) && (pZip->m_pState->m_sorted_central_dir_offsets.m_size))
-    {
-        return mz_zip_locate_file_binary_search(pZip, pName, pIndex);
-    }
-
-    /* Locate the entry by scanning the entire central directory */
-    name_len = strlen(pName);
-    if (name_len > MZ_UINT16_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    comment_len = pComment ? strlen(pComment) : 0;
-    if (comment_len > MZ_UINT16_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    for (file_index = 0; file_index < pZip->m_total_files; file_index++)
-    {
-        const mz_uint8 *pHeader = &MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index));
-        mz_uint filename_len = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-        const char *pFilename = (const char *)pHeader + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
-        if (filename_len < name_len)
-            continue;
-        if (comment_len)
-        {
-            mz_uint file_extra_len = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_EXTRA_LEN_OFS), file_comment_len = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_COMMENT_LEN_OFS);
-            const char *pFile_comment = pFilename + filename_len + file_extra_len;
-            if ((file_comment_len != comment_len) || (!mz_zip_string_equal(pComment, pFile_comment, file_comment_len, flags)))
-                continue;
-        }
-        if ((flags & MZ_ZIP_FLAG_IGNORE_PATH) && (filename_len))
-        {
-            int ofs = filename_len - 1;
-            do
-            {
-                if ((pFilename[ofs] == '/') || (pFilename[ofs] == '\\') || (pFilename[ofs] == ':'))
-                    break;
-            } while (--ofs >= 0);
-            ofs++;
-            pFilename += ofs;
-            filename_len -= ofs;
-        }
-        if ((filename_len == name_len) && (mz_zip_string_equal(pName, pFilename, filename_len, flags)))
-        {
-            if (pIndex)
-                *pIndex = file_index;
-            return MZ_TRUE;
-        }
-    }
-
-    return mz_zip_set_error(pZip, MZ_ZIP_FILE_NOT_FOUND);
-}
-
-static
-mz_bool mz_zip_reader_extract_to_mem_no_alloc1(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size, const mz_zip_archive_file_stat *st)
-{
-    int status = TINFL_STATUS_DONE;
-    mz_uint64 needed_size, cur_file_ofs, comp_remaining, out_buf_ofs = 0, read_buf_size, read_buf_ofs = 0, read_buf_avail;
-    mz_zip_archive_file_stat file_stat;
-    void *pRead_buf;
-    mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
-    tinfl_decompressor inflator;
-
-    if ((!pZip) || (!pZip->m_pState) || ((buf_size) && (!pBuf)) || ((user_read_buf_size) && (!pUser_read_buf)) || (!pZip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (st) {
-        file_stat = *st;
-    } else
-    if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
-        return MZ_FALSE;
-
-    /* A directory or zero length file */
-    if ((file_stat.m_is_directory) || (!file_stat.m_comp_size))
         return MZ_TRUE;
+    }
 
-    /* Encryption and patch files are not supported. */
-    if (file_stat.m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
-
-    /* This function only supports decompressing stored and deflate. */
-    if ((!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (file_stat.m_method != 0) && (file_stat.m_method != MZ_DEFLATED))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
-
-    /* Ensure supplied output buffer is large enough. */
-    needed_size = (flags & MZ_ZIP_FLAG_COMPRESSED_DATA) ? file_stat.m_comp_size : file_stat.m_uncomp_size;
-    if (buf_size < needed_size)
-        return mz_zip_set_error(pZip, MZ_ZIP_BUF_TOO_SMALL);
-
-    /* Read and parse the local directory entry. */
-    cur_file_ofs = file_stat.m_local_header_ofs;
-    if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-
-    if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    cur_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
-    if ((cur_file_ofs + file_stat.m_comp_size) > pZip->m_archive_size)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    if ((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!file_stat.m_method))
+    /* TODO: This func is now pretty freakin complex due to zip64, split it up? */
+    mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *pSource_zip, mz_uint src_file_index)
     {
-        /* The file is stored or the caller has requested the compressed data. */
-        if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pBuf, (size_t)needed_size) != needed_size)
+        mz_uint n, bit_flags, num_alignment_padding_bytes, src_central_dir_following_data_size;
+        mz_uint64 src_archive_bytes_remaining, local_dir_header_ofs;
+        mz_uint64 cur_src_file_ofs, cur_dst_file_ofs;
+        mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
+        mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
+        mz_uint8 new_central_header[MZ_ZIP_CENTRAL_DIR_HEADER_SIZE];
+        size_t orig_central_dir_size;
+        mz_zip_internal_state *pState;
+        void *pBuf;
+        const mz_uint8 *pSrc_central_header;
+        mz_zip_archive_file_stat src_file_stat;
+        mz_uint32 src_filename_len, src_comment_len, src_ext_len;
+        mz_uint32 local_header_filename_size, local_header_extra_len;
+        mz_uint64 local_header_comp_size, local_header_uncomp_size;
+        mz_bool found_zip64_ext_data_in_ldir = MZ_FALSE;
+
+        /* Sanity checks */
+        if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || (!pSource_zip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pState = pZip->m_pState;
+
+        /* Don't support copying files from zip64 archives to non-zip64, even though in some cases this is possible */
+        if ((pSource_zip->m_pState->m_zip64) && (!pZip->m_pState->m_zip64))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        /* Get pointer to the source central dir header and crack it */
+        if (NULL == (pSrc_central_header = mz_zip_get_cdh(pSource_zip, src_file_index)))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (MZ_READ_LE32(pSrc_central_header + MZ_ZIP_CDH_SIG_OFS) != MZ_ZIP_CENTRAL_DIR_HEADER_SIG)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        src_filename_len = MZ_READ_LE16(pSrc_central_header + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+        src_comment_len = MZ_READ_LE16(pSrc_central_header + MZ_ZIP_CDH_COMMENT_LEN_OFS);
+        src_ext_len = MZ_READ_LE16(pSrc_central_header + MZ_ZIP_CDH_EXTRA_LEN_OFS);
+        src_central_dir_following_data_size = src_filename_len + src_ext_len + src_comment_len;
+
+        /* TODO: We don't support central dir's >= MZ_UINT32_MAX bytes right now (+32 fudge factor in case we need to add more extra data) */
+        if ((pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_central_dir_following_data_size + 32) >= MZ_UINT32_MAX)
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
+
+        num_alignment_padding_bytes = mz_zip_writer_compute_padding_needed_for_file_alignment(pZip);
+
+        if (!pState->m_zip64)
+        {
+            if (pZip->m_total_files == MZ_UINT16_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+        }
+        else
+        {
+            /* TODO: Our zip64 support still has some 32-bit limits that may not be worth fixing. */
+            if (pZip->m_total_files == MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+        }
+
+        if (!mz_zip_file_stat_internal(pSource_zip, src_file_index, pSrc_central_header, &src_file_stat, NULL))
+            return MZ_FALSE;
+
+        cur_src_file_ofs = src_file_stat.m_local_header_ofs;
+        cur_dst_file_ofs = pZip->m_archive_size;
+
+        /* Read the source archive's local dir header */
+        if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
             return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
 
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-        if ((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) == 0)
+        if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+
+        cur_src_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE;
+
+        /* Compute the total size we need to copy (filename+extra data+compressed data) */
+        local_header_filename_size = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS);
+        local_header_extra_len = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
+        local_header_comp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS);
+        local_header_uncomp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS);
+        src_archive_bytes_remaining = src_file_stat.m_comp_size + local_header_filename_size + local_header_extra_len;
+
+        /* Try to find a zip64 extended information field */
+        if ((local_header_extra_len) && ((local_header_comp_size == MZ_UINT32_MAX) || (local_header_uncomp_size == MZ_UINT32_MAX)))
         {
-            if (mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)pBuf, (size_t)file_stat.m_uncomp_size) != file_stat.m_crc32)
-                return mz_zip_set_error(pZip, MZ_ZIP_CRC_CHECK_FAILED);
-        }
-#endif
+            mz_zip_array file_data_array;
+            const mz_uint8 *pExtra_data;
+            mz_uint32 extra_size_remaining = local_header_extra_len;
 
-        return MZ_TRUE;
-    }
-
-    /* Decompress the file either directly from memory or from a file input buffer. */
-    tinfl_init(&inflator);
-
-    if (pZip->m_pState->m_pMem)
-    {
-        /* Read directly from the archive in memory. */
-        pRead_buf = (mz_uint8 *)pZip->m_pState->m_pMem + cur_file_ofs;
-        read_buf_size = read_buf_avail = file_stat.m_comp_size;
-        comp_remaining = 0;
-    }
-    else if (pUser_read_buf)
-    {
-        /* Use a user provided read buffer. */
-        if (!user_read_buf_size)
-            return MZ_FALSE;
-        pRead_buf = (mz_uint8 *)pUser_read_buf;
-        read_buf_size = user_read_buf_size;
-        read_buf_avail = 0;
-        comp_remaining = file_stat.m_comp_size;
-    }
-    else
-    {
-        /* Temporarily allocate a read buffer. */
-        read_buf_size = MZ_MIN(file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
-        if (((sizeof(size_t) == sizeof(mz_uint32))) && (read_buf_size > 0x7FFFFFFF))
-            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-        if (NULL == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-        read_buf_avail = 0;
-        comp_remaining = file_stat.m_comp_size;
-    }
-
-    do
-    {
-        /* The size_t cast here should be OK because we've verified that the output buffer is >= file_stat.m_uncomp_size above */
-        size_t in_buf_size, out_buf_size = (size_t)(file_stat.m_uncomp_size - out_buf_ofs);
-        if ((!read_buf_avail) && (!pZip->m_pState->m_pMem))
-        {
-            read_buf_avail = MZ_MIN(read_buf_size, comp_remaining);
-            if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
+            mz_zip_array_init(&file_data_array, 1);
+            if (!mz_zip_array_resize(pZip, &file_data_array, local_header_extra_len, MZ_FALSE))
             {
-                status = TINFL_STATUS_FAILED;
-                mz_zip_set_error(pZip, MZ_ZIP_DECOMPRESSION_FAILED);
-                break;
-            }
-            cur_file_ofs += read_buf_avail;
-            comp_remaining -= read_buf_avail;
-            read_buf_ofs = 0;
-        }
-        in_buf_size = (size_t)read_buf_avail;
-        status = tinfl_decompress(&inflator, (mz_uint8 *)pRead_buf + read_buf_ofs, &in_buf_size, (mz_uint8 *)pBuf, (mz_uint8 *)pBuf + out_buf_ofs, &out_buf_size, TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF | (comp_remaining ? TINFL_FLAG_HAS_MORE_INPUT : 0));
-        read_buf_avail -= in_buf_size;
-        read_buf_ofs += in_buf_size;
-        out_buf_ofs += out_buf_size;
-    } while (status == TINFL_STATUS_NEEDS_MORE_INPUT);
-
-    if (status == TINFL_STATUS_DONE)
-    {
-        /* Make sure the entire file was decompressed, and check its CRC. */
-        if (out_buf_ofs != file_stat.m_uncomp_size)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE);
-            status = TINFL_STATUS_FAILED;
-        }
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-        else if (mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)pBuf, (size_t)file_stat.m_uncomp_size) != file_stat.m_crc32)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_CRC_CHECK_FAILED);
-            status = TINFL_STATUS_FAILED;
-        }
-#endif
-    }
-
-    if ((!pZip->m_pState->m_pMem) && (!pUser_read_buf))
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-
-    return status == TINFL_STATUS_DONE;
-}
-
-mz_bool mz_zip_reader_extract_to_mem_no_alloc(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size)
-{
-    return mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, buf_size, flags, pUser_read_buf, user_read_buf_size, NULL);
-}
-
-mz_bool mz_zip_reader_extract_file_to_mem_no_alloc(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size)
-{
-    mz_uint32 file_index;
-    if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
-        return MZ_FALSE;
-    return mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, buf_size, flags, pUser_read_buf, user_read_buf_size, NULL);
-}
-
-mz_bool mz_zip_reader_extract_to_mem(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags)
-{
-    return mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, buf_size, flags, NULL, 0, NULL);
-}
-
-mz_bool mz_zip_reader_extract_file_to_mem(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags)
-{
-    return mz_zip_reader_extract_file_to_mem_no_alloc(pZip, pFilename, pBuf, buf_size, flags, NULL, 0);
-}
-
-void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, size_t *pSize, mz_uint flags)
-{
-    mz_zip_archive_file_stat file_stat;
-    mz_uint64 alloc_size;
-    void *pBuf;
-
-    if (pSize)
-        *pSize = 0;
-
-    if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
-        return NULL;
-
-    alloc_size = (flags & MZ_ZIP_FLAG_COMPRESSED_DATA) ? file_stat.m_comp_size : file_stat.m_uncomp_size;
-    if (((sizeof(size_t) == sizeof(mz_uint32))) && (alloc_size > 0x7FFFFFFF))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-        return NULL;
-    }
-
-    if (NULL == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)alloc_size)))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        return NULL;
-    }
-
-    if (!mz_zip_reader_extract_to_mem_no_alloc1(pZip, file_index, pBuf, (size_t)alloc_size, flags, NULL, 0, &file_stat))
-    {
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
-        return NULL;
-    }
-
-    if (pSize)
-        *pSize = (size_t)alloc_size;
-    return pBuf;
-}
-
-void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFilename, size_t *pSize, mz_uint flags)
-{
-    mz_uint32 file_index;
-    if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
-    {
-        if (pSize)
-            *pSize = 0;
-        return MZ_FALSE;
-    }
-    return mz_zip_reader_extract_to_heap(pZip, file_index, pSize, flags);
-}
-
-mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_index, mz_file_write_func pCallback, void *pOpaque, mz_uint flags)
-{
-    int status = TINFL_STATUS_DONE;
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-    mz_uint file_crc32 = MZ_CRC32_INIT;
-#endif
-    mz_uint64 read_buf_size, read_buf_ofs = 0, read_buf_avail, comp_remaining, out_buf_ofs = 0, cur_file_ofs;
-    mz_zip_archive_file_stat file_stat;
-    void *pRead_buf = NULL;
-    void *pWrite_buf = NULL;
-    mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
-
-    if ((!pZip) || (!pZip->m_pState) || (!pCallback) || (!pZip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
-        return MZ_FALSE;
-
-    /* A directory or zero length file */
-    if ((file_stat.m_is_directory) || (!file_stat.m_comp_size))
-        return MZ_TRUE;
-
-    /* Encryption and patch files are not supported. */
-    if (file_stat.m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
-
-    /* This function only supports decompressing stored and deflate. */
-    if ((!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (file_stat.m_method != 0) && (file_stat.m_method != MZ_DEFLATED))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
-
-    /* Read and do some minimal validation of the local directory entry (this doesn't crack the zip64 stuff, which we already have from the central dir) */
-    cur_file_ofs = file_stat.m_local_header_ofs;
-    if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-
-    if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    cur_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
-    if ((cur_file_ofs + file_stat.m_comp_size) > pZip->m_archive_size)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    /* Decompress the file either directly from memory or from a file input buffer. */
-    if (pZip->m_pState->m_pMem)
-    {
-        pRead_buf = (mz_uint8 *)pZip->m_pState->m_pMem + cur_file_ofs;
-        read_buf_size = read_buf_avail = file_stat.m_comp_size;
-        comp_remaining = 0;
-    }
-    else
-    {
-        read_buf_size = MZ_MIN(file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
-        if (NULL == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-        read_buf_avail = 0;
-        comp_remaining = file_stat.m_comp_size;
-    }
-
-    if ((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!file_stat.m_method))
-    {
-        /* The file is stored or the caller has requested the compressed data. */
-        if (pZip->m_pState->m_pMem)
-        {
-            if (((sizeof(size_t) == sizeof(mz_uint32))) && (file_stat.m_comp_size > MZ_UINT32_MAX))
-                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-            if (pCallback(pOpaque, out_buf_ofs, pRead_buf, (size_t)file_stat.m_comp_size) != file_stat.m_comp_size)
-            {
-                mz_zip_set_error(pZip, MZ_ZIP_WRITE_CALLBACK_FAILED);
-                status = TINFL_STATUS_FAILED;
-            }
-            else if (!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
-            {
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-                file_crc32 = (mz_uint32)mz_crc32(file_crc32, (const mz_uint8 *)pRead_buf, (size_t)file_stat.m_comp_size);
-#endif
-            }
-
-            cur_file_ofs += file_stat.m_comp_size;
-            out_buf_ofs += file_stat.m_comp_size;
-            comp_remaining = 0;
-        }
-        else
-        {
-            while (comp_remaining)
-            {
-                read_buf_avail = MZ_MIN(read_buf_size, comp_remaining);
-                if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
-                {
-                    mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-                    status = TINFL_STATUS_FAILED;
-                    break;
-                }
-
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-                if (!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
-                {
-                    file_crc32 = (mz_uint32)mz_crc32(file_crc32, (const mz_uint8 *)pRead_buf, (size_t)read_buf_avail);
-                }
-#endif
-
-                if (pCallback(pOpaque, out_buf_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
-                {
-                    mz_zip_set_error(pZip, MZ_ZIP_WRITE_CALLBACK_FAILED);
-                    status = TINFL_STATUS_FAILED;
-                    break;
-                }
-
-                cur_file_ofs += read_buf_avail;
-                out_buf_ofs += read_buf_avail;
-                comp_remaining -= read_buf_avail;
-            }
-        }
-    }
-    else
-    {
-        tinfl_decompressor inflator;
-        tinfl_init(&inflator);
-
-        if (NULL == (pWrite_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, TINFL_LZ_DICT_SIZE)))
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-            status = TINFL_STATUS_FAILED;
-        }
-        else
-        {
-            do
-            {
-                mz_uint8 *pWrite_buf_cur = (mz_uint8 *)pWrite_buf + (out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
-                size_t in_buf_size, out_buf_size = TINFL_LZ_DICT_SIZE - (out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
-                if ((!read_buf_avail) && (!pZip->m_pState->m_pMem))
-                {
-                    read_buf_avail = MZ_MIN(read_buf_size, comp_remaining);
-                    if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pRead_buf, (size_t)read_buf_avail) != read_buf_avail)
-                    {
-                        mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-                        status = TINFL_STATUS_FAILED;
-                        break;
-                    }
-                    cur_file_ofs += read_buf_avail;
-                    comp_remaining -= read_buf_avail;
-                    read_buf_ofs = 0;
-                }
-
-                in_buf_size = (size_t)read_buf_avail;
-                status = tinfl_decompress(&inflator, (const mz_uint8 *)pRead_buf + read_buf_ofs, &in_buf_size, (mz_uint8 *)pWrite_buf, pWrite_buf_cur, &out_buf_size, comp_remaining ? TINFL_FLAG_HAS_MORE_INPUT : 0);
-                read_buf_avail -= in_buf_size;
-                read_buf_ofs += in_buf_size;
-
-                if (out_buf_size)
-                {
-                    if (pCallback(pOpaque, out_buf_ofs, pWrite_buf_cur, out_buf_size) != out_buf_size)
-                    {
-                        mz_zip_set_error(pZip, MZ_ZIP_WRITE_CALLBACK_FAILED);
-                        status = TINFL_STATUS_FAILED;
-                        break;
-                    }
-
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-                    file_crc32 = (mz_uint32)mz_crc32(file_crc32, pWrite_buf_cur, out_buf_size);
-#endif
-                    if ((out_buf_ofs += out_buf_size) > file_stat.m_uncomp_size)
-                    {
-                        mz_zip_set_error(pZip, MZ_ZIP_DECOMPRESSION_FAILED);
-                        status = TINFL_STATUS_FAILED;
-                        break;
-                    }
-                }
-            } while ((status == TINFL_STATUS_NEEDS_MORE_INPUT) || (status == TINFL_STATUS_HAS_MORE_OUTPUT));
-        }
-    }
-
-    if ((status == TINFL_STATUS_DONE) && (!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
-    {
-        /* Make sure the entire file was decompressed, and check its CRC. */
-        if (out_buf_ofs != file_stat.m_uncomp_size)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE);
-            status = TINFL_STATUS_FAILED;
-        }
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-        else if (file_crc32 != file_stat.m_crc32)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_DECOMPRESSION_FAILED);
-            status = TINFL_STATUS_FAILED;
-        }
-#endif
-    }
-
-    if (!pZip->m_pState->m_pMem)
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-
-    if (pWrite_buf)
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pWrite_buf);
-
-    return status == TINFL_STATUS_DONE;
-}
-
-mz_bool mz_zip_reader_extract_file_to_callback(mz_zip_archive *pZip, const char *pFilename, mz_file_write_func pCallback, void *pOpaque, mz_uint flags)
-{
-    mz_uint32 file_index;
-    if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
-        return MZ_FALSE;
-
-    return mz_zip_reader_extract_to_callback(pZip, file_index, pCallback, pOpaque, flags);
-}
-
-mz_zip_reader_extract_iter_state* mz_zip_reader_extract_iter_new(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags)
-{
-    mz_zip_reader_extract_iter_state *pState;
-    mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
-
-    /* Argument sanity check */
-    if ((!pZip) || (!pZip->m_pState))
-        return NULL;
-
-    /* Allocate an iterator status structure */
-    pState = (mz_zip_reader_extract_iter_state*)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_reader_extract_iter_state));
-    if (!pState)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        return NULL;
-    }
-
-    /* Fetch file details */
-    if (!mz_zip_reader_file_stat(pZip, file_index, &pState->file_stat))
-    {
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-        return NULL;
-    }
-
-    /* Encryption and patch files are not supported. */
-    if (pState->file_stat.m_bit_flag & (MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_IS_ENCRYPTED | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_USES_STRONG_ENCRYPTION | MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_COMPRESSED_PATCH_FLAG))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-        return NULL;
-    }
-
-    /* This function only supports decompressing stored and deflate. */
-    if ((!(flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (pState->file_stat.m_method != 0) && (pState->file_stat.m_method != MZ_DEFLATED))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-        return NULL;
-    }
-
-    /* Init state - save args */
-    pState->pZip = pZip;
-    pState->flags = flags;
-
-    /* Init state - reset variables to defaults */
-    pState->status = TINFL_STATUS_DONE;
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-    pState->file_crc32 = MZ_CRC32_INIT;
-#endif
-    pState->read_buf_ofs = 0;
-    pState->out_buf_ofs = 0;
-    pState->pRead_buf = NULL;
-    pState->pWrite_buf = NULL;
-    pState->out_blk_remain = 0;
-
-    /* Read and parse the local directory entry. */
-    pState->cur_file_ofs = pState->file_stat.m_local_header_ofs;
-    if (pZip->m_pRead(pZip->m_pIO_opaque, pState->cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-        return NULL;
-    }
-
-    if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-        return NULL;
-    }
-
-    pState->cur_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS) + MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
-    if ((pState->cur_file_ofs + pState->file_stat.m_comp_size) > pZip->m_archive_size)
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-        return NULL;
-    }
-
-    /* Decompress the file either directly from memory or from a file input buffer. */
-    if (pZip->m_pState->m_pMem)
-    {
-        pState->pRead_buf = (mz_uint8 *)pZip->m_pState->m_pMem + pState->cur_file_ofs;
-        pState->read_buf_size = pState->read_buf_avail = pState->file_stat.m_comp_size;
-        pState->comp_remaining = pState->file_stat.m_comp_size;
-    }
-    else
-    {
-        if (!((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method)))
-        {
-            /* Decompression required, therefore intermediate read buffer required */
-            pState->read_buf_size = MZ_MIN(pState->file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
-            if (NULL == (pState->pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)pState->read_buf_size)))
-            {
-                mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-                pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-                return NULL;
-            }
-        }
-        else
-        {
-            /* Decompression not required - we will be reading directly into user buffer, no temp buf required */
-            pState->read_buf_size = 0;
-        }
-        pState->read_buf_avail = 0;
-        pState->comp_remaining = pState->file_stat.m_comp_size;
-    }
-
-    if (!((flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method)))
-    {
-        /* Decompression required, init decompressor */
-        tinfl_init( &pState->inflator );
-
-        /* Allocate write buffer */
-        if (NULL == (pState->pWrite_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, TINFL_LZ_DICT_SIZE)))
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-            if (pState->pRead_buf)
-                pZip->m_pFree(pZip->m_pAlloc_opaque, pState->pRead_buf);
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-            return NULL;
-        }
-    }
-
-    return pState;
-}
-
-mz_zip_reader_extract_iter_state* mz_zip_reader_extract_file_iter_new(mz_zip_archive *pZip, const char *pFilename, mz_uint flags)
-{
-    mz_uint32 file_index;
-
-    /* Locate file index by name */
-    if (!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
-        return NULL;
-
-    /* Construct iterator */
-    return mz_zip_reader_extract_iter_new(pZip, file_index, flags);
-}
-
-size_t mz_zip_reader_extract_iter_read(mz_zip_reader_extract_iter_state* pState, void* pvBuf, size_t buf_size)
-{
-    size_t copied_to_caller = 0;
-
-    /* Argument sanity check */
-    if ((!pState) || (!pState->pZip) || (!pState->pZip->m_pState) || (!pvBuf))
-        return 0;
-
-    if ((pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method))
-    {
-        /* The file is stored or the caller has requested the compressed data, calc amount to return. */
-        copied_to_caller = (size_t)MZ_MIN( buf_size, pState->comp_remaining );
-
-        /* Zip is in memory....or requires reading from a file? */
-        if (pState->pZip->m_pState->m_pMem)
-        {
-            /* Copy data to caller's buffer */
-            memcpy( pvBuf, pState->pRead_buf, copied_to_caller );
-            pState->pRead_buf = ((mz_uint8*)pState->pRead_buf) + copied_to_caller;
-        }
-        else
-        {
-            /* Read directly into caller's buffer */
-            if (pState->pZip->m_pRead(pState->pZip->m_pIO_opaque, pState->cur_file_ofs, pvBuf, copied_to_caller) != copied_to_caller)
-            {
-                /* Failed to read all that was asked for, flag failure and alert user */
-                mz_zip_set_error(pState->pZip, MZ_ZIP_FILE_READ_FAILED);
-                pState->status = TINFL_STATUS_FAILED;
-                copied_to_caller = 0;
-            }
-        }
-
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-        /* Compute CRC if not returning compressed data only */
-        if (!(pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
-            pState->file_crc32 = (mz_uint32)mz_crc32(pState->file_crc32, (const mz_uint8 *)pvBuf, copied_to_caller);
-#endif
-
-        /* Advance offsets, dec counters */
-        pState->cur_file_ofs += copied_to_caller;
-        pState->out_buf_ofs += copied_to_caller;
-        pState->comp_remaining -= copied_to_caller;
-    }
-    else
-    {
-        do
-        {
-            /* Calc ptr to write buffer - given current output pos and block size */
-            mz_uint8 *pWrite_buf_cur = (mz_uint8 *)pState->pWrite_buf + (pState->out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
-
-            /* Calc max output size - given current output pos and block size */
-            size_t in_buf_size, out_buf_size = TINFL_LZ_DICT_SIZE - (pState->out_buf_ofs & (TINFL_LZ_DICT_SIZE - 1));
-
-            if (!pState->out_blk_remain)
-            {
-                /* Read more data from file if none available (and reading from file) */
-                if ((!pState->read_buf_avail) && (!pState->pZip->m_pState->m_pMem))
-                {
-                    /* Calc read size */
-                    pState->read_buf_avail = MZ_MIN(pState->read_buf_size, pState->comp_remaining);
-                    if (pState->pZip->m_pRead(pState->pZip->m_pIO_opaque, pState->cur_file_ofs, pState->pRead_buf, (size_t)pState->read_buf_avail) != pState->read_buf_avail)
-                    {
-                        mz_zip_set_error(pState->pZip, MZ_ZIP_FILE_READ_FAILED);
-                        pState->status = TINFL_STATUS_FAILED;
-                        break;
-                    }
-
-                    /* Advance offsets, dec counters */
-                    pState->cur_file_ofs += pState->read_buf_avail;
-                    pState->comp_remaining -= pState->read_buf_avail;
-                    pState->read_buf_ofs = 0;
-                }
-
-                /* Perform decompression */
-                in_buf_size = (size_t)pState->read_buf_avail;
-                pState->status = tinfl_decompress(&pState->inflator, (const mz_uint8 *)pState->pRead_buf + pState->read_buf_ofs, &in_buf_size, (mz_uint8 *)pState->pWrite_buf, pWrite_buf_cur, &out_buf_size, pState->comp_remaining ? TINFL_FLAG_HAS_MORE_INPUT : 0);
-                pState->read_buf_avail -= in_buf_size;
-                pState->read_buf_ofs += in_buf_size;
-
-                /* Update current output block size remaining */
-                pState->out_blk_remain = out_buf_size;
-            }
-
-            if (pState->out_blk_remain)
-            {
-                /* Calc amount to return. */
-                size_t to_copy = MZ_MIN( (buf_size - copied_to_caller), pState->out_blk_remain );
-
-                /* Copy data to caller's buffer */
-                memcpy( (mz_uint8*)pvBuf + copied_to_caller, pWrite_buf_cur, to_copy );
-
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-                /* Perform CRC */
-                pState->file_crc32 = (mz_uint32)mz_crc32(pState->file_crc32, pWrite_buf_cur, to_copy);
-#endif
-
-                /* Decrement data consumed from block */
-                pState->out_blk_remain -= to_copy;
-
-                /* Inc output offset, while performing sanity check */
-                if ((pState->out_buf_ofs += to_copy) > pState->file_stat.m_uncomp_size)
-                {
-                    mz_zip_set_error(pState->pZip, MZ_ZIP_DECOMPRESSION_FAILED);
-                    pState->status = TINFL_STATUS_FAILED;
-                    break;
-                }
-
-                /* Increment counter of data copied to caller */
-                copied_to_caller += to_copy;
-            }
-        } while ( (copied_to_caller < buf_size) && ((pState->status == TINFL_STATUS_NEEDS_MORE_INPUT) || (pState->status == TINFL_STATUS_HAS_MORE_OUTPUT)) );
-    }
-
-    /* Return how many bytes were copied into user buffer */
-    return copied_to_caller;
-}
-
-mz_bool mz_zip_reader_extract_iter_free(mz_zip_reader_extract_iter_state* pState)
-{
-    int status;
-
-    /* Argument sanity check */
-    if ((!pState) || (!pState->pZip) || (!pState->pZip->m_pState))
-        return MZ_FALSE;
-
-    /* Was decompression completed and requested? */
-    if ((pState->status == TINFL_STATUS_DONE) && (!(pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
-    {
-        /* Make sure the entire file was decompressed, and check its CRC. */
-        if (pState->out_buf_ofs != pState->file_stat.m_uncomp_size)
-        {
-            mz_zip_set_error(pState->pZip, MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE);
-            pState->status = TINFL_STATUS_FAILED;
-        }
-#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-        else if (pState->file_crc32 != pState->file_stat.m_crc32)
-        {
-            mz_zip_set_error(pState->pZip, MZ_ZIP_DECOMPRESSION_FAILED);
-            pState->status = TINFL_STATUS_FAILED;
-        }
-#endif
-    }
-
-    /* Free buffers */
-    if (!pState->pZip->m_pState->m_pMem)
-        pState->pZip->m_pFree(pState->pZip->m_pAlloc_opaque, pState->pRead_buf);
-    if (pState->pWrite_buf)
-        pState->pZip->m_pFree(pState->pZip->m_pAlloc_opaque, pState->pWrite_buf);
-
-    /* Save status */
-    status = pState->status;
-
-    /* Free context */
-    pState->pZip->m_pFree(pState->pZip->m_pAlloc_opaque, pState);
-
-    return status == TINFL_STATUS_DONE;
-}
-
-#ifndef MINIZ_NO_STDIO
-static size_t mz_zip_file_write_callback(void *pOpaque, mz_uint64 ofs, const void *pBuf, size_t n)
-{
-    (void)ofs;
-
-    return MZ_FWRITE(pBuf, 1, n, (MZ_FILE *)pOpaque);
-}
-
-mz_bool mz_zip_reader_extract_to_file(mz_zip_archive *pZip, mz_uint file_index, const char *pDst_filename, mz_uint flags)
-{
-    mz_bool status;
-    mz_zip_archive_file_stat file_stat;
-    MZ_FILE *pFile;
-
-    if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
-        return MZ_FALSE;
-
-    if ((file_stat.m_is_directory) || (!file_stat.m_is_supported))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
-
-    pFile = MZ_FOPEN(pDst_filename, "wb");
-    if (!pFile)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
-
-    status = mz_zip_reader_extract_to_callback(pZip, file_index, mz_zip_file_write_callback, pFile, flags);
-
-    if (MZ_FCLOSE(pFile) == EOF)
-    {
-        if (status)
-            mz_zip_set_error(pZip, MZ_ZIP_FILE_CLOSE_FAILED);
-
-        status = MZ_FALSE;
-    }
-
-#if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_STDIO)
-    if (status)
-        mz_zip_set_file_times(pDst_filename, file_stat.m_time, file_stat.m_time);
-#endif
-
-    return status;
-}
-
-mz_bool mz_zip_reader_extract_file_to_file(mz_zip_archive *pZip, const char *pArchive_filename, const char *pDst_filename, mz_uint flags)
-{
-    mz_uint32 file_index;
-    if (!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, NULL, flags, &file_index))
-        return MZ_FALSE;
-
-    return mz_zip_reader_extract_to_file(pZip, file_index, pDst_filename, flags);
-}
-
-mz_bool mz_zip_reader_extract_to_cfile(mz_zip_archive *pZip, mz_uint file_index, MZ_FILE *pFile, mz_uint flags)
-{
-    mz_zip_archive_file_stat file_stat;
-
-    if (!mz_zip_reader_file_stat(pZip, file_index, &file_stat))
-        return MZ_FALSE;
-
-    if ((file_stat.m_is_directory) || (!file_stat.m_is_supported))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
-
-    return mz_zip_reader_extract_to_callback(pZip, file_index, mz_zip_file_write_callback, pFile, flags);
-}
-
-mz_bool mz_zip_reader_extract_file_to_cfile(mz_zip_archive *pZip, const char *pArchive_filename, MZ_FILE *pFile, mz_uint flags)
-{
-    mz_uint32 file_index;
-    if (!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, NULL, flags, &file_index))
-        return MZ_FALSE;
-
-    return mz_zip_reader_extract_to_cfile(pZip, file_index, pFile, flags);
-}
-#endif /* #ifndef MINIZ_NO_STDIO */
-
-static size_t mz_zip_compute_crc32_callback(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n)
-{
-    mz_uint32 *p = (mz_uint32 *)pOpaque;
-    (void)file_ofs;
-    *p = (mz_uint32)mz_crc32(*p, (const mz_uint8 *)pBuf, n);
-    return n;
-}
-
-mz_bool mz_zip_validate_file(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags)
-{
-    mz_zip_archive_file_stat file_stat;
-    mz_zip_internal_state *pState;
-    const mz_uint8 *pCentral_dir_header;
-    mz_bool found_zip64_ext_data_in_cdir = MZ_FALSE;
-    mz_bool found_zip64_ext_data_in_ldir = MZ_FALSE;
-    mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
-    mz_uint64 local_header_ofs = 0;
-    mz_uint32 local_header_filename_len, local_header_extra_len, local_header_crc32;
-    mz_uint64 local_header_comp_size, local_header_uncomp_size;
-    mz_uint32 uncomp_crc32 = MZ_CRC32_INIT;
-    mz_bool has_data_descriptor;
-    mz_uint32 local_header_bit_flags;
-
-    mz_zip_array file_data_array;
-    mz_zip_array_init(&file_data_array, 1);
-
-    if ((!pZip) || (!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || (!pZip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (file_index > pZip->m_total_files)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pState = pZip->m_pState;
-
-    pCentral_dir_header = mz_zip_get_cdh(pZip, file_index);
-
-    if (!mz_zip_file_stat_internal(pZip, file_index, pCentral_dir_header, &file_stat, &found_zip64_ext_data_in_cdir))
-        return MZ_FALSE;
-
-    /* A directory or zero length file */
-    if ((file_stat.m_is_directory) || (!file_stat.m_uncomp_size))
-        return MZ_TRUE;
-
-    /* Encryption and patch files are not supported. */
-    if (file_stat.m_is_encrypted)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_ENCRYPTION);
-
-    /* This function only supports stored and deflate. */
-    if ((file_stat.m_method != 0) && (file_stat.m_method != MZ_DEFLATED))
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_METHOD);
-
-    if (!file_stat.m_is_supported)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_FEATURE);
-
-    /* Read and parse the local directory entry. */
-    local_header_ofs = file_stat.m_local_header_ofs;
-    if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-
-    if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    local_header_filename_len = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS);
-    local_header_extra_len = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
-    local_header_comp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS);
-    local_header_uncomp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS);
-    local_header_crc32 = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_CRC32_OFS);
-    local_header_bit_flags = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_BIT_FLAG_OFS);
-    has_data_descriptor = (local_header_bit_flags & 8) != 0;
-
-    if (local_header_filename_len != strlen(file_stat.m_filename))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    if ((local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_len + local_header_extra_len + file_stat.m_comp_size) > pZip->m_archive_size)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    if (!mz_zip_array_resize(pZip, &file_data_array, MZ_MAX(local_header_filename_len, local_header_extra_len), MZ_FALSE))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        goto handle_failure;
-    }
-
-    if (local_header_filename_len)
-    {
-        if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE, file_data_array.m_p, local_header_filename_len) != local_header_filename_len)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-            goto handle_failure;
-        }
-
-        /* I've seen 1 archive that had the same pathname, but used backslashes in the local dir and forward slashes in the central dir. Do we care about this? For now, this case will fail validation. */
-        if (memcmp(file_stat.m_filename, file_data_array.m_p, local_header_filename_len) != 0)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
-            goto handle_failure;
-        }
-    }
-
-    if ((local_header_extra_len) && ((local_header_comp_size == MZ_UINT32_MAX) || (local_header_uncomp_size == MZ_UINT32_MAX)))
-    {
-        mz_uint32 extra_size_remaining = local_header_extra_len;
-        const mz_uint8 *pExtra_data = (const mz_uint8 *)file_data_array.m_p;
-
-        if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_len, file_data_array.m_p, local_header_extra_len) != local_header_extra_len)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-            goto handle_failure;
-        }
-
-        do
-        {
-            mz_uint32 field_id, field_data_size, field_total_size;
-
-            if (extra_size_remaining < (sizeof(mz_uint16) * 2))
-            {
-                mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-                goto handle_failure;
-            }
-
-            field_id = MZ_READ_LE16(pExtra_data);
-            field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
-            field_total_size = field_data_size + sizeof(mz_uint16) * 2;
-
-            if (field_total_size > extra_size_remaining)
-            {
-                mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-                goto handle_failure;
-            }
-
-            if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
-            {
-                const mz_uint8 *pSrc_field_data = pExtra_data + sizeof(mz_uint32);
-
-                if (field_data_size < sizeof(mz_uint64) * 2)
-                {
-                    mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-                    goto handle_failure;
-                }
-
-                local_header_uncomp_size = MZ_READ_LE64(pSrc_field_data);
-                local_header_comp_size = MZ_READ_LE64(pSrc_field_data + sizeof(mz_uint64));
-
-                found_zip64_ext_data_in_ldir = MZ_TRUE;
-                break;
-            }
-
-            pExtra_data += field_total_size;
-            extra_size_remaining -= field_total_size;
-        } while (extra_size_remaining);
-    }
-
-    /* TODO: parse local header extra data when local_header_comp_size is 0xFFFFFFFF! (big_descriptor.zip) */
-    /* I've seen zips in the wild with the data descriptor bit set, but proper local header values and bogus data descriptors */
-    if ((has_data_descriptor) && (!local_header_comp_size) && (!local_header_crc32))
-    {
-        mz_uint8 descriptor_buf[32];
-        mz_bool has_id;
-        const mz_uint8 *pSrc;
-        mz_uint32 file_crc32;
-        mz_uint64 comp_size = 0, uncomp_size = 0;
-
-        mz_uint32 num_descriptor_uint32s = ((pState->m_zip64) || (found_zip64_ext_data_in_ldir)) ? 6 : 4;
-
-        if (pZip->m_pRead(pZip->m_pIO_opaque, local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_len + local_header_extra_len + file_stat.m_comp_size, descriptor_buf, sizeof(mz_uint32) * num_descriptor_uint32s) != (sizeof(mz_uint32) * num_descriptor_uint32s))
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-            goto handle_failure;
-        }
-
-        has_id = (MZ_READ_LE32(descriptor_buf) == MZ_ZIP_DATA_DESCRIPTOR_ID);
-        pSrc = has_id ? (descriptor_buf + sizeof(mz_uint32)) : descriptor_buf;
-
-        file_crc32 = MZ_READ_LE32(pSrc);
-
-        if ((pState->m_zip64) || (found_zip64_ext_data_in_ldir))
-        {
-            comp_size = MZ_READ_LE64(pSrc + sizeof(mz_uint32));
-            uncomp_size = MZ_READ_LE64(pSrc + sizeof(mz_uint32) + sizeof(mz_uint64));
-        }
-        else
-        {
-            comp_size = MZ_READ_LE32(pSrc + sizeof(mz_uint32));
-            uncomp_size = MZ_READ_LE32(pSrc + sizeof(mz_uint32) + sizeof(mz_uint32));
-        }
-
-        if ((file_crc32 != file_stat.m_crc32) || (comp_size != file_stat.m_comp_size) || (uncomp_size != file_stat.m_uncomp_size))
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
-            goto handle_failure;
-        }
-    }
-    else
-    {
-        if ((local_header_crc32 != file_stat.m_crc32) || (local_header_comp_size != file_stat.m_comp_size) || (local_header_uncomp_size != file_stat.m_uncomp_size))
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
-            goto handle_failure;
-        }
-    }
-
-    mz_zip_array_clear(pZip, &file_data_array);
-
-    if ((flags & MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY) == 0)
-    {
-        if (!mz_zip_reader_extract_to_callback(pZip, file_index, mz_zip_compute_crc32_callback, &uncomp_crc32, 0))
-            return MZ_FALSE;
-
-        /* 1 more check to be sure, although the extract checks too. */
-        if (uncomp_crc32 != file_stat.m_crc32)
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
-            return MZ_FALSE;
-        }
-    }
-
-    return MZ_TRUE;
-
-handle_failure:
-    mz_zip_array_clear(pZip, &file_data_array);
-    return MZ_FALSE;
-}
-
-mz_bool mz_zip_validate_archive(mz_zip_archive *pZip, mz_uint flags)
-{
-    mz_zip_internal_state *pState;
-    mz_uint32 i;
-
-    if ((!pZip) || (!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || (!pZip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pState = pZip->m_pState;
-
-    /* Basic sanity checks */
-    if (!pState->m_zip64)
-    {
-        if (pZip->m_total_files > MZ_UINT16_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-
-        if (pZip->m_archive_size > MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-    }
-    else
-    {
-        if (pState->m_central_dir.m_size >= MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-    }
-
-    for (i = 0; i < pZip->m_total_files; i++)
-    {
-        if (MZ_ZIP_FLAG_VALIDATE_LOCATE_FILE_FLAG & flags)
-        {
-            mz_uint32 found_index;
-            mz_zip_archive_file_stat stat;
-
-            if (!mz_zip_reader_file_stat(pZip, i, &stat))
-                return MZ_FALSE;
-
-            if (!mz_zip_reader_locate_file_v2(pZip, stat.m_filename, NULL, 0, &found_index))
-                return MZ_FALSE;
-
-            /* This check can fail if there are duplicate filenames in the archive (which we don't check for when writing - that's up to the user) */
-            if (found_index != i)
-                return mz_zip_set_error(pZip, MZ_ZIP_VALIDATION_FAILED);
-        }
-
-        if (!mz_zip_validate_file(pZip, i, flags))
-            return MZ_FALSE;
-    }
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_validate_mem_archive(const void *pMem, size_t size, mz_uint flags, mz_zip_error *pErr)
-{
-    mz_bool success = MZ_TRUE;
-    mz_zip_archive zip;
-    mz_zip_error actual_err = MZ_ZIP_NO_ERROR;
-
-    if ((!pMem) || (!size))
-    {
-        if (pErr)
-            *pErr = MZ_ZIP_INVALID_PARAMETER;
-        return MZ_FALSE;
-    }
-
-    mz_zip_zero_struct(&zip);
-
-    if (!mz_zip_reader_init_mem(&zip, pMem, size, flags))
-    {
-        if (pErr)
-            *pErr = zip.m_last_error;
-        return MZ_FALSE;
-    }
-
-    if (!mz_zip_validate_archive(&zip, flags))
-    {
-        actual_err = zip.m_last_error;
-        success = MZ_FALSE;
-    }
-
-    if (!mz_zip_reader_end_internal(&zip, success))
-    {
-        if (!actual_err)
-            actual_err = zip.m_last_error;
-        success = MZ_FALSE;
-    }
-
-    if (pErr)
-        *pErr = actual_err;
-
-    return success;
-}
-
-#ifndef MINIZ_NO_STDIO
-mz_bool mz_zip_validate_file_archive(const char *pFilename, mz_uint flags, mz_zip_error *pErr)
-{
-    mz_bool success = MZ_TRUE;
-    mz_zip_archive zip;
-    mz_zip_error actual_err = MZ_ZIP_NO_ERROR;
-
-    if (!pFilename)
-    {
-        if (pErr)
-            *pErr = MZ_ZIP_INVALID_PARAMETER;
-        return MZ_FALSE;
-    }
-
-    mz_zip_zero_struct(&zip);
-
-    if (!mz_zip_reader_init_file_v2(&zip, pFilename, flags, 0, 0))
-    {
-        if (pErr)
-            *pErr = zip.m_last_error;
-        return MZ_FALSE;
-    }
-
-    if (!mz_zip_validate_archive(&zip, flags))
-    {
-        actual_err = zip.m_last_error;
-        success = MZ_FALSE;
-    }
-
-    if (!mz_zip_reader_end_internal(&zip, success))
-    {
-        if (!actual_err)
-            actual_err = zip.m_last_error;
-        success = MZ_FALSE;
-    }
-
-    if (pErr)
-        *pErr = actual_err;
-
-    return success;
-}
-#endif /* #ifndef MINIZ_NO_STDIO */
-
-/* ------------------- .ZIP archive writing */
-
-#ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
-
-static MZ_FORCEINLINE void mz_write_le16(mz_uint8 *p, mz_uint16 v)
-{
-    p[0] = (mz_uint8)v;
-    p[1] = (mz_uint8)(v >> 8);
-}
-static MZ_FORCEINLINE void mz_write_le32(mz_uint8 *p, mz_uint32 v)
-{
-    p[0] = (mz_uint8)v;
-    p[1] = (mz_uint8)(v >> 8);
-    p[2] = (mz_uint8)(v >> 16);
-    p[3] = (mz_uint8)(v >> 24);
-}
-static MZ_FORCEINLINE void mz_write_le64(mz_uint8 *p, mz_uint64 v)
-{
-    mz_write_le32(p, (mz_uint32)v);
-    mz_write_le32(p + sizeof(mz_uint32), (mz_uint32)(v >> 32));
-}
-
-#define MZ_WRITE_LE16(p, v) mz_write_le16((mz_uint8 *)(p), (mz_uint16)(v))
-#define MZ_WRITE_LE32(p, v) mz_write_le32((mz_uint8 *)(p), (mz_uint32)(v))
-#define MZ_WRITE_LE64(p, v) mz_write_le64((mz_uint8 *)(p), (mz_uint64)(v))
-
-static size_t mz_zip_heap_write_func(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n)
-{
-    mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
-    mz_zip_internal_state *pState = pZip->m_pState;
-    mz_uint64 new_size = MZ_MAX(file_ofs + n, pState->m_mem_size);
-
-    if (!n)
-        return 0;
-
-    /* An allocation this big is likely to just fail on 32-bit systems, so don't even go there. */
-    if ((sizeof(size_t) == sizeof(mz_uint32)) && (new_size > 0x7FFFFFFF))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_FILE_TOO_LARGE);
-        return 0;
-    }
-
-    if (new_size > pState->m_mem_capacity)
-    {
-        void *pNew_block;
-        size_t new_capacity = MZ_MAX(64, pState->m_mem_capacity);
-
-        while (new_capacity < new_size)
-            new_capacity *= 2;
-
-        if (NULL == (pNew_block = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pState->m_pMem, 1, new_capacity)))
-        {
-            mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-            return 0;
-        }
-
-        pState->m_pMem = pNew_block;
-        pState->m_mem_capacity = new_capacity;
-    }
-    memcpy((mz_uint8 *)pState->m_pMem + file_ofs, pBuf, n);
-    pState->m_mem_size = (size_t)new_size;
-    return n;
-}
-
-static mz_bool mz_zip_writer_end_internal(mz_zip_archive *pZip, mz_bool set_last_error)
-{
-    mz_zip_internal_state *pState;
-    mz_bool status = MZ_TRUE;
-
-    if ((!pZip) || (!pZip->m_pState) || (!pZip->m_pAlloc) || (!pZip->m_pFree) || ((pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) && (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED)))
-    {
-        if (set_last_error)
-            mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-        return MZ_FALSE;
-    }
-
-    pState = pZip->m_pState;
-    pZip->m_pState = NULL;
-    mz_zip_array_clear(pZip, &pState->m_central_dir);
-    mz_zip_array_clear(pZip, &pState->m_central_dir_offsets);
-    mz_zip_array_clear(pZip, &pState->m_sorted_central_dir_offsets);
-
-#ifndef MINIZ_NO_STDIO
-    if (pState->m_pFile)
-    {
-        if (pZip->m_zip_type == MZ_ZIP_TYPE_FILE)
-        {
-            if (MZ_FCLOSE(pState->m_pFile) == EOF)
-            {
-                if (set_last_error)
-                    mz_zip_set_error(pZip, MZ_ZIP_FILE_CLOSE_FAILED);
-                status = MZ_FALSE;
-            }
-        }
-
-        pState->m_pFile = NULL;
-    }
-#endif /* #ifndef MINIZ_NO_STDIO */
-
-    if ((pZip->m_pWrite == mz_zip_heap_write_func) && (pState->m_pMem))
-    {
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pState->m_pMem);
-        pState->m_pMem = NULL;
-    }
-
-    pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
-    pZip->m_zip_mode = MZ_ZIP_MODE_INVALID;
-    return status;
-}
-
-mz_bool mz_zip_writer_init_v2(mz_zip_archive *pZip, mz_uint64 existing_size, mz_uint flags)
-{
-    mz_bool zip64 = (flags & MZ_ZIP_FLAG_WRITE_ZIP64) != 0;
-
-    if ((!pZip) || (pZip->m_pState) || (!pZip->m_pWrite) || (pZip->m_zip_mode != MZ_ZIP_MODE_INVALID))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
-    {
-        if (!pZip->m_pRead)
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-    }
-
-    if (pZip->m_file_offset_alignment)
-    {
-        /* Ensure user specified file offset alignment is a power of 2. */
-        if (pZip->m_file_offset_alignment & (pZip->m_file_offset_alignment - 1))
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-    }
-
-    if (!pZip->m_pAlloc)
-        pZip->m_pAlloc = miniz_def_alloc_func;
-    if (!pZip->m_pFree)
-        pZip->m_pFree = miniz_def_free_func;
-    if (!pZip->m_pRealloc)
-        pZip->m_pRealloc = miniz_def_realloc_func;
-
-    pZip->m_archive_size = existing_size;
-    pZip->m_central_directory_file_ofs = 0;
-    pZip->m_total_files = 0;
-
-    if (NULL == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-    memset(pZip->m_pState, 0, sizeof(mz_zip_internal_state));
-
-    MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir, sizeof(mz_uint8));
-    MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_central_dir_offsets, sizeof(mz_uint32));
-    MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(&pZip->m_pState->m_sorted_central_dir_offsets, sizeof(mz_uint32));
-
-    pZip->m_pState->m_zip64 = zip64;
-    pZip->m_pState->m_zip64_has_extended_info_fields = zip64;
-
-    pZip->m_zip_type = MZ_ZIP_TYPE_USER;
-    pZip->m_zip_mode = MZ_ZIP_MODE_WRITING;
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_init(mz_zip_archive *pZip, mz_uint64 existing_size)
-{
-    return mz_zip_writer_init_v2(pZip, existing_size, 0);
-}
-
-mz_bool mz_zip_writer_init_heap_v2(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size, mz_uint flags)
-{
-    pZip->m_pWrite = mz_zip_heap_write_func;
-    pZip->m_pNeeds_keepalive = NULL;
-
-    if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
-        pZip->m_pRead = mz_zip_mem_read_func;
-
-    pZip->m_pIO_opaque = pZip;
-
-    if (!mz_zip_writer_init_v2(pZip, size_to_reserve_at_beginning, flags))
-        return MZ_FALSE;
-
-    pZip->m_zip_type = MZ_ZIP_TYPE_HEAP;
-
-    if (0 != (initial_allocation_size = MZ_MAX(initial_allocation_size, size_to_reserve_at_beginning)))
-    {
-        if (NULL == (pZip->m_pState->m_pMem = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, initial_allocation_size)))
-        {
-            mz_zip_writer_end_internal(pZip, MZ_FALSE);
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        }
-        pZip->m_pState->m_mem_capacity = initial_allocation_size;
-    }
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_init_heap(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size)
-{
-    return mz_zip_writer_init_heap_v2(pZip, size_to_reserve_at_beginning, initial_allocation_size, 0);
-}
-
-#ifndef MINIZ_NO_STDIO
-static size_t mz_zip_file_write_func(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n)
-{
-    mz_zip_archive *pZip = (mz_zip_archive *)pOpaque;
-    mz_int64 cur_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
-
-    file_ofs += pZip->m_pState->m_file_archive_start_ofs;
-
-    if (((mz_int64)file_ofs < 0) || (((cur_ofs != (mz_int64)file_ofs)) && (MZ_FSEEK64(pZip->m_pState->m_pFile, (mz_int64)file_ofs, SEEK_SET))))
-    {
-        mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
-        return 0;
-    }
-
-    return MZ_FWRITE(pBuf, 1, n, pZip->m_pState->m_pFile);
-}
-
-mz_bool mz_zip_writer_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning)
-{
-    return mz_zip_writer_init_file_v2(pZip, pFilename, size_to_reserve_at_beginning, 0);
-}
-
-mz_bool mz_zip_writer_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning, mz_uint flags)
-{
-    MZ_FILE *pFile;
-
-    pZip->m_pWrite = mz_zip_file_write_func;
-    pZip->m_pNeeds_keepalive = NULL;
-
-    if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
-        pZip->m_pRead = mz_zip_file_read_func;
-
-    pZip->m_pIO_opaque = pZip;
-
-    if (!mz_zip_writer_init_v2(pZip, size_to_reserve_at_beginning, flags))
-        return MZ_FALSE;
-
-    if (NULL == (pFile = MZ_FOPEN(pFilename, (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING) ? "w+b" : "wb")))
-    {
-        mz_zip_writer_end(pZip);
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
-    }
-
-    pZip->m_pState->m_pFile = pFile;
-    pZip->m_zip_type = MZ_ZIP_TYPE_FILE;
-
-    if (size_to_reserve_at_beginning)
-    {
-        mz_uint64 cur_ofs = 0;
-        char buf[4096];
-
-        MZ_CLEAR_ARR(buf);
-
-        do
-        {
-            size_t n = (size_t)MZ_MIN(sizeof(buf), size_to_reserve_at_beginning);
-            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_ofs, buf, n) != n)
-            {
-                mz_zip_writer_end(pZip);
-                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-            }
-            cur_ofs += n;
-            size_to_reserve_at_beginning -= n;
-        } while (size_to_reserve_at_beginning);
-    }
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint flags)
-{
-    pZip->m_pWrite = mz_zip_file_write_func;
-    pZip->m_pNeeds_keepalive = NULL;
-
-    if (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING)
-        pZip->m_pRead = mz_zip_file_read_func;
-
-    pZip->m_pIO_opaque = pZip;
-
-    if (!mz_zip_writer_init_v2(pZip, 0, flags))
-        return MZ_FALSE;
-
-    pZip->m_pState->m_pFile = pFile;
-    pZip->m_pState->m_file_archive_start_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
-    pZip->m_zip_type = MZ_ZIP_TYPE_CFILE;
-
-    return MZ_TRUE;
-}
-#endif /* #ifndef MINIZ_NO_STDIO */
-
-mz_bool mz_zip_writer_init_from_reader_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags)
-{
-    mz_zip_internal_state *pState;
-
-    if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_READING))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (flags & MZ_ZIP_FLAG_WRITE_ZIP64)
-    {
-        /* We don't support converting a non-zip64 file to zip64 - this seems like more trouble than it's worth. (What about the existing 32-bit data descriptors that could follow the compressed data?) */
-        if (!pZip->m_pState->m_zip64)
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-    }
-
-    /* No sense in trying to write to an archive that's already at the support max size */
-    if (pZip->m_pState->m_zip64)
-    {
-        if (pZip->m_total_files == MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-    else
-    {
-        if (pZip->m_total_files == MZ_UINT16_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-
-        if ((pZip->m_archive_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + MZ_ZIP_LOCAL_DIR_HEADER_SIZE) > MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_TOO_LARGE);
-    }
-
-    pState = pZip->m_pState;
-
-    if (pState->m_pFile)
-    {
-#ifdef MINIZ_NO_STDIO
-        (void)pFilename;
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-#else
-        if (pZip->m_pIO_opaque != pZip)
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-        if (pZip->m_zip_type == MZ_ZIP_TYPE_FILE)
-        {
-            if (!pFilename)
-                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-            /* Archive is being read from stdio and was originally opened only for reading. Try to reopen as writable. */
-            if (NULL == (pState->m_pFile = MZ_FREOPEN(pFilename, "r+b", pState->m_pFile)))
-            {
-                /* The mz_zip_archive is now in a bogus state because pState->m_pFile is NULL, so just close it. */
-                mz_zip_reader_end_internal(pZip, MZ_FALSE);
-                return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
-            }
-        }
-
-        pZip->m_pWrite = mz_zip_file_write_func;
-        pZip->m_pNeeds_keepalive = NULL;
-#endif /* #ifdef MINIZ_NO_STDIO */
-    }
-    else if (pState->m_pMem)
-    {
-        /* Archive lives in a memory block. Assume it's from the heap that we can resize using the realloc callback. */
-        if (pZip->m_pIO_opaque != pZip)
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-        pState->m_mem_capacity = pState->m_mem_size;
-        pZip->m_pWrite = mz_zip_heap_write_func;
-        pZip->m_pNeeds_keepalive = NULL;
-    }
-    /* Archive is being read via a user provided read function - make sure the user has specified a write function too. */
-    else if (!pZip->m_pWrite)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    /* Start writing new files at the archive's current central directory location. */
-    /* TODO: We could add a flag that lets the user start writing immediately AFTER the existing central dir - this would be safer. */
-    pZip->m_archive_size = pZip->m_central_directory_file_ofs;
-    pZip->m_central_directory_file_ofs = 0;
-
-    /* Clear the sorted central dir offsets, they aren't useful or maintained now. */
-    /* Even though we're now in write mode, files can still be extracted and verified, but file locates will be slow. */
-    /* TODO: We could easily maintain the sorted central directory offsets. */
-    mz_zip_array_clear(pZip, &pZip->m_pState->m_sorted_central_dir_offsets);
-
-    pZip->m_zip_mode = MZ_ZIP_MODE_WRITING;
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_init_from_reader(mz_zip_archive *pZip, const char *pFilename)
-{
-    return mz_zip_writer_init_from_reader_v2(pZip, pFilename, 0);
-}
-
-/* TODO: pArchive_name is a terrible name here! */
-mz_bool mz_zip_writer_add_mem(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, mz_uint level_and_flags)
-{
-    return mz_zip_writer_add_mem_ex(pZip, pArchive_name, pBuf, buf_size, NULL, 0, level_and_flags, 0, 0);
-}
-
-typedef struct
-{
-    mz_zip_archive *m_pZip;
-    mz_uint64 m_cur_archive_file_ofs;
-    mz_uint64 m_comp_size;
-} mz_zip_writer_add_state;
-
-static mz_bool mz_zip_writer_add_put_buf_callback(const void *pBuf, int len, void *pUser)
-{
-    mz_zip_writer_add_state *pState = (mz_zip_writer_add_state *)pUser;
-    if ((int)pState->m_pZip->m_pWrite(pState->m_pZip->m_pIO_opaque, pState->m_cur_archive_file_ofs, pBuf, len) != len)
-        return MZ_FALSE;
-
-    pState->m_cur_archive_file_ofs += len;
-    pState->m_comp_size += len;
-    return MZ_TRUE;
-}
-
-#define MZ_ZIP64_MAX_LOCAL_EXTRA_FIELD_SIZE (sizeof(mz_uint16) * 2 + sizeof(mz_uint64) * 2)
-#define MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE (sizeof(mz_uint16) * 2 + sizeof(mz_uint64) * 3)
-static mz_uint32 mz_zip_writer_create_zip64_extra_data(mz_uint8 *pBuf, mz_uint64 *pUncomp_size, mz_uint64 *pComp_size, mz_uint64 *pLocal_header_ofs)
-{
-    mz_uint8 *pDst = pBuf;
-    mz_uint32 field_size = 0;
-
-    MZ_WRITE_LE16(pDst + 0, MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID);
-    MZ_WRITE_LE16(pDst + 2, 0);
-    pDst += sizeof(mz_uint16) * 2;
-
-    if (pUncomp_size)
-    {
-        MZ_WRITE_LE64(pDst, *pUncomp_size);
-        pDst += sizeof(mz_uint64);
-        field_size += sizeof(mz_uint64);
-    }
-
-    if (pComp_size)
-    {
-        MZ_WRITE_LE64(pDst, *pComp_size);
-        pDst += sizeof(mz_uint64);
-        field_size += sizeof(mz_uint64);
-    }
-
-    if (pLocal_header_ofs)
-    {
-        MZ_WRITE_LE64(pDst, *pLocal_header_ofs);
-        pDst += sizeof(mz_uint64);
-        field_size += sizeof(mz_uint64);
-    }
-
-    MZ_WRITE_LE16(pBuf + 2, field_size);
-
-    return (mz_uint32)(pDst - pBuf);
-}
-
-static mz_bool mz_zip_writer_create_local_dir_header(mz_zip_archive *pZip, mz_uint8 *pDst, mz_uint16 filename_size, mz_uint16 extra_size, mz_uint64 uncomp_size, mz_uint64 comp_size, mz_uint32 uncomp_crc32, mz_uint16 method, mz_uint16 bit_flags, mz_uint16 dos_time, mz_uint16 dos_date)
-{
-    (void)pZip;
-    memset(pDst, 0, MZ_ZIP_LOCAL_DIR_HEADER_SIZE);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_SIG_OFS, MZ_ZIP_LOCAL_DIR_HEADER_SIG);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_VERSION_NEEDED_OFS, method ? 20 : 0);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_BIT_FLAG_OFS, bit_flags);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_METHOD_OFS, method);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, dos_time);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, dos_date);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_CRC32_OFS, uncomp_crc32);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
-    MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILENAME_LEN_OFS, filename_size);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_EXTRA_LEN_OFS, extra_size);
-    return MZ_TRUE;
-}
-
-static mz_bool mz_zip_writer_create_central_dir_header(mz_zip_archive *pZip, mz_uint8 *pDst,
-                                                       mz_uint16 filename_size, mz_uint16 extra_size, mz_uint16 comment_size,
-                                                       mz_uint64 uncomp_size, mz_uint64 comp_size, mz_uint32 uncomp_crc32,
-                                                       mz_uint16 method, mz_uint16 bit_flags, mz_uint16 dos_time, mz_uint16 dos_date,
-                                                       mz_uint64 local_header_ofs, mz_uint32 ext_attributes)
-{
-    (void)pZip;
-    memset(pDst, 0, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_SIG_OFS, MZ_ZIP_CENTRAL_DIR_HEADER_SIG);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_NEEDED_OFS, method ? 20 : 0);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_BIT_FLAG_OFS, bit_flags);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_METHOD_OFS, method);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_TIME_OFS, dos_time);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_DATE_OFS, dos_date);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_CRC32_OFS, uncomp_crc32);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
-    MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILENAME_LEN_OFS, filename_size);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_EXTRA_LEN_OFS, extra_size);
-    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_COMMENT_LEN_OFS, comment_size);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_EXTERNAL_ATTR_OFS, ext_attributes);
-    MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_LOCAL_HEADER_OFS, MZ_MIN(local_header_ofs, MZ_UINT32_MAX));
-    return MZ_TRUE;
-}
-
-static mz_bool mz_zip_writer_add_to_central_dir(mz_zip_archive *pZip, const char *pFilename, mz_uint16 filename_size,
-                                                const void *pExtra, mz_uint16 extra_size, const void *pComment, mz_uint16 comment_size,
-                                                mz_uint64 uncomp_size, mz_uint64 comp_size, mz_uint32 uncomp_crc32,
-                                                mz_uint16 method, mz_uint16 bit_flags, mz_uint16 dos_time, mz_uint16 dos_date,
-                                                mz_uint64 local_header_ofs, mz_uint32 ext_attributes,
-                                                const char *user_extra_data, mz_uint user_extra_data_len)
-{
-    mz_zip_internal_state *pState = pZip->m_pState;
-    mz_uint32 central_dir_ofs = (mz_uint32)pState->m_central_dir.m_size;
-    size_t orig_central_dir_size = pState->m_central_dir.m_size;
-    mz_uint8 central_dir_header[MZ_ZIP_CENTRAL_DIR_HEADER_SIZE];
-
-    if (!pZip->m_pState->m_zip64)
-    {
-        if (local_header_ofs > 0xFFFFFFFF)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_TOO_LARGE);
-    }
-
-    /* miniz doesn't support central dirs >= MZ_UINT32_MAX bytes yet */
-    if (((mz_uint64)pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + filename_size + extra_size + user_extra_data_len + comment_size) >= MZ_UINT32_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
-
-    if (!mz_zip_writer_create_central_dir_header(pZip, central_dir_header, filename_size, (mz_uint16)(extra_size + user_extra_data_len), comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_header_ofs, ext_attributes))
-        return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-    if ((!mz_zip_array_push_back(pZip, &pState->m_central_dir, central_dir_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE)) ||
-        (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pFilename, filename_size)) ||
-        (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pExtra, extra_size)) ||
-        (!mz_zip_array_push_back(pZip, &pState->m_central_dir, user_extra_data, user_extra_data_len)) ||
-        (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pComment, comment_size)) ||
-        (!mz_zip_array_push_back(pZip, &pState->m_central_dir_offsets, &central_dir_ofs, 1)))
-    {
-        /* Try to resize the central directory array back into its original state. */
-        mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-    }
-
-    return MZ_TRUE;
-}
-
-static mz_bool mz_zip_writer_validate_archive_name(const char *pArchive_name)
-{
-    /* Basic ZIP archive filename validity checks: Valid filenames cannot start with a forward slash, cannot contain a drive letter, and cannot use DOS-style backward slashes. */
-    if (*pArchive_name == '/')
-        return MZ_FALSE;
-
-    /* Making sure the name does not contain drive letters or DOS style backward slashes is the responsibility of the program using miniz*/
-
-    return MZ_TRUE;
-}
-
-static mz_uint mz_zip_writer_compute_padding_needed_for_file_alignment(mz_zip_archive *pZip)
-{
-    mz_uint32 n;
-    if (!pZip->m_file_offset_alignment)
-        return 0;
-    n = (mz_uint32)(pZip->m_archive_size & (pZip->m_file_offset_alignment - 1));
-    return (mz_uint)((pZip->m_file_offset_alignment - n) & (pZip->m_file_offset_alignment - 1));
-}
-
-static mz_bool mz_zip_writer_write_zeros(mz_zip_archive *pZip, mz_uint64 cur_file_ofs, mz_uint32 n)
-{
-    char buf[4096];
-    memset(buf, 0, MZ_MIN(sizeof(buf), n));
-    while (n)
-    {
-        mz_uint32 s = MZ_MIN(sizeof(buf), n);
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_file_ofs, buf, s) != s)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_file_ofs += s;
-        n -= s;
-    }
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
-                                 mz_uint64 uncomp_size, mz_uint32 uncomp_crc32)
-{
-    return mz_zip_writer_add_mem_ex_v2(pZip, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, uncomp_size, uncomp_crc32, NULL, NULL, 0, NULL, 0);
-}
-
-mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size,
-                                    mz_uint level_and_flags, mz_uint64 uncomp_size, mz_uint32 uncomp_crc32, MZ_TIME_T *last_modified,
-                                    const char *user_extra_data, mz_uint user_extra_data_len, const char *user_extra_data_central, mz_uint user_extra_data_central_len)
-{
-    mz_uint16 method = 0, dos_time = 0, dos_date = 0;
-    mz_uint level, ext_attributes = 0, num_alignment_padding_bytes;
-    mz_uint64 local_dir_header_ofs = pZip->m_archive_size, cur_archive_file_ofs = pZip->m_archive_size, comp_size = 0;
-    size_t archive_name_size;
-    mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
-    tdefl_compressor *pComp = NULL;
-    mz_bool store_data_uncompressed;
-    mz_zip_internal_state *pState;
-    mz_uint8 *pExtra_data = NULL;
-    mz_uint32 extra_size = 0;
-    mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
-    mz_uint16 bit_flags = 0;
-
-    if ((int)level_and_flags < 0)
-        level_and_flags = MZ_DEFAULT_LEVEL;
-
-    if (uncomp_size || (buf_size && !(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
-        bit_flags |= MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR;
-
-    if (!(level_and_flags & MZ_ZIP_FLAG_ASCII_FILENAME))
-        bit_flags |= MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8;
-
-    level = level_and_flags & 0xF;
-    store_data_uncompressed = ((!level) || (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA));
-
-    if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || ((buf_size) && (!pBuf)) || (!pArchive_name) || ((comment_size) && (!pComment)) || (level > MZ_UBER_COMPRESSION))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pState = pZip->m_pState;
-
-    if (pState->m_zip64)
-    {
-        if (pZip->m_total_files == MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-    else
-    {
-        if (pZip->m_total_files == MZ_UINT16_MAX)
-        {
-            pState->m_zip64 = MZ_TRUE;
-            /*return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES); */
-        }
-        if (((mz_uint64)buf_size > 0xFFFFFFFF) || (uncomp_size > 0xFFFFFFFF))
-        {
-            pState->m_zip64 = MZ_TRUE;
-            /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
-        }
-    }
-
-    if ((!(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)) && (uncomp_size))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (!mz_zip_writer_validate_archive_name(pArchive_name))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
-
-#ifndef MINIZ_NO_TIME
-    if (last_modified != NULL)
-    {
-        mz_zip_time_t_to_dos_time(*last_modified, &dos_time, &dos_date);
-    }
-    else
-    {
-        MZ_TIME_T cur_time;
-        time(&cur_time);
-        mz_zip_time_t_to_dos_time(cur_time, &dos_time, &dos_date);
-    }
-#endif /* #ifndef MINIZ_NO_TIME */
-
-	if (!(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
-	{
-		uncomp_crc32 = (mz_uint32)mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)pBuf, buf_size);
-		uncomp_size = buf_size;
-		if (uncomp_size <= 3)
-		{
-			level = 0;
-			store_data_uncompressed = MZ_TRUE;
-		}
-	}
-
-    archive_name_size = strlen(pArchive_name);
-    if (archive_name_size > MZ_UINT16_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
-
-    num_alignment_padding_bytes = mz_zip_writer_compute_padding_needed_for_file_alignment(pZip);
-
-    /* miniz doesn't support central dirs >= MZ_UINT32_MAX bytes yet */
-    if (((mz_uint64)pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE + comment_size) >= MZ_UINT32_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
-
-    if (!pState->m_zip64)
-    {
-        /* Bail early if the archive would obviously become too large */
-        if ((pZip->m_archive_size + num_alignment_padding_bytes + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + archive_name_size
-			+ MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + comment_size + user_extra_data_len +
-			pState->m_central_dir.m_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE + user_extra_data_central_len
-			+ MZ_ZIP_DATA_DESCRIPTER_SIZE32) > 0xFFFFFFFF)
-        {
-            pState->m_zip64 = MZ_TRUE;
-            /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
-        }
-    }
-
-    if ((archive_name_size) && (pArchive_name[archive_name_size - 1] == '/'))
-    {
-        /* Set DOS Subdirectory attribute bit. */
-        ext_attributes |= MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG;
-
-        /* Subdirectories cannot contain data. */
-        if ((buf_size) || (uncomp_size))
-            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-    }
-
-    /* Try to do any allocations before writing to the archive, so if an allocation fails the file remains unmodified. (A good idea if we're doing an in-place modification.) */
-    if ((!mz_zip_array_ensure_room(pZip, &pState->m_central_dir, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + comment_size + (pState->m_zip64 ? MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE : 0))) || (!mz_zip_array_ensure_room(pZip, &pState->m_central_dir_offsets, 1)))
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-    if ((!store_data_uncompressed) && (buf_size))
-    {
-        if (NULL == (pComp = (tdefl_compressor *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(tdefl_compressor))))
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-    }
-
-    if (!mz_zip_writer_write_zeros(pZip, cur_archive_file_ofs, num_alignment_padding_bytes))
-    {
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-        return MZ_FALSE;
-    }
-
-    local_dir_header_ofs += num_alignment_padding_bytes;
-    if (pZip->m_file_offset_alignment)
-    {
-        MZ_ASSERT((local_dir_header_ofs & (pZip->m_file_offset_alignment - 1)) == 0);
-    }
-    cur_archive_file_ofs += num_alignment_padding_bytes;
-
-    MZ_CLEAR_ARR(local_dir_header);
-
-    if (!store_data_uncompressed || (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA))
-    {
-        method = MZ_DEFLATED;
-    }
-
-    if (pState->m_zip64)
-    {
-        if (uncomp_size >= MZ_UINT32_MAX || local_dir_header_ofs >= MZ_UINT32_MAX)
-        {
-            pExtra_data = extra_data;
-            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-        }
-
-        if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)(extra_size + user_extra_data_len), 0, 0, 0, method, bit_flags, dos_time, dos_date))
-            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, local_dir_header_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_archive_file_ofs += sizeof(local_dir_header);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
-        {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-        }
-        cur_archive_file_ofs += archive_name_size;
-
-        if (pExtra_data != NULL)
-        {
-            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, extra_data, extra_size) != extra_size)
-                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-            cur_archive_file_ofs += extra_size;
-        }
-    }
-    else
-    {
-        if ((comp_size > MZ_UINT32_MAX) || (cur_archive_file_ofs > MZ_UINT32_MAX))
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-        if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)user_extra_data_len, 0, 0, 0, method, bit_flags, dos_time, dos_date))
-            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, local_dir_header_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_archive_file_ofs += sizeof(local_dir_header);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
-        {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-        }
-        cur_archive_file_ofs += archive_name_size;
-    }
-
-	if (user_extra_data_len > 0)
-	{
-		if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, user_extra_data, user_extra_data_len) != user_extra_data_len)
-			return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-		cur_archive_file_ofs += user_extra_data_len;
-	}
-
-    if (store_data_uncompressed)
-    {
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pBuf, buf_size) != buf_size)
-        {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-        }
-
-        cur_archive_file_ofs += buf_size;
-        comp_size = buf_size;
-    }
-    else if (buf_size)
-    {
-        mz_zip_writer_add_state state;
-
-        state.m_pZip = pZip;
-        state.m_cur_archive_file_ofs = cur_archive_file_ofs;
-        state.m_comp_size = 0;
-
-        if ((tdefl_init(pComp, mz_zip_writer_add_put_buf_callback, &state, tdefl_create_comp_flags_from_zip_params(level, -15, MZ_DEFAULT_STRATEGY)) != TDEFL_STATUS_OKAY) ||
-            (tdefl_compress_buffer(pComp, pBuf, buf_size, TDEFL_FINISH) != TDEFL_STATUS_DONE))
-        {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-            return mz_zip_set_error(pZip, MZ_ZIP_COMPRESSION_FAILED);
-        }
-
-        comp_size = state.m_comp_size;
-        cur_archive_file_ofs = state.m_cur_archive_file_ofs;
-    }
-
-    pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-    pComp = NULL;
-
-    if (uncomp_size)
-    {
-        mz_uint8 local_dir_footer[MZ_ZIP_DATA_DESCRIPTER_SIZE64];
-        mz_uint32 local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE32;
-
-        MZ_ASSERT(bit_flags & MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR);
-
-        MZ_WRITE_LE32(local_dir_footer + 0, MZ_ZIP_DATA_DESCRIPTOR_ID);
-        MZ_WRITE_LE32(local_dir_footer + 4, uncomp_crc32);
-        if (pExtra_data == NULL)
-        {
-            if (comp_size > MZ_UINT32_MAX)
-                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-
-            MZ_WRITE_LE32(local_dir_footer + 8, comp_size);
-            MZ_WRITE_LE32(local_dir_footer + 12, uncomp_size);
-        }
-        else
-        {
-            MZ_WRITE_LE64(local_dir_footer + 8, comp_size);
-            MZ_WRITE_LE64(local_dir_footer + 16, uncomp_size);
-            local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE64;
-        }
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_footer, local_dir_footer_size) != local_dir_footer_size)
-            return MZ_FALSE;
-
-        cur_archive_file_ofs += local_dir_footer_size;
-    }
-
-    if (pExtra_data != NULL)
-    {
-        extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                           (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-    }
-
-    if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
-                                          comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
-                                          user_extra_data_central, user_extra_data_central_len))
-        return MZ_FALSE;
-
-    pZip->m_total_files++;
-    pZip->m_archive_size = cur_archive_file_ofs;
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_add_read_buf_callback(mz_zip_archive *pZip, const char *pArchive_name, mz_file_read_func read_callback, void* callback_opaque, mz_uint64 max_size, const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
-                                const char *user_extra_data, mz_uint user_extra_data_len, const char *user_extra_data_central, mz_uint user_extra_data_central_len)
-{
-    mz_uint16 gen_flags;
-    mz_uint uncomp_crc32 = MZ_CRC32_INIT, level, num_alignment_padding_bytes;
-    mz_uint16 method = 0, dos_time = 0, dos_date = 0, ext_attributes = 0;
-    mz_uint64 local_dir_header_ofs, cur_archive_file_ofs = pZip->m_archive_size, uncomp_size = 0, comp_size = 0;
-    size_t archive_name_size;
-    mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
-    mz_uint8 *pExtra_data = NULL;
-    mz_uint32 extra_size = 0;
-    mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
-    mz_zip_internal_state *pState;
-    mz_uint64 file_ofs = 0, cur_archive_header_file_ofs;
-
-    if ((int)level_and_flags < 0)
-        level_and_flags = MZ_DEFAULT_LEVEL;
-    level = level_and_flags & 0xF;
-
-    gen_flags = (level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE) ? 0 : MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR;
-
-    if (!(level_and_flags & MZ_ZIP_FLAG_ASCII_FILENAME))
-        gen_flags |= MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8;
-
-    /* Sanity checks */
-    if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || (!pArchive_name) || ((comment_size) && (!pComment)) || (level > MZ_UBER_COMPRESSION))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pState = pZip->m_pState;
-
-    if ((!pState->m_zip64) && (max_size > MZ_UINT32_MAX))
-    {
-        /* Source file is too large for non-zip64 */
-        /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
-        pState->m_zip64 = MZ_TRUE;
-    }
-
-    /* We could support this, but why? */
-    if (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (!mz_zip_writer_validate_archive_name(pArchive_name))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
-
-    if (pState->m_zip64)
-    {
-        if (pZip->m_total_files == MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-    else
-    {
-        if (pZip->m_total_files == MZ_UINT16_MAX)
-        {
-            pState->m_zip64 = MZ_TRUE;
-            /*return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES); */
-        }
-    }
-
-    archive_name_size = strlen(pArchive_name);
-    if (archive_name_size > MZ_UINT16_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
-
-    num_alignment_padding_bytes = mz_zip_writer_compute_padding_needed_for_file_alignment(pZip);
-
-    /* miniz doesn't support central dirs >= MZ_UINT32_MAX bytes yet */
-    if (((mz_uint64)pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE + comment_size) >= MZ_UINT32_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
-
-    if (!pState->m_zip64)
-    {
-        /* Bail early if the archive would obviously become too large */
-        if ((pZip->m_archive_size + num_alignment_padding_bytes + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + archive_name_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE
-			+ archive_name_size + comment_size + user_extra_data_len + pState->m_central_dir.m_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE + 1024
-			+ MZ_ZIP_DATA_DESCRIPTER_SIZE32 + user_extra_data_central_len) > 0xFFFFFFFF)
-        {
-            pState->m_zip64 = MZ_TRUE;
-            /*return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE); */
-        }
-    }
-
-#ifndef MINIZ_NO_TIME
-    if (pFile_time)
-    {
-        mz_zip_time_t_to_dos_time(*pFile_time, &dos_time, &dos_date);
-    }
-#endif
-
-    if (max_size <= 3)
-        level = 0;
-
-    if (!mz_zip_writer_write_zeros(pZip, cur_archive_file_ofs, num_alignment_padding_bytes))
-    {
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-    }
-
-    cur_archive_file_ofs += num_alignment_padding_bytes;
-    local_dir_header_ofs = cur_archive_file_ofs;
-
-    if (pZip->m_file_offset_alignment)
-    {
-        MZ_ASSERT((cur_archive_file_ofs & (pZip->m_file_offset_alignment - 1)) == 0);
-    }
-
-    if (max_size && level)
-    {
-        method = MZ_DEFLATED;
-    }
-
-    MZ_CLEAR_ARR(local_dir_header);
-    if (pState->m_zip64)
-    {
-        if (max_size >= MZ_UINT32_MAX || local_dir_header_ofs >= MZ_UINT32_MAX)
-        {
-            pExtra_data = extra_data;
-            if (level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE)
-                extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (max_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                               (max_size >= MZ_UINT32_MAX) ? &comp_size : NULL,
-                                                                (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-            else
-                extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, NULL,
-                                                                   NULL,
-                                                                   (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-        }
-
-        if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)(extra_size + user_extra_data_len), 0, 0, 0, method, gen_flags, dos_time, dos_date))
-            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_archive_file_ofs += sizeof(local_dir_header);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
-        {
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-        }
-
-        cur_archive_file_ofs += archive_name_size;
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, extra_data, extra_size) != extra_size)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_archive_file_ofs += extra_size;
-    }
-    else
-    {
-        if ((comp_size > MZ_UINT32_MAX) || (cur_archive_file_ofs > MZ_UINT32_MAX))
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-        if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, (mz_uint16)user_extra_data_len, 0, 0, 0, method, gen_flags, dos_time, dos_date))
-            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_archive_file_ofs += sizeof(local_dir_header);
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
-        {
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-        }
-
-        cur_archive_file_ofs += archive_name_size;
-    }
-
-    if (user_extra_data_len > 0)
-    {
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, user_extra_data, user_extra_data_len) != user_extra_data_len)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        cur_archive_file_ofs += user_extra_data_len;
-    }
-
-    if (max_size)
-    {
-        void *pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, MZ_ZIP_MAX_IO_BUF_SIZE);
-        if (!pRead_buf)
-        {
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        }
-
-        if (!level)
-        {
-            while (1)
-            {
-                size_t n = read_callback(callback_opaque, file_ofs, pRead_buf, MZ_ZIP_MAX_IO_BUF_SIZE);
-                if (n == 0)
-                    break;
-
-                if ((n > MZ_ZIP_MAX_IO_BUF_SIZE) || (file_ofs + n > max_size))
-                {
-                    pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-                }
-                if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, pRead_buf, n) != n)
-                {
-                    pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-                }
-                file_ofs += n;
-                uncomp_crc32 = (mz_uint32)mz_crc32(uncomp_crc32, (const mz_uint8 *)pRead_buf, n);
-                cur_archive_file_ofs += n;
-            }
-            uncomp_size = file_ofs;
-            comp_size = uncomp_size;
-        }
-        else
-        {
-            mz_bool result = MZ_FALSE;
-            mz_zip_writer_add_state state;
-            tdefl_compressor *pComp = (tdefl_compressor *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(tdefl_compressor));
-            if (!pComp)
-            {
-                pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
                 return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
             }
 
-            state.m_pZip = pZip;
-            state.m_cur_archive_file_ofs = cur_archive_file_ofs;
-            state.m_comp_size = 0;
-
-            if (tdefl_init(pComp, mz_zip_writer_add_put_buf_callback, &state, tdefl_create_comp_flags_from_zip_params(level, -15, MZ_DEFAULT_STRATEGY)) != TDEFL_STATUS_OKAY)
-            {
-                pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-                pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-                return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-            }
-
-            for (;;)
-            {
-                tdefl_status status;
-                tdefl_flush flush = TDEFL_NO_FLUSH;
-
-                size_t n = read_callback(callback_opaque, file_ofs, pRead_buf, MZ_ZIP_MAX_IO_BUF_SIZE);
-                if ((n > MZ_ZIP_MAX_IO_BUF_SIZE) || (file_ofs + n > max_size))
-                {
-                    mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-                    break;
-                }
-
-                file_ofs += n;
-                uncomp_crc32 = (mz_uint32)mz_crc32(uncomp_crc32, (const mz_uint8 *)pRead_buf, n);
-
-                if (pZip->m_pNeeds_keepalive != NULL && pZip->m_pNeeds_keepalive(pZip->m_pIO_opaque))
-                    flush = TDEFL_FULL_FLUSH;
-
-                if (n == 0)
-                    flush = TDEFL_FINISH;
-
-                status = tdefl_compress_buffer(pComp, pRead_buf, n, flush);
-                if (status == TDEFL_STATUS_DONE)
-                {
-                    result = MZ_TRUE;
-                    break;
-                }
-                else if (status != TDEFL_STATUS_OKAY)
-                {
-                    mz_zip_set_error(pZip, MZ_ZIP_COMPRESSION_FAILED);
-                    break;
-                }
-            }
-
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-
-            if (!result)
-            {
-                pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-                return MZ_FALSE;
-            }
-
-            uncomp_size = file_ofs;
-            comp_size = state.m_comp_size;
-            cur_archive_file_ofs = state.m_cur_archive_file_ofs;
-        }
-
-        pZip->m_pFree(pZip->m_pAlloc_opaque, pRead_buf);
-    }
-
-    if (!(level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE))
-    {
-        mz_uint8 local_dir_footer[MZ_ZIP_DATA_DESCRIPTER_SIZE64];
-        mz_uint32 local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE32;
-
-        MZ_WRITE_LE32(local_dir_footer + 0, MZ_ZIP_DATA_DESCRIPTOR_ID);
-        MZ_WRITE_LE32(local_dir_footer + 4, uncomp_crc32);
-        if (pExtra_data == NULL)
-        {
-            if (comp_size > MZ_UINT32_MAX)
-                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-
-            MZ_WRITE_LE32(local_dir_footer + 8, comp_size);
-            MZ_WRITE_LE32(local_dir_footer + 12, uncomp_size);
-        }
-        else
-        {
-            MZ_WRITE_LE64(local_dir_footer + 8, comp_size);
-            MZ_WRITE_LE64(local_dir_footer + 16, uncomp_size);
-            local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE64;
-        }
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, local_dir_footer, local_dir_footer_size) != local_dir_footer_size)
-            return MZ_FALSE;
-
-        cur_archive_file_ofs += local_dir_footer_size;
-    }
-
-    if (level_and_flags & MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE)
-    {
-        if (pExtra_data != NULL)
-        {
-            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (max_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                               (max_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-        }
-
-        if (!mz_zip_writer_create_local_dir_header(pZip, local_dir_header,
-                                                   (mz_uint16)archive_name_size, (mz_uint16)(extra_size + user_extra_data_len),
-                                                   (max_size >= MZ_UINT32_MAX) ? MZ_UINT32_MAX : uncomp_size, 
-                                                    (max_size >= MZ_UINT32_MAX) ? MZ_UINT32_MAX : comp_size,
-                                                   uncomp_crc32, method, gen_flags, dos_time, dos_date))
-            return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-
-        cur_archive_header_file_ofs = local_dir_header_ofs;
-
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_header_file_ofs, local_dir_header, sizeof(local_dir_header)) != sizeof(local_dir_header))
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        if (pExtra_data != NULL)
-        {
-            cur_archive_header_file_ofs += sizeof(local_dir_header);
-
-            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_header_file_ofs, pArchive_name, archive_name_size) != archive_name_size)
-            {
-                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-            }
-
-            cur_archive_header_file_ofs += archive_name_size;
-
-            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_header_file_ofs, extra_data, extra_size) != extra_size)
-                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-            cur_archive_header_file_ofs += extra_size;
-        }
-    }
-
-    if (pExtra_data != NULL)
-    {
-        extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                           (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-    }
-
-    if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment, comment_size,
-                                          uncomp_size, comp_size, uncomp_crc32, method, gen_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
-                                          user_extra_data_central, user_extra_data_central_len))
-        return MZ_FALSE;
-
-    pZip->m_total_files++;
-    pZip->m_archive_size = cur_archive_file_ofs;
-
-    return MZ_TRUE;
-}
-
-#ifndef MINIZ_NO_STDIO
-
-static size_t mz_file_read_func_stdio(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
-{
-	MZ_FILE *pSrc_file = (MZ_FILE *)pOpaque;
-	mz_int64 cur_ofs = MZ_FTELL64(pSrc_file);
-
-	if (((mz_int64)file_ofs < 0) || (((cur_ofs != (mz_int64)file_ofs)) && (MZ_FSEEK64(pSrc_file, (mz_int64)file_ofs, SEEK_SET))))
-		return 0;
-
-	return MZ_FREAD(pBuf, 1, n, pSrc_file);
-}
-
-mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name, MZ_FILE *pSrc_file, mz_uint64 max_size, const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
-	const char *user_extra_data, mz_uint user_extra_data_len, const char *user_extra_data_central, mz_uint user_extra_data_central_len)
-{
-	return mz_zip_writer_add_read_buf_callback(pZip, pArchive_name, mz_file_read_func_stdio, pSrc_file, max_size, pFile_time, pComment, comment_size, level_and_flags,
-		user_extra_data, user_extra_data_len, user_extra_data_central, user_extra_data_central_len);
-}
-
-mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, const char *pSrc_filename, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags)
-{
-    MZ_FILE *pSrc_file = NULL;
-    mz_uint64 uncomp_size = 0;
-    MZ_TIME_T file_modified_time;
-    MZ_TIME_T *pFile_time = NULL;
-    mz_bool status;
-
-    memset(&file_modified_time, 0, sizeof(file_modified_time));
-
-#if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_STDIO)
-    pFile_time = &file_modified_time;
-    if (!mz_zip_get_file_modified_time(pSrc_filename, &file_modified_time))
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_STAT_FAILED);
-#endif
-
-    pSrc_file = MZ_FOPEN(pSrc_filename, "rb");
-    if (!pSrc_file)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
-
-    MZ_FSEEK64(pSrc_file, 0, SEEK_END);
-    uncomp_size = MZ_FTELL64(pSrc_file);
-    MZ_FSEEK64(pSrc_file, 0, SEEK_SET);
-
-    status = mz_zip_writer_add_cfile(pZip, pArchive_name, pSrc_file, uncomp_size, pFile_time, pComment, comment_size, level_and_flags, NULL, 0, NULL, 0);
-
-    MZ_FCLOSE(pSrc_file);
-
-    return status;
-}
-#endif /* #ifndef MINIZ_NO_STDIO */
-
-static mz_bool mz_zip_writer_update_zip64_extension_block(mz_zip_array *pNew_ext, mz_zip_archive *pZip, const mz_uint8 *pExt, mz_uint32 ext_len, mz_uint64 *pComp_size, mz_uint64 *pUncomp_size, mz_uint64 *pLocal_header_ofs, mz_uint32 *pDisk_start)
-{
-    /* + 64 should be enough for any new zip64 data */
-    if (!mz_zip_array_reserve(pZip, pNew_ext, ext_len + 64, MZ_FALSE))
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-    mz_zip_array_resize(pZip, pNew_ext, 0, MZ_FALSE);
-
-    if ((pUncomp_size) || (pComp_size) || (pLocal_header_ofs) || (pDisk_start))
-    {
-        mz_uint8 new_ext_block[64];
-        mz_uint8 *pDst = new_ext_block;
-        mz_write_le16(pDst, MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID);
-        mz_write_le16(pDst + sizeof(mz_uint16), 0);
-        pDst += sizeof(mz_uint16) * 2;
-
-        if (pUncomp_size)
-        {
-            mz_write_le64(pDst, *pUncomp_size);
-            pDst += sizeof(mz_uint64);
-        }
-
-        if (pComp_size)
-        {
-            mz_write_le64(pDst, *pComp_size);
-            pDst += sizeof(mz_uint64);
-        }
-
-        if (pLocal_header_ofs)
-        {
-            mz_write_le64(pDst, *pLocal_header_ofs);
-            pDst += sizeof(mz_uint64);
-        }
-
-        if (pDisk_start)
-        {
-            mz_write_le32(pDst, *pDisk_start);
-            pDst += sizeof(mz_uint32);
-        }
-
-        mz_write_le16(new_ext_block + sizeof(mz_uint16), (mz_uint16)((pDst - new_ext_block) - sizeof(mz_uint16) * 2));
-
-        if (!mz_zip_array_push_back(pZip, pNew_ext, new_ext_block, pDst - new_ext_block))
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-    }
-
-    if ((pExt) && (ext_len))
-    {
-        mz_uint32 extra_size_remaining = ext_len;
-        const mz_uint8 *pExtra_data = pExt;
-
-        do
-        {
-            mz_uint32 field_id, field_data_size, field_total_size;
-
-            if (extra_size_remaining < (sizeof(mz_uint16) * 2))
-                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-            field_id = MZ_READ_LE16(pExtra_data);
-            field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
-            field_total_size = field_data_size + sizeof(mz_uint16) * 2;
-
-            if (field_total_size > extra_size_remaining)
-                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-            if (field_id != MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
-            {
-                if (!mz_zip_array_push_back(pZip, pNew_ext, pExtra_data, field_total_size))
-                    return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-            }
-
-            pExtra_data += field_total_size;
-            extra_size_remaining -= field_total_size;
-        } while (extra_size_remaining);
-    }
-
-    return MZ_TRUE;
-}
-
-/* TODO: This func is now pretty freakin complex due to zip64, split it up? */
-mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *pSource_zip, mz_uint src_file_index)
-{
-    mz_uint n, bit_flags, num_alignment_padding_bytes, src_central_dir_following_data_size;
-    mz_uint64 src_archive_bytes_remaining, local_dir_header_ofs;
-    mz_uint64 cur_src_file_ofs, cur_dst_file_ofs;
-    mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
-    mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
-    mz_uint8 new_central_header[MZ_ZIP_CENTRAL_DIR_HEADER_SIZE];
-    size_t orig_central_dir_size;
-    mz_zip_internal_state *pState;
-    void *pBuf;
-    const mz_uint8 *pSrc_central_header;
-    mz_zip_archive_file_stat src_file_stat;
-    mz_uint32 src_filename_len, src_comment_len, src_ext_len;
-    mz_uint32 local_header_filename_size, local_header_extra_len;
-    mz_uint64 local_header_comp_size, local_header_uncomp_size;
-    mz_bool found_zip64_ext_data_in_ldir = MZ_FALSE;
-
-    /* Sanity checks */
-    if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || (!pSource_zip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pState = pZip->m_pState;
-
-    /* Don't support copying files from zip64 archives to non-zip64, even though in some cases this is possible */
-    if ((pSource_zip->m_pState->m_zip64) && (!pZip->m_pState->m_zip64))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    /* Get pointer to the source central dir header and crack it */
-    if (NULL == (pSrc_central_header = mz_zip_get_cdh(pSource_zip, src_file_index)))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (MZ_READ_LE32(pSrc_central_header + MZ_ZIP_CDH_SIG_OFS) != MZ_ZIP_CENTRAL_DIR_HEADER_SIG)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    src_filename_len = MZ_READ_LE16(pSrc_central_header + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-    src_comment_len = MZ_READ_LE16(pSrc_central_header + MZ_ZIP_CDH_COMMENT_LEN_OFS);
-    src_ext_len = MZ_READ_LE16(pSrc_central_header + MZ_ZIP_CDH_EXTRA_LEN_OFS);
-    src_central_dir_following_data_size = src_filename_len + src_ext_len + src_comment_len;
-
-    /* TODO: We don't support central dir's >= MZ_UINT32_MAX bytes right now (+32 fudge factor in case we need to add more extra data) */
-    if ((pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_central_dir_following_data_size + 32) >= MZ_UINT32_MAX)
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
-
-    num_alignment_padding_bytes = mz_zip_writer_compute_padding_needed_for_file_alignment(pZip);
-
-    if (!pState->m_zip64)
-    {
-        if (pZip->m_total_files == MZ_UINT16_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-    else
-    {
-        /* TODO: Our zip64 support still has some 32-bit limits that may not be worth fixing. */
-        if (pZip->m_total_files == MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-
-    if (!mz_zip_file_stat_internal(pSource_zip, src_file_index, pSrc_central_header, &src_file_stat, NULL))
-        return MZ_FALSE;
-
-    cur_src_file_ofs = src_file_stat.m_local_header_ofs;
-    cur_dst_file_ofs = pZip->m_archive_size;
-
-    /* Read the source archive's local dir header */
-    if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-
-    if (MZ_READ_LE32(pLocal_header) != MZ_ZIP_LOCAL_DIR_HEADER_SIG)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-
-    cur_src_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE;
-
-    /* Compute the total size we need to copy (filename+extra data+compressed data) */
-    local_header_filename_size = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_FILENAME_LEN_OFS);
-    local_header_extra_len = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_EXTRA_LEN_OFS);
-    local_header_comp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS);
-    local_header_uncomp_size = MZ_READ_LE32(pLocal_header + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS);
-    src_archive_bytes_remaining = local_header_filename_size + local_header_extra_len + src_file_stat.m_comp_size;
-
-    /* Try to find a zip64 extended information field */
-    if ((local_header_extra_len) && ((local_header_comp_size == MZ_UINT32_MAX) || (local_header_uncomp_size == MZ_UINT32_MAX)))
-    {
-        mz_zip_array file_data_array;
-        const mz_uint8 *pExtra_data;
-        mz_uint32 extra_size_remaining = local_header_extra_len;
-
-        mz_zip_array_init(&file_data_array, 1);
-        if (!mz_zip_array_resize(pZip, &file_data_array, local_header_extra_len, MZ_FALSE))
-        {
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        }
-
-        if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, src_file_stat.m_local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_size, file_data_array.m_p, local_header_extra_len) != local_header_extra_len)
-        {
-            mz_zip_array_clear(pZip, &file_data_array);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-        }
-
-        pExtra_data = (const mz_uint8 *)file_data_array.m_p;
-
-        do
-        {
-            mz_uint32 field_id, field_data_size, field_total_size;
-
-            if (extra_size_remaining < (sizeof(mz_uint16) * 2))
+            if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, src_file_stat.m_local_header_ofs + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + local_header_filename_size, file_data_array.m_p, local_header_extra_len) != local_header_extra_len)
             {
                 mz_zip_array_clear(pZip, &file_data_array);
-                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
             }
 
-            field_id = MZ_READ_LE16(pExtra_data);
-            field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
-            field_total_size = field_data_size + sizeof(mz_uint16) * 2;
+            pExtra_data = (const mz_uint8 *)file_data_array.m_p;
 
-            if (field_total_size > extra_size_remaining)
+            do
             {
-                mz_zip_array_clear(pZip, &file_data_array);
-                return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
-            }
+                mz_uint32 field_id, field_data_size, field_total_size;
 
-            if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
-            {
-                const mz_uint8 *pSrc_field_data = pExtra_data + sizeof(mz_uint32);
-
-                if (field_data_size < sizeof(mz_uint64) * 2)
+                if (extra_size_remaining < (sizeof(mz_uint16) * 2))
                 {
                     mz_zip_array_clear(pZip, &file_data_array);
                     return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
                 }
 
-                local_header_uncomp_size = MZ_READ_LE64(pSrc_field_data);
-                local_header_comp_size = MZ_READ_LE64(pSrc_field_data + sizeof(mz_uint64)); /* may be 0 if there's a descriptor */
+                field_id = MZ_READ_LE16(pExtra_data);
+                field_data_size = MZ_READ_LE16(pExtra_data + sizeof(mz_uint16));
+                field_total_size = field_data_size + sizeof(mz_uint16) * 2;
 
-                found_zip64_ext_data_in_ldir = MZ_TRUE;
-                break;
-            }
+                if (field_total_size > extra_size_remaining)
+                {
+                    mz_zip_array_clear(pZip, &file_data_array);
+                    return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                }
 
-            pExtra_data += field_total_size;
-            extra_size_remaining -= field_total_size;
-        } while (extra_size_remaining);
+                if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID)
+                {
+                    const mz_uint8 *pSrc_field_data = pExtra_data + sizeof(mz_uint32);
 
-        mz_zip_array_clear(pZip, &file_data_array);
-    }
+                    if (field_data_size < sizeof(mz_uint64) * 2)
+                    {
+                        mz_zip_array_clear(pZip, &file_data_array);
+                        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
+                    }
 
-    if (!pState->m_zip64)
-    {
-        /* Try to detect if the new archive will most likely wind up too big and bail early (+(sizeof(mz_uint32) * 4) is for the optional descriptor which could be present, +64 is a fudge factor). */
-        /* We also check when the archive is finalized so this doesn't need to be perfect. */
-        mz_uint64 approx_new_archive_size = cur_dst_file_ofs + num_alignment_padding_bytes + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + src_archive_bytes_remaining + (sizeof(mz_uint32) * 4) +
-                                            pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_central_dir_following_data_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE + 64;
+                    local_header_uncomp_size = MZ_READ_LE64(pSrc_field_data);
+                    local_header_comp_size = MZ_READ_LE64(pSrc_field_data + sizeof(mz_uint64)); /* may be 0 if there's a descriptor */
 
-        if (approx_new_archive_size >= MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-    }
+                    found_zip64_ext_data_in_ldir = MZ_TRUE;
+                    break;
+                }
 
-    /* Write dest archive padding */
-    if (!mz_zip_writer_write_zeros(pZip, cur_dst_file_ofs, num_alignment_padding_bytes))
-        return MZ_FALSE;
+                pExtra_data += field_total_size;
+                extra_size_remaining -= field_total_size;
+            } while (extra_size_remaining);
 
-    cur_dst_file_ofs += num_alignment_padding_bytes;
-
-    local_dir_header_ofs = cur_dst_file_ofs;
-    if (pZip->m_file_offset_alignment)
-    {
-        MZ_ASSERT((local_dir_header_ofs & (pZip->m_file_offset_alignment - 1)) == 0);
-    }
-
-    /* The original zip's local header+ext block doesn't change, even with zip64, so we can just copy it over to the dest zip */
-    if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_dst_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-    cur_dst_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE;
-
-    /* Copy over the source archive bytes to the dest archive, also ensure we have enough buf space to handle optional data descriptor */
-    if (NULL == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)MZ_MAX(32U, MZ_MIN((mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE, src_archive_bytes_remaining)))))
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-    while (src_archive_bytes_remaining)
-    {
-        n = (mz_uint)MZ_MIN((mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE, src_archive_bytes_remaining);
-        if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pBuf, n) != n)
-        {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+            mz_zip_array_clear(pZip, &file_data_array);
         }
-        cur_src_file_ofs += n;
 
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_dst_file_ofs, pBuf, n) != n)
+        if (!pState->m_zip64)
         {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
+            /* Try to detect if the new archive will most likely wind up too big and bail early (+(sizeof(mz_uint32) * 4) is for the optional descriptor which could be present, +64 is a fudge factor). */
+            /* We also check when the archive is finalized so this doesn't need to be perfect. */
+            mz_uint64 approx_new_archive_size = cur_dst_file_ofs + num_alignment_padding_bytes + MZ_ZIP_LOCAL_DIR_HEADER_SIZE + src_archive_bytes_remaining + (sizeof(mz_uint32) * 4) +
+                                                pState->m_central_dir.m_size + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_central_dir_following_data_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE + 64;
+
+            if (approx_new_archive_size >= MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+        }
+
+        /* Write dest archive padding */
+        if (!mz_zip_writer_write_zeros(pZip, cur_dst_file_ofs, num_alignment_padding_bytes))
+            return MZ_FALSE;
+
+        cur_dst_file_ofs += num_alignment_padding_bytes;
+
+        local_dir_header_ofs = cur_dst_file_ofs;
+        if (pZip->m_file_offset_alignment)
+        {
+            MZ_ASSERT((local_dir_header_ofs & (pZip->m_file_offset_alignment - 1)) == 0);
+        }
+
+        /* The original zip's local header+ext block doesn't change, even with zip64, so we can just copy it over to the dest zip */
+        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_dst_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
             return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-        }
-        cur_dst_file_ofs += n;
 
-        src_archive_bytes_remaining -= n;
-    }
+        cur_dst_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE;
 
-    /* Now deal with the optional data descriptor */
-    bit_flags = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_BIT_FLAG_OFS);
-    if (bit_flags & 8)
-    {
-        /* Copy data descriptor */
-        if ((pSource_zip->m_pState->m_zip64) || (found_zip64_ext_data_in_ldir))
+        /* Copy over the source archive bytes to the dest archive, also ensure we have enough buf space to handle optional data descriptor */
+        if (NULL == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)MZ_MAX(32U, MZ_MIN((mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE, src_archive_bytes_remaining)))))
+            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+        while (src_archive_bytes_remaining)
         {
-            /* src is zip64, dest must be zip64 */
-
-            /* name			uint32_t's */
-            /* id				1 (optional in zip64?) */
-            /* crc			1 */
-            /* comp_size	2 */
-            /* uncomp_size 2 */
-            if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pBuf, (sizeof(mz_uint32) * 6)) != (sizeof(mz_uint32) * 6))
+            n = (mz_uint)MZ_MIN((mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE, src_archive_bytes_remaining);
+            if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pBuf, n) != n)
             {
                 pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
                 return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
             }
+            cur_src_file_ofs += n;
 
-            n = sizeof(mz_uint32) * ((MZ_READ_LE32(pBuf) == MZ_ZIP_DATA_DESCRIPTOR_ID) ? 6 : 5);
-        }
-        else
-        {
-            /* src is NOT zip64 */
-            mz_bool has_id;
-
-            if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pBuf, sizeof(mz_uint32) * 4) != sizeof(mz_uint32) * 4)
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_dst_file_ofs, pBuf, n) != n)
             {
                 pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
-                return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
             }
+            cur_dst_file_ofs += n;
 
-            has_id = (MZ_READ_LE32(pBuf) == MZ_ZIP_DATA_DESCRIPTOR_ID);
+            src_archive_bytes_remaining -= n;
+        }
 
-            if (pZip->m_pState->m_zip64)
+        /* Now deal with the optional data descriptor */
+        bit_flags = MZ_READ_LE16(pLocal_header + MZ_ZIP_LDH_BIT_FLAG_OFS);
+        if (bit_flags & 8)
+        {
+            /* Copy data descriptor */
+            if ((pSource_zip->m_pState->m_zip64) || (found_zip64_ext_data_in_ldir))
             {
-                /* dest is zip64, so upgrade the data descriptor */
-                const mz_uint8 *pSrc_descriptor = (const mz_uint8 *)pBuf + (has_id ? sizeof(mz_uint32) : 0);
-                const mz_uint32 src_crc32 = MZ_READ_LE32(pSrc_descriptor);
-                const mz_uint64 src_comp_size = MZ_READ_LE32(pSrc_descriptor + sizeof(mz_uint32));
-                const mz_uint64 src_uncomp_size = MZ_READ_LE32(pSrc_descriptor + 2*sizeof(mz_uint32));
+                /* src is zip64, dest must be zip64 */
 
-                mz_write_le32((mz_uint8 *)pBuf, MZ_ZIP_DATA_DESCRIPTOR_ID);
-                mz_write_le32((mz_uint8 *)pBuf + sizeof(mz_uint32) * 1, src_crc32);
-                mz_write_le64((mz_uint8 *)pBuf + sizeof(mz_uint32) * 2, src_comp_size);
-                mz_write_le64((mz_uint8 *)pBuf + sizeof(mz_uint32) * 4, src_uncomp_size);
+                /* name			uint32_t's */
+                /* id				1 (optional in zip64?) */
+                /* crc			1 */
+                /* comp_size	2 */
+                /* uncomp_size 2 */
+                if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pBuf, (sizeof(mz_uint32) * 6)) != (sizeof(mz_uint32) * 6))
+                {
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                }
 
-                n = sizeof(mz_uint32) * 6;
+                n = sizeof(mz_uint32) * ((MZ_READ_LE32(pBuf) == MZ_ZIP_DATA_DESCRIPTOR_ID) ? 6 : 5);
             }
             else
             {
-                /* dest is NOT zip64, just copy it as-is */
-                n = sizeof(mz_uint32) * (has_id ? 4 : 3);
+                /* src is NOT zip64 */
+                mz_bool has_id;
+
+                if (pSource_zip->m_pRead(pSource_zip->m_pIO_opaque, cur_src_file_ofs, pBuf, sizeof(mz_uint32) * 4) != sizeof(mz_uint32) * 4)
+                {
+                    pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
+                    return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
+                }
+
+                has_id = (MZ_READ_LE32(pBuf) == MZ_ZIP_DATA_DESCRIPTOR_ID);
+
+                if (pZip->m_pState->m_zip64)
+                {
+                    /* dest is zip64, so upgrade the data descriptor */
+                    const mz_uint8 *pSrc_descriptor = (const mz_uint8 *)pBuf + (has_id ? sizeof(mz_uint32) : 0);
+                    const mz_uint32 src_crc32 = MZ_READ_LE32(pSrc_descriptor);
+                    const mz_uint64 src_comp_size = MZ_READ_LE32(pSrc_descriptor + sizeof(mz_uint32));
+                    const mz_uint64 src_uncomp_size = MZ_READ_LE32(pSrc_descriptor + 2 * sizeof(mz_uint32));
+
+                    mz_write_le32((mz_uint8 *)pBuf, MZ_ZIP_DATA_DESCRIPTOR_ID);
+                    mz_write_le32((mz_uint8 *)pBuf + sizeof(mz_uint32) * 1, src_crc32);
+                    mz_write_le64((mz_uint8 *)pBuf + sizeof(mz_uint32) * 2, src_comp_size);
+                    mz_write_le64((mz_uint8 *)pBuf + sizeof(mz_uint32) * 4, src_uncomp_size);
+
+                    n = sizeof(mz_uint32) * 6;
+                }
+                else
+                {
+                    /* dest is NOT zip64, just copy it as-is */
+                    n = sizeof(mz_uint32) * (has_id ? 4 : 3);
+                }
+            }
+
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_dst_file_ofs, pBuf, n) != n)
+            {
+                pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            }
+
+            cur_src_file_ofs += n;
+            cur_dst_file_ofs += n;
+        }
+        pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
+
+        /* Finally, add the new central dir header */
+        orig_central_dir_size = pState->m_central_dir.m_size;
+
+        memcpy(new_central_header, pSrc_central_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE);
+
+        if (pState->m_zip64)
+        {
+            /* This is the painful part: We need to write a new central dir header + ext block with updated zip64 fields, and ensure the old fields (if any) are not included. */
+            const mz_uint8 *pSrc_ext = pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_filename_len;
+            mz_zip_array new_ext_block;
+
+            mz_zip_array_init(&new_ext_block, sizeof(mz_uint8));
+
+            MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS, MZ_UINT32_MAX);
+            MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_UINT32_MAX);
+            MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_LOCAL_HEADER_OFS, MZ_UINT32_MAX);
+
+            if (!mz_zip_writer_update_zip64_extension_block(&new_ext_block, pZip, pSrc_ext, src_ext_len, &src_file_stat.m_comp_size, &src_file_stat.m_uncomp_size, &local_dir_header_ofs, NULL))
+            {
+                mz_zip_array_clear(pZip, &new_ext_block);
+                return MZ_FALSE;
+            }
+
+            MZ_WRITE_LE16(new_central_header + MZ_ZIP_CDH_EXTRA_LEN_OFS, new_ext_block.m_size);
+
+            if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, new_central_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE))
+            {
+                mz_zip_array_clear(pZip, &new_ext_block);
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
+
+            if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, src_filename_len))
+            {
+                mz_zip_array_clear(pZip, &new_ext_block);
+                mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
+
+            if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, new_ext_block.m_p, new_ext_block.m_size))
+            {
+                mz_zip_array_clear(pZip, &new_ext_block);
+                mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
+
+            if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_filename_len + src_ext_len, src_comment_len))
+            {
+                mz_zip_array_clear(pZip, &new_ext_block);
+                mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            }
+
+            mz_zip_array_clear(pZip, &new_ext_block);
+        }
+        else
+        {
+            /* sanity checks */
+            if (cur_dst_file_ofs > MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+
+            if (local_dir_header_ofs >= MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
+
+            MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_LOCAL_HEADER_OFS, local_dir_header_ofs);
+
+            if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, new_central_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE))
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+
+            if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, src_central_dir_following_data_size))
+            {
+                mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
+                return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
             }
         }
 
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, cur_dst_file_ofs, pBuf, n) != n)
+        /* This shouldn't trigger unless we screwed up during the initial sanity checks */
+        if (pState->m_central_dir.m_size >= MZ_UINT32_MAX)
         {
-            pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+            /* TODO: Support central dirs >= 32-bits in size */
+            mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
+            return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
         }
 
-        cur_src_file_ofs += n;
-        cur_dst_file_ofs += n;
-    }
-    pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
-
-    /* Finally, add the new central dir header */
-    orig_central_dir_size = pState->m_central_dir.m_size;
-
-    memcpy(new_central_header, pSrc_central_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE);
-
-    if (pState->m_zip64)
-    {
-        /* This is the painful part: We need to write a new central dir header + ext block with updated zip64 fields, and ensure the old fields (if any) are not included. */
-        const mz_uint8 *pSrc_ext = pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_filename_len;
-        mz_zip_array new_ext_block;
-
-        mz_zip_array_init(&new_ext_block, sizeof(mz_uint8));
-
-        MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS, MZ_UINT32_MAX);
-        MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_UINT32_MAX);
-        MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_LOCAL_HEADER_OFS, MZ_UINT32_MAX);
-
-        if (!mz_zip_writer_update_zip64_extension_block(&new_ext_block, pZip, pSrc_ext, src_ext_len, &src_file_stat.m_comp_size, &src_file_stat.m_uncomp_size, &local_dir_header_ofs, NULL))
+        n = (mz_uint32)orig_central_dir_size;
+        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir_offsets, &n, 1))
         {
-            mz_zip_array_clear(pZip, &new_ext_block);
-            return MZ_FALSE;
-        }
-
-        MZ_WRITE_LE16(new_central_header + MZ_ZIP_CDH_EXTRA_LEN_OFS, new_ext_block.m_size);
-
-        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, new_central_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE))
-        {
-            mz_zip_array_clear(pZip, &new_ext_block);
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        }
-
-        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, src_filename_len))
-        {
-            mz_zip_array_clear(pZip, &new_ext_block);
             mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
             return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
         }
 
-        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, new_ext_block.m_p, new_ext_block.m_size))
+        pZip->m_total_files++;
+        pZip->m_archive_size = cur_dst_file_ofs;
+
+        return MZ_TRUE;
+    }
+
+    mz_bool mz_zip_writer_finalize_archive(mz_zip_archive *pZip)
+    {
+        mz_zip_internal_state *pState;
+        mz_uint64 central_dir_ofs, central_dir_size;
+        mz_uint8 hdr[256];
+
+        if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        pState = pZip->m_pState;
+
+        if (pState->m_zip64)
         {
-            mz_zip_array_clear(pZip, &new_ext_block);
-            mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            if ((mz_uint64)pState->m_central_dir.m_size >= MZ_UINT32_MAX)
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
+        }
+        else
+        {
+            if ((pZip->m_total_files > MZ_UINT16_MAX) || ((pZip->m_archive_size + pState->m_central_dir.m_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE) > MZ_UINT32_MAX))
+                return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
         }
 
-        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + src_filename_len + src_ext_len, src_comment_len))
+        central_dir_ofs = 0;
+        central_dir_size = 0;
+        if (pZip->m_total_files)
         {
-            mz_zip_array_clear(pZip, &new_ext_block);
-            mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            /* Write central directory */
+            central_dir_ofs = pZip->m_archive_size;
+            central_dir_size = pState->m_central_dir.m_size;
+            pZip->m_central_directory_file_ofs = central_dir_ofs;
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, central_dir_ofs, pState->m_central_dir.m_p, (size_t)central_dir_size) != central_dir_size)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            pZip->m_archive_size += central_dir_size;
         }
 
-        mz_zip_array_clear(pZip, &new_ext_block);
-    }
-    else
-    {
-        /* sanity checks */
-        if (cur_dst_file_ofs > MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-
-        if (local_dir_header_ofs >= MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
-
-        MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_LOCAL_HEADER_OFS, local_dir_header_ofs);
-
-        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, new_central_header, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE))
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-
-        if (!mz_zip_array_push_back(pZip, &pState->m_central_dir, pSrc_central_header + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, src_central_dir_following_data_size))
+        if (pState->m_zip64)
         {
-            mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
-            return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
+            /* Write zip64 end of central directory header */
+            mz_uint64 rel_ofs_to_zip64_ecdr = pZip->m_archive_size;
+
+            MZ_CLEAR_ARR(hdr);
+            MZ_WRITE_LE32(hdr + MZ_ZIP64_ECDH_SIG_OFS, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIG);
+            MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_SIZE_OF_RECORD_OFS, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE - sizeof(mz_uint32) - sizeof(mz_uint64));
+            MZ_WRITE_LE16(hdr + MZ_ZIP64_ECDH_VERSION_MADE_BY_OFS, 0x031E); /* TODO: always Unix */
+            MZ_WRITE_LE16(hdr + MZ_ZIP64_ECDH_VERSION_NEEDED_OFS, 0x002D);
+            MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS, pZip->m_total_files);
+            MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_TOTAL_ENTRIES_OFS, pZip->m_total_files);
+            MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_SIZE_OFS, central_dir_size);
+            MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_OFS_OFS, central_dir_ofs);
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, pZip->m_archive_size, hdr, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE) != MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            pZip->m_archive_size += MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE;
+
+            /* Write zip64 end of central directory locator */
+            MZ_CLEAR_ARR(hdr);
+            MZ_WRITE_LE32(hdr + MZ_ZIP64_ECDL_SIG_OFS, MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIG);
+            MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDL_REL_OFS_TO_ZIP64_ECDR_OFS, rel_ofs_to_zip64_ecdr);
+            MZ_WRITE_LE32(hdr + MZ_ZIP64_ECDL_TOTAL_NUMBER_OF_DISKS_OFS, 1);
+            if (pZip->m_pWrite(pZip->m_pIO_opaque, pZip->m_archive_size, hdr, MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE) != MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE)
+                return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
+
+            pZip->m_archive_size += MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE;
         }
-    }
 
-    /* This shouldn't trigger unless we screwed up during the initial sanity checks */
-    if (pState->m_central_dir.m_size >= MZ_UINT32_MAX)
-    {
-        /* TODO: Support central dirs >= 32-bits in size */
-        mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
-        return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_CDIR_SIZE);
-    }
-
-    n = (mz_uint32)orig_central_dir_size;
-    if (!mz_zip_array_push_back(pZip, &pState->m_central_dir_offsets, &n, 1))
-    {
-        mz_zip_array_resize(pZip, &pState->m_central_dir, orig_central_dir_size, MZ_FALSE);
-        return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-    }
-
-    pZip->m_total_files++;
-    pZip->m_archive_size = cur_dst_file_ofs;
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_finalize_archive(mz_zip_archive *pZip)
-{
-    mz_zip_internal_state *pState;
-    mz_uint64 central_dir_ofs, central_dir_size;
-    mz_uint8 hdr[256];
-
-    if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    pState = pZip->m_pState;
-
-    if (pState->m_zip64)
-    {
-        if ((mz_uint64)pState->m_central_dir.m_size >= MZ_UINT32_MAX)
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-    else
-    {
-        if ((pZip->m_total_files > MZ_UINT16_MAX) || ((pZip->m_archive_size + pState->m_central_dir.m_size + MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE) > MZ_UINT32_MAX))
-            return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
-    }
-
-    central_dir_ofs = 0;
-    central_dir_size = 0;
-    if (pZip->m_total_files)
-    {
-        /* Write central directory */
-        central_dir_ofs = pZip->m_archive_size;
-        central_dir_size = pState->m_central_dir.m_size;
-        pZip->m_central_directory_file_ofs = central_dir_ofs;
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, central_dir_ofs, pState->m_central_dir.m_p, (size_t)central_dir_size) != central_dir_size)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        pZip->m_archive_size += central_dir_size;
-    }
-
-    if (pState->m_zip64)
-    {
-        /* Write zip64 end of central directory header */
-        mz_uint64 rel_ofs_to_zip64_ecdr = pZip->m_archive_size;
-
+        /* Write end of central directory record */
         MZ_CLEAR_ARR(hdr);
-        MZ_WRITE_LE32(hdr + MZ_ZIP64_ECDH_SIG_OFS, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIG);
-        MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_SIZE_OF_RECORD_OFS, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE - sizeof(mz_uint32) - sizeof(mz_uint64));
-        MZ_WRITE_LE16(hdr + MZ_ZIP64_ECDH_VERSION_MADE_BY_OFS, 0x031E); /* TODO: always Unix */
-        MZ_WRITE_LE16(hdr + MZ_ZIP64_ECDH_VERSION_NEEDED_OFS, 0x002D);
-        MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS, pZip->m_total_files);
-        MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_TOTAL_ENTRIES_OFS, pZip->m_total_files);
-        MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_SIZE_OFS, central_dir_size);
-        MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDH_CDIR_OFS_OFS, central_dir_ofs);
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, pZip->m_archive_size, hdr, MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE) != MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE)
+        MZ_WRITE_LE32(hdr + MZ_ZIP_ECDH_SIG_OFS, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG);
+        MZ_WRITE_LE16(hdr + MZ_ZIP_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS, MZ_MIN(MZ_UINT16_MAX, pZip->m_total_files));
+        MZ_WRITE_LE16(hdr + MZ_ZIP_ECDH_CDIR_TOTAL_ENTRIES_OFS, MZ_MIN(MZ_UINT16_MAX, pZip->m_total_files));
+        MZ_WRITE_LE32(hdr + MZ_ZIP_ECDH_CDIR_SIZE_OFS, MZ_MIN(MZ_UINT32_MAX, central_dir_size));
+        MZ_WRITE_LE32(hdr + MZ_ZIP_ECDH_CDIR_OFS_OFS, MZ_MIN(MZ_UINT32_MAX, central_dir_ofs));
+
+        if (pZip->m_pWrite(pZip->m_pIO_opaque, pZip->m_archive_size, hdr, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE) != MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
             return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        pZip->m_archive_size += MZ_ZIP64_END_OF_CENTRAL_DIR_HEADER_SIZE;
-
-        /* Write zip64 end of central directory locator */
-        MZ_CLEAR_ARR(hdr);
-        MZ_WRITE_LE32(hdr + MZ_ZIP64_ECDL_SIG_OFS, MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIG);
-        MZ_WRITE_LE64(hdr + MZ_ZIP64_ECDL_REL_OFS_TO_ZIP64_ECDR_OFS, rel_ofs_to_zip64_ecdr);
-        MZ_WRITE_LE32(hdr + MZ_ZIP64_ECDL_TOTAL_NUMBER_OF_DISKS_OFS, 1);
-        if (pZip->m_pWrite(pZip->m_pIO_opaque, pZip->m_archive_size, hdr, MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE) != MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE)
-            return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
-
-        pZip->m_archive_size += MZ_ZIP64_END_OF_CENTRAL_DIR_LOCATOR_SIZE;
-    }
-
-    /* Write end of central directory record */
-    MZ_CLEAR_ARR(hdr);
-    MZ_WRITE_LE32(hdr + MZ_ZIP_ECDH_SIG_OFS, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIG);
-    MZ_WRITE_LE16(hdr + MZ_ZIP_ECDH_CDIR_NUM_ENTRIES_ON_DISK_OFS, MZ_MIN(MZ_UINT16_MAX, pZip->m_total_files));
-    MZ_WRITE_LE16(hdr + MZ_ZIP_ECDH_CDIR_TOTAL_ENTRIES_OFS, MZ_MIN(MZ_UINT16_MAX, pZip->m_total_files));
-    MZ_WRITE_LE32(hdr + MZ_ZIP_ECDH_CDIR_SIZE_OFS, MZ_MIN(MZ_UINT32_MAX, central_dir_size));
-    MZ_WRITE_LE32(hdr + MZ_ZIP_ECDH_CDIR_OFS_OFS, MZ_MIN(MZ_UINT32_MAX, central_dir_ofs));
-
-    if (pZip->m_pWrite(pZip->m_pIO_opaque, pZip->m_archive_size, hdr, MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE) != MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE)
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
 
 #ifndef MINIZ_NO_STDIO
-    if ((pState->m_pFile) && (MZ_FFLUSH(pState->m_pFile) == EOF))
-        return mz_zip_set_error(pZip, MZ_ZIP_FILE_CLOSE_FAILED);
+        if ((pState->m_pFile) && (MZ_FFLUSH(pState->m_pFile) == EOF))
+            return mz_zip_set_error(pZip, MZ_ZIP_FILE_CLOSE_FAILED);
 #endif /* #ifndef MINIZ_NO_STDIO */
 
-    pZip->m_archive_size += MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE;
+        pZip->m_archive_size += MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE;
 
-    pZip->m_zip_mode = MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED;
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_finalize_heap_archive(mz_zip_archive *pZip, void **ppBuf, size_t *pSize)
-{
-    if ((!ppBuf) || (!pSize))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    *ppBuf = NULL;
-    *pSize = 0;
-
-    if ((!pZip) || (!pZip->m_pState))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (pZip->m_pWrite != mz_zip_heap_write_func)
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    if (!mz_zip_writer_finalize_archive(pZip))
-        return MZ_FALSE;
-
-    *ppBuf = pZip->m_pState->m_pMem;
-    *pSize = pZip->m_pState->m_mem_size;
-    pZip->m_pState->m_pMem = NULL;
-    pZip->m_pState->m_mem_size = pZip->m_pState->m_mem_capacity = 0;
-
-    return MZ_TRUE;
-}
-
-mz_bool mz_zip_writer_end(mz_zip_archive *pZip)
-{
-    return mz_zip_writer_end_internal(pZip, MZ_TRUE);
-}
-
-#ifndef MINIZ_NO_STDIO
-mz_bool mz_zip_add_mem_to_archive_file_in_place(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags)
-{
-    return mz_zip_add_mem_to_archive_file_in_place_v2(pZip_filename, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, NULL);
-}
-
-mz_bool mz_zip_add_mem_to_archive_file_in_place_v2(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, mz_zip_error *pErr)
-{
-    mz_bool status, created_new_archive = MZ_FALSE;
-    mz_zip_archive zip_archive;
-    struct MZ_FILE_STAT_STRUCT file_stat;
-    mz_zip_error actual_err = MZ_ZIP_NO_ERROR;
-
-    mz_zip_zero_struct(&zip_archive);
-    if ((int)level_and_flags < 0)
-        level_and_flags = MZ_DEFAULT_LEVEL;
-
-    if ((!pZip_filename) || (!pArchive_name) || ((buf_size) && (!pBuf)) || ((comment_size) && (!pComment)) || ((level_and_flags & 0xF) > MZ_UBER_COMPRESSION))
-    {
-        if (pErr)
-            *pErr = MZ_ZIP_INVALID_PARAMETER;
-        return MZ_FALSE;
+        pZip->m_zip_mode = MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED;
+        return MZ_TRUE;
     }
 
-    if (!mz_zip_writer_validate_archive_name(pArchive_name))
+    mz_bool mz_zip_writer_finalize_heap_archive(mz_zip_archive *pZip, void **ppBuf, size_t *pSize)
     {
-        if (pErr)
-            *pErr = MZ_ZIP_INVALID_FILENAME;
-        return MZ_FALSE;
-    }
+        if ((!ppBuf) || (!pSize))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
-    /* Important: The regular non-64 bit version of stat() can fail here if the file is very large, which could cause the archive to be overwritten. */
-    /* So be sure to compile with _LARGEFILE64_SOURCE 1 */
-    if (MZ_FILE_STAT(pZip_filename, &file_stat) != 0)
-    {
-        /* Create a new archive. */
-        if (!mz_zip_writer_init_file_v2(&zip_archive, pZip_filename, 0, level_and_flags))
-        {
-            if (pErr)
-                *pErr = zip_archive.m_last_error;
-            return MZ_FALSE;
-        }
-
-        created_new_archive = MZ_TRUE;
-    }
-    else
-    {
-        /* Append to an existing archive. */
-        if (!mz_zip_reader_init_file_v2(&zip_archive, pZip_filename, level_and_flags | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY, 0, 0))
-        {
-            if (pErr)
-                *pErr = zip_archive.m_last_error;
-            return MZ_FALSE;
-        }
-
-        if (!mz_zip_writer_init_from_reader_v2(&zip_archive, pZip_filename, level_and_flags))
-        {
-            if (pErr)
-                *pErr = zip_archive.m_last_error;
-
-            mz_zip_reader_end_internal(&zip_archive, MZ_FALSE);
-
-            return MZ_FALSE;
-        }
-    }
-
-    status = mz_zip_writer_add_mem_ex(&zip_archive, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, 0, 0);
-    actual_err = zip_archive.m_last_error;
-
-    /* Always finalize, even if adding failed for some reason, so we have a valid central directory. (This may not always succeed, but we can try.) */
-    if (!mz_zip_writer_finalize_archive(&zip_archive))
-    {
-        if (!actual_err)
-            actual_err = zip_archive.m_last_error;
-
-        status = MZ_FALSE;
-    }
-
-    if (!mz_zip_writer_end_internal(&zip_archive, status))
-    {
-        if (!actual_err)
-            actual_err = zip_archive.m_last_error;
-
-        status = MZ_FALSE;
-    }
-
-    if ((!status) && (created_new_archive))
-    {
-        /* It's a new archive and something went wrong, so just delete it. */
-        int ignoredStatus = MZ_DELETE_FILE(pZip_filename);
-        (void)ignoredStatus;
-    }
-
-    if (pErr)
-        *pErr = actual_err;
-
-    return status;
-}
-
-void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const char *pArchive_name, const char *pComment, size_t *pSize, mz_uint flags, mz_zip_error *pErr)
-{
-    mz_uint32 file_index;
-    mz_zip_archive zip_archive;
-    void *p = NULL;
-
-    if (pSize)
+        *ppBuf = NULL;
         *pSize = 0;
 
-    if ((!pZip_filename) || (!pArchive_name))
-    {
-        if (pErr)
-            *pErr = MZ_ZIP_INVALID_PARAMETER;
+        if ((!pZip) || (!pZip->m_pState))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
-        return NULL;
+        if (pZip->m_pWrite != mz_zip_heap_write_func)
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        if (!mz_zip_writer_finalize_archive(pZip))
+            return MZ_FALSE;
+
+        *ppBuf = pZip->m_pState->m_pMem;
+        *pSize = pZip->m_pState->m_mem_size;
+        pZip->m_pState->m_pMem = NULL;
+        pZip->m_pState->m_mem_size = pZip->m_pState->m_mem_capacity = 0;
+
+        return MZ_TRUE;
     }
 
-    mz_zip_zero_struct(&zip_archive);
-    if (!mz_zip_reader_init_file_v2(&zip_archive, pZip_filename, flags | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY, 0, 0))
+    mz_bool mz_zip_writer_end(mz_zip_archive *pZip)
     {
+        return mz_zip_writer_end_internal(pZip, MZ_TRUE);
+    }
+
+#ifndef MINIZ_NO_STDIO
+    mz_bool mz_zip_add_mem_to_archive_file_in_place(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags)
+    {
+        return mz_zip_add_mem_to_archive_file_in_place_v2(pZip_filename, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, NULL);
+    }
+
+    mz_bool mz_zip_add_mem_to_archive_file_in_place_v2(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, mz_zip_error *pErr)
+    {
+        mz_bool status, created_new_archive = MZ_FALSE;
+        mz_zip_archive zip_archive;
+        struct MZ_FILE_STAT_STRUCT file_stat;
+        mz_zip_error actual_err = MZ_ZIP_NO_ERROR;
+
+        mz_zip_zero_struct(&zip_archive);
+        if ((int)level_and_flags < 0)
+            level_and_flags = MZ_DEFAULT_LEVEL;
+
+        if ((!pZip_filename) || (!pArchive_name) || ((buf_size) && (!pBuf)) || ((comment_size) && (!pComment)) || ((level_and_flags & 0xF) > MZ_UBER_COMPRESSION))
+        {
+            if (pErr)
+                *pErr = MZ_ZIP_INVALID_PARAMETER;
+            return MZ_FALSE;
+        }
+
+        if (!mz_zip_writer_validate_archive_name(pArchive_name))
+        {
+            if (pErr)
+                *pErr = MZ_ZIP_INVALID_FILENAME;
+            return MZ_FALSE;
+        }
+
+        /* Important: The regular non-64 bit version of stat() can fail here if the file is very large, which could cause the archive to be overwritten. */
+        /* So be sure to compile with _LARGEFILE64_SOURCE 1 */
+        if (MZ_FILE_STAT(pZip_filename, &file_stat) != 0)
+        {
+            /* Create a new archive. */
+            if (!mz_zip_writer_init_file_v2(&zip_archive, pZip_filename, 0, level_and_flags))
+            {
+                if (pErr)
+                    *pErr = zip_archive.m_last_error;
+                return MZ_FALSE;
+            }
+
+            created_new_archive = MZ_TRUE;
+        }
+        else
+        {
+            /* Append to an existing archive. */
+            if (!mz_zip_reader_init_file_v2(&zip_archive, pZip_filename, level_and_flags | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY | MZ_ZIP_FLAG_READ_ALLOW_WRITING, 0, 0))
+            {
+                if (pErr)
+                    *pErr = zip_archive.m_last_error;
+                return MZ_FALSE;
+            }
+
+            if (!mz_zip_writer_init_from_reader_v2(&zip_archive, pZip_filename, level_and_flags | MZ_ZIP_FLAG_READ_ALLOW_WRITING))
+            {
+                if (pErr)
+                    *pErr = zip_archive.m_last_error;
+
+                mz_zip_reader_end_internal(&zip_archive, MZ_FALSE);
+
+                return MZ_FALSE;
+            }
+        }
+
+        status = mz_zip_writer_add_mem_ex(&zip_archive, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, 0, 0);
+        actual_err = zip_archive.m_last_error;
+
+        /* Always finalize, even if adding failed for some reason, so we have a valid central directory. (This may not always succeed, but we can try.) */
+        if (!mz_zip_writer_finalize_archive(&zip_archive))
+        {
+            if (!actual_err)
+                actual_err = zip_archive.m_last_error;
+
+            status = MZ_FALSE;
+        }
+
+        if (!mz_zip_writer_end_internal(&zip_archive, status))
+        {
+            if (!actual_err)
+                actual_err = zip_archive.m_last_error;
+
+            status = MZ_FALSE;
+        }
+
+        if ((!status) && (created_new_archive))
+        {
+            /* It's a new archive and something went wrong, so just delete it. */
+            int ignoredStatus = MZ_DELETE_FILE(pZip_filename);
+            (void)ignoredStatus;
+        }
+
+        if (pErr)
+            *pErr = actual_err;
+
+        return status;
+    }
+
+    void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const char *pArchive_name, const char *pComment, size_t *pSize, mz_uint flags, mz_zip_error *pErr)
+    {
+        mz_uint32 file_index;
+        mz_zip_archive zip_archive;
+        void *p = NULL;
+
+        if (pSize)
+            *pSize = 0;
+
+        if ((!pZip_filename) || (!pArchive_name))
+        {
+            if (pErr)
+                *pErr = MZ_ZIP_INVALID_PARAMETER;
+
+            return NULL;
+        }
+
+        mz_zip_zero_struct(&zip_archive);
+        if (!mz_zip_reader_init_file_v2(&zip_archive, pZip_filename, flags | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY, 0, 0))
+        {
+            if (pErr)
+                *pErr = zip_archive.m_last_error;
+
+            return NULL;
+        }
+
+        if (mz_zip_reader_locate_file_v2(&zip_archive, pArchive_name, pComment, flags, &file_index))
+        {
+            p = mz_zip_reader_extract_to_heap(&zip_archive, file_index, pSize, flags);
+        }
+
+        mz_zip_reader_end_internal(&zip_archive, p != NULL);
+
         if (pErr)
             *pErr = zip_archive.m_last_error;
 
-        return NULL;
+        return p;
     }
 
-    if (mz_zip_reader_locate_file_v2(&zip_archive, pArchive_name, pComment, flags, &file_index))
+    void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char *pArchive_name, size_t *pSize, mz_uint flags)
     {
-        p = mz_zip_reader_extract_to_heap(&zip_archive, file_index, pSize, flags);
+        return mz_zip_extract_archive_file_to_heap_v2(pZip_filename, pArchive_name, NULL, pSize, flags, NULL);
     }
-
-    mz_zip_reader_end_internal(&zip_archive, p != NULL);
-
-    if (pErr)
-        *pErr = zip_archive.m_last_error;
-
-    return p;
-}
-
-void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char *pArchive_name, size_t *pSize, mz_uint flags)
-{
-    return mz_zip_extract_archive_file_to_heap_v2(pZip_filename, pArchive_name, NULL, pSize, flags, NULL);
-}
 
 #endif /* #ifndef MINIZ_NO_STDIO */
 
 #endif /* #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS */
 
-/* ------------------- Misc utils */
+    /* ------------------- Misc utils */
 
-mz_zip_mode mz_zip_get_mode(mz_zip_archive *pZip)
-{
-    return pZip ? pZip->m_zip_mode : MZ_ZIP_MODE_INVALID;
-}
-
-mz_zip_type mz_zip_get_type(mz_zip_archive *pZip)
-{
-    return pZip ? pZip->m_zip_type : MZ_ZIP_TYPE_INVALID;
-}
-
-mz_zip_error mz_zip_set_last_error(mz_zip_archive *pZip, mz_zip_error err_num)
-{
-    mz_zip_error prev_err;
-
-    if (!pZip)
-        return MZ_ZIP_INVALID_PARAMETER;
-
-    prev_err = pZip->m_last_error;
-
-    pZip->m_last_error = err_num;
-    return prev_err;
-}
-
-mz_zip_error mz_zip_peek_last_error(mz_zip_archive *pZip)
-{
-    if (!pZip)
-        return MZ_ZIP_INVALID_PARAMETER;
-
-    return pZip->m_last_error;
-}
-
-mz_zip_error mz_zip_clear_last_error(mz_zip_archive *pZip)
-{
-    return mz_zip_set_last_error(pZip, MZ_ZIP_NO_ERROR);
-}
-
-mz_zip_error mz_zip_get_last_error(mz_zip_archive *pZip)
-{
-    mz_zip_error prev_err;
-
-    if (!pZip)
-        return MZ_ZIP_INVALID_PARAMETER;
-
-    prev_err = pZip->m_last_error;
-
-    pZip->m_last_error = MZ_ZIP_NO_ERROR;
-    return prev_err;
-}
-
-const char *mz_zip_get_error_string(mz_zip_error mz_err)
-{
-    switch (mz_err)
+    mz_zip_mode mz_zip_get_mode(mz_zip_archive *pZip)
     {
-        case MZ_ZIP_NO_ERROR:
-            return "no error";
-        case MZ_ZIP_UNDEFINED_ERROR:
-            return "undefined error";
-        case MZ_ZIP_TOO_MANY_FILES:
-            return "too many files";
-        case MZ_ZIP_FILE_TOO_LARGE:
-            return "file too large";
-        case MZ_ZIP_UNSUPPORTED_METHOD:
-            return "unsupported method";
-        case MZ_ZIP_UNSUPPORTED_ENCRYPTION:
-            return "unsupported encryption";
-        case MZ_ZIP_UNSUPPORTED_FEATURE:
-            return "unsupported feature";
-        case MZ_ZIP_FAILED_FINDING_CENTRAL_DIR:
-            return "failed finding central directory";
-        case MZ_ZIP_NOT_AN_ARCHIVE:
-            return "not a ZIP archive";
-        case MZ_ZIP_INVALID_HEADER_OR_CORRUPTED:
-            return "invalid header or archive is corrupted";
-        case MZ_ZIP_UNSUPPORTED_MULTIDISK:
-            return "unsupported multidisk archive";
-        case MZ_ZIP_DECOMPRESSION_FAILED:
-            return "decompression failed or archive is corrupted";
-        case MZ_ZIP_COMPRESSION_FAILED:
-            return "compression failed";
-        case MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE:
-            return "unexpected decompressed size";
-        case MZ_ZIP_CRC_CHECK_FAILED:
-            return "CRC-32 check failed";
-        case MZ_ZIP_UNSUPPORTED_CDIR_SIZE:
-            return "unsupported central directory size";
-        case MZ_ZIP_ALLOC_FAILED:
-            return "allocation failed";
-        case MZ_ZIP_FILE_OPEN_FAILED:
-            return "file open failed";
-        case MZ_ZIP_FILE_CREATE_FAILED:
-            return "file create failed";
-        case MZ_ZIP_FILE_WRITE_FAILED:
-            return "file write failed";
-        case MZ_ZIP_FILE_READ_FAILED:
-            return "file read failed";
-        case MZ_ZIP_FILE_CLOSE_FAILED:
-            return "file close failed";
-        case MZ_ZIP_FILE_SEEK_FAILED:
-            return "file seek failed";
-        case MZ_ZIP_FILE_STAT_FAILED:
-            return "file stat failed";
-        case MZ_ZIP_INVALID_PARAMETER:
-            return "invalid parameter";
-        case MZ_ZIP_INVALID_FILENAME:
-            return "invalid filename";
-        case MZ_ZIP_BUF_TOO_SMALL:
-            return "buffer too small";
-        case MZ_ZIP_INTERNAL_ERROR:
-            return "internal error";
-        case MZ_ZIP_FILE_NOT_FOUND:
-            return "file not found";
-        case MZ_ZIP_ARCHIVE_TOO_LARGE:
-            return "archive is too large";
-        case MZ_ZIP_VALIDATION_FAILED:
-            return "validation failed";
-        case MZ_ZIP_WRITE_CALLBACK_FAILED:
-            return "write callback failed";
-	case MZ_ZIP_TOTAL_ERRORS:
-            return "total errors";
-        default:
-            break;
+        return pZip ? pZip->m_zip_mode : MZ_ZIP_MODE_INVALID;
     }
 
-    return "unknown error";
-}
-
-/* Note: Just because the archive is not zip64 doesn't necessarily mean it doesn't have Zip64 extended information extra field, argh. */
-mz_bool mz_zip_is_zip64(mz_zip_archive *pZip)
-{
-    if ((!pZip) || (!pZip->m_pState))
-        return MZ_FALSE;
-
-    return pZip->m_pState->m_zip64;
-}
-
-size_t mz_zip_get_central_dir_size(mz_zip_archive *pZip)
-{
-    if ((!pZip) || (!pZip->m_pState))
-        return 0;
-
-    return pZip->m_pState->m_central_dir.m_size;
-}
-
-mz_uint mz_zip_reader_get_num_files(mz_zip_archive *pZip)
-{
-    return pZip ? pZip->m_total_files : 0;
-}
-
-mz_uint64 mz_zip_get_archive_size(mz_zip_archive *pZip)
-{
-    if (!pZip)
-        return 0;
-    return pZip->m_archive_size;
-}
-
-mz_uint64 mz_zip_get_archive_file_start_offset(mz_zip_archive *pZip)
-{
-    if ((!pZip) || (!pZip->m_pState))
-        return 0;
-    return pZip->m_pState->m_file_archive_start_ofs;
-}
-
-MZ_FILE *mz_zip_get_cfile(mz_zip_archive *pZip)
-{
-    if ((!pZip) || (!pZip->m_pState))
-        return 0;
-    return pZip->m_pState->m_pFile;
-}
-
-size_t mz_zip_read_archive_data(mz_zip_archive *pZip, mz_uint64 file_ofs, void *pBuf, size_t n)
-{
-    if ((!pZip) || (!pZip->m_pState) || (!pBuf) || (!pZip->m_pRead))
-        return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-
-    return pZip->m_pRead(pZip->m_pIO_opaque, file_ofs, pBuf, n);
-}
-
-mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, char *pFilename, mz_uint filename_buf_size)
-{
-    mz_uint n;
-    const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
-    if (!p)
+    mz_zip_type mz_zip_get_type(mz_zip_archive *pZip)
     {
+        return pZip ? pZip->m_zip_type : MZ_ZIP_TYPE_INVALID;
+    }
+
+    mz_zip_error mz_zip_set_last_error(mz_zip_archive *pZip, mz_zip_error err_num)
+    {
+        mz_zip_error prev_err;
+
+        if (!pZip)
+            return MZ_ZIP_INVALID_PARAMETER;
+
+        prev_err = pZip->m_last_error;
+
+        pZip->m_last_error = err_num;
+        return prev_err;
+    }
+
+    mz_zip_error mz_zip_peek_last_error(mz_zip_archive *pZip)
+    {
+        if (!pZip)
+            return MZ_ZIP_INVALID_PARAMETER;
+
+        return pZip->m_last_error;
+    }
+
+    mz_zip_error mz_zip_clear_last_error(mz_zip_archive *pZip)
+    {
+        return mz_zip_set_last_error(pZip, MZ_ZIP_NO_ERROR);
+    }
+
+    mz_zip_error mz_zip_get_last_error(mz_zip_archive *pZip)
+    {
+        mz_zip_error prev_err;
+
+        if (!pZip)
+            return MZ_ZIP_INVALID_PARAMETER;
+
+        prev_err = pZip->m_last_error;
+
+        pZip->m_last_error = MZ_ZIP_NO_ERROR;
+        return prev_err;
+    }
+
+    const char *mz_zip_get_error_string(mz_zip_error mz_err)
+    {
+        switch (mz_err)
+        {
+            case MZ_ZIP_NO_ERROR:
+                return "no error";
+            case MZ_ZIP_UNDEFINED_ERROR:
+                return "undefined error";
+            case MZ_ZIP_TOO_MANY_FILES:
+                return "too many files";
+            case MZ_ZIP_FILE_TOO_LARGE:
+                return "file too large";
+            case MZ_ZIP_UNSUPPORTED_METHOD:
+                return "unsupported method";
+            case MZ_ZIP_UNSUPPORTED_ENCRYPTION:
+                return "unsupported encryption";
+            case MZ_ZIP_UNSUPPORTED_FEATURE:
+                return "unsupported feature";
+            case MZ_ZIP_FAILED_FINDING_CENTRAL_DIR:
+                return "failed finding central directory";
+            case MZ_ZIP_NOT_AN_ARCHIVE:
+                return "not a ZIP archive";
+            case MZ_ZIP_INVALID_HEADER_OR_CORRUPTED:
+                return "invalid header or archive is corrupted";
+            case MZ_ZIP_UNSUPPORTED_MULTIDISK:
+                return "unsupported multidisk archive";
+            case MZ_ZIP_DECOMPRESSION_FAILED:
+                return "decompression failed or archive is corrupted";
+            case MZ_ZIP_COMPRESSION_FAILED:
+                return "compression failed";
+            case MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE:
+                return "unexpected decompressed size";
+            case MZ_ZIP_CRC_CHECK_FAILED:
+                return "CRC-32 check failed";
+            case MZ_ZIP_UNSUPPORTED_CDIR_SIZE:
+                return "unsupported central directory size";
+            case MZ_ZIP_ALLOC_FAILED:
+                return "allocation failed";
+            case MZ_ZIP_FILE_OPEN_FAILED:
+                return "file open failed";
+            case MZ_ZIP_FILE_CREATE_FAILED:
+                return "file create failed";
+            case MZ_ZIP_FILE_WRITE_FAILED:
+                return "file write failed";
+            case MZ_ZIP_FILE_READ_FAILED:
+                return "file read failed";
+            case MZ_ZIP_FILE_CLOSE_FAILED:
+                return "file close failed";
+            case MZ_ZIP_FILE_SEEK_FAILED:
+                return "file seek failed";
+            case MZ_ZIP_FILE_STAT_FAILED:
+                return "file stat failed";
+            case MZ_ZIP_INVALID_PARAMETER:
+                return "invalid parameter";
+            case MZ_ZIP_INVALID_FILENAME:
+                return "invalid filename";
+            case MZ_ZIP_BUF_TOO_SMALL:
+                return "buffer too small";
+            case MZ_ZIP_INTERNAL_ERROR:
+                return "internal error";
+            case MZ_ZIP_FILE_NOT_FOUND:
+                return "file not found";
+            case MZ_ZIP_ARCHIVE_TOO_LARGE:
+                return "archive is too large";
+            case MZ_ZIP_VALIDATION_FAILED:
+                return "validation failed";
+            case MZ_ZIP_WRITE_CALLBACK_FAILED:
+                return "write callback failed";
+            case MZ_ZIP_TOTAL_ERRORS:
+                return "total errors";
+            default:
+                break;
+        }
+
+        return "unknown error";
+    }
+
+    /* Note: Just because the archive is not zip64 doesn't necessarily mean it doesn't have Zip64 extended information extra field, argh. */
+    mz_bool mz_zip_is_zip64(mz_zip_archive *pZip)
+    {
+        if ((!pZip) || (!pZip->m_pState))
+            return MZ_FALSE;
+
+        return pZip->m_pState->m_zip64;
+    }
+
+    size_t mz_zip_get_central_dir_size(mz_zip_archive *pZip)
+    {
+        if ((!pZip) || (!pZip->m_pState))
+            return 0;
+
+        return pZip->m_pState->m_central_dir.m_size;
+    }
+
+    mz_uint mz_zip_reader_get_num_files(mz_zip_archive *pZip)
+    {
+        return pZip ? pZip->m_total_files : 0;
+    }
+
+    mz_uint64 mz_zip_get_archive_size(mz_zip_archive *pZip)
+    {
+        if (!pZip)
+            return 0;
+        return pZip->m_archive_size;
+    }
+
+    mz_uint64 mz_zip_get_archive_file_start_offset(mz_zip_archive *pZip)
+    {
+        if ((!pZip) || (!pZip->m_pState))
+            return 0;
+        return pZip->m_pState->m_file_archive_start_ofs;
+    }
+
+    MZ_FILE *mz_zip_get_cfile(mz_zip_archive *pZip)
+    {
+        if ((!pZip) || (!pZip->m_pState))
+            return 0;
+        return pZip->m_pState->m_pFile;
+    }
+
+    size_t mz_zip_read_archive_data(mz_zip_archive *pZip, mz_uint64 file_ofs, void *pBuf, size_t n)
+    {
+        if ((!pZip) || (!pZip->m_pState) || (!pBuf) || (!pZip->m_pRead))
+            return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+
+        return pZip->m_pRead(pZip->m_pIO_opaque, file_ofs, pBuf, n);
+    }
+
+    mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, char *pFilename, mz_uint filename_buf_size)
+    {
+        mz_uint n;
+        const mz_uint8 *p = mz_zip_get_cdh(pZip, file_index);
+        if (!p)
+        {
+            if (filename_buf_size)
+                pFilename[0] = '\0';
+            mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
+            return 0;
+        }
+        n = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
         if (filename_buf_size)
-            pFilename[0] = '\0';
-        mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-        return 0;
+        {
+            n = MZ_MIN(n, filename_buf_size - 1);
+            memcpy(pFilename, p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, n);
+            pFilename[n] = '\0';
+        }
+        return n + 1;
     }
-    n = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-    if (filename_buf_size)
+
+    mz_bool mz_zip_reader_file_stat(mz_zip_archive *pZip, mz_uint file_index, mz_zip_archive_file_stat *pStat)
     {
-        n = MZ_MIN(n, filename_buf_size - 1);
-        memcpy(pFilename, p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE, n);
-        pFilename[n] = '\0';
+        return mz_zip_file_stat_internal(pZip, file_index, mz_zip_get_cdh(pZip, file_index), pStat, NULL);
     }
-    return n + 1;
-}
 
-mz_bool mz_zip_reader_file_stat(mz_zip_archive *pZip, mz_uint file_index, mz_zip_archive_file_stat *pStat)
-{
-    return mz_zip_file_stat_internal(pZip, file_index, mz_zip_get_cdh(pZip, file_index), pStat, NULL);
-}
+    mz_bool mz_zip_end(mz_zip_archive *pZip)
+    {
+        if (!pZip)
+            return MZ_FALSE;
 
-mz_bool mz_zip_end(mz_zip_archive *pZip)
-{
-    if (!pZip)
-        return MZ_FALSE;
-
-    if (pZip->m_zip_mode == MZ_ZIP_MODE_READING)
-        return mz_zip_reader_end(pZip);
+        if (pZip->m_zip_mode == MZ_ZIP_MODE_READING)
+            return mz_zip_reader_end(pZip);
 #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
-    else if ((pZip->m_zip_mode == MZ_ZIP_MODE_WRITING) || (pZip->m_zip_mode == MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED))
-        return mz_zip_writer_end(pZip);
+        else if ((pZip->m_zip_mode == MZ_ZIP_MODE_WRITING) || (pZip->m_zip_mode == MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED))
+            return mz_zip_writer_end(pZip);
 #endif
 
-    return MZ_FALSE;
-}
+        return MZ_FALSE;
+    }
 
 #ifdef __cplusplus
 }

--- a/third-party/include/miniz/miniz.h
+++ b/third-party/include/miniz/miniz.h
@@ -1,4 +1,7 @@
-/* miniz.c 3.0.0 - public domain deflate/inflate, zlib-subset, ZIP reading/writing/appending, PNG writing
+#ifndef MINIZ_EXPORT
+#define MINIZ_EXPORT
+#endif
+/* miniz.c 3.0.2 - public domain deflate/inflate, zlib-subset, ZIP reading/writing/appending, PNG writing
    See "unlicense" statement at the end of this file.
    Rich Geldreich <richgel99@gmail.com>, last updated Oct. 13, 2013
    Implements RFC 1950: http://www.ietf.org/rfc/rfc1950.txt and RFC 1951: http://www.ietf.org/rfc/rfc1951.txt
@@ -112,21 +115,22 @@
 */
 #pragma once
 
-//#include "miniz_export.h"
-#define MINIZ_EXPORT
+#ifndef __STANDALONE__
+#define MINIZ_NO_STDIO
+#define MINIZ_NO_ARCHIVE_APIS
+#define MINIZ_NO_ARCHIVE_WRITING_APIS
+#endif
 
-/* Defines to completely disable specific portions of miniz.c: 
+/* Defines to completely disable specific portions of miniz.c:
    If all macros here are defined the only functionality remaining will be CRC-32 and adler-32. */
 
 /* Define MINIZ_NO_STDIO to disable all usage and any functions which rely on stdio for file I/O. */
-#ifndef __STANDALONE__
-#define MINIZ_NO_STDIO
-#endif
+/*#define MINIZ_NO_STDIO */
 
 /* If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or */
 /* get/set file times, and the C run-time funcs that get/set times won't be called. */
 /* The current downside is the times written to your archives will be from 1979. */
-#define MINIZ_NO_TIME
+/*#define MINIZ_NO_TIME */
 
 /* Define MINIZ_NO_DEFLATE_APIS to disable all compression API's. */
 /*#define MINIZ_NO_DEFLATE_APIS */
@@ -135,14 +139,10 @@
 /*#define MINIZ_NO_INFLATE_APIS */
 
 /* Define MINIZ_NO_ARCHIVE_APIS to disable all ZIP archive API's. */
-#ifndef __STANDALONE__
-#define MINIZ_NO_ARCHIVE_APIS
-#endif
+/*#define MINIZ_NO_ARCHIVE_APIS */
 
 /* Define MINIZ_NO_ARCHIVE_WRITING_APIS to disable all writing related ZIP archive API's. */
-#ifndef __STANDALONE__
-#define MINIZ_NO_ARCHIVE_WRITING_APIS
-#endif
+/*#define MINIZ_NO_ARCHIVE_WRITING_APIS */
 
 /* Define MINIZ_NO_ZLIB_APIS to remove all ZLIB-style compression/decompression API's. */
 /*#define MINIZ_NO_ZLIB_APIS */
@@ -150,7 +150,7 @@
 /* Define MINIZ_NO_ZLIB_COMPATIBLE_NAME to disable zlib names, to prevent conflicts against stock zlib. */
 /*#define MINIZ_NO_ZLIB_COMPATIBLE_NAMES */
 
-/* Define MINIZ_NO_MALLOC to disable all calls to malloc, free, and realloc. 
+/* Define MINIZ_NO_MALLOC to disable all calls to malloc, free, and realloc.
    Note if MINIZ_NO_MALLOC is defined then the user must always provide custom user alloc/free/realloc
    callbacks to the zlib and archive API's, and a few stand-alone helper API's which don't provide custom user
    functions (such as tdefl_compress_mem_to_heap() and tinfl_decompress_mem_to_heap()) won't work. */
@@ -230,54 +230,55 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* ------------------- zlib-style API Definitions. */
+    /* ------------------- zlib-style API Definitions. */
 
-/* For more compatibility with zlib, miniz.c uses unsigned long for some parameters/struct members. Beware: mz_ulong can be either 32 or 64-bits! */
-typedef unsigned long mz_ulong;
+    /* For more compatibility with zlib, miniz.c uses unsigned long for some parameters/struct members. Beware: mz_ulong can be either 32 or 64-bits! */
+    typedef unsigned long mz_ulong;
 
-/* mz_free() internally uses the MZ_FREE() macro (which by default calls free() unless you've modified the MZ_MALLOC macro) to release a block allocated from the heap. */
-MINIZ_EXPORT void mz_free(void *p);
+    /* mz_free() internally uses the MZ_FREE() macro (which by default calls free() unless you've modified the MZ_MALLOC macro) to release a block allocated from the heap. */
+    MINIZ_EXPORT void mz_free(void *p);
 
 #define MZ_ADLER32_INIT (1)
-/* mz_adler32() returns the initial adler-32 value to use when called with ptr==NULL. */
-MINIZ_EXPORT mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len);
+    /* mz_adler32() returns the initial adler-32 value to use when called with ptr==NULL. */
+    MINIZ_EXPORT mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len);
 
 #define MZ_CRC32_INIT (0)
-/* mz_crc32() returns the initial CRC-32 value to use when called with ptr==NULL. */
-MINIZ_EXPORT mz_ulong mz_crc32(mz_ulong crc, const unsigned char *ptr, size_t buf_len);
+    /* mz_crc32() returns the initial CRC-32 value to use when called with ptr==NULL. */
+    MINIZ_EXPORT mz_ulong mz_crc32(mz_ulong crc, const unsigned char *ptr, size_t buf_len);
 
-/* Compression strategies. */
-enum
-{
-    MZ_DEFAULT_STRATEGY = 0,
-    MZ_FILTERED = 1,
-    MZ_HUFFMAN_ONLY = 2,
-    MZ_RLE = 3,
-    MZ_FIXED = 4
-};
+    /* Compression strategies. */
+    enum
+    {
+        MZ_DEFAULT_STRATEGY = 0,
+        MZ_FILTERED = 1,
+        MZ_HUFFMAN_ONLY = 2,
+        MZ_RLE = 3,
+        MZ_FIXED = 4
+    };
 
 /* Method */
 #define MZ_DEFLATED 8
 
-/* Heap allocation callbacks.
-Note that mz_alloc_func parameter types purposely differ from zlib's: items/size is size_t, not unsigned long. */
-typedef void *(*mz_alloc_func)(void *opaque, size_t items, size_t size);
-typedef void (*mz_free_func)(void *opaque, void *address);
-typedef void *(*mz_realloc_func)(void *opaque, void *address, size_t items, size_t size);
+    /* Heap allocation callbacks.
+    Note that mz_alloc_func parameter types purposely differ from zlib's: items/size is size_t, not unsigned long. */
+    typedef void *(*mz_alloc_func)(void *opaque, size_t items, size_t size);
+    typedef void (*mz_free_func)(void *opaque, void *address);
+    typedef void *(*mz_realloc_func)(void *opaque, void *address, size_t items, size_t size);
 
-/* Compression levels: 0-9 are the standard zlib-style levels, 10 is best possible compression (not zlib compatible, and may be very slow), MZ_DEFAULT_COMPRESSION=MZ_DEFAULT_LEVEL. */
-enum
-{
-    MZ_NO_COMPRESSION = 0,
-    MZ_BEST_SPEED = 1,
-    MZ_BEST_COMPRESSION = 9,
-    MZ_UBER_COMPRESSION = 10,
-    MZ_DEFAULT_LEVEL = 6,
-    MZ_DEFAULT_COMPRESSION = -1
-};
+    /* Compression levels: 0-9 are the standard zlib-style levels, 10 is best possible compression (not zlib compatible, and may be very slow), MZ_DEFAULT_COMPRESSION=MZ_DEFAULT_LEVEL. */
+    enum
+    {
+        MZ_NO_COMPRESSION = 0,
+        MZ_BEST_SPEED = 1,
+        MZ_BEST_COMPRESSION = 9,
+        MZ_UBER_COMPRESSION = 10,
+        MZ_DEFAULT_LEVEL = 6,
+        MZ_DEFAULT_COMPRESSION = -1
+    };
 
 #define MZ_VERSION "11.0.2"
 #define MZ_VERNUM 0xB002
@@ -288,175 +289,175 @@ enum
 
 #ifndef MINIZ_NO_ZLIB_APIS
 
-/* Flush values. For typical usage you only need MZ_NO_FLUSH and MZ_FINISH. The other values are for advanced use (refer to the zlib docs). */
-enum
-{
-    MZ_NO_FLUSH = 0,
-    MZ_PARTIAL_FLUSH = 1,
-    MZ_SYNC_FLUSH = 2,
-    MZ_FULL_FLUSH = 3,
-    MZ_FINISH = 4,
-    MZ_BLOCK = 5
-};
+    /* Flush values. For typical usage you only need MZ_NO_FLUSH and MZ_FINISH. The other values are for advanced use (refer to the zlib docs). */
+    enum
+    {
+        MZ_NO_FLUSH = 0,
+        MZ_PARTIAL_FLUSH = 1,
+        MZ_SYNC_FLUSH = 2,
+        MZ_FULL_FLUSH = 3,
+        MZ_FINISH = 4,
+        MZ_BLOCK = 5
+    };
 
-/* Return status codes. MZ_PARAM_ERROR is non-standard. */
-enum
-{
-    MZ_OK = 0,
-    MZ_STREAM_END = 1,
-    MZ_NEED_DICT = 2,
-    MZ_ERRNO = -1,
-    MZ_STREAM_ERROR = -2,
-    MZ_DATA_ERROR = -3,
-    MZ_MEM_ERROR = -4,
-    MZ_BUF_ERROR = -5,
-    MZ_VERSION_ERROR = -6,
-    MZ_PARAM_ERROR = -10000
-};
+    /* Return status codes. MZ_PARAM_ERROR is non-standard. */
+    enum
+    {
+        MZ_OK = 0,
+        MZ_STREAM_END = 1,
+        MZ_NEED_DICT = 2,
+        MZ_ERRNO = -1,
+        MZ_STREAM_ERROR = -2,
+        MZ_DATA_ERROR = -3,
+        MZ_MEM_ERROR = -4,
+        MZ_BUF_ERROR = -5,
+        MZ_VERSION_ERROR = -6,
+        MZ_PARAM_ERROR = -10000
+    };
 
 /* Window bits */
 #define MZ_DEFAULT_WINDOW_BITS 15
 
-struct mz_internal_state;
+    struct mz_internal_state;
 
-/* Compression/decompression stream struct. */
-typedef struct mz_stream_s
-{
-    const unsigned char *next_in; /* pointer to next byte to read */
-    unsigned int avail_in;        /* number of bytes available at next_in */
-    mz_ulong total_in;            /* total number of bytes consumed so far */
+    /* Compression/decompression stream struct. */
+    typedef struct mz_stream_s
+    {
+        const unsigned char *next_in; /* pointer to next byte to read */
+        unsigned int avail_in;        /* number of bytes available at next_in */
+        mz_ulong total_in;            /* total number of bytes consumed so far */
 
-    unsigned char *next_out; /* pointer to next byte to write */
-    unsigned int avail_out;  /* number of bytes that can be written to next_out */
-    mz_ulong total_out;      /* total number of bytes produced so far */
+        unsigned char *next_out; /* pointer to next byte to write */
+        unsigned int avail_out;  /* number of bytes that can be written to next_out */
+        mz_ulong total_out;      /* total number of bytes produced so far */
 
-    char *msg;                       /* error msg (unused) */
-    struct mz_internal_state *state; /* internal state, allocated by zalloc/zfree */
+        char *msg;                       /* error msg (unused) */
+        struct mz_internal_state *state; /* internal state, allocated by zalloc/zfree */
 
-    mz_alloc_func zalloc; /* optional heap allocation function (defaults to malloc) */
-    mz_free_func zfree;   /* optional heap free function (defaults to free) */
-    void *opaque;         /* heap alloc function user pointer */
+        mz_alloc_func zalloc; /* optional heap allocation function (defaults to malloc) */
+        mz_free_func zfree;   /* optional heap free function (defaults to free) */
+        void *opaque;         /* heap alloc function user pointer */
 
-    int data_type;     /* data_type (unused) */
-    mz_ulong adler;    /* adler32 of the source or uncompressed data */
-    mz_ulong reserved; /* not used */
-} mz_stream;
+        int data_type;     /* data_type (unused) */
+        mz_ulong adler;    /* adler32 of the source or uncompressed data */
+        mz_ulong reserved; /* not used */
+    } mz_stream;
 
-typedef mz_stream *mz_streamp;
+    typedef mz_stream *mz_streamp;
 
-/* Returns the version string of miniz.c. */
-MINIZ_EXPORT const char *mz_version(void);
+    /* Returns the version string of miniz.c. */
+    MINIZ_EXPORT const char *mz_version(void);
 
 #ifndef MINIZ_NO_DEFLATE_APIS
 
-/* mz_deflateInit() initializes a compressor with default options: */
-/* Parameters: */
-/*  pStream must point to an initialized mz_stream struct. */
-/*  level must be between [MZ_NO_COMPRESSION, MZ_BEST_COMPRESSION]. */
-/*  level 1 enables a specially optimized compression function that's been optimized purely for performance, not ratio. */
-/*  (This special func. is currently only enabled when MINIZ_USE_UNALIGNED_LOADS_AND_STORES and MINIZ_LITTLE_ENDIAN are defined.) */
-/* Return values: */
-/*  MZ_OK on success. */
-/*  MZ_STREAM_ERROR if the stream is bogus. */
-/*  MZ_PARAM_ERROR if the input parameters are bogus. */
-/*  MZ_MEM_ERROR on out of memory. */
-MINIZ_EXPORT int mz_deflateInit(mz_streamp pStream, int level);
+    /* mz_deflateInit() initializes a compressor with default options: */
+    /* Parameters: */
+    /*  pStream must point to an initialized mz_stream struct. */
+    /*  level must be between [MZ_NO_COMPRESSION, MZ_BEST_COMPRESSION]. */
+    /*  level 1 enables a specially optimized compression function that's been optimized purely for performance, not ratio. */
+    /*  (This special func. is currently only enabled when MINIZ_USE_UNALIGNED_LOADS_AND_STORES and MINIZ_LITTLE_ENDIAN are defined.) */
+    /* Return values: */
+    /*  MZ_OK on success. */
+    /*  MZ_STREAM_ERROR if the stream is bogus. */
+    /*  MZ_PARAM_ERROR if the input parameters are bogus. */
+    /*  MZ_MEM_ERROR on out of memory. */
+    MINIZ_EXPORT int mz_deflateInit(mz_streamp pStream, int level);
 
-/* mz_deflateInit2() is like mz_deflate(), except with more control: */
-/* Additional parameters: */
-/*   method must be MZ_DEFLATED */
-/*   window_bits must be MZ_DEFAULT_WINDOW_BITS (to wrap the deflate stream with zlib header/adler-32 footer) or -MZ_DEFAULT_WINDOW_BITS (raw deflate/no header or footer) */
-/*   mem_level must be between [1, 9] (it's checked but ignored by miniz.c) */
-MINIZ_EXPORT int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits, int mem_level, int strategy);
+    /* mz_deflateInit2() is like mz_deflate(), except with more control: */
+    /* Additional parameters: */
+    /*   method must be MZ_DEFLATED */
+    /*   window_bits must be MZ_DEFAULT_WINDOW_BITS (to wrap the deflate stream with zlib header/adler-32 footer) or -MZ_DEFAULT_WINDOW_BITS (raw deflate/no header or footer) */
+    /*   mem_level must be between [1, 9] (it's checked but ignored by miniz.c) */
+    MINIZ_EXPORT int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits, int mem_level, int strategy);
 
-/* Quickly resets a compressor without having to reallocate anything. Same as calling mz_deflateEnd() followed by mz_deflateInit()/mz_deflateInit2(). */
-MINIZ_EXPORT int mz_deflateReset(mz_streamp pStream);
+    /* Quickly resets a compressor without having to reallocate anything. Same as calling mz_deflateEnd() followed by mz_deflateInit()/mz_deflateInit2(). */
+    MINIZ_EXPORT int mz_deflateReset(mz_streamp pStream);
 
-/* mz_deflate() compresses the input to output, consuming as much of the input and producing as much output as possible. */
-/* Parameters: */
-/*   pStream is the stream to read from and write to. You must initialize/update the next_in, avail_in, next_out, and avail_out members. */
-/*   flush may be MZ_NO_FLUSH, MZ_PARTIAL_FLUSH/MZ_SYNC_FLUSH, MZ_FULL_FLUSH, or MZ_FINISH. */
-/* Return values: */
-/*   MZ_OK on success (when flushing, or if more input is needed but not available, and/or there's more output to be written but the output buffer is full). */
-/*   MZ_STREAM_END if all input has been consumed and all output bytes have been written. Don't call mz_deflate() on the stream anymore. */
-/*   MZ_STREAM_ERROR if the stream is bogus. */
-/*   MZ_PARAM_ERROR if one of the parameters is invalid. */
-/*   MZ_BUF_ERROR if no forward progress is possible because the input and/or output buffers are empty. (Fill up the input buffer or free up some output space and try again.) */
-MINIZ_EXPORT int mz_deflate(mz_streamp pStream, int flush);
+    /* mz_deflate() compresses the input to output, consuming as much of the input and producing as much output as possible. */
+    /* Parameters: */
+    /*   pStream is the stream to read from and write to. You must initialize/update the next_in, avail_in, next_out, and avail_out members. */
+    /*   flush may be MZ_NO_FLUSH, MZ_PARTIAL_FLUSH/MZ_SYNC_FLUSH, MZ_FULL_FLUSH, or MZ_FINISH. */
+    /* Return values: */
+    /*   MZ_OK on success (when flushing, or if more input is needed but not available, and/or there's more output to be written but the output buffer is full). */
+    /*   MZ_STREAM_END if all input has been consumed and all output bytes have been written. Don't call mz_deflate() on the stream anymore. */
+    /*   MZ_STREAM_ERROR if the stream is bogus. */
+    /*   MZ_PARAM_ERROR if one of the parameters is invalid. */
+    /*   MZ_BUF_ERROR if no forward progress is possible because the input and/or output buffers are empty. (Fill up the input buffer or free up some output space and try again.) */
+    MINIZ_EXPORT int mz_deflate(mz_streamp pStream, int flush);
 
-/* mz_deflateEnd() deinitializes a compressor: */
-/* Return values: */
-/*  MZ_OK on success. */
-/*  MZ_STREAM_ERROR if the stream is bogus. */
-MINIZ_EXPORT int mz_deflateEnd(mz_streamp pStream);
+    /* mz_deflateEnd() deinitializes a compressor: */
+    /* Return values: */
+    /*  MZ_OK on success. */
+    /*  MZ_STREAM_ERROR if the stream is bogus. */
+    MINIZ_EXPORT int mz_deflateEnd(mz_streamp pStream);
 
-/* mz_deflateBound() returns a (very) conservative upper bound on the amount of data that could be generated by deflate(), assuming flush is set to only MZ_NO_FLUSH or MZ_FINISH. */
-MINIZ_EXPORT mz_ulong mz_deflateBound(mz_streamp pStream, mz_ulong source_len);
+    /* mz_deflateBound() returns a (very) conservative upper bound on the amount of data that could be generated by deflate(), assuming flush is set to only MZ_NO_FLUSH or MZ_FINISH. */
+    MINIZ_EXPORT mz_ulong mz_deflateBound(mz_streamp pStream, mz_ulong source_len);
 
-/* Single-call compression functions mz_compress() and mz_compress2(): */
-/* Returns MZ_OK on success, or one of the error codes from mz_deflate() on failure. */
-MINIZ_EXPORT int mz_compress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len);
-MINIZ_EXPORT int mz_compress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len, int level);
+    /* Single-call compression functions mz_compress() and mz_compress2(): */
+    /* Returns MZ_OK on success, or one of the error codes from mz_deflate() on failure. */
+    MINIZ_EXPORT int mz_compress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len);
+    MINIZ_EXPORT int mz_compress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len, int level);
 
-/* mz_compressBound() returns a (very) conservative upper bound on the amount of data that could be generated by calling mz_compress(). */
-MINIZ_EXPORT mz_ulong mz_compressBound(mz_ulong source_len);
+    /* mz_compressBound() returns a (very) conservative upper bound on the amount of data that could be generated by calling mz_compress(). */
+    MINIZ_EXPORT mz_ulong mz_compressBound(mz_ulong source_len);
 
 #endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
 
 #ifndef MINIZ_NO_INFLATE_APIS
 
-/* Initializes a decompressor. */
-MINIZ_EXPORT int mz_inflateInit(mz_streamp pStream);
+    /* Initializes a decompressor. */
+    MINIZ_EXPORT int mz_inflateInit(mz_streamp pStream);
 
-/* mz_inflateInit2() is like mz_inflateInit() with an additional option that controls the window size and whether or not the stream has been wrapped with a zlib header/footer: */
-/* window_bits must be MZ_DEFAULT_WINDOW_BITS (to parse zlib header/footer) or -MZ_DEFAULT_WINDOW_BITS (raw deflate). */
-MINIZ_EXPORT int mz_inflateInit2(mz_streamp pStream, int window_bits);
+    /* mz_inflateInit2() is like mz_inflateInit() with an additional option that controls the window size and whether or not the stream has been wrapped with a zlib header/footer: */
+    /* window_bits must be MZ_DEFAULT_WINDOW_BITS (to parse zlib header/footer) or -MZ_DEFAULT_WINDOW_BITS (raw deflate). */
+    MINIZ_EXPORT int mz_inflateInit2(mz_streamp pStream, int window_bits);
 
-/* Quickly resets a compressor without having to reallocate anything. Same as calling mz_inflateEnd() followed by mz_inflateInit()/mz_inflateInit2(). */
-MINIZ_EXPORT int mz_inflateReset(mz_streamp pStream);
+    /* Quickly resets a compressor without having to reallocate anything. Same as calling mz_inflateEnd() followed by mz_inflateInit()/mz_inflateInit2(). */
+    MINIZ_EXPORT int mz_inflateReset(mz_streamp pStream);
 
-/* Decompresses the input stream to the output, consuming only as much of the input as needed, and writing as much to the output as possible. */
-/* Parameters: */
-/*   pStream is the stream to read from and write to. You must initialize/update the next_in, avail_in, next_out, and avail_out members. */
-/*   flush may be MZ_NO_FLUSH, MZ_SYNC_FLUSH, or MZ_FINISH. */
-/*   On the first call, if flush is MZ_FINISH it's assumed the input and output buffers are both sized large enough to decompress the entire stream in a single call (this is slightly faster). */
-/*   MZ_FINISH implies that there are no more source bytes available beside what's already in the input buffer, and that the output buffer is large enough to hold the rest of the decompressed data. */
-/* Return values: */
-/*   MZ_OK on success. Either more input is needed but not available, and/or there's more output to be written but the output buffer is full. */
-/*   MZ_STREAM_END if all needed input has been consumed and all output bytes have been written. For zlib streams, the adler-32 of the decompressed data has also been verified. */
-/*   MZ_STREAM_ERROR if the stream is bogus. */
-/*   MZ_DATA_ERROR if the deflate stream is invalid. */
-/*   MZ_PARAM_ERROR if one of the parameters is invalid. */
-/*   MZ_BUF_ERROR if no forward progress is possible because the input buffer is empty but the inflater needs more input to continue, or if the output buffer is not large enough. Call mz_inflate() again */
-/*   with more input data, or with more room in the output buffer (except when using single call decompression, described above). */
-MINIZ_EXPORT int mz_inflate(mz_streamp pStream, int flush);
+    /* Decompresses the input stream to the output, consuming only as much of the input as needed, and writing as much to the output as possible. */
+    /* Parameters: */
+    /*   pStream is the stream to read from and write to. You must initialize/update the next_in, avail_in, next_out, and avail_out members. */
+    /*   flush may be MZ_NO_FLUSH, MZ_SYNC_FLUSH, or MZ_FINISH. */
+    /*   On the first call, if flush is MZ_FINISH it's assumed the input and output buffers are both sized large enough to decompress the entire stream in a single call (this is slightly faster). */
+    /*   MZ_FINISH implies that there are no more source bytes available beside what's already in the input buffer, and that the output buffer is large enough to hold the rest of the decompressed data. */
+    /* Return values: */
+    /*   MZ_OK on success. Either more input is needed but not available, and/or there's more output to be written but the output buffer is full. */
+    /*   MZ_STREAM_END if all needed input has been consumed and all output bytes have been written. For zlib streams, the adler-32 of the decompressed data has also been verified. */
+    /*   MZ_STREAM_ERROR if the stream is bogus. */
+    /*   MZ_DATA_ERROR if the deflate stream is invalid. */
+    /*   MZ_PARAM_ERROR if one of the parameters is invalid. */
+    /*   MZ_BUF_ERROR if no forward progress is possible because the input buffer is empty but the inflater needs more input to continue, or if the output buffer is not large enough. Call mz_inflate() again */
+    /*   with more input data, or with more room in the output buffer (except when using single call decompression, described above). */
+    MINIZ_EXPORT int mz_inflate(mz_streamp pStream, int flush);
 
-/* Deinitializes a decompressor. */
-MINIZ_EXPORT int mz_inflateEnd(mz_streamp pStream);
+    /* Deinitializes a decompressor. */
+    MINIZ_EXPORT int mz_inflateEnd(mz_streamp pStream);
 
-/* Single-call decompression. */
-/* Returns MZ_OK on success, or one of the error codes from mz_inflate() on failure. */
-MINIZ_EXPORT int mz_uncompress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len);
-MINIZ_EXPORT int mz_uncompress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong *pSource_len);
+    /* Single-call decompression. */
+    /* Returns MZ_OK on success, or one of the error codes from mz_inflate() on failure. */
+    MINIZ_EXPORT int mz_uncompress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len);
+    MINIZ_EXPORT int mz_uncompress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong *pSource_len);
 #endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
 
-/* Returns a string description of the specified error code, or NULL if the error code is invalid. */
-MINIZ_EXPORT const char *mz_error(int err);
+    /* Returns a string description of the specified error code, or NULL if the error code is invalid. */
+    MINIZ_EXPORT const char *mz_error(int err);
 
 /* Redefine zlib-compatible names to miniz equivalents, so miniz.c can be used as a drop-in replacement for the subset of zlib that miniz.c supports. */
 /* Define MINIZ_NO_ZLIB_COMPATIBLE_NAMES to disable zlib-compatibility if you use zlib in the same project. */
 #ifndef MINIZ_NO_ZLIB_COMPATIBLE_NAMES
-typedef unsigned char Byte;
-typedef unsigned int uInt;
-typedef mz_ulong uLong;
-typedef Byte Bytef;
-typedef uInt uIntf;
-typedef char charf;
-typedef int intf;
-typedef void *voidpf;
-typedef uLong uLongf;
-typedef void *voidp;
-typedef void *const voidpc;
+    typedef unsigned char Byte;
+    typedef unsigned int uInt;
+    typedef mz_ulong uLong;
+    typedef Byte Bytef;
+    typedef uInt uIntf;
+    typedef char charf;
+    typedef int intf;
+    typedef void *voidpf;
+    typedef uLong uLongf;
+    typedef void *voidp;
+    typedef void *const voidpc;
 #define Z_NULL 0
 #define Z_NO_FLUSH MZ_NO_FLUSH
 #define Z_PARTIAL_FLUSH MZ_PARTIAL_FLUSH
@@ -485,44 +486,116 @@ typedef void *const voidpc;
 #define Z_FIXED MZ_FIXED
 #define Z_DEFLATED MZ_DEFLATED
 #define Z_DEFAULT_WINDOW_BITS MZ_DEFAULT_WINDOW_BITS
-#define alloc_func mz_alloc_func
-#define free_func mz_free_func
+    /* See mz_alloc_func */
+    typedef void *(*alloc_func)(void *opaque, size_t items, size_t size);
+    /* See mz_free_func */
+    typedef void (*free_func)(void *opaque, void *address);
+
 #define internal_state mz_internal_state
 #define z_stream mz_stream
 
 #ifndef MINIZ_NO_DEFLATE_APIS
-#define deflateInit mz_deflateInit
-#define deflateInit2 mz_deflateInit2
-#define deflateReset mz_deflateReset
-#define deflate mz_deflate
-#define deflateEnd mz_deflateEnd
-#define deflateBound mz_deflateBound
-#define compress mz_compress
-#define compress2 mz_compress2
-#define compressBound mz_compressBound
+    /* Compatiblity with zlib API. See called functions for documentation */
+    static int deflateInit(mz_streamp pStream, int level)
+    {
+        return mz_deflateInit(pStream, level);
+    }
+    static int deflateInit2(mz_streamp pStream, int level, int method, int window_bits, int mem_level, int strategy)
+    {
+        return mz_deflateInit2(pStream, level, method, window_bits, mem_level, strategy);
+    }
+    static int deflateReset(mz_streamp pStream)
+    {
+        return mz_deflateReset(pStream);
+    }
+    static int deflate(mz_streamp pStream, int flush)
+    {
+        return mz_deflate(pStream, flush);
+    }
+    static int deflateEnd(mz_streamp pStream)
+    {
+        return mz_deflateEnd(pStream);
+    }
+    static mz_ulong deflateBound(mz_streamp pStream, mz_ulong source_len)
+    {
+        return mz_deflateBound(pStream, source_len);
+    }
+    static int compress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len)
+    {
+        return mz_compress(pDest, pDest_len, pSource, source_len);
+    }
+    static int compress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *pSource, mz_ulong source_len, int level)
+    {
+        return mz_compress2(pDest, pDest_len, pSource, source_len, level);
+    }
+    static mz_ulong compressBound(mz_ulong source_len)
+    {
+        return mz_compressBound(source_len);
+    }
 #endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
 
 #ifndef MINIZ_NO_INFLATE_APIS
-#define inflateInit mz_inflateInit
-#define inflateInit2 mz_inflateInit2
-#define inflateReset mz_inflateReset
-#define inflate mz_inflate
-#define inflateEnd mz_inflateEnd
-#define uncompress mz_uncompress
-#define uncompress2 mz_uncompress2
+    /* Compatiblity with zlib API. See called functions for documentation */
+    static int inflateInit(mz_streamp pStream)
+    {
+        return mz_inflateInit(pStream);
+    }
+
+    static int inflateInit2(mz_streamp pStream, int window_bits)
+    {
+        return mz_inflateInit2(pStream, window_bits);
+    }
+
+    static int inflateReset(mz_streamp pStream)
+    {
+        return mz_inflateReset(pStream);
+    }
+
+    static int inflate(mz_streamp pStream, int flush)
+    {
+        return mz_inflate(pStream, flush);
+    }
+
+    static int inflateEnd(mz_streamp pStream)
+    {
+        return mz_inflateEnd(pStream);
+    }
+
+    static int uncompress(unsigned char* pDest, mz_ulong* pDest_len, const unsigned char* pSource, mz_ulong source_len)
+    {
+        return mz_uncompress(pDest, pDest_len, pSource, source_len);
+    }
+
+    static int uncompress2(unsigned char* pDest, mz_ulong* pDest_len, const unsigned char* pSource, mz_ulong* pSource_len)
+    {
+        return mz_uncompress2(pDest, pDest_len, pSource, pSource_len);
+    }
 #endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
 
-#define crc32 mz_crc32
-#define adler32 mz_adler32
+    static mz_ulong crc32(mz_ulong crc, const unsigned char *ptr, size_t buf_len)
+    {
+        return mz_crc32(crc, ptr, buf_len);
+    }
+
+    static mz_ulong adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len)
+    {
+        return mz_adler32(adler, ptr, buf_len);
+    }
+    
 #define MAX_WBITS 15
 #define MAX_MEM_LEVEL 9
-#define zError mz_error
+
+    static const char* zError(int err)
+    {
+        return mz_error(err);
+    }
 #define ZLIB_VERSION MZ_VERSION
 #define ZLIB_VERNUM MZ_VERNUM
 #define ZLIB_VER_MAJOR MZ_VER_MAJOR
 #define ZLIB_VER_MINOR MZ_VER_MINOR
 #define ZLIB_VER_REVISION MZ_VER_REVISION
 #define ZLIB_VER_SUBREVISION MZ_VER_SUBREVISION
+
 #define zlibVersion mz_version
 #define zlib_version mz_version()
 #endif /* #ifndef MINIZ_NO_ZLIB_COMPATIBLE_NAMES */
@@ -533,19 +606,23 @@ typedef void *const voidpc;
 }
 #endif
 
+
+
+
+#pragma once
 #include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-//#include "miniz_export.h"
+
 
 /* ------------------- Types and macros */
 typedef unsigned char mz_uint8;
-typedef signed short mz_int16;
-typedef unsigned short mz_uint16;
-typedef unsigned int mz_uint32;
-typedef unsigned int mz_uint;
+typedef int16_t mz_int16;
+typedef uint16_t mz_uint16;
+typedef uint32_t mz_uint32;
+typedef uint32_t mz_uint;
 typedef int64_t mz_int64;
 typedef uint64_t mz_uint64;
 typedef int mz_bool;
@@ -615,12 +692,13 @@ typedef struct mz_dummy_time_t_tag
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-extern MINIZ_EXPORT void *miniz_def_alloc_func(void *opaque, size_t items, size_t size);
-extern MINIZ_EXPORT void miniz_def_free_func(void *opaque, void *address);
-extern MINIZ_EXPORT void *miniz_def_realloc_func(void *opaque, void *address, size_t items, size_t size);
+    extern MINIZ_EXPORT void *miniz_def_alloc_func(void *opaque, size_t items, size_t size);
+    extern MINIZ_EXPORT void miniz_def_free_func(void *opaque, void *address);
+    extern MINIZ_EXPORT void *miniz_def_realloc_func(void *opaque, void *address, size_t items, size_t size);
 
 #define MZ_UINT16_MAX (0xFFFFU)
 #define MZ_UINT32_MAX (0xFFFFFFFFU)
@@ -628,109 +706,115 @@ extern MINIZ_EXPORT void *miniz_def_realloc_func(void *opaque, void *address, si
 #ifdef __cplusplus
 }
 #endif
+ #pragma once
 
+
+#ifndef MINIZ_NO_DEFLATE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 /* ------------------- Low-level Compression API Definitions */
 
 /* Set TDEFL_LESS_MEMORY to 1 to use less memory (compression will be slightly slower, and raw/dynamic blocks will be output more frequently). */
+#ifndef TDEFL_LESS_MEMORY
 #define TDEFL_LESS_MEMORY 0
+#endif
 
-/* tdefl_init() compression flags logically OR'd together (low 12 bits contain the max. number of probes per dictionary search): */
-/* TDEFL_DEFAULT_MAX_PROBES: The compressor defaults to 128 dictionary probes per dictionary search. 0=Huffman only, 1=Huffman+LZ (fastest/crap compression), 4095=Huffman+LZ (slowest/best compression). */
-enum
-{
-    TDEFL_HUFFMAN_ONLY = 0,
-    TDEFL_DEFAULT_MAX_PROBES = 128,
-    TDEFL_MAX_PROBES_MASK = 0xFFF
-};
+    /* tdefl_init() compression flags logically OR'd together (low 12 bits contain the max. number of probes per dictionary search): */
+    /* TDEFL_DEFAULT_MAX_PROBES: The compressor defaults to 128 dictionary probes per dictionary search. 0=Huffman only, 1=Huffman+LZ (fastest/crap compression), 4095=Huffman+LZ (slowest/best compression). */
+    enum
+    {
+        TDEFL_HUFFMAN_ONLY = 0,
+        TDEFL_DEFAULT_MAX_PROBES = 128,
+        TDEFL_MAX_PROBES_MASK = 0xFFF
+    };
 
-/* TDEFL_WRITE_ZLIB_HEADER: If set, the compressor outputs a zlib header before the deflate data, and the Adler-32 of the source data at the end. Otherwise, you'll get raw deflate data. */
-/* TDEFL_COMPUTE_ADLER32: Always compute the adler-32 of the input data (even when not writing zlib headers). */
-/* TDEFL_GREEDY_PARSING_FLAG: Set to use faster greedy parsing, instead of more efficient lazy parsing. */
-/* TDEFL_NONDETERMINISTIC_PARSING_FLAG: Enable to decrease the compressor's initialization time to the minimum, but the output may vary from run to run given the same input (depending on the contents of memory). */
-/* TDEFL_RLE_MATCHES: Only look for RLE matches (matches with a distance of 1) */
-/* TDEFL_FILTER_MATCHES: Discards matches <= 5 chars if enabled. */
-/* TDEFL_FORCE_ALL_STATIC_BLOCKS: Disable usage of optimized Huffman tables. */
-/* TDEFL_FORCE_ALL_RAW_BLOCKS: Only use raw (uncompressed) deflate blocks. */
-/* The low 12 bits are reserved to control the max # of hash probes per dictionary lookup (see TDEFL_MAX_PROBES_MASK). */
-enum
-{
-    TDEFL_WRITE_ZLIB_HEADER = 0x01000,
-    TDEFL_COMPUTE_ADLER32 = 0x02000,
-    TDEFL_GREEDY_PARSING_FLAG = 0x04000,
-    TDEFL_NONDETERMINISTIC_PARSING_FLAG = 0x08000,
-    TDEFL_RLE_MATCHES = 0x10000,
-    TDEFL_FILTER_MATCHES = 0x20000,
-    TDEFL_FORCE_ALL_STATIC_BLOCKS = 0x40000,
-    TDEFL_FORCE_ALL_RAW_BLOCKS = 0x80000
-};
+    /* TDEFL_WRITE_ZLIB_HEADER: If set, the compressor outputs a zlib header before the deflate data, and the Adler-32 of the source data at the end. Otherwise, you'll get raw deflate data. */
+    /* TDEFL_COMPUTE_ADLER32: Always compute the adler-32 of the input data (even when not writing zlib headers). */
+    /* TDEFL_GREEDY_PARSING_FLAG: Set to use faster greedy parsing, instead of more efficient lazy parsing. */
+    /* TDEFL_NONDETERMINISTIC_PARSING_FLAG: Enable to decrease the compressor's initialization time to the minimum, but the output may vary from run to run given the same input (depending on the contents of memory). */
+    /* TDEFL_RLE_MATCHES: Only look for RLE matches (matches with a distance of 1) */
+    /* TDEFL_FILTER_MATCHES: Discards matches <= 5 chars if enabled. */
+    /* TDEFL_FORCE_ALL_STATIC_BLOCKS: Disable usage of optimized Huffman tables. */
+    /* TDEFL_FORCE_ALL_RAW_BLOCKS: Only use raw (uncompressed) deflate blocks. */
+    /* The low 12 bits are reserved to control the max # of hash probes per dictionary lookup (see TDEFL_MAX_PROBES_MASK). */
+    enum
+    {
+        TDEFL_WRITE_ZLIB_HEADER = 0x01000,
+        TDEFL_COMPUTE_ADLER32 = 0x02000,
+        TDEFL_GREEDY_PARSING_FLAG = 0x04000,
+        TDEFL_NONDETERMINISTIC_PARSING_FLAG = 0x08000,
+        TDEFL_RLE_MATCHES = 0x10000,
+        TDEFL_FILTER_MATCHES = 0x20000,
+        TDEFL_FORCE_ALL_STATIC_BLOCKS = 0x40000,
+        TDEFL_FORCE_ALL_RAW_BLOCKS = 0x80000
+    };
 
-/* High level compression functions: */
-/* tdefl_compress_mem_to_heap() compresses a block in memory to a heap block allocated via malloc(). */
-/* On entry: */
-/*  pSrc_buf, src_buf_len: Pointer and size of source block to compress. */
-/*  flags: The max match finder probes (default is 128) logically OR'd against the above flags. Higher probes are slower but improve compression. */
-/* On return: */
-/*  Function returns a pointer to the compressed data, or NULL on failure. */
-/*  *pOut_len will be set to the compressed data's size, which could be larger than src_buf_len on uncompressible data. */
-/*  The caller must free() the returned block when it's no longer needed. */
-MINIZ_EXPORT void *tdefl_compress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags);
+    /* High level compression functions: */
+    /* tdefl_compress_mem_to_heap() compresses a block in memory to a heap block allocated via malloc(). */
+    /* On entry: */
+    /*  pSrc_buf, src_buf_len: Pointer and size of source block to compress. */
+    /*  flags: The max match finder probes (default is 128) logically OR'd against the above flags. Higher probes are slower but improve compression. */
+    /* On return: */
+    /*  Function returns a pointer to the compressed data, or NULL on failure. */
+    /*  *pOut_len will be set to the compressed data's size, which could be larger than src_buf_len on uncompressible data. */
+    /*  The caller must free() the returned block when it's no longer needed. */
+    MINIZ_EXPORT void *tdefl_compress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags);
 
-/* tdefl_compress_mem_to_mem() compresses a block in memory to another block in memory. */
-/* Returns 0 on failure. */
-MINIZ_EXPORT size_t tdefl_compress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags);
+    /* tdefl_compress_mem_to_mem() compresses a block in memory to another block in memory. */
+    /* Returns 0 on failure. */
+    MINIZ_EXPORT size_t tdefl_compress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags);
 
-/* Compresses an image to a compressed PNG file in memory. */
-/* On entry: */
-/*  pImage, w, h, and num_chans describe the image to compress. num_chans may be 1, 2, 3, or 4. */
-/*  The image pitch in bytes per scanline will be w*num_chans. The leftmost pixel on the top scanline is stored first in memory. */
-/*  level may range from [0,10], use MZ_NO_COMPRESSION, MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc. or a decent default is MZ_DEFAULT_LEVEL */
-/*  If flip is true, the image will be flipped on the Y axis (useful for OpenGL apps). */
-/* On return: */
-/*  Function returns a pointer to the compressed data, or NULL on failure. */
-/*  *pLen_out will be set to the size of the PNG image file. */
-/*  The caller must mz_free() the returned heap block (which will typically be larger than *pLen_out) when it's no longer needed. */
-MINIZ_EXPORT void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int h, int num_chans, size_t *pLen_out, mz_uint level, mz_bool flip);
-MINIZ_EXPORT void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, int num_chans, size_t *pLen_out);
+    /* Compresses an image to a compressed PNG file in memory. */
+    /* On entry: */
+    /*  pImage, w, h, and num_chans describe the image to compress. num_chans may be 1, 2, 3, or 4. */
+    /*  The image pitch in bytes per scanline will be w*num_chans. The leftmost pixel on the top scanline is stored first in memory. */
+    /*  level may range from [0,10], use MZ_NO_COMPRESSION, MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc. or a decent default is MZ_DEFAULT_LEVEL */
+    /*  If flip is true, the image will be flipped on the Y axis (useful for OpenGL apps). */
+    /* On return: */
+    /*  Function returns a pointer to the compressed data, or NULL on failure. */
+    /*  *pLen_out will be set to the size of the PNG image file. */
+    /*  The caller must mz_free() the returned heap block (which will typically be larger than *pLen_out) when it's no longer needed. */
+    MINIZ_EXPORT void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int h, int num_chans, size_t *pLen_out, mz_uint level, mz_bool flip);
+    MINIZ_EXPORT void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, int num_chans, size_t *pLen_out);
 
-/* Output stream interface. The compressor uses this interface to write compressed data. It'll typically be called TDEFL_OUT_BUF_SIZE at a time. */
-typedef mz_bool (*tdefl_put_buf_func_ptr)(const void *pBuf, int len, void *pUser);
+    /* Output stream interface. The compressor uses this interface to write compressed data. It'll typically be called TDEFL_OUT_BUF_SIZE at a time. */
+    typedef mz_bool (*tdefl_put_buf_func_ptr)(const void *pBuf, int len, void *pUser);
 
-/* tdefl_compress_mem_to_output() compresses a block to an output stream. The above helpers use this function internally. */
-MINIZ_EXPORT mz_bool tdefl_compress_mem_to_output(const void *pBuf, size_t buf_len, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
+    /* tdefl_compress_mem_to_output() compresses a block to an output stream. The above helpers use this function internally. */
+    MINIZ_EXPORT mz_bool tdefl_compress_mem_to_output(const void *pBuf, size_t buf_len, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
 
-enum
-{
-    TDEFL_MAX_HUFF_TABLES = 3,
-    TDEFL_MAX_HUFF_SYMBOLS_0 = 288,
-    TDEFL_MAX_HUFF_SYMBOLS_1 = 32,
-    TDEFL_MAX_HUFF_SYMBOLS_2 = 19,
-    TDEFL_LZ_DICT_SIZE = 32768,
-    TDEFL_LZ_DICT_SIZE_MASK = TDEFL_LZ_DICT_SIZE - 1,
-    TDEFL_MIN_MATCH_LEN = 3,
-    TDEFL_MAX_MATCH_LEN = 258
-};
+    enum
+    {
+        TDEFL_MAX_HUFF_TABLES = 3,
+        TDEFL_MAX_HUFF_SYMBOLS_0 = 288,
+        TDEFL_MAX_HUFF_SYMBOLS_1 = 32,
+        TDEFL_MAX_HUFF_SYMBOLS_2 = 19,
+        TDEFL_LZ_DICT_SIZE = 32768,
+        TDEFL_LZ_DICT_SIZE_MASK = TDEFL_LZ_DICT_SIZE - 1,
+        TDEFL_MIN_MATCH_LEN = 3,
+        TDEFL_MAX_MATCH_LEN = 258
+    };
 
 /* TDEFL_OUT_BUF_SIZE MUST be large enough to hold a single entire compressed output block (using static/fixed Huffman codes). */
 #if TDEFL_LESS_MEMORY
-enum
-{
-    TDEFL_LZ_CODE_BUF_SIZE = 24 * 1024,
-    TDEFL_OUT_BUF_SIZE = (TDEFL_LZ_CODE_BUF_SIZE * 13) / 10,
-    TDEFL_MAX_HUFF_SYMBOLS = 288,
-    TDEFL_LZ_HASH_BITS = 12,
-    TDEFL_LEVEL1_HASH_SIZE_MASK = 4095,
-    TDEFL_LZ_HASH_SHIFT = (TDEFL_LZ_HASH_BITS + 2) / 3,
-    TDEFL_LZ_HASH_SIZE = 1 << TDEFL_LZ_HASH_BITS
-};
+    enum
+    {
+        TDEFL_LZ_CODE_BUF_SIZE = 24 * 1024,
+        TDEFL_OUT_BUF_SIZE = (TDEFL_LZ_CODE_BUF_SIZE * 13) / 10,
+        TDEFL_MAX_HUFF_SYMBOLS = 288,
+        TDEFL_LZ_HASH_BITS = 12,
+        TDEFL_LEVEL1_HASH_SIZE_MASK = 4095,
+        TDEFL_LZ_HASH_SHIFT = (TDEFL_LZ_HASH_BITS + 2) / 3,
+        TDEFL_LZ_HASH_SIZE = 1 << TDEFL_LZ_HASH_BITS
+    };
 #else
 enum
 {
     TDEFL_LZ_CODE_BUF_SIZE = 64 * 1024,
-    TDEFL_OUT_BUF_SIZE = (TDEFL_LZ_CODE_BUF_SIZE * 13) / 10,
+    TDEFL_OUT_BUF_SIZE = (mz_uint)((TDEFL_LZ_CODE_BUF_SIZE * 13) / 10),
     TDEFL_MAX_HUFF_SYMBOLS = 288,
     TDEFL_LZ_HASH_BITS = 15,
     TDEFL_LEVEL1_HASH_SIZE_MASK = 4095,
@@ -739,170 +823,179 @@ enum
 };
 #endif
 
-/* The low-level tdefl functions below may be used directly if the above helper functions aren't flexible enough. The low-level functions don't make any heap allocations, unlike the above helper functions. */
-typedef enum {
-    TDEFL_STATUS_BAD_PARAM = -2,
-    TDEFL_STATUS_PUT_BUF_FAILED = -1,
-    TDEFL_STATUS_OKAY = 0,
-    TDEFL_STATUS_DONE = 1
-} tdefl_status;
+    /* The low-level tdefl functions below may be used directly if the above helper functions aren't flexible enough. The low-level functions don't make any heap allocations, unlike the above helper functions. */
+    typedef enum
+    {
+        TDEFL_STATUS_BAD_PARAM = -2,
+        TDEFL_STATUS_PUT_BUF_FAILED = -1,
+        TDEFL_STATUS_OKAY = 0,
+        TDEFL_STATUS_DONE = 1
+    } tdefl_status;
 
-/* Must map to MZ_NO_FLUSH, MZ_SYNC_FLUSH, etc. enums */
-typedef enum {
-    TDEFL_NO_FLUSH = 0,
-    TDEFL_SYNC_FLUSH = 2,
-    TDEFL_FULL_FLUSH = 3,
-    TDEFL_FINISH = 4
-} tdefl_flush;
+    /* Must map to MZ_NO_FLUSH, MZ_SYNC_FLUSH, etc. enums */
+    typedef enum
+    {
+        TDEFL_NO_FLUSH = 0,
+        TDEFL_SYNC_FLUSH = 2,
+        TDEFL_FULL_FLUSH = 3,
+        TDEFL_FINISH = 4
+    } tdefl_flush;
 
-/* tdefl's compression state structure. */
-typedef struct
-{
-    tdefl_put_buf_func_ptr m_pPut_buf_func;
-    void *m_pPut_buf_user;
-    mz_uint m_flags, m_max_probes[2];
-    int m_greedy_parsing;
-    mz_uint m_adler32, m_lookahead_pos, m_lookahead_size, m_dict_size;
-    mz_uint8 *m_pLZ_code_buf, *m_pLZ_flags, *m_pOutput_buf, *m_pOutput_buf_end;
-    mz_uint m_num_flags_left, m_total_lz_bytes, m_lz_code_buf_dict_pos, m_bits_in, m_bit_buffer;
-    mz_uint m_saved_match_dist, m_saved_match_len, m_saved_lit, m_output_flush_ofs, m_output_flush_remaining, m_finished, m_block_index, m_wants_to_finish;
-    tdefl_status m_prev_return_status;
-    const void *m_pIn_buf;
-    void *m_pOut_buf;
-    size_t *m_pIn_buf_size, *m_pOut_buf_size;
-    tdefl_flush m_flush;
-    const mz_uint8 *m_pSrc;
-    size_t m_src_buf_left, m_out_buf_ofs;
-    mz_uint8 m_dict[TDEFL_LZ_DICT_SIZE + TDEFL_MAX_MATCH_LEN - 1];
-    mz_uint16 m_huff_count[TDEFL_MAX_HUFF_TABLES][TDEFL_MAX_HUFF_SYMBOLS];
-    mz_uint16 m_huff_codes[TDEFL_MAX_HUFF_TABLES][TDEFL_MAX_HUFF_SYMBOLS];
-    mz_uint8 m_huff_code_sizes[TDEFL_MAX_HUFF_TABLES][TDEFL_MAX_HUFF_SYMBOLS];
-    mz_uint8 m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE];
-    mz_uint16 m_next[TDEFL_LZ_DICT_SIZE];
-    mz_uint16 m_hash[TDEFL_LZ_HASH_SIZE];
-    mz_uint8 m_output_buf[TDEFL_OUT_BUF_SIZE];
-} tdefl_compressor;
+    /* tdefl's compression state structure. */
+    typedef struct
+    {
+        tdefl_put_buf_func_ptr m_pPut_buf_func;
+        void *m_pPut_buf_user;
+        mz_uint m_flags, m_max_probes[2];
+        int m_greedy_parsing;
+        mz_uint m_adler32, m_lookahead_pos, m_lookahead_size, m_dict_size;
+        mz_uint8 *m_pLZ_code_buf, *m_pLZ_flags, *m_pOutput_buf, *m_pOutput_buf_end;
+        mz_uint m_num_flags_left, m_total_lz_bytes, m_lz_code_buf_dict_pos, m_bits_in, m_bit_buffer;
+        mz_uint m_saved_match_dist, m_saved_match_len, m_saved_lit, m_output_flush_ofs, m_output_flush_remaining, m_finished, m_block_index, m_wants_to_finish;
+        tdefl_status m_prev_return_status;
+        const void *m_pIn_buf;
+        void *m_pOut_buf;
+        size_t *m_pIn_buf_size, *m_pOut_buf_size;
+        tdefl_flush m_flush;
+        const mz_uint8 *m_pSrc;
+        size_t m_src_buf_left, m_out_buf_ofs;
+        mz_uint8 m_dict[TDEFL_LZ_DICT_SIZE + TDEFL_MAX_MATCH_LEN - 1];
+        mz_uint16 m_huff_count[TDEFL_MAX_HUFF_TABLES][TDEFL_MAX_HUFF_SYMBOLS];
+        mz_uint16 m_huff_codes[TDEFL_MAX_HUFF_TABLES][TDEFL_MAX_HUFF_SYMBOLS];
+        mz_uint8 m_huff_code_sizes[TDEFL_MAX_HUFF_TABLES][TDEFL_MAX_HUFF_SYMBOLS];
+        mz_uint8 m_lz_code_buf[TDEFL_LZ_CODE_BUF_SIZE];
+        mz_uint16 m_next[TDEFL_LZ_DICT_SIZE];
+        mz_uint16 m_hash[TDEFL_LZ_HASH_SIZE];
+        mz_uint8 m_output_buf[TDEFL_OUT_BUF_SIZE];
+    } tdefl_compressor;
 
-/* Initializes the compressor. */
-/* There is no corresponding deinit() function because the tdefl API's do not dynamically allocate memory. */
-/* pBut_buf_func: If NULL, output data will be supplied to the specified callback. In this case, the user should call the tdefl_compress_buffer() API for compression. */
-/* If pBut_buf_func is NULL the user should always call the tdefl_compress() API. */
-/* flags: See the above enums (TDEFL_HUFFMAN_ONLY, TDEFL_WRITE_ZLIB_HEADER, etc.) */
-MINIZ_EXPORT tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
+    /* Initializes the compressor. */
+    /* There is no corresponding deinit() function because the tdefl API's do not dynamically allocate memory. */
+    /* pBut_buf_func: If NULL, output data will be supplied to the specified callback. In this case, the user should call the tdefl_compress_buffer() API for compression. */
+    /* If pBut_buf_func is NULL the user should always call the tdefl_compress() API. */
+    /* flags: See the above enums (TDEFL_HUFFMAN_ONLY, TDEFL_WRITE_ZLIB_HEADER, etc.) */
+    MINIZ_EXPORT tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
 
-/* Compresses a block of data, consuming as much of the specified input buffer as possible, and writing as much compressed data to the specified output buffer as possible. */
-MINIZ_EXPORT tdefl_status tdefl_compress(tdefl_compressor *d, const void *pIn_buf, size_t *pIn_buf_size, void *pOut_buf, size_t *pOut_buf_size, tdefl_flush flush);
+    /* Compresses a block of data, consuming as much of the specified input buffer as possible, and writing as much compressed data to the specified output buffer as possible. */
+    MINIZ_EXPORT tdefl_status tdefl_compress(tdefl_compressor *d, const void *pIn_buf, size_t *pIn_buf_size, void *pOut_buf, size_t *pOut_buf_size, tdefl_flush flush);
 
-/* tdefl_compress_buffer() is only usable when the tdefl_init() is called with a non-NULL tdefl_put_buf_func_ptr. */
-/* tdefl_compress_buffer() always consumes the entire input buffer. */
-MINIZ_EXPORT tdefl_status tdefl_compress_buffer(tdefl_compressor *d, const void *pIn_buf, size_t in_buf_size, tdefl_flush flush);
+    /* tdefl_compress_buffer() is only usable when the tdefl_init() is called with a non-NULL tdefl_put_buf_func_ptr. */
+    /* tdefl_compress_buffer() always consumes the entire input buffer. */
+    MINIZ_EXPORT tdefl_status tdefl_compress_buffer(tdefl_compressor *d, const void *pIn_buf, size_t in_buf_size, tdefl_flush flush);
 
-MINIZ_EXPORT tdefl_status tdefl_get_prev_return_status(tdefl_compressor *d);
-MINIZ_EXPORT mz_uint32 tdefl_get_adler32(tdefl_compressor *d);
+    MINIZ_EXPORT tdefl_status tdefl_get_prev_return_status(tdefl_compressor *d);
+    MINIZ_EXPORT mz_uint32 tdefl_get_adler32(tdefl_compressor *d);
 
-/* Create tdefl_compress() flags given zlib-style compression parameters. */
-/* level may range from [0,10] (where 10 is absolute max compression, but may be much slower on some files) */
-/* window_bits may be -15 (raw deflate) or 15 (zlib) */
-/* strategy may be either MZ_DEFAULT_STRATEGY, MZ_FILTERED, MZ_HUFFMAN_ONLY, MZ_RLE, or MZ_FIXED */
-MINIZ_EXPORT mz_uint tdefl_create_comp_flags_from_zip_params(int level, int window_bits, int strategy);
+    /* Create tdefl_compress() flags given zlib-style compression parameters. */
+    /* level may range from [0,10] (where 10 is absolute max compression, but may be much slower on some files) */
+    /* window_bits may be -15 (raw deflate) or 15 (zlib) */
+    /* strategy may be either MZ_DEFAULT_STRATEGY, MZ_FILTERED, MZ_HUFFMAN_ONLY, MZ_RLE, or MZ_FIXED */
+    MINIZ_EXPORT mz_uint tdefl_create_comp_flags_from_zip_params(int level, int window_bits, int strategy);
 
 #ifndef MINIZ_NO_MALLOC
-/* Allocate the tdefl_compressor structure in C so that */
-/* non-C language bindings to tdefl_ API don't need to worry about */
-/* structure size and allocation mechanism. */
-MINIZ_EXPORT tdefl_compressor *tdefl_compressor_alloc(void);
-MINIZ_EXPORT void tdefl_compressor_free(tdefl_compressor *pComp);
+    /* Allocate the tdefl_compressor structure in C so that */
+    /* non-C language bindings to tdefl_ API don't need to worry about */
+    /* structure size and allocation mechanism. */
+    MINIZ_EXPORT tdefl_compressor *tdefl_compressor_alloc(void);
+    MINIZ_EXPORT void tdefl_compressor_free(tdefl_compressor *pComp);
 #endif
 
 #ifdef __cplusplus
 }
 #endif
 
+#endif /*#ifndef MINIZ_NO_DEFLATE_APIS*/
+ #pragma once
+
 /* ------------------- Low-level Decompression API Definitions */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-/* Decompression flags used by tinfl_decompress(). */
-/* TINFL_FLAG_PARSE_ZLIB_HEADER: If set, the input has a valid zlib header and ends with an adler32 checksum (it's a valid zlib stream). Otherwise, the input is a raw deflate stream. */
-/* TINFL_FLAG_HAS_MORE_INPUT: If set, there are more input bytes available beyond the end of the supplied input buffer. If clear, the input buffer contains all remaining input. */
-/* TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF: If set, the output buffer is large enough to hold the entire decompressed stream. If clear, the output buffer is at least the size of the dictionary (typically 32KB). */
-/* TINFL_FLAG_COMPUTE_ADLER32: Force adler-32 checksum computation of the decompressed bytes. */
-enum
-{
-    TINFL_FLAG_PARSE_ZLIB_HEADER = 1,
-    TINFL_FLAG_HAS_MORE_INPUT = 2,
-    TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF = 4,
-    TINFL_FLAG_COMPUTE_ADLER32 = 8
-};
+#ifndef MINIZ_NO_INFLATE_APIS
 
-/* High level decompression functions: */
-/* tinfl_decompress_mem_to_heap() decompresses a block in memory to a heap block allocated via malloc(). */
-/* On entry: */
-/*  pSrc_buf, src_buf_len: Pointer and size of the Deflate or zlib source data to decompress. */
-/* On return: */
-/*  Function returns a pointer to the decompressed data, or NULL on failure. */
-/*  *pOut_len will be set to the decompressed data's size, which could be larger than src_buf_len on uncompressible data. */
-/*  The caller must call mz_free() on the returned block when it's no longer needed. */
-MINIZ_EXPORT void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags);
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    /* Decompression flags used by tinfl_decompress(). */
+    /* TINFL_FLAG_PARSE_ZLIB_HEADER: If set, the input has a valid zlib header and ends with an adler32 checksum (it's a valid zlib stream). Otherwise, the input is a raw deflate stream. */
+    /* TINFL_FLAG_HAS_MORE_INPUT: If set, there are more input bytes available beyond the end of the supplied input buffer. If clear, the input buffer contains all remaining input. */
+    /* TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF: If set, the output buffer is large enough to hold the entire decompressed stream. If clear, the output buffer is at least the size of the dictionary (typically 32KB). */
+    /* TINFL_FLAG_COMPUTE_ADLER32: Force adler-32 checksum computation of the decompressed bytes. */
+    enum
+    {
+        TINFL_FLAG_PARSE_ZLIB_HEADER = 1,
+        TINFL_FLAG_HAS_MORE_INPUT = 2,
+        TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF = 4,
+        TINFL_FLAG_COMPUTE_ADLER32 = 8
+    };
+
+    /* High level decompression functions: */
+    /* tinfl_decompress_mem_to_heap() decompresses a block in memory to a heap block allocated via malloc(). */
+    /* On entry: */
+    /*  pSrc_buf, src_buf_len: Pointer and size of the Deflate or zlib source data to decompress. */
+    /* On return: */
+    /*  Function returns a pointer to the decompressed data, or NULL on failure. */
+    /*  *pOut_len will be set to the decompressed data's size, which could be larger than src_buf_len on uncompressible data. */
+    /*  The caller must call mz_free() on the returned block when it's no longer needed. */
+    MINIZ_EXPORT void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags);
 
 /* tinfl_decompress_mem_to_mem() decompresses a block in memory to another block in memory. */
 /* Returns TINFL_DECOMPRESS_MEM_TO_MEM_FAILED on failure, or the number of bytes written on success. */
 #define TINFL_DECOMPRESS_MEM_TO_MEM_FAILED ((size_t)(-1))
-MINIZ_EXPORT size_t tinfl_decompress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags);
+    MINIZ_EXPORT size_t tinfl_decompress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void *pSrc_buf, size_t src_buf_len, int flags);
 
-/* tinfl_decompress_mem_to_callback() decompresses a block in memory to an internal 32KB buffer, and a user provided callback function will be called to flush the buffer. */
-/* Returns 1 on success or 0 on failure. */
-typedef int (*tinfl_put_buf_func_ptr)(const void *pBuf, int len, void *pUser);
-MINIZ_EXPORT int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, tinfl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
+    /* tinfl_decompress_mem_to_callback() decompresses a block in memory to an internal 32KB buffer, and a user provided callback function will be called to flush the buffer. */
+    /* Returns 1 on success or 0 on failure. */
+    typedef int (*tinfl_put_buf_func_ptr)(const void *pBuf, int len, void *pUser);
+    MINIZ_EXPORT int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, tinfl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
 
-struct tinfl_decompressor_tag;
-typedef struct tinfl_decompressor_tag tinfl_decompressor;
+    struct tinfl_decompressor_tag;
+    typedef struct tinfl_decompressor_tag tinfl_decompressor;
 
 #ifndef MINIZ_NO_MALLOC
-/* Allocate the tinfl_decompressor structure in C so that */
-/* non-C language bindings to tinfl_ API don't need to worry about */
-/* structure size and allocation mechanism. */
-MINIZ_EXPORT tinfl_decompressor *tinfl_decompressor_alloc(void);
-MINIZ_EXPORT void tinfl_decompressor_free(tinfl_decompressor *pDecomp);
+    /* Allocate the tinfl_decompressor structure in C so that */
+    /* non-C language bindings to tinfl_ API don't need to worry about */
+    /* structure size and allocation mechanism. */
+    MINIZ_EXPORT tinfl_decompressor *tinfl_decompressor_alloc(void);
+    MINIZ_EXPORT void tinfl_decompressor_free(tinfl_decompressor *pDecomp);
 #endif
 
 /* Max size of LZ dictionary. */
 #define TINFL_LZ_DICT_SIZE 32768
 
-/* Return status. */
-typedef enum {
-    /* This flags indicates the inflator needs 1 or more input bytes to make forward progress, but the caller is indicating that no more are available. The compressed data */
-    /* is probably corrupted. If you call the inflator again with more bytes it'll try to continue processing the input but this is a BAD sign (either the data is corrupted or you called it incorrectly). */
-    /* If you call it again with no input you'll just get TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS again. */
-    TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS = -4,
+    /* Return status. */
+    typedef enum
+    {
+        /* This flags indicates the inflator needs 1 or more input bytes to make forward progress, but the caller is indicating that no more are available. The compressed data */
+        /* is probably corrupted. If you call the inflator again with more bytes it'll try to continue processing the input but this is a BAD sign (either the data is corrupted or you called it incorrectly). */
+        /* If you call it again with no input you'll just get TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS again. */
+        TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS = -4,
 
-    /* This flag indicates that one or more of the input parameters was obviously bogus. (You can try calling it again, but if you get this error the calling code is wrong.) */
-    TINFL_STATUS_BAD_PARAM = -3,
+        /* This flag indicates that one or more of the input parameters was obviously bogus. (You can try calling it again, but if you get this error the calling code is wrong.) */
+        TINFL_STATUS_BAD_PARAM = -3,
 
-    /* This flags indicate the inflator is finished but the adler32 check of the uncompressed data didn't match. If you call it again it'll return TINFL_STATUS_DONE. */
-    TINFL_STATUS_ADLER32_MISMATCH = -2,
+        /* This flags indicate the inflator is finished but the adler32 check of the uncompressed data didn't match. If you call it again it'll return TINFL_STATUS_DONE. */
+        TINFL_STATUS_ADLER32_MISMATCH = -2,
 
-    /* This flags indicate the inflator has somehow failed (bad code, corrupted input, etc.). If you call it again without resetting via tinfl_init() it it'll just keep on returning the same status failure code. */
-    TINFL_STATUS_FAILED = -1,
+        /* This flags indicate the inflator has somehow failed (bad code, corrupted input, etc.). If you call it again without resetting via tinfl_init() it it'll just keep on returning the same status failure code. */
+        TINFL_STATUS_FAILED = -1,
 
-    /* Any status code less than TINFL_STATUS_DONE must indicate a failure. */
+        /* Any status code less than TINFL_STATUS_DONE must indicate a failure. */
 
-    /* This flag indicates the inflator has returned every byte of uncompressed data that it can, has consumed every byte that it needed, has successfully reached the end of the deflate stream, and */
-    /* if zlib headers and adler32 checking enabled that it has successfully checked the uncompressed data's adler32. If you call it again you'll just get TINFL_STATUS_DONE over and over again. */
-    TINFL_STATUS_DONE = 0,
+        /* This flag indicates the inflator has returned every byte of uncompressed data that it can, has consumed every byte that it needed, has successfully reached the end of the deflate stream, and */
+        /* if zlib headers and adler32 checking enabled that it has successfully checked the uncompressed data's adler32. If you call it again you'll just get TINFL_STATUS_DONE over and over again. */
+        TINFL_STATUS_DONE = 0,
 
-    /* This flag indicates the inflator MUST have more input data (even 1 byte) before it can make any more forward progress, or you need to clear the TINFL_FLAG_HAS_MORE_INPUT */
-    /* flag on the next call if you don't have any more source data. If the source data was somehow corrupted it's also possible (but unlikely) for the inflator to keep on demanding input to */
-    /* proceed, so be sure to properly set the TINFL_FLAG_HAS_MORE_INPUT flag. */
-    TINFL_STATUS_NEEDS_MORE_INPUT = 1,
+        /* This flag indicates the inflator MUST have more input data (even 1 byte) before it can make any more forward progress, or you need to clear the TINFL_FLAG_HAS_MORE_INPUT */
+        /* flag on the next call if you don't have any more source data. If the source data was somehow corrupted it's also possible (but unlikely) for the inflator to keep on demanding input to */
+        /* proceed, so be sure to properly set the TINFL_FLAG_HAS_MORE_INPUT flag. */
+        TINFL_STATUS_NEEDS_MORE_INPUT = 1,
 
-    /* This flag indicates the inflator definitely has 1 or more bytes of uncompressed data available, but it cannot write this data into the output buffer. */
-    /* Note if the source compressed data was corrupted it's possible for the inflator to return a lot of uncompressed data to the caller. I've been assuming you know how much uncompressed data to expect */
-    /* (either exact or worst case) and will stop calling the inflator and fail after receiving too much. In pure streaming scenarios where you have no idea how many bytes to expect this may not be possible */
-    /* so I may need to add some code to address this. */
-    TINFL_STATUS_HAS_MORE_OUTPUT = 2
-} tinfl_status;
+        /* This flag indicates the inflator definitely has 1 or more bytes of uncompressed data available, but it cannot write this data into the output buffer. */
+        /* Note if the source compressed data was corrupted it's possible for the inflator to return a lot of uncompressed data to the caller. I've been assuming you know how much uncompressed data to expect */
+        /* (either exact or worst case) and will stop calling the inflator and fail after receiving too much. In pure streaming scenarios where you have no idea how many bytes to expect this may not be possible */
+        /* so I may need to add some code to address this. */
+        TINFL_STATUS_HAS_MORE_OUTPUT = 2
+    } tinfl_status;
 
 /* Initializes the decompressor to its initial state. */
 #define tinfl_init(r)     \
@@ -913,20 +1006,20 @@ typedef enum {
     MZ_MACRO_END
 #define tinfl_get_adler32(r) (r)->m_check_adler32
 
-/* Main low-level decompressor coroutine function. This is the only function actually needed for decompression. All the other functions are just high-level helpers for improved usability. */
-/* This is a universal API, i.e. it can be used as a building block to build any desired higher level decompression API. In the limit case, it can be called once per every byte input or output. */
-MINIZ_EXPORT tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_next, size_t *pIn_buf_size, mz_uint8 *pOut_buf_start, mz_uint8 *pOut_buf_next, size_t *pOut_buf_size, const mz_uint32 decomp_flags);
+    /* Main low-level decompressor coroutine function. This is the only function actually needed for decompression. All the other functions are just high-level helpers for improved usability. */
+    /* This is a universal API, i.e. it can be used as a building block to build any desired higher level decompression API. In the limit case, it can be called once per every byte input or output. */
+    MINIZ_EXPORT tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_next, size_t *pIn_buf_size, mz_uint8 *pOut_buf_start, mz_uint8 *pOut_buf_next, size_t *pOut_buf_size, const mz_uint32 decomp_flags);
 
-/* Internal/private bits follow. */
-enum
-{
-    TINFL_MAX_HUFF_TABLES = 3,
-    TINFL_MAX_HUFF_SYMBOLS_0 = 288,
-    TINFL_MAX_HUFF_SYMBOLS_1 = 32,
-    TINFL_MAX_HUFF_SYMBOLS_2 = 19,
-    TINFL_FAST_LOOKUP_BITS = 10,
-    TINFL_FAST_LOOKUP_SIZE = 1 << TINFL_FAST_LOOKUP_BITS
-};
+    /* Internal/private bits follow. */
+    enum
+    {
+        TINFL_MAX_HUFF_TABLES = 3,
+        TINFL_MAX_HUFF_SYMBOLS_0 = 288,
+        TINFL_MAX_HUFF_SYMBOLS_1 = 32,
+        TINFL_MAX_HUFF_SYMBOLS_2 = 19,
+        TINFL_FAST_LOOKUP_BITS = 10,
+        TINFL_FAST_LOOKUP_SIZE = 1 << TINFL_FAST_LOOKUP_BITS
+    };
 
 #if MINIZ_HAS_64BIT_REGISTERS
 #define TINFL_USE_64BIT_BITBUF 1
@@ -935,347 +1028,358 @@ enum
 #endif
 
 #if TINFL_USE_64BIT_BITBUF
-typedef mz_uint64 tinfl_bit_buf_t;
+    typedef mz_uint64 tinfl_bit_buf_t;
 #define TINFL_BITBUF_SIZE (64)
 #else
 typedef mz_uint32 tinfl_bit_buf_t;
 #define TINFL_BITBUF_SIZE (32)
 #endif
 
-struct tinfl_decompressor_tag
-{
-    mz_uint32 m_state, m_num_bits, m_zhdr0, m_zhdr1, m_z_adler32, m_final, m_type, m_check_adler32, m_dist, m_counter, m_num_extra, m_table_sizes[TINFL_MAX_HUFF_TABLES];
-    tinfl_bit_buf_t m_bit_buf;
-    size_t m_dist_from_out_buf_start;
-    mz_int16 m_look_up[TINFL_MAX_HUFF_TABLES][TINFL_FAST_LOOKUP_SIZE];
-    mz_int16 m_tree_0[TINFL_MAX_HUFF_SYMBOLS_0 * 2];
-    mz_int16 m_tree_1[TINFL_MAX_HUFF_SYMBOLS_1 * 2];
-    mz_int16 m_tree_2[TINFL_MAX_HUFF_SYMBOLS_2 * 2];
-    mz_uint8 m_code_size_0[TINFL_MAX_HUFF_SYMBOLS_0];
-    mz_uint8 m_code_size_1[TINFL_MAX_HUFF_SYMBOLS_1];
-    mz_uint8 m_code_size_2[TINFL_MAX_HUFF_SYMBOLS_2];
-    mz_uint8 m_raw_header[4], m_len_codes[TINFL_MAX_HUFF_SYMBOLS_0 + TINFL_MAX_HUFF_SYMBOLS_1 + 137];
-};
+    struct tinfl_decompressor_tag
+    {
+        mz_uint32 m_state, m_num_bits, m_zhdr0, m_zhdr1, m_z_adler32, m_final, m_type, m_check_adler32, m_dist, m_counter, m_num_extra, m_table_sizes[TINFL_MAX_HUFF_TABLES];
+        tinfl_bit_buf_t m_bit_buf;
+        size_t m_dist_from_out_buf_start;
+        mz_int16 m_look_up[TINFL_MAX_HUFF_TABLES][TINFL_FAST_LOOKUP_SIZE];
+        mz_int16 m_tree_0[TINFL_MAX_HUFF_SYMBOLS_0 * 2];
+        mz_int16 m_tree_1[TINFL_MAX_HUFF_SYMBOLS_1 * 2];
+        mz_int16 m_tree_2[TINFL_MAX_HUFF_SYMBOLS_2 * 2];
+        mz_uint8 m_code_size_0[TINFL_MAX_HUFF_SYMBOLS_0];
+        mz_uint8 m_code_size_1[TINFL_MAX_HUFF_SYMBOLS_1];
+        mz_uint8 m_code_size_2[TINFL_MAX_HUFF_SYMBOLS_2];
+        mz_uint8 m_raw_header[4], m_len_codes[TINFL_MAX_HUFF_SYMBOLS_0 + TINFL_MAX_HUFF_SYMBOLS_1 + 137];
+    };
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /*#ifndef MINIZ_NO_INFLATE_APIS*/
+ 
+#pragma once
+
 
 /* ------------------- ZIP archive reading/writing */
 
 #ifndef MINIZ_NO_ARCHIVE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-enum
-{
-    /* Note: These enums can be reduced as needed to save memory or stack space - they are pretty conservative. */
-    MZ_ZIP_MAX_IO_BUF_SIZE = 64 * 1024,
-    MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE = 512,
-    MZ_ZIP_MAX_ARCHIVE_FILE_COMMENT_SIZE = 512
-};
+    enum
+    { 
+        /* Note: These enums can be reduced as needed to save memory or stack space - they are pretty conservative. */
+        MZ_ZIP_MAX_IO_BUF_SIZE = 64 * 1024,
+        MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE = 512,
+        MZ_ZIP_MAX_ARCHIVE_FILE_COMMENT_SIZE = 512
+    };
 
-typedef struct
-{
-    /* Central directory file index. */
-    mz_uint32 m_file_index;
+    typedef struct
+    {
+        /* Central directory file index. */
+        mz_uint32 m_file_index;
 
-    /* Byte offset of this entry in the archive's central directory. Note we currently only support up to UINT_MAX or less bytes in the central dir. */
-    mz_uint64 m_central_dir_ofs;
+        /* Byte offset of this entry in the archive's central directory. Note we currently only support up to UINT_MAX or less bytes in the central dir. */
+        mz_uint64 m_central_dir_ofs;
 
-    /* These fields are copied directly from the zip's central dir. */
-    mz_uint16 m_version_made_by;
-    mz_uint16 m_version_needed;
-    mz_uint16 m_bit_flag;
-    mz_uint16 m_method;
+        /* These fields are copied directly from the zip's central dir. */
+        mz_uint16 m_version_made_by;
+        mz_uint16 m_version_needed;
+        mz_uint16 m_bit_flag;
+        mz_uint16 m_method;
 
-    /* CRC-32 of uncompressed data. */
-    mz_uint32 m_crc32;
+        /* CRC-32 of uncompressed data. */
+        mz_uint32 m_crc32;
 
-    /* File's compressed size. */
-    mz_uint64 m_comp_size;
+        /* File's compressed size. */
+        mz_uint64 m_comp_size;
 
-    /* File's uncompressed size. Note, I've seen some old archives where directory entries had 512 bytes for their uncompressed sizes, but when you try to unpack them you actually get 0 bytes. */
-    mz_uint64 m_uncomp_size;
+        /* File's uncompressed size. Note, I've seen some old archives where directory entries had 512 bytes for their uncompressed sizes, but when you try to unpack them you actually get 0 bytes. */
+        mz_uint64 m_uncomp_size;
 
-    /* Zip internal and external file attributes. */
-    mz_uint16 m_internal_attr;
-    mz_uint32 m_external_attr;
+        /* Zip internal and external file attributes. */
+        mz_uint16 m_internal_attr;
+        mz_uint32 m_external_attr;
 
-    /* Entry's local header file offset in bytes. */
-    mz_uint64 m_local_header_ofs;
+        /* Entry's local header file offset in bytes. */
+        mz_uint64 m_local_header_ofs;
 
-    /* Size of comment in bytes. */
-    mz_uint32 m_comment_size;
+        /* Size of comment in bytes. */
+        mz_uint32 m_comment_size;
 
-    /* MZ_TRUE if the entry appears to be a directory. */
-    mz_bool m_is_directory;
+        /* MZ_TRUE if the entry appears to be a directory. */
+        mz_bool m_is_directory;
 
-    /* MZ_TRUE if the entry uses encryption/strong encryption (which miniz_zip doesn't support) */
-    mz_bool m_is_encrypted;
+        /* MZ_TRUE if the entry uses encryption/strong encryption (which miniz_zip doesn't support) */
+        mz_bool m_is_encrypted;
 
-    /* MZ_TRUE if the file is not encrypted, a patch file, and if it uses a compression method we support. */
-    mz_bool m_is_supported;
+        /* MZ_TRUE if the file is not encrypted, a patch file, and if it uses a compression method we support. */
+        mz_bool m_is_supported;
 
-    /* Filename. If string ends in '/' it's a subdirectory entry. */
-    /* Guaranteed to be zero terminated, may be truncated to fit. */
-    char m_filename[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE];
+        /* Filename. If string ends in '/' it's a subdirectory entry. */
+        /* Guaranteed to be zero terminated, may be truncated to fit. */
+        char m_filename[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE];
 
-    /* Comment field. */
-    /* Guaranteed to be zero terminated, may be truncated to fit. */
-    char m_comment[MZ_ZIP_MAX_ARCHIVE_FILE_COMMENT_SIZE];
+        /* Comment field. */
+        /* Guaranteed to be zero terminated, may be truncated to fit. */
+        char m_comment[MZ_ZIP_MAX_ARCHIVE_FILE_COMMENT_SIZE];
 
 #ifdef MINIZ_NO_TIME
-    MZ_TIME_T m_padding;
+        MZ_TIME_T m_padding;
 #else
     MZ_TIME_T m_time;
 #endif
-} mz_zip_archive_file_stat;
+    } mz_zip_archive_file_stat;
 
-typedef size_t (*mz_file_read_func)(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n);
-typedef size_t (*mz_file_write_func)(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n);
-typedef mz_bool (*mz_file_needs_keepalive)(void *pOpaque);
+    typedef size_t (*mz_file_read_func)(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n);
+    typedef size_t (*mz_file_write_func)(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n);
+    typedef mz_bool (*mz_file_needs_keepalive)(void *pOpaque);
 
-struct mz_zip_internal_state_tag;
-typedef struct mz_zip_internal_state_tag mz_zip_internal_state;
+    struct mz_zip_internal_state_tag;
+    typedef struct mz_zip_internal_state_tag mz_zip_internal_state;
 
-typedef enum {
-    MZ_ZIP_MODE_INVALID = 0,
-    MZ_ZIP_MODE_READING = 1,
-    MZ_ZIP_MODE_WRITING = 2,
-    MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED = 3
-} mz_zip_mode;
+    typedef enum
+    {
+        MZ_ZIP_MODE_INVALID = 0,
+        MZ_ZIP_MODE_READING = 1,
+        MZ_ZIP_MODE_WRITING = 2,
+        MZ_ZIP_MODE_WRITING_HAS_BEEN_FINALIZED = 3
+    } mz_zip_mode;
 
-typedef enum {
-    MZ_ZIP_FLAG_CASE_SENSITIVE = 0x0100,
-    MZ_ZIP_FLAG_IGNORE_PATH = 0x0200,
-    MZ_ZIP_FLAG_COMPRESSED_DATA = 0x0400,
-    MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY = 0x0800,
-    MZ_ZIP_FLAG_VALIDATE_LOCATE_FILE_FLAG = 0x1000, /* if enabled, mz_zip_reader_locate_file() will be called on each file as its validated to ensure the func finds the file in the central dir (intended for testing) */
-    MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY = 0x2000,     /* validate the local headers, but don't decompress the entire file and check the crc32 */
-    MZ_ZIP_FLAG_WRITE_ZIP64 = 0x4000,               /* always use the zip64 file format, instead of the original zip file format with automatic switch to zip64. Use as flags parameter with mz_zip_writer_init*_v2 */
-    MZ_ZIP_FLAG_WRITE_ALLOW_READING = 0x8000,
-    MZ_ZIP_FLAG_ASCII_FILENAME = 0x10000,
-    /*After adding a compressed file, seek back
-    to local file header and set the correct sizes*/
-    MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE = 0x20000
-} mz_zip_flags;
+    typedef enum
+    {
+        MZ_ZIP_FLAG_CASE_SENSITIVE = 0x0100,
+        MZ_ZIP_FLAG_IGNORE_PATH = 0x0200,
+        MZ_ZIP_FLAG_COMPRESSED_DATA = 0x0400,
+        MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY = 0x0800,
+        MZ_ZIP_FLAG_VALIDATE_LOCATE_FILE_FLAG = 0x1000, /* if enabled, mz_zip_reader_locate_file() will be called on each file as its validated to ensure the func finds the file in the central dir (intended for testing) */
+        MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY = 0x2000,     /* validate the local headers, but don't decompress the entire file and check the crc32 */
+        MZ_ZIP_FLAG_WRITE_ZIP64 = 0x4000,               /* always use the zip64 file format, instead of the original zip file format with automatic switch to zip64. Use as flags parameter with mz_zip_writer_init*_v2 */
+        MZ_ZIP_FLAG_WRITE_ALLOW_READING = 0x8000,
+        MZ_ZIP_FLAG_ASCII_FILENAME = 0x10000,
+        /*After adding a compressed file, seek back
+        to local file header and set the correct sizes*/
+        MZ_ZIP_FLAG_WRITE_HEADER_SET_SIZE = 0x20000,
+        MZ_ZIP_FLAG_READ_ALLOW_WRITING = 0x40000
+    } mz_zip_flags;
 
-typedef enum {
-    MZ_ZIP_TYPE_INVALID = 0,
-    MZ_ZIP_TYPE_USER,
-    MZ_ZIP_TYPE_MEMORY,
-    MZ_ZIP_TYPE_HEAP,
-    MZ_ZIP_TYPE_FILE,
-    MZ_ZIP_TYPE_CFILE,
-    MZ_ZIP_TOTAL_TYPES
-} mz_zip_type;
+    typedef enum
+    {
+        MZ_ZIP_TYPE_INVALID = 0,
+        MZ_ZIP_TYPE_USER,
+        MZ_ZIP_TYPE_MEMORY,
+        MZ_ZIP_TYPE_HEAP,
+        MZ_ZIP_TYPE_FILE,
+        MZ_ZIP_TYPE_CFILE,
+        MZ_ZIP_TOTAL_TYPES
+    } mz_zip_type;
 
-/* miniz error codes. Be sure to update mz_zip_get_error_string() if you add or modify this enum. */
-typedef enum {
-    MZ_ZIP_NO_ERROR = 0,
-    MZ_ZIP_UNDEFINED_ERROR,
-    MZ_ZIP_TOO_MANY_FILES,
-    MZ_ZIP_FILE_TOO_LARGE,
-    MZ_ZIP_UNSUPPORTED_METHOD,
-    MZ_ZIP_UNSUPPORTED_ENCRYPTION,
-    MZ_ZIP_UNSUPPORTED_FEATURE,
-    MZ_ZIP_FAILED_FINDING_CENTRAL_DIR,
-    MZ_ZIP_NOT_AN_ARCHIVE,
-    MZ_ZIP_INVALID_HEADER_OR_CORRUPTED,
-    MZ_ZIP_UNSUPPORTED_MULTIDISK,
-    MZ_ZIP_DECOMPRESSION_FAILED,
-    MZ_ZIP_COMPRESSION_FAILED,
-    MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE,
-    MZ_ZIP_CRC_CHECK_FAILED,
-    MZ_ZIP_UNSUPPORTED_CDIR_SIZE,
-    MZ_ZIP_ALLOC_FAILED,
-    MZ_ZIP_FILE_OPEN_FAILED,
-    MZ_ZIP_FILE_CREATE_FAILED,
-    MZ_ZIP_FILE_WRITE_FAILED,
-    MZ_ZIP_FILE_READ_FAILED,
-    MZ_ZIP_FILE_CLOSE_FAILED,
-    MZ_ZIP_FILE_SEEK_FAILED,
-    MZ_ZIP_FILE_STAT_FAILED,
-    MZ_ZIP_INVALID_PARAMETER,
-    MZ_ZIP_INVALID_FILENAME,
-    MZ_ZIP_BUF_TOO_SMALL,
-    MZ_ZIP_INTERNAL_ERROR,
-    MZ_ZIP_FILE_NOT_FOUND,
-    MZ_ZIP_ARCHIVE_TOO_LARGE,
-    MZ_ZIP_VALIDATION_FAILED,
-    MZ_ZIP_WRITE_CALLBACK_FAILED,
-    MZ_ZIP_TOTAL_ERRORS
-} mz_zip_error;
+    /* miniz error codes. Be sure to update mz_zip_get_error_string() if you add or modify this enum. */
+    typedef enum
+    {
+        MZ_ZIP_NO_ERROR = 0,
+        MZ_ZIP_UNDEFINED_ERROR,
+        MZ_ZIP_TOO_MANY_FILES,
+        MZ_ZIP_FILE_TOO_LARGE,
+        MZ_ZIP_UNSUPPORTED_METHOD,
+        MZ_ZIP_UNSUPPORTED_ENCRYPTION,
+        MZ_ZIP_UNSUPPORTED_FEATURE,
+        MZ_ZIP_FAILED_FINDING_CENTRAL_DIR,
+        MZ_ZIP_NOT_AN_ARCHIVE,
+        MZ_ZIP_INVALID_HEADER_OR_CORRUPTED,
+        MZ_ZIP_UNSUPPORTED_MULTIDISK,
+        MZ_ZIP_DECOMPRESSION_FAILED,
+        MZ_ZIP_COMPRESSION_FAILED,
+        MZ_ZIP_UNEXPECTED_DECOMPRESSED_SIZE,
+        MZ_ZIP_CRC_CHECK_FAILED,
+        MZ_ZIP_UNSUPPORTED_CDIR_SIZE,
+        MZ_ZIP_ALLOC_FAILED,
+        MZ_ZIP_FILE_OPEN_FAILED,
+        MZ_ZIP_FILE_CREATE_FAILED,
+        MZ_ZIP_FILE_WRITE_FAILED,
+        MZ_ZIP_FILE_READ_FAILED,
+        MZ_ZIP_FILE_CLOSE_FAILED,
+        MZ_ZIP_FILE_SEEK_FAILED,
+        MZ_ZIP_FILE_STAT_FAILED,
+        MZ_ZIP_INVALID_PARAMETER,
+        MZ_ZIP_INVALID_FILENAME,
+        MZ_ZIP_BUF_TOO_SMALL,
+        MZ_ZIP_INTERNAL_ERROR,
+        MZ_ZIP_FILE_NOT_FOUND,
+        MZ_ZIP_ARCHIVE_TOO_LARGE,
+        MZ_ZIP_VALIDATION_FAILED,
+        MZ_ZIP_WRITE_CALLBACK_FAILED,
+        MZ_ZIP_TOTAL_ERRORS
+    } mz_zip_error;
 
-typedef struct
-{
-    mz_uint64 m_archive_size;
-    mz_uint64 m_central_directory_file_ofs;
+    typedef struct
+    {
+        mz_uint64 m_archive_size;
+        mz_uint64 m_central_directory_file_ofs;
 
-    /* We only support up to UINT32_MAX files in zip64 mode. */
-    mz_uint32 m_total_files;
-    mz_zip_mode m_zip_mode;
-    mz_zip_type m_zip_type;
-    mz_zip_error m_last_error;
+        /* We only support up to UINT32_MAX files in zip64 mode. */
+        mz_uint32 m_total_files;
+        mz_zip_mode m_zip_mode;
+        mz_zip_type m_zip_type;
+        mz_zip_error m_last_error;
 
-    mz_uint64 m_file_offset_alignment;
+        mz_uint64 m_file_offset_alignment;
 
-    mz_alloc_func m_pAlloc;
-    mz_free_func m_pFree;
-    mz_realloc_func m_pRealloc;
-    void *m_pAlloc_opaque;
+        mz_alloc_func m_pAlloc;
+        mz_free_func m_pFree;
+        mz_realloc_func m_pRealloc;
+        void *m_pAlloc_opaque;
 
-    mz_file_read_func m_pRead;
-    mz_file_write_func m_pWrite;
-    mz_file_needs_keepalive m_pNeeds_keepalive;
-    void *m_pIO_opaque;
+        mz_file_read_func m_pRead;
+        mz_file_write_func m_pWrite;
+        mz_file_needs_keepalive m_pNeeds_keepalive;
+        void *m_pIO_opaque;
 
-    mz_zip_internal_state *m_pState;
+        mz_zip_internal_state *m_pState;
 
-} mz_zip_archive;
+    } mz_zip_archive;
 
-typedef struct
-{
-    mz_zip_archive *pZip;
-    mz_uint flags;
+    typedef struct
+    {
+        mz_zip_archive *pZip;
+        mz_uint flags;
 
-    int status;
+        int status;
 
-    mz_uint64 read_buf_size, read_buf_ofs, read_buf_avail, comp_remaining, out_buf_ofs, cur_file_ofs;
-    mz_zip_archive_file_stat file_stat;
-    void *pRead_buf;
-    void *pWrite_buf;
+        mz_uint64 read_buf_size, read_buf_ofs, read_buf_avail, comp_remaining, out_buf_ofs, cur_file_ofs;
+        mz_zip_archive_file_stat file_stat;
+        void *pRead_buf;
+        void *pWrite_buf;
 
-    size_t out_blk_remain;
+        size_t out_blk_remain;
 
-    tinfl_decompressor inflator;
+        tinfl_decompressor inflator;
 
 #ifdef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
-    mz_uint padding;
+        mz_uint padding;
 #else
     mz_uint file_crc32;
 #endif
 
-} mz_zip_reader_extract_iter_state;
+    } mz_zip_reader_extract_iter_state;
 
-/* -------- ZIP reading */
+    /* -------- ZIP reading */
 
-/* Inits a ZIP archive reader. */
-/* These functions read and validate the archive's central directory. */
-MINIZ_EXPORT mz_bool mz_zip_reader_init(mz_zip_archive *pZip, mz_uint64 size, mz_uint flags);
+    /* Inits a ZIP archive reader. */
+    /* These functions read and validate the archive's central directory. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_init(mz_zip_archive *pZip, mz_uint64 size, mz_uint flags);
 
-MINIZ_EXPORT mz_bool mz_zip_reader_init_mem(mz_zip_archive *pZip, const void *pMem, size_t size, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_init_mem(mz_zip_archive *pZip, const void *pMem, size_t size, mz_uint flags);
 
 #ifndef MINIZ_NO_STDIO
-/* Read a archive from a disk file. */
-/* file_start_ofs is the file offset where the archive actually begins, or 0. */
-/* actual_archive_size is the true total size of the archive, which may be smaller than the file's actual size on disk. If zero the entire file is treated as the archive. */
-MINIZ_EXPORT mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint32 flags);
-MINIZ_EXPORT mz_bool mz_zip_reader_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags, mz_uint64 file_start_ofs, mz_uint64 archive_size);
+    /* Read a archive from a disk file. */
+    /* file_start_ofs is the file offset where the archive actually begins, or 0. */
+    /* actual_archive_size is the true total size of the archive, which may be smaller than the file's actual size on disk. If zero the entire file is treated as the archive. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint32 flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags, mz_uint64 file_start_ofs, mz_uint64 archive_size);
 
-/* Read an archive from an already opened FILE, beginning at the current file position. */
-/* The archive is assumed to be archive_size bytes long. If archive_size is 0, then the entire rest of the file is assumed to contain the archive. */
-/* The FILE will NOT be closed when mz_zip_reader_end() is called. */
-MINIZ_EXPORT mz_bool mz_zip_reader_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint64 archive_size, mz_uint flags);
+    /* Read an archive from an already opened FILE, beginning at the current file position. */
+    /* The archive is assumed to be archive_size bytes long. If archive_size is 0, then the entire rest of the file is assumed to contain the archive. */
+    /* The FILE will NOT be closed when mz_zip_reader_end() is called. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint64 archive_size, mz_uint flags);
 #endif
 
-/* Ends archive reading, freeing all allocations, and closing the input archive file if mz_zip_reader_init_file() was used. */
-MINIZ_EXPORT mz_bool mz_zip_reader_end(mz_zip_archive *pZip);
+    /* Ends archive reading, freeing all allocations, and closing the input archive file if mz_zip_reader_init_file() was used. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_end(mz_zip_archive *pZip);
 
-/* -------- ZIP reading or writing */
+    /* -------- ZIP reading or writing */
 
-/* Clears a mz_zip_archive struct to all zeros. */
-/* Important: This must be done before passing the struct to any mz_zip functions. */
-MINIZ_EXPORT void mz_zip_zero_struct(mz_zip_archive *pZip);
+    /* Clears a mz_zip_archive struct to all zeros. */
+    /* Important: This must be done before passing the struct to any mz_zip functions. */
+    MINIZ_EXPORT void mz_zip_zero_struct(mz_zip_archive *pZip);
 
-MINIZ_EXPORT mz_zip_mode mz_zip_get_mode(mz_zip_archive *pZip);
-MINIZ_EXPORT mz_zip_type mz_zip_get_type(mz_zip_archive *pZip);
+    MINIZ_EXPORT mz_zip_mode mz_zip_get_mode(mz_zip_archive *pZip);
+    MINIZ_EXPORT mz_zip_type mz_zip_get_type(mz_zip_archive *pZip);
 
-/* Returns the total number of files in the archive. */
-MINIZ_EXPORT mz_uint mz_zip_reader_get_num_files(mz_zip_archive *pZip);
+    /* Returns the total number of files in the archive. */
+    MINIZ_EXPORT mz_uint mz_zip_reader_get_num_files(mz_zip_archive *pZip);
 
-MINIZ_EXPORT mz_uint64 mz_zip_get_archive_size(mz_zip_archive *pZip);
-MINIZ_EXPORT mz_uint64 mz_zip_get_archive_file_start_offset(mz_zip_archive *pZip);
-MINIZ_EXPORT MZ_FILE *mz_zip_get_cfile(mz_zip_archive *pZip);
+    MINIZ_EXPORT mz_uint64 mz_zip_get_archive_size(mz_zip_archive *pZip);
+    MINIZ_EXPORT mz_uint64 mz_zip_get_archive_file_start_offset(mz_zip_archive *pZip);
+    MINIZ_EXPORT MZ_FILE *mz_zip_get_cfile(mz_zip_archive *pZip);
 
-/* Reads n bytes of raw archive data, starting at file offset file_ofs, to pBuf. */
-MINIZ_EXPORT size_t mz_zip_read_archive_data(mz_zip_archive *pZip, mz_uint64 file_ofs, void *pBuf, size_t n);
+    /* Reads n bytes of raw archive data, starting at file offset file_ofs, to pBuf. */
+    MINIZ_EXPORT size_t mz_zip_read_archive_data(mz_zip_archive *pZip, mz_uint64 file_ofs, void *pBuf, size_t n);
 
-/* All mz_zip funcs set the m_last_error field in the mz_zip_archive struct. These functions retrieve/manipulate this field. */
-/* Note that the m_last_error functionality is not thread safe. */
-MINIZ_EXPORT mz_zip_error mz_zip_set_last_error(mz_zip_archive *pZip, mz_zip_error err_num);
-MINIZ_EXPORT mz_zip_error mz_zip_peek_last_error(mz_zip_archive *pZip);
-MINIZ_EXPORT mz_zip_error mz_zip_clear_last_error(mz_zip_archive *pZip);
-MINIZ_EXPORT mz_zip_error mz_zip_get_last_error(mz_zip_archive *pZip);
-MINIZ_EXPORT const char *mz_zip_get_error_string(mz_zip_error mz_err);
+    /* All mz_zip funcs set the m_last_error field in the mz_zip_archive struct. These functions retrieve/manipulate this field. */
+    /* Note that the m_last_error functionality is not thread safe. */
+    MINIZ_EXPORT mz_zip_error mz_zip_set_last_error(mz_zip_archive *pZip, mz_zip_error err_num);
+    MINIZ_EXPORT mz_zip_error mz_zip_peek_last_error(mz_zip_archive *pZip);
+    MINIZ_EXPORT mz_zip_error mz_zip_clear_last_error(mz_zip_archive *pZip);
+    MINIZ_EXPORT mz_zip_error mz_zip_get_last_error(mz_zip_archive *pZip);
+    MINIZ_EXPORT const char *mz_zip_get_error_string(mz_zip_error mz_err);
 
-/* MZ_TRUE if the archive file entry is a directory entry. */
-MINIZ_EXPORT mz_bool mz_zip_reader_is_file_a_directory(mz_zip_archive *pZip, mz_uint file_index);
+    /* MZ_TRUE if the archive file entry is a directory entry. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_is_file_a_directory(mz_zip_archive *pZip, mz_uint file_index);
 
-/* MZ_TRUE if the file is encrypted/strong encrypted. */
-MINIZ_EXPORT mz_bool mz_zip_reader_is_file_encrypted(mz_zip_archive *pZip, mz_uint file_index);
+    /* MZ_TRUE if the file is encrypted/strong encrypted. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_is_file_encrypted(mz_zip_archive *pZip, mz_uint file_index);
 
-/* MZ_TRUE if the compression method is supported, and the file is not encrypted, and the file is not a compressed patch file. */
-MINIZ_EXPORT mz_bool mz_zip_reader_is_file_supported(mz_zip_archive *pZip, mz_uint file_index);
+    /* MZ_TRUE if the compression method is supported, and the file is not encrypted, and the file is not a compressed patch file. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_is_file_supported(mz_zip_archive *pZip, mz_uint file_index);
 
-/* Retrieves the filename of an archive file entry. */
-/* Returns the number of bytes written to pFilename, or if filename_buf_size is 0 this function returns the number of bytes needed to fully store the filename. */
-MINIZ_EXPORT mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, char *pFilename, mz_uint filename_buf_size);
+    /* Retrieves the filename of an archive file entry. */
+    /* Returns the number of bytes written to pFilename, or if filename_buf_size is 0 this function returns the number of bytes needed to fully store the filename. */
+    MINIZ_EXPORT mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, char *pFilename, mz_uint filename_buf_size);
 
-/* Attempts to locates a file in the archive's central directory. */
-/* Valid flags: MZ_ZIP_FLAG_CASE_SENSITIVE, MZ_ZIP_FLAG_IGNORE_PATH */
-/* Returns -1 if the file cannot be found. */
-MINIZ_EXPORT int mz_zip_reader_locate_file(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags);
-MINIZ_EXPORT mz_bool mz_zip_reader_locate_file_v2(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags, mz_uint32 *file_index);
+    /* Attempts to locates a file in the archive's central directory. */
+    /* Valid flags: MZ_ZIP_FLAG_CASE_SENSITIVE, MZ_ZIP_FLAG_IGNORE_PATH */
+    /* Returns -1 if the file cannot be found. */
+    MINIZ_EXPORT int mz_zip_reader_locate_file(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_locate_file_v2(mz_zip_archive *pZip, const char *pName, const char *pComment, mz_uint flags, mz_uint32 *file_index);
 
-/* Returns detailed information about an archive file entry. */
-MINIZ_EXPORT mz_bool mz_zip_reader_file_stat(mz_zip_archive *pZip, mz_uint file_index, mz_zip_archive_file_stat *pStat);
+    /* Returns detailed information about an archive file entry. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_file_stat(mz_zip_archive *pZip, mz_uint file_index, mz_zip_archive_file_stat *pStat);
 
-/* MZ_TRUE if the file is in zip64 format. */
-/* A file is considered zip64 if it contained a zip64 end of central directory marker, or if it contained any zip64 extended file information fields in the central directory. */
-MINIZ_EXPORT mz_bool mz_zip_is_zip64(mz_zip_archive *pZip);
+    /* MZ_TRUE if the file is in zip64 format. */
+    /* A file is considered zip64 if it contained a zip64 end of central directory marker, or if it contained any zip64 extended file information fields in the central directory. */
+    MINIZ_EXPORT mz_bool mz_zip_is_zip64(mz_zip_archive *pZip);
 
-/* Returns the total central directory size in bytes. */
-/* The current max supported size is <= MZ_UINT32_MAX. */
-MINIZ_EXPORT size_t mz_zip_get_central_dir_size(mz_zip_archive *pZip);
+    /* Returns the total central directory size in bytes. */
+    /* The current max supported size is <= MZ_UINT32_MAX. */
+    MINIZ_EXPORT size_t mz_zip_get_central_dir_size(mz_zip_archive *pZip);
 
-/* Extracts a archive file to a memory buffer using no memory allocation. */
-/* There must be at least enough room on the stack to store the inflator's state (~34KB or so). */
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_mem_no_alloc(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size);
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_mem_no_alloc(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size);
+    /* Extracts a archive file to a memory buffer using no memory allocation. */
+    /* There must be at least enough room on the stack to store the inflator's state (~34KB or so). */
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_mem_no_alloc(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size);
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_mem_no_alloc(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size);
 
-/* Extracts a archive file to a memory buffer. */
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_mem(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags);
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_mem(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags);
+    /* Extracts a archive file to a memory buffer. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_mem(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_mem(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags);
 
-/* Extracts a archive file to a dynamically allocated heap buffer. */
-/* The memory will be allocated via the mz_zip_archive's alloc/realloc functions. */
-/* Returns NULL and sets the last error on failure. */
-MINIZ_EXPORT void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, size_t *pSize, mz_uint flags);
-MINIZ_EXPORT void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFilename, size_t *pSize, mz_uint flags);
+    /* Extracts a archive file to a dynamically allocated heap buffer. */
+    /* The memory will be allocated via the mz_zip_archive's alloc/realloc functions. */
+    /* Returns NULL and sets the last error on failure. */
+    MINIZ_EXPORT void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, size_t *pSize, mz_uint flags);
+    MINIZ_EXPORT void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFilename, size_t *pSize, mz_uint flags);
 
-/* Extracts a archive file using a callback function to output the file's data. */
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_index, mz_file_write_func pCallback, void *pOpaque, mz_uint flags);
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_callback(mz_zip_archive *pZip, const char *pFilename, mz_file_write_func pCallback, void *pOpaque, mz_uint flags);
+    /* Extracts a archive file using a callback function to output the file's data. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_index, mz_file_write_func pCallback, void *pOpaque, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_callback(mz_zip_archive *pZip, const char *pFilename, mz_file_write_func pCallback, void *pOpaque, mz_uint flags);
 
-/* Extract a file iteratively */
-MINIZ_EXPORT mz_zip_reader_extract_iter_state* mz_zip_reader_extract_iter_new(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags);
-MINIZ_EXPORT mz_zip_reader_extract_iter_state* mz_zip_reader_extract_file_iter_new(mz_zip_archive *pZip, const char *pFilename, mz_uint flags);
-MINIZ_EXPORT size_t mz_zip_reader_extract_iter_read(mz_zip_reader_extract_iter_state* pState, void* pvBuf, size_t buf_size);
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_iter_free(mz_zip_reader_extract_iter_state* pState);
+    /* Extract a file iteratively */
+    MINIZ_EXPORT mz_zip_reader_extract_iter_state *mz_zip_reader_extract_iter_new(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags);
+    MINIZ_EXPORT mz_zip_reader_extract_iter_state *mz_zip_reader_extract_file_iter_new(mz_zip_archive *pZip, const char *pFilename, mz_uint flags);
+    MINIZ_EXPORT size_t mz_zip_reader_extract_iter_read(mz_zip_reader_extract_iter_state *pState, void *pvBuf, size_t buf_size);
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_iter_free(mz_zip_reader_extract_iter_state *pState);
 
 #ifndef MINIZ_NO_STDIO
-/* Extracts a archive file to a disk file and sets its last accessed and modified times. */
-/* This function only extracts files, not archive directory records. */
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_file(mz_zip_archive *pZip, mz_uint file_index, const char *pDst_filename, mz_uint flags);
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_file(mz_zip_archive *pZip, const char *pArchive_filename, const char *pDst_filename, mz_uint flags);
+    /* Extracts a archive file to a disk file and sets its last accessed and modified times. */
+    /* This function only extracts files, not archive directory records. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_file(mz_zip_archive *pZip, mz_uint file_index, const char *pDst_filename, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_file(mz_zip_archive *pZip, const char *pArchive_filename, const char *pDst_filename, mz_uint flags);
 
-/* Extracts a archive file starting at the current position in the destination FILE stream. */
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_cfile(mz_zip_archive *pZip, mz_uint file_index, MZ_FILE *File, mz_uint flags);
-MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_cfile(mz_zip_archive *pZip, const char *pArchive_filename, MZ_FILE *pFile, mz_uint flags);
+    /* Extracts a archive file starting at the current position in the destination FILE stream. */
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_to_cfile(mz_zip_archive *pZip, mz_uint file_index, MZ_FILE *File, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_cfile(mz_zip_archive *pZip, const char *pArchive_filename, MZ_FILE *pFile, mz_uint flags);
 #endif
 
 #if 0
@@ -1289,114 +1393,113 @@ MINIZ_EXPORT mz_bool mz_zip_reader_extract_file_to_cfile(mz_zip_archive *pZip, c
 	mz_bool mz_zip_streaming_extract_end(mz_zip_archive *pZip, mz_zip_streaming_extract_state_ptr pState);
 #endif
 
-/* This function compares the archive's local headers, the optional local zip64 extended information block, and the optional descriptor following the compressed data vs. the data in the central directory. */
-/* It also validates that each file can be successfully uncompressed unless the MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY is specified. */
-MINIZ_EXPORT mz_bool mz_zip_validate_file(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags);
+    /* This function compares the archive's local headers, the optional local zip64 extended information block, and the optional descriptor following the compressed data vs. the data in the central directory. */
+    /* It also validates that each file can be successfully uncompressed unless the MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY is specified. */
+    MINIZ_EXPORT mz_bool mz_zip_validate_file(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags);
 
-/* Validates an entire archive by calling mz_zip_validate_file() on each file. */
-MINIZ_EXPORT mz_bool mz_zip_validate_archive(mz_zip_archive *pZip, mz_uint flags);
+    /* Validates an entire archive by calling mz_zip_validate_file() on each file. */
+    MINIZ_EXPORT mz_bool mz_zip_validate_archive(mz_zip_archive *pZip, mz_uint flags);
 
-/* Misc utils/helpers, valid for ZIP reading or writing */
-MINIZ_EXPORT mz_bool mz_zip_validate_mem_archive(const void *pMem, size_t size, mz_uint flags, mz_zip_error *pErr);
+    /* Misc utils/helpers, valid for ZIP reading or writing */
+    MINIZ_EXPORT mz_bool mz_zip_validate_mem_archive(const void *pMem, size_t size, mz_uint flags, mz_zip_error *pErr);
 #ifndef MINIZ_NO_STDIO
-MINIZ_EXPORT mz_bool mz_zip_validate_file_archive(const char *pFilename, mz_uint flags, mz_zip_error *pErr);
+    MINIZ_EXPORT mz_bool mz_zip_validate_file_archive(const char *pFilename, mz_uint flags, mz_zip_error *pErr);
 #endif
 
-/* Universal end function - calls either mz_zip_reader_end() or mz_zip_writer_end(). */
-MINIZ_EXPORT mz_bool mz_zip_end(mz_zip_archive *pZip);
+    /* Universal end function - calls either mz_zip_reader_end() or mz_zip_writer_end(). */
+    MINIZ_EXPORT mz_bool mz_zip_end(mz_zip_archive *pZip);
 
-/* -------- ZIP writing */
+    /* -------- ZIP writing */
 
 #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
 
-/* Inits a ZIP archive writer. */
-/*Set pZip->m_pWrite (and pZip->m_pIO_opaque) before calling mz_zip_writer_init or mz_zip_writer_init_v2*/
-/*The output is streamable, i.e. file_ofs in mz_file_write_func always increases only by n*/
-MINIZ_EXPORT mz_bool mz_zip_writer_init(mz_zip_archive *pZip, mz_uint64 existing_size);
-MINIZ_EXPORT mz_bool mz_zip_writer_init_v2(mz_zip_archive *pZip, mz_uint64 existing_size, mz_uint flags);
+    /* Inits a ZIP archive writer. */
+    /*Set pZip->m_pWrite (and pZip->m_pIO_opaque) before calling mz_zip_writer_init or mz_zip_writer_init_v2*/
+    /*The output is streamable, i.e. file_ofs in mz_file_write_func always increases only by n*/
+    MINIZ_EXPORT mz_bool mz_zip_writer_init(mz_zip_archive *pZip, mz_uint64 existing_size);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_v2(mz_zip_archive *pZip, mz_uint64 existing_size, mz_uint flags);
 
-MINIZ_EXPORT mz_bool mz_zip_writer_init_heap(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size);
-MINIZ_EXPORT mz_bool mz_zip_writer_init_heap_v2(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_heap(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_heap_v2(mz_zip_archive *pZip, size_t size_to_reserve_at_beginning, size_t initial_allocation_size, mz_uint flags);
 
 #ifndef MINIZ_NO_STDIO
-MINIZ_EXPORT mz_bool mz_zip_writer_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning);
-MINIZ_EXPORT mz_bool mz_zip_writer_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning, mz_uint flags);
-MINIZ_EXPORT mz_bool mz_zip_writer_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint64 size_to_reserve_at_beginning, mz_uint flags);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint flags);
 #endif
 
-/* Converts a ZIP archive reader object into a writer object, to allow efficient in-place file appends to occur on an existing archive. */
-/* For archives opened using mz_zip_reader_init_file, pFilename must be the archive's filename so it can be reopened for writing. If the file can't be reopened, mz_zip_reader_end() will be called. */
-/* For archives opened using mz_zip_reader_init_mem, the memory block must be growable using the realloc callback (which defaults to realloc unless you've overridden it). */
-/* Finally, for archives opened using mz_zip_reader_init, the mz_zip_archive's user provided m_pWrite function cannot be NULL. */
-/* Note: In-place archive modification is not recommended unless you know what you're doing, because if execution stops or something goes wrong before */
-/* the archive is finalized the file's central directory will be hosed. */
-MINIZ_EXPORT mz_bool mz_zip_writer_init_from_reader(mz_zip_archive *pZip, const char *pFilename);
-MINIZ_EXPORT mz_bool mz_zip_writer_init_from_reader_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags);
+    /* Converts a ZIP archive reader object into a writer object, to allow efficient in-place file appends to occur on an existing archive. */
+    /* For archives opened using mz_zip_reader_init_file, pFilename must be the archive's filename so it can be reopened for writing. If the file can't be reopened, mz_zip_reader_end() will be called. */
+    /* For archives opened using mz_zip_reader_init_mem, the memory block must be growable using the realloc callback (which defaults to realloc unless you've overridden it). */
+    /* Finally, for archives opened using mz_zip_reader_init, the mz_zip_archive's user provided m_pWrite function cannot be NULL. */
+    /* Note: In-place archive modification is not recommended unless you know what you're doing, because if execution stops or something goes wrong before */
+    /* the archive is finalized the file's central directory will be hosed. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_from_reader(mz_zip_archive *pZip, const char *pFilename);
+    MINIZ_EXPORT mz_bool mz_zip_writer_init_from_reader_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags);
 
-/* Adds the contents of a memory buffer to an archive. These functions record the current local time into the archive. */
-/* To add a directory entry, call this method with an archive name ending in a forwardslash with an empty buffer. */
-/* level_and_flags - compression level (0-10, see MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc.) logically OR'd with zero or more mz_zip_flags, or just set to MZ_DEFAULT_COMPRESSION. */
-MINIZ_EXPORT mz_bool mz_zip_writer_add_mem(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, mz_uint level_and_flags);
+    /* Adds the contents of a memory buffer to an archive. These functions record the current local time into the archive. */
+    /* To add a directory entry, call this method with an archive name ending in a forwardslash with an empty buffer. */
+    /* level_and_flags - compression level (0-10, see MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc.) logically OR'd with zero or more mz_zip_flags, or just set to MZ_DEFAULT_COMPRESSION. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_mem(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, mz_uint level_and_flags);
 
-/* Like mz_zip_writer_add_mem(), except you can specify a file comment field, and optionally supply the function with already compressed data. */
-/* uncomp_size/uncomp_crc32 are only used if the MZ_ZIP_FLAG_COMPRESSED_DATA flag is specified. */
-MINIZ_EXPORT mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
-                                              mz_uint64 uncomp_size, mz_uint32 uncomp_crc32);
+    /* Like mz_zip_writer_add_mem(), except you can specify a file comment field, and optionally supply the function with already compressed data. */
+    /* uncomp_size/uncomp_crc32 are only used if the MZ_ZIP_FLAG_COMPRESSED_DATA flag is specified. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
+                                                  mz_uint64 uncomp_size, mz_uint32 uncomp_crc32);
 
-MINIZ_EXPORT mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
-                                                 mz_uint64 uncomp_size, mz_uint32 uncomp_crc32, MZ_TIME_T *last_modified, const char *user_extra_data_local, mz_uint user_extra_data_local_len,
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
+                                                     mz_uint64 uncomp_size, mz_uint32 uncomp_crc32, MZ_TIME_T *last_modified, const char *user_extra_data_local, mz_uint user_extra_data_local_len,
+                                                     const char *user_extra_data_central, mz_uint user_extra_data_central_len);
+
+    /* Adds the contents of a file to an archive. This function also records the disk file's modified time into the archive. */
+    /* File data is supplied via a read callback function. User mz_zip_writer_add_(c)file to add a file directly.*/
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_read_buf_callback(mz_zip_archive *pZip, const char *pArchive_name, mz_file_read_func read_callback, void *callback_opaque, mz_uint64 max_size,
+                                                             const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, const char *user_extra_data_local, mz_uint user_extra_data_local_len,
+                                                             const char *user_extra_data_central, mz_uint user_extra_data_central_len);
+
+#ifndef MINIZ_NO_STDIO
+    /* Adds the contents of a disk file to an archive. This function also records the disk file's modified time into the archive. */
+    /* level_and_flags - compression level (0-10, see MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc.) logically OR'd with zero or more mz_zip_flags, or just set to MZ_DEFAULT_COMPRESSION. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, const char *pSrc_filename, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags);
+
+    /* Like mz_zip_writer_add_file(), except the file data is read from the specified FILE stream. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name, MZ_FILE *pSrc_file, mz_uint64 max_size,
+                                                 const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, const char *user_extra_data_local, mz_uint user_extra_data_local_len,
                                                  const char *user_extra_data_central, mz_uint user_extra_data_central_len);
-
-/* Adds the contents of a file to an archive. This function also records the disk file's modified time into the archive. */
-/* File data is supplied via a read callback function. User mz_zip_writer_add_(c)file to add a file directly.*/
-MINIZ_EXPORT mz_bool mz_zip_writer_add_read_buf_callback(mz_zip_archive *pZip, const char *pArchive_name, mz_file_read_func read_callback, void* callback_opaque, mz_uint64 max_size,
-	const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, const char *user_extra_data_local, mz_uint user_extra_data_local_len,
-	const char *user_extra_data_central, mz_uint user_extra_data_central_len);
-
-
-#ifndef MINIZ_NO_STDIO
-/* Adds the contents of a disk file to an archive. This function also records the disk file's modified time into the archive. */
-/* level_and_flags - compression level (0-10, see MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc.) logically OR'd with zero or more mz_zip_flags, or just set to MZ_DEFAULT_COMPRESSION. */
-MINIZ_EXPORT mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, const char *pSrc_filename, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags);
-
-/* Like mz_zip_writer_add_file(), except the file data is read from the specified FILE stream. */
-MINIZ_EXPORT mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name, MZ_FILE *pSrc_file, mz_uint64 max_size,
-                                const MZ_TIME_T *pFile_time, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, const char *user_extra_data_local, mz_uint user_extra_data_local_len,
-                                const char *user_extra_data_central, mz_uint user_extra_data_central_len);
 #endif
 
-/* Adds a file to an archive by fully cloning the data from another archive. */
-/* This function fully clones the source file's compressed data (no recompression), along with its full filename, extra data (it may add or modify the zip64 local header extra data field), and the optional descriptor following the compressed data. */
-MINIZ_EXPORT mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *pSource_zip, mz_uint src_file_index);
+    /* Adds a file to an archive by fully cloning the data from another archive. */
+    /* This function fully clones the source file's compressed data (no recompression), along with its full filename, extra data (it may add or modify the zip64 local header extra data field), and the optional descriptor following the compressed data. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *pSource_zip, mz_uint src_file_index);
 
-/* Finalizes the archive by writing the central directory records followed by the end of central directory record. */
-/* After an archive is finalized, the only valid call on the mz_zip_archive struct is mz_zip_writer_end(). */
-/* An archive must be manually finalized by calling this function for it to be valid. */
-MINIZ_EXPORT mz_bool mz_zip_writer_finalize_archive(mz_zip_archive *pZip);
+    /* Finalizes the archive by writing the central directory records followed by the end of central directory record. */
+    /* After an archive is finalized, the only valid call on the mz_zip_archive struct is mz_zip_writer_end(). */
+    /* An archive must be manually finalized by calling this function for it to be valid. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_finalize_archive(mz_zip_archive *pZip);
 
-/* Finalizes a heap archive, returning a pointer to the heap block and its size. */
-/* The heap block will be allocated using the mz_zip_archive's alloc/realloc callbacks. */
-MINIZ_EXPORT mz_bool mz_zip_writer_finalize_heap_archive(mz_zip_archive *pZip, void **ppBuf, size_t *pSize);
+    /* Finalizes a heap archive, returning a pointer to the heap block and its size. */
+    /* The heap block will be allocated using the mz_zip_archive's alloc/realloc callbacks. */
+    MINIZ_EXPORT mz_bool mz_zip_writer_finalize_heap_archive(mz_zip_archive *pZip, void **ppBuf, size_t *pSize);
 
-/* Ends archive writing, freeing all allocations, and closing the output file if mz_zip_writer_init_file() was used. */
-/* Note for the archive to be valid, it *must* have been finalized before ending (this function will not do it for you). */
-MINIZ_EXPORT mz_bool mz_zip_writer_end(mz_zip_archive *pZip);
+    /* Ends archive writing, freeing all allocations, and closing the output file if mz_zip_writer_init_file() was used. */
+    /* Note for the archive to be valid, it *must* have been finalized before ending (this function will not do it for you). */
+    MINIZ_EXPORT mz_bool mz_zip_writer_end(mz_zip_archive *pZip);
 
-/* -------- Misc. high-level helper functions: */
+    /* -------- Misc. high-level helper functions: */
 
-/* mz_zip_add_mem_to_archive_file_in_place() efficiently (but not atomically) appends a memory blob to a ZIP archive. */
-/* Note this is NOT a fully safe operation. If it crashes or dies in some way your archive can be left in a screwed up state (without a central directory). */
-/* level_and_flags - compression level (0-10, see MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc.) logically OR'd with zero or more mz_zip_flags, or just set to MZ_DEFAULT_COMPRESSION. */
-/* TODO: Perhaps add an option to leave the existing central dir in place in case the add dies? We could then truncate the file (so the old central dir would be at the end) if something goes wrong. */
-MINIZ_EXPORT mz_bool mz_zip_add_mem_to_archive_file_in_place(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags);
-MINIZ_EXPORT mz_bool mz_zip_add_mem_to_archive_file_in_place_v2(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, mz_zip_error *pErr);
+    /* mz_zip_add_mem_to_archive_file_in_place() efficiently (but not atomically) appends a memory blob to a ZIP archive. */
+    /* Note this is NOT a fully safe operation. If it crashes or dies in some way your archive can be left in a screwed up state (without a central directory). */
+    /* level_and_flags - compression level (0-10, see MZ_BEST_SPEED, MZ_BEST_COMPRESSION, etc.) logically OR'd with zero or more mz_zip_flags, or just set to MZ_DEFAULT_COMPRESSION. */
+    /* TODO: Perhaps add an option to leave the existing central dir in place in case the add dies? We could then truncate the file (so the old central dir would be at the end) if something goes wrong. */
+    MINIZ_EXPORT mz_bool mz_zip_add_mem_to_archive_file_in_place(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags);
+    MINIZ_EXPORT mz_bool mz_zip_add_mem_to_archive_file_in_place_v2(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, mz_zip_error *pErr);
 
 #ifndef MINIZ_NO_STDIO
-/* Reads a single file from an archive into a heap block. */
-/* If pComment is not NULL, only the file with the specified comment will be extracted. */
-/* Returns NULL on failure. */
-MINIZ_EXPORT void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char *pArchive_name, size_t *pSize, mz_uint flags);
-MINIZ_EXPORT void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const char *pArchive_name, const char *pComment, size_t *pSize, mz_uint flags, mz_zip_error *pErr);
+    /* Reads a single file from an archive into a heap block. */
+    /* If pComment is not NULL, only the file with the specified comment will be extracted. */
+    /* Returns NULL on failure. */
+    MINIZ_EXPORT void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char *pArchive_name, size_t *pSize, mz_uint flags);
+    MINIZ_EXPORT void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const char *pArchive_name, const char *pComment, size_t *pSize, mz_uint flags, mz_zip_error *pErr);
 #endif
 
 #endif /* #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS */


### PR DESCRIPTION
After spending some time on vpxbct, I figured I could make the webserver for standalone look nicer. 

Currently it looks like:

![Screenshot 2025-04-19 at 12 44 49 AM](https://github.com/user-attachments/assets/a1b1088b-92a3-45d0-a4eb-eace98a33f24)

Now it looks like:

![Screenshot 2025-04-19 at 12 50 31 AM](https://github.com/user-attachments/assets/97c8f9fd-487d-4632-a6d0-aa8beddd240e)

A few other things in this PR:

- upgraded Mongoose ws to 7.17
- upgraded miniz to latest head to fix zip uncompress issues caused by Windows built in compressor
- removed all references `LaunchTable` ini settings
- removed Web Server and IP address from LiveUI
- Added a new `/status` endpoint to return the version and currently running table
- Removed the `/activate` endpoint since that was linked to `LaunchTable`
- Added the ability to fetch other assets inside of assets folder instead of only `vpx.html`
- fixed two type info sections for the now enabled VBScript RegExp

