### PR TITLE
pup: support for advanced triggers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,11 +3,7 @@
 BasedOnStyle: WebKit
 AccessModifierOffset: -3
 AllowShortCaseLabelsOnASingleLine: true
-BreakBeforeBraces: Custom
-BraceWrapping:
-  AfterControlStatement: false
-  BeforeCatch: true
-  AfterFunction: true
+BreakBeforeBraces: Allman
 ColumnLimit: 190
 ConstructorInitializerIndentWidth : 3
 ContinuationIndentWidth: 3

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,11 @@
 BasedOnStyle: WebKit
 AccessModifierOffset: -3
 AllowShortCaseLabelsOnASingleLine: true
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterControlStatement: false
+  BeforeCatch: true
+  AfterFunction: true
 ColumnLimit: 190
 ConstructorInitializerIndentWidth : 3
 ContinuationIndentWidth: 3

--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -120,7 +120,7 @@ void PUPManager::LoadPlaylists()
    std::ifstream playlistsFile;
    playlistsFile.open(szPlaylistsPath, std::ifstream::in);
    if (playlistsFile.is_open()) {
-      ankerl::unordered_dense::set<std::string> lowerPlaylistNames;
+      ankerl::unordered_dense::set<string> lowerPlaylistNames;
       string line;
       int i = 0;
       while (std::getline(playlistsFile, line)) {

--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -230,14 +230,10 @@ TTF_Font* PUPManager::GetFont(const string& szFont)
 
 void PUPManager::QueueTriggerData(PUPTriggerData data)
 {
-   if (data.value == 0)
-      return;
-
    {
       std::lock_guard<std::mutex> lock(m_queueMutex);
       m_triggerDataQueue.push({ data.type, data.number, data.value });
    }
-
    m_queueCondVar.notify_one();
 }
 

--- a/standalone/inc/pup/PUPMediaManager.h
+++ b/standalone/inc/pup/PUPMediaManager.h
@@ -29,7 +29,7 @@ public:
    ~PUPMediaManager() {};
 
    void SetRenderer(SDL_Renderer* pRenderer);
-   void Play(PUPPlaylist* pPlaylist, const std::string& szPlayFile, float volume, int priority, bool skipSamePriority);
+   void Play(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority);
    void SetBG(bool isBackground);
    void SetLoop(bool isLoop);
    void Stop();

--- a/standalone/inc/pup/PUPPlugin.cpp
+++ b/standalone/inc/pup/PUPPlugin.cpp
@@ -20,9 +20,9 @@ PUPPlugin::~PUPPlugin()
 {
 }
 
-const std::string& PUPPlugin::GetName() const
+const string& PUPPlugin::GetName() const
 {
-   static const std::string name = "PinUpPlugin"s;
+   static const string name = "PinUpPlugin"s;
    return name;
 }
 

--- a/standalone/inc/pup/PUPPlugin.h
+++ b/standalone/inc/pup/PUPPlugin.h
@@ -10,7 +10,7 @@ public:
    PUPPlugin();
    ~PUPPlugin();
 
-   const std::string& GetName() const override;
+   const string& GetName() const override;
    void PluginInit(const string& szTableFilename, const string& szRomName) override;
    void PluginFinish() override;
    void DataReceive(char type, int number, int value) override;

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -476,14 +476,8 @@ void PUPScreen::QueueTrigger(char type, int number, int value)
       for (const auto& [expectedTypeNumber, expectedValue] : pTrigger->GetTriggers())
       {
          auto currentValue = m_triggersState.find(expectedTypeNumber);
-         if (currentValue == m_triggersState.end())
-         {
+         if (currentValue == m_triggersState.end() || currentValue->second != expectedValue)
             return;
-         }
-         if (currentValue->second != expectedValue)
-         {
-            return;
-         }
       }
 
       auto* pRequest = new PUPTriggerRequest();

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -468,13 +468,11 @@ void PUPScreen::QueueTrigger(char type, int number, int value)
    if (!pTriggers)
       return;
 
-   for (PUPTrigger* pTrigger : *pTriggers)
-   {
+   for (PUPTrigger* pTrigger : *pTriggers) {
       if (!pTrigger->IsActive())
          continue;
 
-      for (const auto& [expectedTypeNumber, expectedValue] : pTrigger->GetTriggers())
-      {
+      for (const auto& [expectedTypeNumber, expectedValue] : pTrigger->GetTriggers()) {
          auto currentValue = m_triggersState.find(expectedTypeNumber);
          if (currentValue == m_triggersState.end() || currentValue->second != expectedValue)
             return;

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -468,16 +468,20 @@ void PUPScreen::QueueTrigger(char type, int number, int value)
    if (!pTriggers)
       return;
 
-   for (PUPTrigger* pTrigger : *pTriggers) {
+   for (PUPTrigger* pTrigger : *pTriggers)
+   {
       if (!pTrigger->IsActive())
          continue;
 
-      for (const auto& [m_sName, value] : pTrigger->GetTriggers()) {
+      for (const auto& [m_sName, value] : pTrigger->GetTriggers())
+      {
          auto currentValue = m_triggersState.find(m_sName);
-         if (currentValue == m_triggersState.end()) {
+         if (currentValue == m_triggersState.end())
+         {
             return;
          }
-         if (currentValue->second != value) {
+         if (currentValue->second != value)
+         {
             return;
          }
       }

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -460,7 +460,7 @@ void PUPScreen::QueueBG(int mode)
 void PUPScreen::QueueTrigger(char type, int number, int value)
 {
    // we store the whole state to be able to mach later
-   const string typeNumber = string(1, type) + std::to_string(number);
+   const string typeNumber = type + std::to_string(number);
    m_triggersState[typeNumber] = value;
 
    // The first condition is the main trigger, the rest is matched on their current state

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -257,7 +257,7 @@ void PUPScreen::AddTrigger(PUPTrigger* pTrigger)
    if (!pTrigger)
       return;
 
-   m_triggerMap[pTrigger->GetMainTriggerName()].push_back(pTrigger);
+   m_triggerMap[pTrigger->GetMainConditionName()].push_back(pTrigger);
 }
 
 vector<PUPTrigger*>* PUPScreen::GetTriggers(const string& szTrigger)

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -463,8 +463,8 @@ void PUPScreen::QueueTrigger(char type, int number, int value)
    const string typeNumber = string(1, type) + std::to_string(number);
    m_triggersState[typeNumber] = value;
 
-   // The first trigger is the main trigger, the rest we just check
-   vector<PUPTrigger*>* pTriggers = GetTriggers(type + std::to_string(number));
+   // The first condition is the main trigger, the rest is matched on their current state
+   vector<PUPTrigger*>* pTriggers = GetTriggers(typeNumber);
    if (!pTriggers)
       return;
 

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -57,7 +57,7 @@ const char* PUP_PINDISPLAY_REQUEST_TYPE_TO_STRING(PUP_PINDISPLAY_REQUEST_TYPE va
      CustomPos = CustomPos
 */
 
-PUPScreen::PUPScreen(PUP_SCREEN_MODE mode, int screenNum, const string& szScreenDes, const string& szBackgroundPlaylist, const string& szBackgroundFilename, bool transparent, float volume, PUPCustomPos* pCustomPos, const std::vector<PUPPlaylist*>& playlists)
+PUPScreen::PUPScreen(PUP_SCREEN_MODE mode, int screenNum, const string& szScreenDes, const string& szBackgroundPlaylist, const string& szBackgroundFilename, bool transparent, float volume, PUPCustomPos* pCustomPos, const vector<PUPPlaylist*>& playlists)
 {
    m_pManager = PUPManager::GetInstance();
 
@@ -127,7 +127,7 @@ PUPScreen::~PUPScreen()
       pChildren->clear();
 }
 
-PUPScreen* PUPScreen::CreateFromCSV(const string& line, const std::vector<PUPPlaylist*>& playlists)
+PUPScreen* PUPScreen::CreateFromCSV(const string& line, const vector<PUPPlaylist*>& playlists)
 {
    vector<string> parts = parse_csv_line(line);
    if (parts.size() != 8) {
@@ -166,7 +166,7 @@ PUPScreen* PUPScreen::CreateFromCSV(const string& line, const std::vector<PUPPla
       PUPCustomPos::CreateFromCSV(parts[7]), playlists);
 }
 
-PUPScreen* PUPScreen::CreateDefault(int screenNum, const std::vector<PUPPlaylist*>& playlists)
+PUPScreen* PUPScreen::CreateDefault(int screenNum, const vector<PUPPlaylist*>& playlists)
 {
    if (PUPManager::GetInstance()->HasScreen(screenNum)) {
       PLOGW.printf("Screen already exists: screenNum=%d", screenNum);
@@ -333,7 +333,7 @@ void PUPScreen::SetSize(int w, int h)
    }
 }
 
-void PUPScreen::SetBackground(PUPPlaylist* pPlaylist, const std::string& szPlayFile)
+void PUPScreen::SetBackground(PUPPlaylist* pPlaylist, const string& szPlayFile)
 {
    std::lock_guard<std::mutex> lock(m_renderMutex);
    LoadRenderable(&m_background, pPlaylist->GetPlayFilePath(szPlayFile));
@@ -346,13 +346,13 @@ void PUPScreen::SetCustomPos(const string& szCustomPos)
    m_pCustomPos = PUPCustomPos::CreateFromCSV(szCustomPos);
 }
 
-void PUPScreen::SetOverlay(PUPPlaylist* pPlaylist, const std::string& szPlayFile)
+void PUPScreen::SetOverlay(PUPPlaylist* pPlaylist, const string& szPlayFile)
 {
    std::lock_guard<std::mutex> lock(m_renderMutex);
    LoadRenderable(&m_overlay, pPlaylist->GetPlayFilePath(szPlayFile));
 }
 
-void PUPScreen::SetMedia(PUPPlaylist* pPlaylist, const std::string& szPlayFile, float volume, int priority, bool skipSamePriority)
+void PUPScreen::SetMedia(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority)
 {
    std::lock_guard<std::mutex> lock(m_renderMutex);
    m_pMediaPlayerManager->Play(pPlaylist, szPlayFile, m_pParent ? (volume / 100.0f) * m_pParent->GetVolume() : volume, priority, skipSamePriority);
@@ -370,7 +370,7 @@ void PUPScreen::StopMedia(int priority)
    m_pMediaPlayerManager->Stop(priority);
 }
 
-void PUPScreen::StopMedia(PUPPlaylist* pPlaylist, const std::string& szPlayFile)
+void PUPScreen::StopMedia(PUPPlaylist* pPlaylist, const string& szPlayFile)
 {
    std::lock_guard<std::mutex> lock(m_renderMutex);
    m_pMediaPlayerManager->Stop(pPlaylist, szPlayFile);
@@ -460,7 +460,7 @@ void PUPScreen::QueueBG(int mode)
 void PUPScreen::QueueTrigger(char type, int number, int value)
 {
    // we store the whole state to be able to mach later
-   const std::string name = std::string(1, type) + std::to_string(number);
+   const string name = string(1, type) + std::to_string(number);
    m_triggersState[name] = value;
 
    // The first trigger is the main trigger, the rest we just check

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -460,8 +460,8 @@ void PUPScreen::QueueBG(int mode)
 void PUPScreen::QueueTrigger(char type, int number, int value)
 {
    // we store the whole state to be able to mach later
-   const string name = string(1, type) + std::to_string(number);
-   m_triggersState[name] = value;
+   const string typeNumber = string(1, type) + std::to_string(number);
+   m_triggersState[typeNumber] = value;
 
    // The first trigger is the main trigger, the rest we just check
    vector<PUPTrigger*>* pTriggers = GetTriggers(type + std::to_string(number));
@@ -473,14 +473,14 @@ void PUPScreen::QueueTrigger(char type, int number, int value)
       if (!pTrigger->IsActive())
          continue;
 
-      for (const auto& [m_sName, value] : pTrigger->GetTriggers())
+      for (const auto& [expectedTypeNumber, expectedValue] : pTrigger->GetTriggers())
       {
-         auto currentValue = m_triggersState.find(m_sName);
+         auto currentValue = m_triggersState.find(expectedTypeNumber);
          if (currentValue == m_triggersState.end())
          {
             return;
          }
-         if (currentValue->second != value)
+         if (currentValue->second != expectedValue)
          {
             return;
          }

--- a/standalone/inc/pup/PUPScreen.h
+++ b/standalone/inc/pup/PUPScreen.h
@@ -80,8 +80,8 @@ class PUPScreen
 public:
    ~PUPScreen();
 
-   static PUPScreen* CreateFromCSV(const string& line, const std::vector<PUPPlaylist*>& playlists);
-   static PUPScreen* CreateDefault(int screenNum, const std::vector<PUPPlaylist*>& playlists);
+   static PUPScreen* CreateFromCSV(const string& line, const vector<PUPPlaylist*>& playlists);
+   static PUPScreen* CreateDefault(int screenNum, const vector<PUPPlaylist*>& playlists);
    PUP_SCREEN_MODE GetMode() const { return m_mode; }
    void SetMode(PUP_SCREEN_MODE mode) { m_mode = mode; }
    int GetScreenNum() const { return m_screenNum; }
@@ -113,13 +113,13 @@ public:
    void SetPage(int pagenum, int seconds);
    void Render();
    const SDL_Rect& GetRect() const { return m_rect; }
-   void SetBackground(PUPPlaylist* pPlaylist, const std::string& szPlayFile);
+   void SetBackground(PUPPlaylist* pPlaylist, const string& szPlayFile);
    void SetCustomPos(const string& string);
-   void SetOverlay(PUPPlaylist* pPlaylist, const std::string& szPlayFile);
-   void SetMedia(PUPPlaylist* pPlaylist, const std::string& szPlayFile, float volume, int priority, bool skipSamePriority);
+   void SetOverlay(PUPPlaylist* pPlaylist, const string& szPlayFile);
+   void SetMedia(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority);
    void StopMedia();
    void StopMedia(int priority);
-   void StopMedia(PUPPlaylist* pPlaylist, const std::string& szPlayFile);
+   void StopMedia(PUPPlaylist* pPlaylist, const string& szPlayFile);
    void SetLoop(int state);
    void SetBG(int mode);
    void QueuePlay(const string& szPlaylist, const string& szPlayFile, float volume, int priority);
@@ -130,7 +130,7 @@ public:
    string ToString(bool full = true) const;
 
 private:
-   PUPScreen(PUP_SCREEN_MODE mode, int screenNum, const string& screenDes, const string& backgroundPlaylist, const string& backgroundFilename, bool transparent, float volume, PUPCustomPos* pCustomPos, const std::vector<PUPPlaylist*>& playlists);
+   PUPScreen(PUP_SCREEN_MODE mode, int screenNum, const string& screenDes, const string& backgroundPlaylist, const string& backgroundFilename, bool transparent, float volume, PUPCustomPos* pCustomPos, const vector<PUPPlaylist*>& playlists);
 
    void LoadTriggers();
    void ProcessQueue();
@@ -173,5 +173,5 @@ private:
    bool m_isRunning;
    std::thread m_thread;
    std::mutex m_renderMutex;
-   std::unordered_map<std::string, int> m_triggersState;
+   std::unordered_map<string, int> m_triggersState;
 };

--- a/standalone/inc/pup/PUPScreen.h
+++ b/standalone/inc/pup/PUPScreen.h
@@ -173,4 +173,5 @@ private:
    bool m_isRunning;
    std::thread m_thread;
    std::mutex m_renderMutex;
+   std::unordered_map<std::string, int> m_triggersState;
 };

--- a/standalone/inc/pup/PUPScreen.h
+++ b/standalone/inc/pup/PUPScreen.h
@@ -173,5 +173,5 @@ private:
    bool m_isRunning;
    std::thread m_thread;
    std::mutex m_renderMutex;
-   std::unordered_map<string, int> m_triggersState;
+   ankerl::unordered_dense::map<string, int> m_triggersState;
 };

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -4,6 +4,7 @@
 #include "PUPScreen.h"
 #include "PUPPlaylist.h"
 
+// clang-format off
 const char* PUP_TRIGGER_PLAY_ACTION_STRINGS[] = {
    "PUP_TRIGGER_PLAY_ACTION_NORMAL",
    "PUP_TRIGGER_PLAY_ACTION_LOOP",
@@ -16,6 +17,7 @@ const char* PUP_TRIGGER_PLAY_ACTION_STRINGS[] = {
    "PUP_TRIGGER_PLAY_ACTION_SKIP_SAME_PRTY",
    "PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC"
 };
+// clang-format on
 
 const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
 {
@@ -56,7 +58,8 @@ const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
      D = PupCap DMD Match
 */
 
-PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<PUPStateTrigger>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
+PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<PUPStateTrigger>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume,
+   int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
 {
    m_active = active;
    m_szDescript = szDescript;
@@ -76,8 +79,7 @@ PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<PUPSt
 PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
 {
    vector<string> parts = parse_csv_line(line);
-   if (parts.size() != 14)
-   {
+   if (parts.size() != 14) {
       PLOGD.printf("Invalid trigger: %s", line.c_str());
       return nullptr;
    }
@@ -90,39 +92,33 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
       return nullptr;
 
    bool active = (string_to_int(parts[1], 0) == 1);
-   if (!active)
-   {
+   if (!active) {
       PLOGD.printf("Inactive trigger: %s", line.c_str());
       return nullptr;
    }
 
-   if (StrCompareNoCase(triggerPlayAction, "CustomFunc"))
-   {
+   if (StrCompareNoCase(triggerPlayAction, "CustomFunc")) {
       // TODO parse the custom function and call PUPPinDisplay::SendMSG when triggered
       PLOGW.printf("CustomFunc not implemented: %s", line.c_str());
       return nullptr;
    }
 
    // Sometimes an empty playlist but with description is used as a comment/separator.
-   if (triggerPlaylist.empty())
-   {
+   if (triggerPlaylist.empty()) {
       // TODO A PuP Pack Audit should mark these as comment triggers if the trigger is active
       return nullptr;
    }
 
    PUPPlaylist* pPlaylist = pScreen->GetPlaylist(triggerPlaylist);
-   if (!pPlaylist)
-   {
+   if (!pPlaylist) {
       PLOGW.printf("Playlist not found: %s", triggerPlaylist.c_str());
       return nullptr;
    }
 
    string szPlayFile = parts[6];
-   if (!szPlayFile.empty())
-   {
+   if (!szPlayFile.empty()) {
       szPlayFile = pPlaylist->GetPlayFile(szPlayFile);
-      if (szPlayFile.empty())
-      {
+      if (szPlayFile.empty()) {
          PLOGW.printf("PlayFile not found for playlist %s: %s", pPlaylist->GetFolder().c_str(), parts[6].c_str());
          return nullptr;
       }
@@ -150,20 +146,15 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
    else
       playAction = PUP_TRIGGER_PLAY_ACTION_NORMAL;
 
-   return new PUPTrigger(
-      active,
+   return new PUPTrigger(active,
       parts[2], // descript
       ParseTriggers(parts[3]), // trigger
-      pScreen,
-      pPlaylist,
-      szPlayFile,
-      parts[7].empty() ? pPlaylist->GetVolume() : string_to_int(parts[7], 0), // volume
+      pScreen, pPlaylist, szPlayFile, parts[7].empty() ? pPlaylist->GetVolume() : string_to_int(parts[7], 0), // volume
       parts[8].empty() ? pPlaylist->GetPriority() : string_to_int(parts[8], 0), // priority
       string_to_int(parts[9], 0), // length
       string_to_int(parts[10], 0), // counter
       parts[11].empty() ? pPlaylist->GetRestSeconds() : string_to_int(parts[11], 0), // rest seconds
-      playAction
-   );
+      playAction);
 }
 
 vector<PUPStateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
@@ -172,32 +163,25 @@ vector<PUPStateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
    std::istringstream stream(triggerString);
    string token;
 
-   while (std::getline(stream, token, ','))
-   {
-      if (token.empty())
-      {
+   while (std::getline(stream, token, ',')) {
+      if (token.empty()) {
          PLOGW.printf("Empty token found in trigger string: %s", triggerString.c_str());
          continue;
       }
 
-      try
-      {
+      try {
          size_t equalPos = token.find('=');
          PUPStateTrigger trigger;
 
-         if (equalPos != string::npos)
-         {
+         if (equalPos != string::npos) {
             // Parse triggers with state (e.g., "W5=1")
             trigger.m_sName = token.substr(0, equalPos);
-            if (trigger.m_sName.empty())
-            {
+            if (trigger.m_sName.empty()) {
                PLOGW.printf("Invalid trigger name in token: %s", token.c_str());
                continue;
             }
             trigger.value = stoi(token.substr(equalPos + 1));
-         }
-         else
-         {
+         } else {
             // Parse triggers without state (e.g., "S10")
             trigger.m_sName = token;
             trigger.value = 1;
@@ -205,12 +189,10 @@ vector<PUPStateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
 
          vTriggers.push_back(std::move(trigger));
       }
-      catch (const std::invalid_argument& e)
-      {
+      catch (const std::invalid_argument& e) {
          PLOGE.printf("Invalid trigger format: %s, error: %s", token.c_str(), e.what());
       }
-      catch (const std::out_of_range& e)
-      {
+      catch (const std::out_of_range& e) {
          PLOGE.printf("Trigger value out of range: %s, error: %s", token.c_str(), e.what());
       }
    }
@@ -239,7 +221,9 @@ const string& PUPTrigger::GetMainTriggerName() const
    return NO_TRIGGER;
 }
 
-string PUPTrigger::ToString() const {
+string PUPTrigger::ToString() const
+{
+   // clang-format off
    return string("active=") + ((m_active == true) ? "true" : "false") +
       ", descript=" + m_szDescript +
       ", trigger=[" + [&]() {
@@ -261,4 +245,5 @@ string PUPTrigger::ToString() const {
       ", count=" + std::to_string(m_counter) +
       ", restSeconds=" + std::to_string(m_restSeconds) +
       ", playAction=" + string(PUP_TRIGGER_PLAY_ACTION_TO_STRING(m_playAction));
+   // clang-format on
 }

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -157,7 +157,7 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
 
 vector<PUPTriggerCondition> PUPTrigger::ParseTriggers(const string& triggerString)
 {
-   vector<PUPTriggerCondition> vTriggers;
+   vector<PUPTriggerCondition> conditions;
    std::istringstream stream(triggerString);
    string token;
 
@@ -179,13 +179,14 @@ vector<PUPTriggerCondition> PUPTrigger::ParseTriggers(const string& triggerStrin
                continue;
             }
             trigger.value = stoi(token.substr(equalPos + 1));
-         } else {
+         }
+         else {
             // Parse triggers without state (e.g., "S10")
             trigger.m_sName = token;
             trigger.value = 1;
          }
 
-         vTriggers.push_back(std::move(trigger));
+         conditions.push_back(std::move(trigger));
       }
       catch (const std::invalid_argument& e) {
          PLOGE.printf("Invalid trigger format: %s, error: %s", token.c_str(), e.what());
@@ -195,7 +196,7 @@ vector<PUPTriggerCondition> PUPTrigger::ParseTriggers(const string& triggerStrin
       }
    }
 
-   return vTriggers;
+   return conditions;
 }
 
 bool PUPTrigger::IsResting()
@@ -213,9 +214,9 @@ void PUPTrigger::SetTriggered() { m_lastTriggered = SDL_GetTicks(); }
 
 const string& PUPTrigger::GetMainConditionName() const
 {
-   if (!m_conditions.empty()) {
+   if (!m_conditions.empty())
       return m_conditions.front().m_sName;
-   }
+
    return NO_CONDITIONS;
 }
 

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -56,7 +56,7 @@ const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
      D = PupCap DMD Match
 */
 
-PUPTrigger::PUPTrigger(bool active, const string& szDescript, const std::vector<StateTrigger>& vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
+PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
 {
    m_active = active;
    m_szDescript = szDescript;
@@ -166,11 +166,11 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
    );
 }
 
-std::vector<StateTrigger> PUPTrigger::ParseTriggers(const std::string& triggerString)
+vector<StateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
 {
-   std::vector<StateTrigger> vTriggers;
+   vector<StateTrigger> vTriggers;
    std::istringstream stream(triggerString);
-   std::string token;
+   string token;
 
    while (std::getline(stream, token, ','))
    {
@@ -185,7 +185,7 @@ std::vector<StateTrigger> PUPTrigger::ParseTriggers(const std::string& triggerSt
          size_t equalPos = token.find('=');
          StateTrigger trigger;
 
-         if (equalPos != std::string::npos)
+         if (equalPos != string::npos)
          {
             // Parse triggers with state (e.g., "W5=1")
             trigger.m_sName = token.substr(0, equalPos);
@@ -194,7 +194,7 @@ std::vector<StateTrigger> PUPTrigger::ParseTriggers(const std::string& triggerSt
                PLOGW.printf("Invalid trigger name in token: %s", token.c_str());
                continue;
             }
-            trigger.value = std::stoi(token.substr(equalPos + 1));
+            trigger.value = stoi(token.substr(equalPos + 1));
          }
          else
          {
@@ -235,7 +235,7 @@ string PUPTrigger::ToString() const {
    return string("active=") + ((m_active == true) ? "true" : "false") +
       ", descript=" + m_szDescript +
       ", trigger=[" + [&]() {
-            std::string result;
+            string result;
             for (const auto& trigger : m_vTriggers) {
                if (!result.empty()) {
                   result += ", ";

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -4,7 +4,6 @@
 #include "PUPScreen.h"
 #include "PUPPlaylist.h"
 
-// clang-format off
 const char* PUP_TRIGGER_PLAY_ACTION_STRINGS[] = {
    "PUP_TRIGGER_PLAY_ACTION_NORMAL",
    "PUP_TRIGGER_PLAY_ACTION_LOOP",
@@ -17,7 +16,6 @@ const char* PUP_TRIGGER_PLAY_ACTION_STRINGS[] = {
    "PUP_TRIGGER_PLAY_ACTION_SKIP_SAME_PRTY",
    "PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC"
 };
-// clang-format on
 
 const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
 {
@@ -58,12 +56,12 @@ const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
      D = PupCap DMD Match
 */
 
-PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<PUPStateTrigger>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume,
+PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<PUPTriggerCondition>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume,
    int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
 {
    m_active = active;
    m_szDescript = szDescript;
-   m_triggers = triggers;
+   m_conditions = triggers;
    m_pScreen = pScreen;
    m_pPlaylist = pPlaylist;
    m_szPlayFile = szPlayFile;
@@ -157,9 +155,9 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
       playAction);
 }
 
-vector<PUPStateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
+vector<PUPTriggerCondition> PUPTrigger::ParseTriggers(const string& triggerString)
 {
-   vector<PUPStateTrigger> vTriggers;
+   vector<PUPTriggerCondition> vTriggers;
    std::istringstream stream(triggerString);
    string token;
 
@@ -171,7 +169,7 @@ vector<PUPStateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
 
       try {
          size_t equalPos = token.find('=');
-         PUPStateTrigger trigger;
+         PUPTriggerCondition trigger;
 
          if (equalPos != string::npos) {
             // Parse triggers with state (e.g., "W5=1")
@@ -213,22 +211,21 @@ bool PUPTrigger::IsResting()
 
 void PUPTrigger::SetTriggered() { m_lastTriggered = SDL_GetTicks(); }
 
-const string& PUPTrigger::GetMainTriggerName() const
+const string& PUPTrigger::GetMainConditionName() const
 {
-   if (!m_triggers.empty()) {
-      return m_triggers.front().m_sName;
+   if (!m_conditions.empty()) {
+      return m_conditions.front().m_sName;
    }
-   return NO_TRIGGER;
+   return NO_CONDITIONS;
 }
 
 string PUPTrigger::ToString() const
 {
-   // clang-format off
    return string("active=") + ((m_active == true) ? "true" : "false") +
       ", descript=" + m_szDescript +
       ", trigger=[" + [&]() {
             string result;
-            for (const auto& trigger : m_triggers) {
+            for (const auto& trigger : m_conditions) {
                if (!result.empty()) {
                   result += ", ";
                }
@@ -245,5 +242,4 @@ string PUPTrigger::ToString() const
       ", count=" + std::to_string(m_counter) +
       ", restSeconds=" + std::to_string(m_restSeconds) +
       ", playAction=" + string(PUP_TRIGGER_PLAY_ACTION_TO_STRING(m_playAction));
-   // clang-format on
 }

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -56,7 +56,7 @@ const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
      D = PupCap DMD Match
 */
 
-PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
+PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<PUPStateTrigger>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
 {
    m_active = active;
    m_szDescript = szDescript;
@@ -166,9 +166,9 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
    );
 }
 
-vector<StateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
+vector<PUPStateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
 {
-   vector<StateTrigger> vTriggers;
+   vector<PUPStateTrigger> vTriggers;
    std::istringstream stream(triggerString);
    string token;
 
@@ -183,7 +183,7 @@ vector<StateTrigger> PUPTrigger::ParseTriggers(const string& triggerString)
       try
       {
          size_t equalPos = token.find('=');
-         StateTrigger trigger;
+         PUPStateTrigger trigger;
 
          if (equalPos != string::npos)
          {

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -231,6 +231,14 @@ bool PUPTrigger::IsResting()
 
 void PUPTrigger::SetTriggered() { m_lastTriggered = SDL_GetTicks(); }
 
+const string& PUPTrigger::GetMainTriggerName() const
+{
+   if (!m_triggers.empty()) {
+      return m_triggers.front().m_sName;
+   }
+   return NO_TRIGGER;
+}
+
 string PUPTrigger::ToString() const {
    return string("active=") + ((m_active == true) ? "true" : "false") +
       ", descript=" + m_szDescript +

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -76,7 +76,8 @@ PUPTrigger::PUPTrigger(bool active, const string& szDescript, const std::vector<
 PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
 {
    vector<string> parts = parse_csv_line(line);
-   if (parts.size() != 14) {
+   if (parts.size() != 14)
+   {
       PLOGD.printf("Invalid trigger: %s", line.c_str());
       return nullptr;
    }
@@ -89,33 +90,39 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
       return nullptr;
 
    bool active = (string_to_int(parts[1], 0) == 1);
-   if (!active) {
+   if (!active)
+   {
       PLOGD.printf("Inactive trigger: %s", line.c_str());
       return nullptr;
    }
 
-   if (StrCompareNoCase(triggerPlayAction, "CustomFunc")) {
+   if (StrCompareNoCase(triggerPlayAction, "CustomFunc"))
+   {
       // TODO parse the custom function and call PUPPinDisplay::SendMSG when triggered
       PLOGW.printf("CustomFunc not implemented: %s", line.c_str());
       return nullptr;
    }
 
    // Sometimes an empty playlist but with description is used as a comment/separator.
-   if (triggerPlaylist.empty()) {
+   if (triggerPlaylist.empty())
+   {
       // TODO A PuP Pack Audit should mark these as comment triggers if the trigger is active
       return nullptr;
    }
 
    PUPPlaylist* pPlaylist = pScreen->GetPlaylist(triggerPlaylist);
-   if (!pPlaylist) {
+   if (!pPlaylist)
+   {
       PLOGW.printf("Playlist not found: %s", triggerPlaylist.c_str());
       return nullptr;
    }
 
    string szPlayFile = parts[6];
-   if (!szPlayFile.empty()) {
+   if (!szPlayFile.empty())
+   {
       szPlayFile = pPlaylist->GetPlayFile(szPlayFile);
-      if (szPlayFile.empty()) {
+      if (szPlayFile.empty())
+      {
          PLOGW.printf("PlayFile not found for playlist %s: %s", pPlaylist->GetFolder().c_str(), parts[6].c_str());
          return nullptr;
       }
@@ -159,39 +166,51 @@ PUPTrigger* PUPTrigger::CreateFromCSV(PUPScreen* pScreen, string line)
    );
 }
 
-std::vector<StateTrigger> PUPTrigger::ParseTriggers(const std::string& triggerString) {
+std::vector<StateTrigger> PUPTrigger::ParseTriggers(const std::string& triggerString)
+{
    std::vector<StateTrigger> vTriggers;
    std::istringstream stream(triggerString);
    std::string token;
 
-   while (std::getline(stream, token, ',')) {
-      if (token.empty()) {
+   while (std::getline(stream, token, ','))
+   {
+      if (token.empty())
+      {
          PLOGW.printf("Empty token found in trigger string: %s", triggerString.c_str());
          continue;
       }
 
-      try {
+      try
+      {
          size_t equalPos = token.find('=');
          StateTrigger trigger;
 
-         if (equalPos != std::string::npos) {
+         if (equalPos != std::string::npos)
+         {
             // Parse triggers with state (e.g., "W5=1")
             trigger.m_sName = token.substr(0, equalPos);
-            if (trigger.m_sName.empty()) {
+            if (trigger.m_sName.empty())
+            {
                PLOGW.printf("Invalid trigger name in token: %s", token.c_str());
                continue;
             }
             trigger.value = std::stoi(token.substr(equalPos + 1));
-         } else {
+         }
+         else
+         {
             // Parse triggers without state (e.g., "S10")
             trigger.m_sName = token;
             trigger.value = 1;
          }
 
          vTriggers.push_back(std::move(trigger));
-      } catch (const std::invalid_argument& e) {
+      }
+      catch (const std::invalid_argument& e)
+      {
          PLOGE.printf("Invalid trigger format: %s, error: %s", token.c_str(), e.what());
-      } catch (const std::out_of_range& e) {
+      }
+      catch (const std::out_of_range& e)
+      {
          PLOGE.printf("Trigger value out of range: %s, error: %s", token.c_str(), e.what());
       }
    }
@@ -210,10 +229,7 @@ bool PUPTrigger::IsResting()
    return (SDL_GetTicks() - m_lastTriggered) < (m_restSeconds * 1000);
 }
 
-void PUPTrigger::SetTriggered()
-{
-   m_lastTriggered = SDL_GetTicks();
-}
+void PUPTrigger::SetTriggered() { m_lastTriggered = SDL_GetTicks(); }
 
 string PUPTrigger::ToString() const {
    return string("active=") + ((m_active == true) ? "true" : "false") +

--- a/standalone/inc/pup/PUPTrigger.cpp
+++ b/standalone/inc/pup/PUPTrigger.cpp
@@ -56,11 +56,11 @@ const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value)
      D = PupCap DMD Match
 */
 
-PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
+PUPTrigger::PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& triggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction)
 {
    m_active = active;
    m_szDescript = szDescript;
-   m_vTriggers = vTriggers;
+   m_triggers = triggers;
    m_pScreen = pScreen;
    m_pPlaylist = pPlaylist;
    m_szPlayFile = szPlayFile;
@@ -236,7 +236,7 @@ string PUPTrigger::ToString() const {
       ", descript=" + m_szDescript +
       ", trigger=[" + [&]() {
             string result;
-            for (const auto& trigger : m_vTriggers) {
+            for (const auto& trigger : m_triggers) {
                if (!result.empty()) {
                   result += ", ";
                }

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -19,7 +19,7 @@ typedef enum
    PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC     // Call a custom function
 } PUP_TRIGGER_PLAY_ACTION;
 
-struct StateTrigger{
+struct PUPStateTrigger{
    string m_sName;
    int value;
 };
@@ -48,7 +48,7 @@ public:
       }
       return NO_TRIGGER;
    }
-   vector<StateTrigger> GetTriggers() const
+   vector<PUPStateTrigger> GetTriggers() const
    {
       return m_triggers;
    }
@@ -66,11 +66,11 @@ public:
    string ToString() const;
 
 private:
-   static vector<StateTrigger> ParseTriggers(vector<string>::const_reference part);
-   PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
+   static vector<PUPStateTrigger> ParseTriggers(vector<string>::const_reference part);
+   PUPTrigger(bool active, const string& szDescript, const vector<PUPStateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
    bool m_active;
    string m_szDescript;
-   vector<StateTrigger> m_triggers;
+   vector<PUPStateTrigger> m_triggers;
    PUPScreen* m_pScreen;
    PUPPlaylist* m_pPlaylist;
    string m_szPlayFile;

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -19,7 +19,8 @@ typedef enum
    PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC     // Call a custom function
 } PUP_TRIGGER_PLAY_ACTION;
 
-struct PUPStateTrigger{
+struct PUPStateTrigger
+{
    string m_sName;
    int value;
 };

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -19,13 +19,13 @@ typedef enum
    PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC     // Call a custom function
 } PUP_TRIGGER_PLAY_ACTION;
 
-struct PUPStateTrigger
+struct PUPTriggerCondition
 {
    string m_sName;
    int value;
 };
 
-const string NO_TRIGGER = "";
+const string NO_CONDITIONS = "";
 
 const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value);
 
@@ -36,7 +36,7 @@ public:
    static PUPTrigger* CreateFromCSV(PUPScreen* pScreen, string line);
    bool IsActive() const { return m_active; }
    const string& GetDescription() const { return m_szDescript; }
-   vector<PUPStateTrigger> GetTriggers() const { return m_triggers; }
+   vector<PUPTriggerCondition> GetTriggers() const { return m_conditions; }
    PUPScreen* GetScreen() const { return m_pScreen; }
    PUPPlaylist* GetPlaylist() const { return m_pPlaylist; }
    const string& GetPlayFile() const { return m_szPlayFile; }
@@ -49,20 +49,25 @@ public:
    bool IsResting();
    void SetTriggered();
    /**
-    * @brief Retrieves the name of the first trigger.
+    * @brief Retrieves the name of the first condition.
     *
-    * @return The name of the first trigger as a `string`.
-    *         Returns NO_TRIGGER if no triggers are available.
+    * @return The name of the first condition as a `string`.
+    *         Returns NO_CONDITIONS if no triggers are available.
     */
-   const string& GetMainTriggerName() const;
+   const string& GetMainConditionName() const;
    string ToString() const;
 
 private:
-   static vector<PUPStateTrigger> ParseTriggers(vector<string>::const_reference part);
-   PUPTrigger(bool active, const string& szDescript, const vector<PUPStateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
+   static vector<PUPTriggerCondition> ParseTriggers(vector<string>::const_reference part);
+   PUPTrigger(bool active, const string& szDescript, const vector<PUPTriggerCondition>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
    bool m_active;
    string m_szDescript;
-   vector<PUPStateTrigger> m_triggers;
+   /**
+    * @brief The vector of trigger conditions
+    *
+    * A trigger will only be activated if all conditions are met.
+    */
+   vector<PUPTriggerCondition> m_conditions;
    PUPScreen* m_pScreen;
    PUPPlaylist* m_pPlaylist;
    string m_szPlayFile;

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -43,14 +43,14 @@ public:
     */
    const string& GetMainTriggerName() const
    {
-      if (!m_vTriggers.empty()) {
-         return m_vTriggers.front().m_sName;
+      if (!m_triggers.empty()) {
+         return m_triggers.front().m_sName;
       }
       return NO_TRIGGER;
    }
    vector<StateTrigger> GetTriggers() const
    {
-      return m_vTriggers;
+      return m_triggers;
    }
    PUPScreen* GetScreen() const { return m_pScreen; }
    PUPPlaylist* GetPlaylist() const { return m_pPlaylist; }
@@ -70,7 +70,7 @@ private:
    PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
    bool m_active;
    string m_szDescript;
-   vector<StateTrigger> m_vTriggers;
+   vector<StateTrigger> m_triggers;
    PUPScreen* m_pScreen;
    PUPPlaylist* m_pPlaylist;
    string m_szPlayFile;

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -36,23 +36,7 @@ public:
    static PUPTrigger* CreateFromCSV(PUPScreen* pScreen, string line);
    bool IsActive() const { return m_active; }
    const string& GetDescription() const { return m_szDescript; }
-   /**
-    * @brief Retrieves the name of the first trigger.
-    *
-    * @return The name of the first trigger as a `string`.
-    *         Returns NO_TRIGGER if no triggers are available.
-    */
-   const string& GetMainTriggerName() const
-   {
-      if (!m_triggers.empty()) {
-         return m_triggers.front().m_sName;
-      }
-      return NO_TRIGGER;
-   }
-   vector<PUPStateTrigger> GetTriggers() const
-   {
-      return m_triggers;
-   }
+   vector<PUPStateTrigger> GetTriggers() const { return m_triggers; }
    PUPScreen* GetScreen() const { return m_pScreen; }
    PUPPlaylist* GetPlaylist() const { return m_pPlaylist; }
    const string& GetPlayFile() const { return m_szPlayFile; }
@@ -64,6 +48,13 @@ public:
    PUP_TRIGGER_PLAY_ACTION GetPlayAction() const { return m_playAction; }
    bool IsResting();
    void SetTriggered();
+   /**
+    * @brief Retrieves the name of the first trigger.
+    *
+    * @return The name of the first trigger as a `string`.
+    *         Returns NO_TRIGGER if no triggers are available.
+    */
+   const string& GetMainTriggerName() const;
    string ToString() const;
 
 private:

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -19,17 +19,39 @@ typedef enum
    PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC     // Call a custom function
 } PUP_TRIGGER_PLAY_ACTION;
 
+struct StateTrigger{
+   string m_sName;
+   int value;
+};
+
+const string NO_TRIGGER = "";
+
 const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value);
 
 class PUPTrigger
 {
 public:
-   ~PUPTrigger() {}
-
+   ~PUPTrigger() { }
    static PUPTrigger* CreateFromCSV(PUPScreen* pScreen, string line);
    bool IsActive() const { return m_active; }
    const string& GetDescription() const { return m_szDescript; }
-   const string& GetTrigger() const { return m_szTrigger; }
+   /**
+    * @brief Retrieves the name of the first trigger.
+    *
+    * @return The name of the first trigger as a `string`.
+    *         Returns NO_TRIGGER if no triggers are available.
+    */
+   const string& GetMainTriggerName() const
+   {
+      if (!m_vTriggers.empty()) {
+         return m_vTriggers.front().m_sName;
+      }
+      return NO_TRIGGER;
+   }
+   std::vector<StateTrigger> GetTriggers() const
+   {
+      return m_vTriggers;
+   }
    PUPScreen* GetScreen() const { return m_pScreen; }
    PUPPlaylist* GetPlaylist() const { return m_pPlaylist; }
    const string& GetPlayFile() const { return m_szPlayFile; }
@@ -44,10 +66,11 @@ public:
    string ToString() const;
 
 private:
-   PUPTrigger(bool active, const string& szDescript, const string& szTrigger, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
+   static std::vector<StateTrigger> ParseTriggers(vector<string>::const_reference part);
+   PUPTrigger(bool active, const string& szDescript, const std::vector<StateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
    bool m_active;
    string m_szDescript;
-   string m_szTrigger;
+   std::vector<StateTrigger> m_vTriggers;
    PUPScreen* m_pScreen;
    PUPPlaylist* m_pPlaylist;
    string m_szPlayFile;

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -48,7 +48,7 @@ public:
       }
       return NO_TRIGGER;
    }
-   std::vector<StateTrigger> GetTriggers() const
+   vector<StateTrigger> GetTriggers() const
    {
       return m_vTriggers;
    }
@@ -66,11 +66,11 @@ public:
    string ToString() const;
 
 private:
-   static std::vector<StateTrigger> ParseTriggers(vector<string>::const_reference part);
-   PUPTrigger(bool active, const string& szDescript, const std::vector<StateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
+   static vector<StateTrigger> ParseTriggers(vector<string>::const_reference part);
+   PUPTrigger(bool active, const string& szDescript, const vector<StateTrigger>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
    bool m_active;
    string m_szDescript;
-   std::vector<StateTrigger> m_vTriggers;
+   vector<StateTrigger> m_vTriggers;
    PUPScreen* m_pScreen;
    PUPPlaylist* m_pPlaylist;
    string m_szPlayFile;


### PR DESCRIPTION
eg: `L23,W38=1,W39=1,W40=0`

this fixes #1786

* removed the trigger filters where only 1 values were passed
* keeps track of latest values
* parses all pup triggers
* makes sure all values match

The only thing I am not 100% sure about is if for example in above case `W40` goes to `0` and the rest already matched if we should also cause an event? Currently we see the first one as the main trigger so only a change to that one while the rest already matches can initiate an event.
