### PR TITLE
renderer: add m_drawableWidth/Height to better support high dpi in SDL3

### DIFF
--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -1134,8 +1134,8 @@ void VPinball::DoPlay(const int playMode)
                if (isPFWnd) {
                   // We scale motion data since SDL expects DPI scaled points coordinates on Apple device, while it uses pixel coordinates on other devices (see SDL_WINDOWS_DPI_SCALING)
                   // For the time being, VPX always uses pixel coordinates, using setup obtained at window creation time.
-                  e.motion.x *= g_pplayer->m_playfieldWnd->GetHiDPIScale();
-                  e.motion.y *= g_pplayer->m_playfieldWnd->GetHiDPIScale();
+                  e.motion.x *= SDL_GetWindowPixelDensity(g_pplayer->m_playfieldWnd->GetCore());
+                  e.motion.y *= SDL_GetWindowPixelDensity(g_pplayer->m_playfieldWnd->GetCore());
                   static float m_lastcursorx = FLT_MAX, m_lastcursory = FLT_MAX;
                   if (m_lastcursorx != e.motion.x || m_lastcursory != e.motion.y)
                   {
@@ -1148,16 +1148,19 @@ void VPinball::DoPlay(const int playMode)
                {
                   // Handle dragging of auxiliary windows
                   SDL_Window *sdlWnd = SDL_GetWindowFromID(e.motion.windowID);
-                  VPX::Window *windows[] = { g_pplayer->m_scoreviewOutput.GetWindow(), g_pplayer->m_backglassOutput.GetWindow() };
-                  for (size_t i = 0; i < sizeof(windows) / sizeof(VPX::Window *); i++)
+                  std::vector<VPX::Window*> windows = {
+                     g_pplayer->m_scoreviewOutput.GetWindow(),
+                     g_pplayer->m_backglassOutput.GetWindow()
+                  };
+                  for (VPX::Window* wnd : windows)
                   {
-                     if (windows[i] && sdlWnd == windows[i]->GetCore())
+                     if (wnd && sdlWnd == wnd->GetCore())
                      {
                         int x, y;
-                        windows[i]->GetPos(x, y);
+                        wnd->GetPos(x, y);
                         Vertex2D click(x + e.motion.x, y + e.motion.y);
                         if (dragging > 1)
-                           windows[i]->SetPos(static_cast<int>(x + click.x - dragStart.x), static_cast<int>(y + click.y - dragStart.y));
+                           wnd->SetPos(static_cast<int>(x + click.x - dragStart.x), static_cast<int>(y + click.y - dragStart.y));
                         dragStart = click;
                         dragging = 2;
                         break;

--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -743,8 +743,8 @@ RenderDevice::RenderDevice(VPX::Window* const wnd, const bool isVR, const int nE
    if (m_outputWnd[0]->IsFullScreen())
       init.resolution.reset |= BGFX_RESET_FULLSCREEN;
 
-   init.resolution.width = wnd->GetWidth();
-   init.resolution.height = wnd->GetHeight();
+   init.resolution.width = wnd->GetPixelWidth();
+   init.resolution.height = wnd->GetPixelHeight();
    switch (wnd->GetBitDepth())
    {
    case 32: init.resolution.format = bgfx::TextureFormat::RGBA8; break;
@@ -1450,10 +1450,10 @@ void RenderDevice::AddWindow(VPX::Window* wnd)
 #else
    return nullptr;
 #endif // BX_PLATFORM_
-   bgfx::FrameBufferHandle fbh = bgfx::createFrameBuffer(nwh, uint16_t(wnd->GetWidth()), uint16_t(wnd->GetHeight()));
+   bgfx::FrameBufferHandle fbh = bgfx::createFrameBuffer(nwh, uint16_t(wnd->GetPixelWidth()), uint16_t(wnd->GetPixelHeight()));
    m_outputWnd[m_nOutputWnd] = wnd;
    m_nOutputWnd++;
-   wnd->SetBackBuffer(new RenderTarget(this, SurfaceType::RT_DEFAULT, fbh, BGFX_INVALID_HANDLE, BGFX_INVALID_HANDLE, "BackBuffer #" + std::to_string(m_nOutputWnd), wnd->GetWidth(), wnd->GetHeight(), fmt));
+   wnd->SetBackBuffer(new RenderTarget(this, SurfaceType::RT_DEFAULT, fbh, BGFX_INVALID_HANDLE, BGFX_INVALID_HANDLE, "BackBuffer #" + std::to_string(m_nOutputWnd), wnd->GetPixelWidth(), wnd->GetPixelHeight(), fmt));
 #endif
 }
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -161,20 +161,20 @@ Renderer::Renderer(PinTable* const table, VPX::Window* wnd, VideoSyncMode& syncM
    else if (m_stereo3D == STEREO_SBS)
    {
       // Side by side fits the 2 views along the output width, so each view is rendered at half the output width
-      m_renderWidth = wnd->GetWidth() / 2;
-      m_renderHeight = wnd->GetHeight();
+      m_renderWidth = wnd->GetPixelWidth() / 2;
+      m_renderHeight = wnd->GetPixelHeight();
    }
    else if (m_stereo3D == STEREO_TB || m_stereo3D == STEREO_INT || m_stereo3D == STEREO_FLIPPED_INT)
    {
       // Top/Bottom (and interlaced) fits the 2 views along the output height, so each view is rendered at half the output height
-      m_renderWidth = wnd->GetWidth();
-      m_renderHeight = wnd->GetHeight() / 2;
+      m_renderWidth = wnd->GetPixelWidth();
+      m_renderHeight = wnd->GetPixelHeight() / 2;
    }
    else
    {
       // Default renders at the output window pixel resolution
-      m_renderWidth = wnd->GetWidth();
-      m_renderHeight = wnd->GetHeight();
+      m_renderWidth = wnd->GetPixelWidth();
+      m_renderHeight = wnd->GetPixelHeight();
    }
    const float AAfactor = m_table->m_settings.LoadValueWithDefault(Settings::Player, "AAFactor"s, m_table->m_settings.LoadValueWithDefault(Settings::Player, "USEAA"s, false) ? 2.0f : 1.0f);
    const int renderWidthAA = (int)((float)m_renderWidth * AAfactor);

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -23,9 +23,10 @@ Window::Window(const int width, const int height)
    , m_settingsPrefix("Headset"s)
    , m_isVR(true)
 {
-   m_hidpiScale = 1.f;
    m_width = width;
    m_height = height;
+   m_pixelWidth = 0; // ?
+   m_pixelHeight = 0; // ?
    m_display = -1;
    m_adapter = -1;
    m_screenwidth = width;
@@ -277,19 +278,7 @@ Window::Window(const string &title, const Settings::Section section, const strin
          PLOGI << "SDL display mode for window '" << m_settingsPrefix << "': " << mode->w << 'x' << mode->h << ' ' << mode->refresh_rate << "Hz " << SDL_GetPixelFormatName(mode->format);
       }
 
-      #if defined(__APPLE__)
-         // FIXME remove when porting to SDL3: horrible hack to handle the (strange) way Apple apply DPI: user DPI is applied as other OS but HiDPI of Retina display is applied internally
-         // FIXME this only solves the window size, not its position which is in HiDPI units while it should be in pixel units
-         // JSM174 SDL_GLContext sdl_context = SDL_GL_CreateContext(m_nwnd);
-         // JSM174 SDL_GL_MakeCurrent(m_nwnd, sdl_context);
-         int drawableWidth, drawableHeight;
-         SDL_GetWindowSizeInPixels(m_nwnd, &drawableWidth, &drawableHeight); // Size in pixels
-         // JSM174 SDL_GL_DestroyContext(sdl_context);
-         m_hidpiScale = (float)drawableWidth / (float)m_width;
-         PLOGI << "SDL HiDPI defined to " << m_hidpiScale;
-         m_width = drawableWidth;
-         m_height = drawableHeight;
-      #endif
+      SDL_GetWindowSizeInPixels(m_nwnd, &m_pixelWidth, &m_pixelHeight);
 
       #ifdef __STANDALONE__
          const string iconPath = g_pvp->m_szMyPath + "assets" + PATH_SEPARATOR_CHAR + "vpinball.png";

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -45,11 +45,12 @@ public:
    void GetPos(int&x, int &y) const;
    int GetWidth() const { return m_width; }
    int GetHeight() const { return m_height; }
+   int GetPixelWidth() const { return m_pixelWidth; }
+   int GetPixelHeight() const { return m_pixelHeight; }
    float GetRefreshRate() const { return m_refreshrate; } // Refresh rate of the device displaying the window. Window spread over multiple devices are not supported.
    bool IsFullScreen() const { return m_fullscreen; }
    int GetAdapterId() const { return m_adapter; }
    int GetBitDepth() const { return m_bitdepth; }
-   float GetHiDPIScale() const { return m_hidpiScale; } // HiDPI scale on Apple devices
    bool IsWCGDisplay() const { return m_wcgDisplay; } // Whether this window is on a WCG enabled display
    float GetSDRWhitePoint() const { return m_sdrWhitePoint; } // Selected SDR White Point of display in multiple of 80nits (so 3 gives 240nits for SDR white)
    float GetHDRHeadRoom() const { return m_hdrHeadRoom; } // Maximum luminance of display expressed in multiple of SDRWhitePoint (so 6 means 6 times the SDR whitepoint)
@@ -58,7 +59,7 @@ public:
    void Show(const bool show = true);
    void RaiseAndFocus(const bool raise = true);
 
-   void SetBackBuffer(RenderTarget* rt, const bool wcgBackbuffer = false) { assert(rt == nullptr || (rt->GetWidth() == m_width && rt->GetHeight() == m_height)); m_backBuffer = rt; m_wcgBackbuffer = wcgBackbuffer; }
+   void SetBackBuffer(RenderTarget* rt, const bool wcgBackbuffer = false) { assert(rt == nullptr || (rt->GetWidth() == m_pixelWidth && rt->GetHeight() == m_pixelHeight)); m_backBuffer = rt; m_wcgBackbuffer = wcgBackbuffer; }
    RenderTarget* GetBackBuffer() const { return m_backBuffer; }
    bool IsWCGBackBuffer() const { return m_wcgBackbuffer; } // Return true for HDR10/BT.2100 colorspace, otherwise Rec 709 colorspace
 
@@ -102,8 +103,8 @@ public:
    static void GetDisplayModes(const int display, vector<VideoMode>& modes);
 
 private:
-   float m_hidpiScale = 1.f;
    int m_width, m_height;
+   int m_pixelWidth, m_pixelHeight;
    int m_display, m_adapter;
    int m_screenwidth, m_screenheight;
    bool m_fullscreen;


### PR DESCRIPTION
SDL3 has much better support for HighDPI. 

The HighDPI docs are [here](https://wiki.libsdl.org/SDL3/README/highdpi)

One issue on Mac has always been the reported window size vs the drawable size. On MacOS, we are over-writing the window's internal `m_width` and `m_height` with the drawable size. This is confusing especially when you really need to know the real `m_width` and `m_height`. 

This PR adds a new `m_drawableHeight` and `m_drawableWidth` to the Window. Now we can always get the real `m_width` and `m_height` where-ever we need to.

This may introduce some regressions, but I hope it doesn't.

Also, the imgui mouse is still offset (see https://github.com/vpinball/vpinball/issues/2057#issuecomment-2649567181), so hopefully these changes can help get us closer to working.

 

