### PR TITLE
standalone: more multiple trigger enhancements

### DIFF
--- a/make/CMakeLists_bgfx-linux-aarch64.txt
+++ b/make/CMakeLists_bgfx-linux-aarch64.txt
@@ -598,6 +598,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_bgfx-linux-x64.txt
+++ b/make/CMakeLists_bgfx-linux-x64.txt
@@ -586,6 +586,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_bgfx-macos-arm64.txt
+++ b/make/CMakeLists_bgfx-macos-arm64.txt
@@ -591,6 +591,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_bgfx-macos-x64.txt
+++ b/make/CMakeLists_bgfx-macos-x64.txt
@@ -591,6 +591,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_bgfx_lib.txt
+++ b/make/CMakeLists_bgfx_lib.txt
@@ -605,6 +605,8 @@ set(VPINBALL_SOURCES
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_gl-linux-aarch64.txt
+++ b/make/CMakeLists_gl-linux-aarch64.txt
@@ -602,6 +602,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_gl-linux-x64.txt
+++ b/make/CMakeLists_gl-linux-x64.txt
@@ -589,6 +589,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_gl-macos-arm64.txt
+++ b/make/CMakeLists_gl-macos-arm64.txt
@@ -594,6 +594,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/make/CMakeLists_gl-macos-x64.txt
+++ b/make/CMakeLists_gl-macos-x64.txt
@@ -594,6 +594,8 @@ add_executable(vpinball
    standalone/inc/pup/PUPPlaylist.h
    standalone/inc/pup/PUPTrigger.cpp
    standalone/inc/pup/PUPTrigger.h
+   standalone/inc/pup/PUPTriggerCondition.cpp
+   standalone/inc/pup/PUPTriggerCondition.h
    standalone/inc/pup/PUPScreen.cpp
    standalone/inc/pup/PUPScreen.h
    standalone/inc/pup/PUPLabel.cpp

--- a/standalone/inc/pup/PUPLabel.cpp
+++ b/standalone/inc/pup/PUPLabel.cpp
@@ -478,7 +478,7 @@ void PUPLabel::UpdateLabelTexture(SDL_Renderer* pRenderer, SDL_Rect& rect)
          m_width = pMergedSurface->w;
          m_height = pMergedSurface->h;
 
-         m_dirty = true;
+         m_dirty = false;
       }
 
       SDL_DestroySurface(pMergedSurface);

--- a/standalone/inc/pup/PUPManager.h
+++ b/standalone/inc/pup/PUPManager.h
@@ -70,7 +70,8 @@ public:
    PUPScreen* GetScreen(int screenNum);
    bool AddFont(TTF_Font* pFont, const string& szFilename);
    TTF_Font* GetFont(const string& szFamily);
-   void QueueTriggerData(PUPTriggerData data);
+   void QueueTriggerData(const PUPTriggerData& data);
+   int GetTriggerValue(const string& triggerId);
    void Start();
    void Stop();
 
@@ -96,4 +97,5 @@ private:
    bool m_isRunning;
    std::thread m_thread;
    vector<PUPPlaylist*> m_playlists;
+   ankerl::unordered_dense::map<string, int> m_triggerMap;
 };

--- a/standalone/inc/pup/PUPScreen.h
+++ b/standalone/inc/pup/PUPScreen.h
@@ -65,7 +65,6 @@ struct PUPPinDisplayRequest : PUPScreenRequest
 struct PUPTriggerRequest : PUPScreenRequest
 {
    PUPTrigger* pTrigger;
-   int value;
 };
 
 struct PUPScreenRenderable
@@ -99,7 +98,6 @@ public:
    void AddPlaylist(PUPPlaylist* pPlaylist);
    PUPPlaylist* GetPlaylist(const string& szFolder);
    void AddTrigger(PUPTrigger* pTrigger);
-   vector<PUPTrigger*>* GetTriggers(const string& szTrigger);
    void SendToFront();
    void SetSize(int w, int h);
    void Init(SDL_Renderer* pRenderer);
@@ -126,7 +124,7 @@ public:
    void QueueStop();
    void QueueLoop(int state);
    void QueueBG(int mode);
-   void QueueTrigger(char type, int number, int value);
+   void QueueTrigger(const PUPTriggerData& data);
    string ToString(bool full = true) const;
 
 private:
@@ -154,7 +152,7 @@ private:
    vector<PUPLabel*> m_labels;
    std::map<string, PUPLabel*> m_labelMap;
    std::map<string, PUPPlaylist*> m_playlistMap;
-   std::map<string, vector<PUPTrigger*>> m_triggerMap;
+   vector<PUPTrigger*> m_triggers;
    SDL_Renderer* m_pRenderer;
    PUPScreenRenderable m_background;
    PUPScreenRenderable m_overlay;
@@ -173,5 +171,4 @@ private:
    bool m_isRunning;
    std::thread m_thread;
    std::mutex m_renderMutex;
-   ankerl::unordered_dense::map<string, int> m_triggersState;
 };

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -4,6 +4,7 @@
 
 class PUPPlaylist;
 class PUPScreen;
+class PUPTriggerCondition;
 
 typedef enum
 {
@@ -19,24 +20,16 @@ typedef enum
    PUP_TRIGGER_PLAY_ACTION_CUSTOM_FUNC     // Call a custom function
 } PUP_TRIGGER_PLAY_ACTION;
 
-struct PUPTriggerCondition
-{
-   string m_sName;
-   int value;
-};
-
-const string NO_CONDITIONS = "";
-
 const char* PUP_TRIGGER_PLAY_ACTION_TO_STRING(PUP_TRIGGER_PLAY_ACTION value);
 
 class PUPTrigger
 {
 public:
-   ~PUPTrigger() { }
+   ~PUPTrigger();
+
    static PUPTrigger* CreateFromCSV(PUPScreen* pScreen, string line);
    bool IsActive() const { return m_active; }
    const string& GetDescription() const { return m_szDescript; }
-   vector<PUPTriggerCondition> GetTriggers() const { return m_conditions; }
    PUPScreen* GetScreen() const { return m_pScreen; }
    PUPPlaylist* GetPlaylist() const { return m_pPlaylist; }
    const string& GetPlayFile() const { return m_szPlayFile; }
@@ -46,28 +39,15 @@ public:
    int GetCounter() const { return m_counter; }
    int GetRestSeconds() const { return m_restSeconds; }
    PUP_TRIGGER_PLAY_ACTION GetPlayAction() const { return m_playAction; }
-   bool IsResting();
-   void SetTriggered();
-   /**
-    * @brief Retrieves the name of the first condition.
-    *
-    * @return The name of the first condition as a `string`.
-    *         Returns NO_CONDITIONS if no triggers are available.
-    */
-   const string& GetMainConditionName() const;
+   bool Evaluate(PUPManager* pManager, const PUPTriggerData& data);
    string ToString() const;
 
 private:
-   static vector<PUPTriggerCondition> ParseTriggers(vector<string>::const_reference part);
-   PUPTrigger(bool active, const string& szDescript, const vector<PUPTriggerCondition>& m_vTriggers, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
+   PUPTrigger(bool active, const string& szDescript, const vector<PUPTriggerCondition*>& conditions, PUPScreen* pScreen, PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, int length, int counter, int restSeconds, PUP_TRIGGER_PLAY_ACTION playAction);
+   bool IsResting();
    bool m_active;
    string m_szDescript;
-   /**
-    * @brief The vector of trigger conditions
-    *
-    * A trigger will only be activated if all conditions are met.
-    */
-   vector<PUPTriggerCondition> m_conditions;
+   vector<PUPTriggerCondition*> m_conditions;
    PUPScreen* m_pScreen;
    PUPPlaylist* m_pPlaylist;
    string m_szPlayFile;

--- a/standalone/inc/pup/PUPTriggerCondition.cpp
+++ b/standalone/inc/pup/PUPTriggerCondition.cpp
@@ -1,0 +1,40 @@
+#include "core/stdafx.h"
+
+#include "PUPTriggerCondition.h"
+
+#include "PUPManager.h"
+
+PUPTriggerCondition::PUPTriggerCondition(const string& szId, int value)
+{
+   m_szId = szId;
+   m_value = value;
+}
+
+vector<PUPTriggerCondition*> PUPTriggerCondition::CreateFromCSV(const string& line)
+{
+   vector<PUPTriggerCondition*> conditions;
+
+   std::stringstream ss(line);
+   std::string token;
+   while (std::getline(ss, token, ',')) {
+       auto pos = token.find('=');
+       string id = trim_string(token.substr(0, pos));
+       int value = (pos == string::npos)
+           ? 1
+           : string_to_int(token.substr(pos + 1));
+       conditions.push_back(new PUPTriggerCondition(id, value));
+   }
+   return conditions;
+}
+
+bool PUPTriggerCondition::Evaluate(PUPManager* pManager, const PUPTriggerData& data, bool& idMatch)
+{
+   idMatch = m_szId == data.type + std::to_string(data.number);
+
+   return pManager->GetTriggerValue(m_szId) == m_value;
+}
+
+string PUPTriggerCondition::ToString() const
+{
+   return m_szId + "=" + std::to_string(m_value);
+}

--- a/standalone/inc/pup/PUPTriggerCondition.h
+++ b/standalone/inc/pup/PUPTriggerCondition.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "PUPManager.h"
+
+class PUPTriggerCondition
+{
+public:
+   ~PUPTriggerCondition() { };
+
+   static vector<PUPTriggerCondition*> CreateFromCSV(const string& line);
+   bool Evaluate(PUPManager* pManager, const PUPTriggerData& data, bool& idMatch);
+   string ToString() const;
+
+private:
+   PUPTriggerCondition(const string& szId, int value);
+
+   string m_szId;
+   int m_value;
+};


### PR DESCRIPTION
This PR makes the following changes:

- `PUPTriggerCondition` is now a class that contains an `Evaluate` method and is responsible for parsing the triggers field
- `PUPManager` now contains a cache for all past trigger states
- `PUPTrigger` is now responsible for evaluating if it has triggered
- Fixes an issue with `PUPLabel` being marked dirty [thanks @vbousquet]

Tested on TNA, B66, and MB.

- Does introduce a regression where the background is not showing up in TF.  Will follow up with a fix