### PR TITLE
Small readme fix in make/README.md for Fedora x64

### DIFF
--- a/make/README.md
+++ b/make/README.md
@@ -168,7 +168,7 @@ cd standalone/android
 sudo dnf install @development-tools
 sudo dnf install gcc-c++ pkg-config autoconf automake libtool cmake nasm bison curl systemd-devel libX11-devel mesa-libGL-devel libXext-devel zlib-ng-compat-static zlib-ng-compat-devel wayland-devel libxkbcommon-devel
 platforms/linux-x64/external.sh
-cp make/CMakeLists_bgfx-linux-aarch64.txt CMakeLists.txt
+cp make/CMakeLists_bgfx-linux-x64.txt CMakeLists.txt
 cmake -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 

--- a/make/README.md
+++ b/make/README.md
@@ -183,7 +183,7 @@ build/VPinballX_BGFX -play src/assets/exampleTable.vpx -disabletruefullscreen
 ```
 sudo dnf install @development-tools
 sudo dnf install gcc-c++ pkg-config autoconf automake libtool cmake nasm bison curl systemd-devel libX11-devel mesa-libGL-devel libXext-devel zlib-ng-compat-static zlib-ng-compat-devel wayland-devel libxkbcommon-devel
-platforms/linux-x64/external.sh
+platforms/linux-aarch64/external.sh
 cp make/CMakeLists_bgfx-linux-aarch64.txt CMakeLists.txt
 cmake -DBUILD_RK3588=ON -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)


### PR DESCRIPTION
The Linux x64 section contains a copy command for the aarch64 CMakeLists.txt instead of x64