### PR TITLE
standalone: improved case insensitive find file and directory paths

### DIFF
--- a/plugins/flexdmd/common.h
+++ b/plugins/flexdmd/common.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <cstdint>
 #include <cassert>
+#include <cstdarg>
+#include <cstdio>
 
 #include <string>
 using namespace std::string_literals;
@@ -29,10 +30,8 @@ typedef uint32_t ColorRGBA32;
 
 #ifdef _MSC_VER
 #define PATH_SEPARATOR_CHAR '\\'
-#define PATH_SEPARATOR_WCHAR L'\\'
 #else
 #define PATH_SEPARATOR_CHAR '/'
-#define PATH_SEPARATOR_WCHAR L'/'
 #endif
 
 #ifdef min
@@ -46,8 +45,9 @@ template <typename T> __forceinline T max(const T x, const T y) { return x < y ?
 
 string string_to_lower(string str);
 string trim_string(const string& str);
-string extension_from_path(const string& path);
-string normalize_path_separators(const string& szPath);
 int string_to_int(const string& str, int defaultValue = 0);
 bool try_parse_int(const string& str, int& value);
 bool try_parse_color(const string& str, ColorRGBA32& value);
+string normalize_path_separators(const string& szPath);
+string extension_from_path(const string& path);
+string find_case_insensitive_file_path(const string& szPath);

--- a/plugins/flexdmd/resources/AssetManager.cpp
+++ b/plugins/flexdmd/resources/AssetManager.cpp
@@ -124,7 +124,7 @@ AssetSrc* AssetManager::ResolveSrc(const string& src, AssetSrc* pBaseSrc)
          {
             pAssetSrc->SetAssetType(AssetType_Image);
             if (file.size() > 4)
-               ext = string_to_lower(extension_from_path(file));
+               ext = extension_from_path(file);
          }
       }
    }
@@ -234,14 +234,15 @@ void* AssetManager::Open(AssetSrc* pSrc)
    switch(pSrc->GetSrcType()) {
       case AssetSrcType_File:
       {
-        const string& path = pSrc->GetPath();
-
-        if (pSrc->GetAssetType() == AssetType_BMFont)
-           pAsset = BitmapFont::Create(path);
-        else if (pSrc->GetAssetType() != AssetType_GIF)
-           pAsset = IMG_Load(path.c_str());
-        else
-           pAsset = IMG_LoadAnimation(path.c_str());
+        string path = find_case_insensitive_file_path(pSrc->GetPath());
+        if (!path.empty()) {
+           if (pSrc->GetAssetType() == AssetType_BMFont)
+              pAsset = BitmapFont::Create(path);
+           else if (pSrc->GetAssetType() != AssetType_GIF)
+              pAsset = IMG_Load(path.c_str());
+           else
+              pAsset = IMG_LoadAnimation(path.c_str());
+        }
       }
       break;
       case AssetSrcType_FlexResource:
@@ -270,12 +271,15 @@ void* AssetManager::Open(AssetSrc* pSrc)
                }
             }
          #endif
-         if (pSrc->GetAssetType() == AssetType_BMFont)
-            pAsset = BitmapFont::Create(path);
-         else if (pSrc->GetAssetType() != AssetType_GIF)
-            pAsset = IMG_Load(path.c_str());
-         else
-            pAsset = IMG_LoadAnimation(path.c_str());
+         path = find_case_insensitive_file_path(path);
+         if (!path.empty()) {
+            if (pSrc->GetAssetType() == AssetType_BMFont)
+               pAsset = BitmapFont::Create(path);
+            else if (pSrc->GetAssetType() != AssetType_GIF)
+               pAsset = IMG_Load(path.c_str());
+            else
+               pAsset = IMG_LoadAnimation(path.c_str());
+         }
       }
       break;
       case AssetSrcType_VPXResource:

--- a/plugins/pinmame/PinMamePlugin.cpp
+++ b/plugins/pinmame/PinMamePlugin.cpp
@@ -591,7 +591,7 @@ MSGPI_EXPORT void MSGPIAPI PluginLoad(const uint32_t sessionId, MsgPluginAPI* ap
          VPXTableInfo tableInfo;
          vpxApi->GetTableInfo(&tableInfo);
          std::filesystem::path tablePath = tableInfo.path;
-         pinmamePath = find_directory_case_insensitive(tablePath.parent_path().string(), "pinmame"s);
+         pinmamePath = find_case_insensitive_directory_path(tablePath.parent_path().string() + "pinmame"s);
       }
       if (pinmamePath.empty())
       {

--- a/plugins/pinmame/common.cpp
+++ b/plugins/pinmame/common.cpp
@@ -11,34 +11,74 @@ static inline char cLower(char c)
    return c;
 }
 
-static inline string string_to_lower(string str)
+static inline bool StrCompareNoCase(const string& strA, const string& strB)
 {
-   std::ranges::transform(str.begin(), str.end(), str.begin(), cLower);
-   return str;
+   return strA.length() == strB.length()
+      && std::equal(strA.begin(), strA.end(), strB.begin(),
+         [](char a, char b) { return cLower(a) == cLower(b); });
 }
 
-string find_directory_case_insensitive(const std::string& szParentPath, const std::string& szDirName)
+string normalize_path_separators(const string& szPath)
 {
-   const std::filesystem::path parentPath(szParentPath);
-   if (!std::filesystem::exists(parentPath) || !std::filesystem::is_directory(parentPath))
-      return string();
+   string szResult = szPath;
 
-   const std::filesystem::path fullPath = parentPath / szDirName;
-   if (std::filesystem::exists(fullPath) && std::filesystem::is_directory(fullPath))
-      return fullPath.string() + PATH_SEPARATOR_CHAR;
+   if (PATH_SEPARATOR_CHAR == '/')
+      std::ranges::replace(szResult.begin(), szResult.end(), '\\', PATH_SEPARATOR_CHAR);
+   else
+      std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
 
-   const string szDirLower = string_to_lower(szDirName);
-   for (const auto& entry : std::filesystem::directory_iterator(parentPath)) {
-      if (!std::filesystem::is_directory(entry.status()))
-         continue;
+   auto end = std::unique(szResult.begin(), szResult.end(),
+      [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
+   szResult.erase(end, szResult.end());
 
-      if (string_to_lower(entry.path().filename().string()) == szDirLower) {
-         string szMatch = entry.path().string() + PATH_SEPARATOR_CHAR;
-         LOGI("case-insensitive match was found: szParentPath=%s, szDirName=%s, match=%s",
-            szParentPath.c_str(), szDirName.c_str(), szMatch.c_str());
-         return szMatch;
-      }
+   return szResult;
+}
+
+string find_case_insensitive_directory_path(const string& szPath)
+{
+   std::filesystem::path p(normalize_path_separators(szPath));
+   if (p.is_relative())
+      p = std::filesystem::current_path() / p;
+   p = p.lexically_normal();
+
+   if (std::filesystem::exists(p) && std::filesystem::is_directory(p)) {
+      auto realPath = std::filesystem::canonical(p);
+      string match = realPath.string();
+      if (!match.empty() && match.back() != PATH_SEPARATOR_CHAR)
+         match.push_back(PATH_SEPARATOR_CHAR);
+      return match;
    }
 
-   return string();
+   std::filesystem::path result = p.root_path();
+   if (result.empty())
+      result = std::filesystem::current_path().root_path();
+
+   for (auto it = std::next(p.begin()); it != p.end(); ++it) {
+      const string name = it->string();
+      if (!std::filesystem::exists(result) || !std::filesystem::is_directory(result))
+         return string();
+
+      bool matched = false;
+      for (const auto& entry : std::filesystem::directory_iterator(result)) {
+         const string fname = entry.path().filename().string();
+         if (StrCompareNoCase(fname, name)) {
+            result /= entry.path().filename();
+            matched = true;
+            break;
+         }
+      }
+      if (!matched)
+         return string();
+   }
+
+   if (!std::filesystem::exists(result) || !std::filesystem::is_directory(result))
+      return string();
+
+   auto realPath = std::filesystem::canonical(result);
+   string match = realPath.string();
+   if (!match.empty() && match.back() != PATH_SEPARATOR_CHAR)
+      match.push_back(PATH_SEPARATOR_CHAR);
+
+   LOGI("exact directory not found, but a case-insensitive directory match was found: szPath=%s, match=%s", szPath.c_str(), match.c_str());
+   return match;
 }

--- a/plugins/pinmame/common.h
+++ b/plugins/pinmame/common.h
@@ -1,12 +1,16 @@
 #pragma once
 
-#include "libpinmame.h"
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
 
 #include <string>
 using std::string;
 
 #include <vector>
 using std::vector;
+
+#include "libpinmame.h"
 
 // Shared logging
 #include "LoggingPlugin.h"
@@ -21,10 +25,8 @@ PSC_USE_ERROR();
 
 #ifdef _MSC_VER
 #define PATH_SEPARATOR_CHAR '\\'
-#define PATH_SEPARATOR_WCHAR L'\\'
 #else
 #define PATH_SEPARATOR_CHAR '/'
-#define PATH_SEPARATOR_WCHAR L'/'
 #endif
 
-string find_directory_case_insensitive(const std::string& szParentPath, const std::string& szDirName);
+string find_case_insensitive_directory_path(const string& szPath);

--- a/plugins/serum/common.cpp
+++ b/plugins/serum/common.cpp
@@ -10,32 +10,74 @@ inline char cLower(char c)
    return c;
 }
 
-string string_to_lower(string str)
+static inline bool StrCompareNoCase(const string& strA, const string& strB)
 {
-   std::ranges::transform(str.begin(), str.end(), str.begin(), cLower);
-   return str;
+   return strA.length() == strB.length()
+      && std::equal(strA.begin(), strA.end(), strB.begin(),
+         [](char a, char b) { return cLower(a) == cLower(b); });
 }
 
-string find_directory_case_insensitive(const string& szParentPath, const string& szDirName)
+string normalize_path_separators(const string& szPath)
 {
-   const std::filesystem::path parentPath(szParentPath);
-   if (!std::filesystem::exists(parentPath) || !std::filesystem::is_directory(parentPath))
-      return string();
+   string szResult = szPath;
 
-   const std::filesystem::path fullPath = parentPath / szDirName;
-   if (std::filesystem::exists(fullPath) && std::filesystem::is_directory(fullPath))
-      return fullPath.string() + PATH_SEPARATOR_CHAR;
+   if (PATH_SEPARATOR_CHAR == '/')
+      std::ranges::replace(szResult.begin(), szResult.end(), '\\', PATH_SEPARATOR_CHAR);
+   else
+      std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
 
-   const string szDirLower = string_to_lower(szDirName);
-   for (const auto& entry : std::filesystem::directory_iterator(parentPath)) {
-      if (!std::filesystem::is_directory(entry.status()))
-         continue;
+   auto end = std::unique(szResult.begin(), szResult.end(),
+      [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
+   szResult.erase(end, szResult.end());
 
-      if (string_to_lower(entry.path().filename().string()) == szDirLower) {
-         string szMatch = entry.path().string() + PATH_SEPARATOR_CHAR;
-         return szMatch;
-      }
+   return szResult;
+}
+
+string find_case_insensitive_directory_path(const string& szPath)
+{
+   std::filesystem::path p(normalize_path_separators(szPath));
+   if (p.is_relative())
+      p = std::filesystem::current_path() / p;
+   p = p.lexically_normal();
+
+   if (std::filesystem::exists(p) && std::filesystem::is_directory(p)) {
+      auto realPath = std::filesystem::canonical(p);
+      string match = realPath.string();
+      if (!match.empty() && match.back() != PATH_SEPARATOR_CHAR)
+         match.push_back(PATH_SEPARATOR_CHAR);
+      return match;
    }
 
-   return string();
+   std::filesystem::path result = p.root_path();
+   if (result.empty())
+      result = std::filesystem::current_path().root_path();
+
+   for (auto it = std::next(p.begin()); it != p.end(); ++it) {
+      const string name = it->string();
+      if (!std::filesystem::exists(result) || !std::filesystem::is_directory(result))
+         return string();
+
+      bool matched = false;
+      for (const auto& entry : std::filesystem::directory_iterator(result)) {
+         const string fname = entry.path().filename().string();
+         if (StrCompareNoCase(fname, name)) {
+            result /= entry.path().filename();
+            matched = true;
+            break;
+         }
+      }
+      if (!matched)
+         return string();
+   }
+
+   if (!std::filesystem::exists(result) || !std::filesystem::is_directory(result))
+      return string();
+
+   auto realPath = std::filesystem::canonical(result);
+   string match = realPath.string();
+   if (!match.empty() && match.back() != PATH_SEPARATOR_CHAR)
+      match.push_back(PATH_SEPARATOR_CHAR);
+
+   LOGI("exact directory not found, but a case-insensitive directory match was found: szPath=%s, match=%s", szPath.c_str(), match.c_str());
+   return match;
 }

--- a/plugins/serum/common.h
+++ b/plugins/serum/common.h
@@ -1,14 +1,23 @@
 #pragma once
 
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+
 #include <string>
 using std::string;
 
+// Shared logging
+#include "LoggingPlugin.h"
+LPI_USE();
+#define LOGD LPI_LOGD
+#define LOGI LPI_LOGI
+#define LOGE LPI_LOGE
+
 #ifdef _MSC_VER
 #define PATH_SEPARATOR_CHAR '\\'
-#define PATH_SEPARATOR_WCHAR L'\\'
 #else
 #define PATH_SEPARATOR_CHAR '/'
-#define PATH_SEPARATOR_WCHAR L'/'
 #endif
 
-string find_directory_case_insensitive(const string& szParentPath, const string& szDirName);
+string find_case_insensitive_directory_path(const string& szPath);

--- a/plugins/serum/serum.cpp
+++ b/plugins/serum/serum.cpp
@@ -17,6 +17,8 @@ using namespace std::string_literals;
  #define strcpy_s(A, B, C) strncpy(A, C, B)
 #endif
 
+LPI_IMPLEMENT // Implement shared login support
+
 ///////////////////////////////////////////////////////////////////////////////
 // Serum Colorization plugin
 //
@@ -268,7 +270,7 @@ static void onGameStart(const unsigned int eventId, void* userData, void* msgDat
    // Setup Serum on the selected DMD
    const PMPI_MSG_ON_GAME_START* msg = static_cast<const PMPI_MSG_ON_GAME_START*>(msgData);
    assert(msg != nullptr && msg->vpmPath != nullptr && msg->gameId != nullptr);
-   std::string altColorPath = find_directory_case_insensitive(msg->vpmPath, "altcolor"s);
+   std::string altColorPath = find_case_insensitive_directory_path(msg->vpmPath + "altcolor"s);
    char crzFolder[512];
    if (!altColorPath.empty())
       strcpy_s(crzFolder, sizeof(crzFolder), altColorPath.c_str());
@@ -303,6 +305,10 @@ MSGPI_EXPORT void MSGPIAPI PluginLoad(const uint32_t sessionId, MsgPluginAPI* ap
 {
    msgApi = api;
    endpointId = sessionId;
+
+   // Request and setup shared login API
+   LPISetup(endpointId, msgApi);
+
    onDmdSrcChangedId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_ONDMD_SRC_CHG_MSG);
    getDmdSrcId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_GETDMD_SRC_MSG);
    getRenderDmdId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_GETDMD_RENDER_MSG);

--- a/src/audio/pinsound.cpp
+++ b/src/audio/pinsound.cpp
@@ -648,8 +648,14 @@ bool PinSound::SetMusicFile(const string& szFileName)
    if(m_pMixMusic != nullptr)
       Mix_FreeMusic(m_pMixMusic);
 
-   if(!(m_pMixMusic = Mix_LoadMUS(szFileName.c_str())))
-   {
+   string path = find_case_insensitive_file_path(szFileName);
+   if (path.empty()) {
+      PLOGE << "Failed to find music file: " << szFileName;
+      return false;
+   }
+
+   m_pMixMusic = Mix_LoadMUS(path.c_str());
+   if (!m_pMixMusic) {
       PLOGE << "Failed to load sound: " << SDL_GetError();
       return false;
    }
@@ -679,11 +685,7 @@ bool PinSound::MusicInit(const string& szFileName, const float volume)
 {
    m_outputTarget = SNDOUT_BACKGLASS;
 
-   #ifndef __STANDALONE__
-      const string& filename = szFileName;
-   #else
-      const string filename = normalize_path_separators(szFileName);
-   #endif
+   const string& filename = szFileName;
 
    if(m_pMixMusic != nullptr)
       Mix_FreeMusic(m_pMixMusic);
@@ -695,21 +697,15 @@ bool PinSound::MusicInit(const string& szFileName, const float volume)
       switch (i)
       {
       case 0: break;
-      #ifdef __STANDALONE__
-      case 1: path = find_directory_case_insensitive(g_pvp->m_szMyPath, "music"s) + PATH_SEPARATOR_CHAR; break;
-      case 2: path = g_pvp->m_currentTablePath; break;
-      case 3: path = find_directory_case_insensitive(g_pvp->m_currentTablePath, "music"s) + PATH_SEPARATOR_CHAR; break;
-      #else
       case 1: path = g_pvp->m_szMyPath + "music" + PATH_SEPARATOR_CHAR; break;
       case 2: path = g_pvp->m_currentTablePath; break;
       case 3: path = g_pvp->m_currentTablePath + "music" + PATH_SEPARATOR_CHAR; break;
-      #endif
       case 4: path = PATH_MUSIC; break;
       }
       path += filename;
 
       #ifdef __STANDALONE__
-      path = find_path_case_insensitive(path);
+      path = find_case_insensitive_file_path(path);
       #endif
 
       if ((m_pMixMusic = Mix_LoadMUS(path.c_str())))

--- a/src/core/def.h
+++ b/src/core/def.h
@@ -715,6 +715,13 @@ CONSTEXPR inline void StrToUpper(string& str)
    std::ranges::transform(str.begin(), str.end(), str.begin(), cUpper);
 }
 
+inline bool StrCompareNoCase(const string& strA, const string& strB)
+{
+   return strA.length() == strB.length()
+      && std::equal(strA.begin(), strA.end(), strB.begin(),
+         [](char a, char b) { return cLower(a) == cLower(b); });
+}
+
 CONSTEXPR inline string lowerCase(string input)
 {
    StrToLower(input);
@@ -727,13 +734,6 @@ CONSTEXPR inline string upperCase(string input)
    return input;
 }
 
-inline bool StrCompareNoCase(const string& strA, const string& strB)
-{
-   return strA.length() == strB.length()
-      && std::equal(strA.begin(), strA.end(), strB.begin(), 
-         [](char a, char b) { return cLower(a) == cLower(b); });
-}
-
 /**
  * @brief Detect whether the program is running on the Wine compatibility layer
  */
@@ -744,11 +744,10 @@ bool IsWindows10_1803orAbove();
 #include "renderer/typedefs3D.h"
 
 void copy_folder(const string& srcPath, const string& dstPath);
-vector<string> find_files_by_extension(const string& directoryPath, const string& extension);
-string find_path_case_insensitive(const string& szPath);
-string find_directory_case_insensitive(const string& szParentPath, const string& szDirName);
-string extension_from_path(const string& path);
 string normalize_path_separators(const string& szPath);
+string find_case_insensitive_file_path(const string& szPath);
+string find_case_insensitive_directory_path(const string& szPath);
+string extension_from_path(const string& path);
 bool path_has_extension(const string& path, const string& extension);
 bool try_parse_int(const string& str, int& value);
 bool try_parse_float(const string& str, float& value);
@@ -760,7 +759,6 @@ string trim_string(const string& str);
 vector<string> parse_csv_line(const string& line);
 string color_to_hex(OLE_COLOR color);
 bool string_contains_case_insensitive(const string& str1, const string& str2);
-bool string_compare_case_insensitive(const string& str1, const string& str2);
 bool string_starts_with_case_insensitive(const string& str, const string& prefix);
 string string_replace_all(const string& szStr, const string& szFrom, const string& szTo, const size_t offs = 0);
 string create_hex_dump(const UINT8* buffer, size_t size);

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -339,7 +339,7 @@ bool ScriptGlobalTable::GetTextFileFromDirectory(const string& szfilename, const
    // else: use current directory
    szPath += szfilename;
    #ifdef __STANDALONE__
-   szPath = find_path_case_insensitive(szPath);
+   szPath = find_case_insensitive_file_path(szPath);
    #endif
    if (!szPath.empty()) {
       std::ifstream scriptFile;

--- a/src/parts/textbox.cpp
+++ b/src/parts/textbox.cpp
@@ -892,7 +892,7 @@ TTF_Font* Textbox::LoadFont()
 
    string szPath;
    for (const auto& szStyle : styles) {
-      szPath = find_path_case_insensitive(g_pvp->m_currentTablePath + szFontName + szStyle + ".ttf");
+      szPath = find_case_insensitive_file_path(g_pvp->m_currentTablePath + szFontName + szStyle + ".ttf");
       if (!szPath.empty()) {
          pFont = TTF_OpenFont(szPath.c_str(), m_fontSize);
          if (pFont) {

--- a/standalone/inc/b2s/forms/FormBackglass.cpp
+++ b/standalone/inc/b2s/forms/FormBackglass.cpp
@@ -335,7 +335,7 @@ void FormBackglass::StopSound(const string& szSoundName)
 
 void FormBackglass::LoadB2SData()
 {
-   string szFilename = find_path_case_insensitive(TitleAndPathFromFilename(m_pB2SData->GetTableFileName().c_str()) + ".directb2s");
+   string szFilename = find_case_insensitive_file_path(TitleAndPathFromFilename(m_pB2SData->GetTableFileName().c_str()) + ".directb2s");
    if (szFilename.empty()) {
       PLOGW.printf("No directb2s file found");
       return;

--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -21,7 +21,7 @@ PUPManager::PUPManager()
 {
    m_init = false;
    m_isRunning = false;
-   m_szRootPath = find_directory_case_insensitive(g_pvp->m_currentTablePath, "pupvideos");
+   m_szRootPath = find_case_insensitive_directory_path(g_pvp->m_currentTablePath + "pupvideos");
 }
 
 PUPManager::~PUPManager()
@@ -41,7 +41,7 @@ void PUPManager::LoadConfig(const string& szRomName)
       return;
    }
 
-   m_szPath = find_directory_case_insensitive(m_szRootPath, szRomName);
+   m_szPath = find_case_insensitive_directory_path(m_szRootPath + szRomName);
    if (m_szPath.empty())
       return;
 
@@ -53,7 +53,7 @@ void PUPManager::LoadConfig(const string& szRomName)
 
    // Load screens
 
-   string szScreensPath = find_path_case_insensitive(m_szPath + "screens.pup");
+   string szScreensPath = find_case_insensitive_file_path(m_szPath + "screens.pup");
    if (!szScreensPath.empty()) {
       std::ifstream screensFile;
       screensFile.open(szScreensPath, std::ifstream::in);
@@ -88,7 +88,7 @@ void PUPManager::LoadConfig(const string& szRomName)
 
    // Load Fonts
 
-   string szFontsPath = find_directory_case_insensitive(m_szPath, "FONTS");
+   string szFontsPath = find_case_insensitive_directory_path(m_szPath + "FONTS");
    if (!szFontsPath.empty()) {
       for (const auto& entry : std::filesystem::directory_iterator(szFontsPath)) {
          if (entry.is_regular_file()) {
@@ -116,7 +116,7 @@ void PUPManager::LoadConfig(const string& szRomName)
 
 void PUPManager::LoadPlaylists()
 {
-   string szPlaylistsPath = find_path_case_insensitive(GetPath() + "playlists.pup");
+   string szPlaylistsPath = find_case_insensitive_file_path(GetPath() + "playlists.pup");
    std::ifstream playlistsFile;
    playlistsFile.open(szPlaylistsPath, std::ifstream::in);
    if (playlistsFile.is_open()) {

--- a/standalone/inc/pup/PUPPlaylist.cpp
+++ b/standalone/inc/pup/PUPPlaylist.cpp
@@ -48,18 +48,18 @@ PUPPlaylist::PUPPlaylist(const string& szFolder, const string& szDescription, bo
    m_priority = priority;
    m_lastIndex = 0;
 
-   if (string_compare_case_insensitive(szFolder, "PUPOverlays"))
+   if (StrCompareNoCase(szFolder, "PUPOverlays"))
       m_function = PUP_PLAYLIST_FUNCTION_OVERLAYS;
-   else if (string_compare_case_insensitive(szFolder, "PUPFrames"))
+   else if (StrCompareNoCase(szFolder, "PUPFrames"))
       m_function = PUP_PLAYLIST_FUNCTION_FRAMES;
-   else if (string_compare_case_insensitive(szFolder, "PUPAlphas"))
+   else if (StrCompareNoCase(szFolder, "PUPAlphas"))
       m_function = PUP_PLAYLIST_FUNCTION_ALPHAS;
-   else if (string_compare_case_insensitive(szFolder, "PuPShapes"))
+   else if (StrCompareNoCase(szFolder, "PuPShapes"))
       m_function = PUP_PLAYLIST_FUNCTION_SHAPES;
    else
       m_function = PUP_PLAYLIST_FUNCTION_DEFAULT;
 
-   m_szBasePath = find_directory_case_insensitive(PUPManager::GetInstance()->GetPath(), szFolder);
+   m_szBasePath = find_case_insensitive_directory_path(PUPManager::GetInstance()->GetPath() + szFolder);
    if (m_szBasePath.empty()) {
       PLOGE.printf("Playlist folder not found: %s", szFolder.c_str());
       return;
@@ -90,7 +90,7 @@ PUPPlaylist* PUPPlaylist::CreateFromCSV(const string& line)
       return nullptr;
    }
 
-   string szFolderPath = find_directory_case_insensitive(PUPManager::GetInstance()->GetPath(), parts[1]);
+   string szFolderPath = find_case_insensitive_directory_path(PUPManager::GetInstance()->GetPath() + parts[1]);
    if (szFolderPath.empty()) {
       PLOGW.printf("Playlist folder not found: %s", parts[1].c_str());
       return nullptr;

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -134,19 +134,19 @@ PUPScreen* PUPScreen::CreateFromCSV(const string& line, const std::vector<PUPPla
    }
 
    PUP_SCREEN_MODE mode;
-   if (string_compare_case_insensitive(parts[5], "Show"))
+   if (StrCompareNoCase(parts[5], "Show"))
       mode = PUP_SCREEN_MODE_SHOW;
-   else if (string_compare_case_insensitive(parts[5], "ForceON"))
+   else if (StrCompareNoCase(parts[5], "ForceON"))
       mode = PUP_SCREEN_MODE_FORCE_ON;
-   else if (string_compare_case_insensitive(parts[5], "ForcePoP"))
+   else if (StrCompareNoCase(parts[5], "ForcePoP"))
       mode = PUP_SCREEN_MODE_FORCE_POP;
-   else if (string_compare_case_insensitive(parts[5], "ForceBack"))
+   else if (StrCompareNoCase(parts[5], "ForceBack"))
       mode = PUP_SCREEN_MODE_FORCE_BACK;
-   else if (string_compare_case_insensitive(parts[5], "ForcePopBack"))
+   else if (StrCompareNoCase(parts[5], "ForcePopBack"))
       mode = PUP_SCREEN_MODE_FORCE_POP_BACK;
-   else if (string_compare_case_insensitive(parts[5], "MusicOnly"))
+   else if (StrCompareNoCase(parts[5], "MusicOnly"))
       mode = PUP_SCREEN_MODE_MUSIC_ONLY;
-   else if (string_compare_case_insensitive(parts[5], "Off"))
+   else if (StrCompareNoCase(parts[5], "Off"))
       mode = PUP_SCREEN_MODE_OFF;
    else {
       PLOGW.printf("Invalid screen mode: %s", parts[5].c_str());
@@ -189,7 +189,7 @@ PUPScreen* PUPScreen::CreateDefault(int screenNum, const std::vector<PUPPlaylist
 
 void PUPScreen::LoadTriggers()
 {
-   string szPlaylistsPath = find_path_case_insensitive(m_pManager->GetPath() + "triggers.pup");
+   string szPlaylistsPath = find_case_insensitive_file_path(m_pManager->GetPath() + "triggers.pup");
    std::ifstream triggersFile;
    triggersFile.open(szPlaylistsPath, std::ifstream::in);
    if (triggersFile.is_open()) {

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -94,7 +94,7 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
       return nullptr;
    }
 
-   if (string_compare_case_insensitive(triggerPlayAction, "CustomFunc")) {
+   if (StrCompareNoCase(triggerPlayAction, "CustomFunc")) {
       // TODO parse the custom function and call PUPPinDisplay::SendMSG when triggered
       PLOGW.printf("CustomFunc not implemented: %s", line.c_str());
       return nullptr;
@@ -122,23 +122,23 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
    }
 
    PUP_TRIGGER_PLAY_ACTION playAction;
-   if (string_compare_case_insensitive(triggerPlayAction, "Loop"))
+   if (StrCompareNoCase(triggerPlayAction, "Loop"))
       playAction = PUP_TRIGGER_PLAY_ACTION_LOOP;
-   else if (string_compare_case_insensitive(triggerPlayAction, "SplashReset"))
+   else if (StrCompareNoCase(triggerPlayAction, "SplashReset"))
       playAction = PUP_TRIGGER_PLAY_ACTION_SPLASH_RESET;
-   else if (string_compare_case_insensitive(triggerPlayAction, "SplashReturn"))
+   else if (StrCompareNoCase(triggerPlayAction, "SplashReturn"))
       playAction = PUP_TRIGGER_PLAY_ACTION_SPLASH_RESET;
-   else if (string_compare_case_insensitive(triggerPlayAction, "StopPlayer"))
+   else if (StrCompareNoCase(triggerPlayAction, "StopPlayer"))
       playAction = PUP_TRIGGER_PLAY_ACTION_STOP_PLAYER;
-   else if (string_compare_case_insensitive(triggerPlayAction, "StopFile"))
+   else if (StrCompareNoCase(triggerPlayAction, "StopFile"))
       playAction = PUP_TRIGGER_PLAY_ACTION_STOP_FILE;
-   else if (string_compare_case_insensitive(triggerPlayAction, "SetBG"))
+   else if (StrCompareNoCase(triggerPlayAction, "SetBG"))
       playAction = PUP_TRIGGER_PLAY_ACTION_SET_BG;
-   else if (string_compare_case_insensitive(triggerPlayAction, "PlaySSF"))
+   else if (StrCompareNoCase(triggerPlayAction, "PlaySSF"))
       playAction = PUP_TRIGGER_PLAY_ACTION_PLAY_SSF;
-   else if (string_compare_case_insensitive(triggerPlayAction, "SkipSamePrty"))
+   else if (StrCompareNoCase(triggerPlayAction, "SkipSamePrty"))
       playAction = PUP_TRIGGER_PLAY_ACTION_SKIP_SAME_PRTY;
-   else if (string_compare_case_insensitive(triggerPlayAction, "CustomFunc"))
+   else if (StrCompareNoCase(triggerPlayAction, "CustomFunc"))
       playAction = PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC;
    else
       playAction = PUP_TRIGGER_PLAY_ACTION_NORMAL;

--- a/standalone/inc/vpinmame/VPinMAMEController.cpp
+++ b/standalone/inc/vpinmame/VPinMAMEController.cpp
@@ -56,13 +56,13 @@ void PINMAMECALLBACK VPinMAMEController::OnDisplayAvailable(int index, int displ
       pDisplay->pDMD->SetRomName(pController->m_pPinmameGame->name);
 
       if (g_pplayer->m_ptable->m_settings.LoadValueWithDefault(Settings::Standalone, "AltColor"s, true)) {
-         string szAltColorPath = find_directory_case_insensitive(pController->m_szPath, "AltColor");
+         string szAltColorPath = find_case_insensitive_directory_path(pController->m_szPath + "AltColor");
          if (!szAltColorPath.empty())
             pDisplay->pDMD->SetAltColorPath(szAltColorPath.c_str());
       }
 
       if (g_pplayer->m_ptable->m_settings.LoadValueWithDefault(Settings::Standalone, "PUPCapture"s, false)) {
-         string szPupVideosPath = find_directory_case_insensitive(g_pvp->m_currentTablePath, "pupvideos");
+         string szPupVideosPath = find_case_insensitive_directory_path(g_pvp->m_currentTablePath + "pupvideos");
          if (!szPupVideosPath.empty())
             pDisplay->pDMD->SetPUPVideosPath(szPupVideosPath.c_str());
       }
@@ -171,17 +171,16 @@ VPinMAMEController::VPinMAMEController()
 
    Settings* const pSettings = &g_pplayer->m_ptable->m_settings;
 
-   m_szPath = find_directory_case_insensitive(g_pvp->m_currentTablePath, "pinmame");
+   m_szPath = find_case_insensitive_directory_path(g_pvp->m_currentTablePath + "pinmame");
    if (m_szPath.empty()) {
       m_szPath = pSettings->LoadValueWithDefault(Settings::Standalone, "PinMAMEPath"s, ""s);
-
       if (!m_szPath.empty()) {
          if (!m_szPath.ends_with(PATH_SEPARATOR_CHAR))
             m_szPath += PATH_SEPARATOR_CHAR;
       }
       else {
 #if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
-         m_szPath = find_directory_case_insensitive(g_pvp->m_szMyPath, "pinmame");
+         m_szPath = find_case_insensitive_directory_path(g_pvp->m_szMyPath + "pinmame");
 #else
          m_szPath = string(getenv("HOME")) + PATH_SEPARATOR_CHAR + ".pinmame" + PATH_SEPARATOR_CHAR;
 #endif
@@ -192,7 +191,7 @@ VPinMAMEController::VPinMAMEController()
 
    PLOGI.printf("PinMAME path set to: %s", m_szPath.c_str());
 
-   m_szIniPath = find_directory_case_insensitive(m_szPath, "ini");
+   m_szIniPath = find_case_insensitive_directory_path(m_szPath + "ini");
    if (m_szIniPath.empty()) {
       m_szIniPath = m_szPath + "ini" + PATH_SEPARATOR_CHAR;
       std::filesystem::create_directories(m_szIniPath);

--- a/standalone/inc/wmp/WMPCore.cpp
+++ b/standalone/inc/wmp/WMPCore.cpp
@@ -48,7 +48,7 @@ STDMETHODIMP WMPCore::get_URL(BSTR *pbstrURL)
 
 STDMETHODIMP WMPCore::put_URL(BSTR pbstrURL)
 {
-   m_szURL = normalize_path_separators(MakeString(pbstrURL));
+   m_szURL = MakeString(pbstrURL);
 
    PLOGI.printf("player=%p, URL=%s", this, m_szURL.c_str());
 


### PR DESCRIPTION
iOS and Linux have case sensitive filesystems. (I think MacOS can too)

Over time, we implemented some functions that would help find case insensitive directories and files:

```
find_directory_case_insensitive()
find_path_case_insensitive()
```

While these functions have worked, they really would only go one level deep trying.

For example if a script had a reference to `A/b/c/d/e/F.txt` and the file was really at `A/B/c/d/e/F.txt` it would never be found.

This isn't so much an issue with PuP and B2S, but we've seen it happen more with FlexDMD and WMP.

This PR rewrites these functions to:

```
find_case_insensitive_directory_path()
find_case_insensitive_file_path()
```

These now normalize path separators, and then get the canonical absolute path - ie: `.` and `..` are calculated and stripped.

This PR also replaces all references of `string_compare_case_insensitive` with the `StrCompareNoCase` that was already there.

I've tested this pretty thoroughly but there is a chance I introduced a regression. 

This is a follow up to https://github.com/vpinball/vpinball/pull/2347
