### PR TITLE
fix: configured display lookup

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -79,9 +79,10 @@ Window::Window(const string &title, const Settings::Section section, const strin
          break;
       }
    }
+   const int configuredDisplay = m_display;
    for (const DisplayConfig& dispConf : displays)
    {
-      if (dispConf.isPrimary || dispConf.display == m_display)
+      if (dispConf.isPrimary || dispConf.display == configuredDisplay)
       {
          wnd_x = dispConf.left;
          wnd_y = dispConf.top;


### PR DESCRIPTION
fixes #2400

The condition variable used to be updated during the loop causing primary to be selected if it came first.