### PR TITLE
fix: PuP memory leak

### DIFF
--- a/standalone/inc/pup/PUPMediaPlayer.cpp
+++ b/standalone/inc/pup/PUPMediaPlayer.cpp
@@ -17,6 +17,8 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+constexpr size_t MAX_BUFFERED_FRAMES = 60;
+
 PUPMediaPlayer::PUPMediaPlayer()
 {
    m_loop = false;
@@ -305,6 +307,11 @@ void PUPMediaPlayer::Run()
                AVFrame* pClonedFrame = av_frame_clone(pFrame);
                if (pClonedFrame) {
                   std::lock_guard<std::mutex> lock(m_mutex);
+                  if (m_queue.size() >= MAX_BUFFERED_FRAMES) {
+                     AVFrame* oldFrame = m_queue.front();
+                     av_frame_free(&oldFrame);
+                     m_queue.pop();
+                  }
                   m_queue.push(pClonedFrame);
                }
             }

--- a/standalone/inc/pup/PUPMediaPlayer.cpp
+++ b/standalone/inc/pup/PUPMediaPlayer.cpp
@@ -308,8 +308,8 @@ void PUPMediaPlayer::Run()
                if (pClonedFrame) {
                   std::lock_guard<std::mutex> lock(m_mutex);
                   if (m_queue.size() >= MAX_BUFFERED_FRAMES) {
-                     AVFrame* oldFrame = m_queue.front();
-                     av_frame_free(&oldFrame);
+                     AVFrame* pOldFrame = m_queue.front();
+                     av_frame_free(&pOldFrame);
                      m_queue.pop();
                   }
                   m_queue.push(pClonedFrame);

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -507,7 +507,7 @@ void PUPScreen::ProcessQueue()
       std::unique_lock<std::mutex> lock(m_queueMutex);
       m_queueCondVar.wait(lock, [this] { return !m_queue.empty() || !m_isRunning; });
 
-      if (!m_isRunning) {
+      if (!m_isRunning || m_mode == PUP_SCREEN_MODE_OFF) {
          while (!m_queue.empty()) {
             PUPScreenRequest* pRequest = m_queue.front();
             m_queue.pop();


### PR DESCRIPTION
* a screen that is off should not handle events
* the media player should not have an unbound queue

fixes #2388

I'm keeping this to a minimum as this code is currently being moved to a plugin