### PR TITLE
audio: added the loopcount adjustment for BG sounds for SDL mixer.

### DIFF
--- a/src/audio/pinsound.cpp
+++ b/src/audio/pinsound.cpp
@@ -397,11 +397,11 @@ void PinSound::PlayBGSound(float volume, const int loopcount, const bool usesame
          Mix_HaltChannel(m_assignedChannel);
       Mix_Volume(m_assignedChannel, nVolume);
       if (restart || !usesame) // stop and reload
-         Mix_PlayChannel(m_assignedChannel, m_pMixChunkOrg, loopcount);
+         Mix_PlayChannel(m_assignedChannel, m_pMixChunkOrg, loopcount > 0 ? loopcount -1 : loopcount);
    }
    else { // not playing
       Mix_Volume(m_assignedChannel, nVolume);
-      Mix_PlayChannel(m_assignedChannel, m_pMixChunkOrg, loopcount);
+      Mix_PlayChannel(m_assignedChannel, m_pMixChunkOrg, loopcount > 0 ? loopcount -1 : loopcount);
    }
 }
 


### PR DESCRIPTION
This fixes the mentioned "double sound" issue in [2355](https://github.com/vpinball/vpinball/issues/2355).  Its also related to the changes in PR [2345](https://github.com/vpinball/vpinball/pull/2345).  I needed to add this same fix for BG sounds.