### PR TITLE
standalone: update PUP media player to closer match new plugin

### DIFF
--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -23,7 +23,7 @@ PUPManager::PUPManager()
    m_isRunning = false;
    m_szRootPath = find_case_insensitive_directory_path(g_pvp->m_currentTablePath + "pupvideos");
 
-   m_triggerDataQueue.push({ 'D', 0, 1 });
+   QueueTriggerData({ 'D', 0, 1 });
 }
 
 PUPManager::~PUPManager()

--- a/standalone/inc/pup/PUPMediaManager.cpp
+++ b/standalone/inc/pup/PUPMediaManager.cpp
@@ -9,13 +9,19 @@ PUPMediaManager::PUPMediaManager(PUPScreen* pScreen)
    m_pBackgroundPlayer = nullptr;
    m_pScreen = pScreen;
    m_pop = (pScreen->GetMode() == PUP_SCREEN_MODE_FORCE_POP_BACK || pScreen->GetMode() == PUP_SCREEN_MODE_FORCE_POP);
+   m_pRenderer = nullptr;
 }
 
-void PUPMediaManager::Play(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority)
+void PUPMediaManager::SetRenderer(SDL_Renderer* pRenderer)
+{
+   m_pRenderer = pRenderer;
+}
+
+void PUPMediaManager::Play(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority, int length)
 {
    if (skipSamePriority && priority == m_pMainPlayer->priority) {
-      PLOGW.printf("skipping same priority, screen={%s}, playlist={%s}, playFile=%s, priority=%d",
-         m_pScreen->ToString(false).c_str(), pPlaylist->ToString().c_str(), szPlayFile.c_str(), priority);
+      PLOGW.printf("skipping same priority, screen={%s}, playlist={%s}, playFile=%s, priority=%d, length=%d",
+         m_pScreen->ToString(false).c_str(), pPlaylist->ToString().c_str(), szPlayFile.c_str(), priority, length);
       return;
    }
 
@@ -26,20 +32,15 @@ void PUPMediaManager::Play(PUPPlaylist* pPlaylist, const string& szPlayFile, flo
       return;
    }
 
-   PLOGD.printf("screen={%s}, playlist={%s}, playFile=%s, path=%s, volume=%.1f, priority=%d",
-      m_pScreen->ToString(false).c_str(), pPlaylist->ToString().c_str(), szPlayFile.c_str(), szPath.c_str(), volume, priority);
+   PLOGD.printf("screen={%s}, playlist={%s}, playFile=%s, path=%s, volume=%.1f, priority=%d, length=%d",
+      m_pScreen->ToString(false).c_str(), pPlaylist->ToString().c_str(), szPlayFile.c_str(), szPath.c_str(), volume, priority, length);
 
    m_pMainPlayer->player.Play(szPath);
    m_pMainPlayer->player.SetVolume(volume);
+   m_pMainPlayer->player.SetLength(length);
    m_pMainPlayer->szPath = szPath;
    m_pMainPlayer->volume = volume;
    m_pMainPlayer->priority = priority;
-}
-
-void PUPMediaManager::SetRenderer(SDL_Renderer* pRenderer)
-{
-   m_player1.player.SetRenderer(pRenderer);
-   m_player2.player.SetRenderer(pRenderer);
 }
 
 void PUPMediaManager::SetBG(bool isBackground)
@@ -103,11 +104,11 @@ void PUPMediaManager::Render(const SDL_Rect& destRect)
    if (m_pBackgroundPlayer) {
       backgroundPlaying = m_pBackgroundPlayer->player.IsPlaying();
       if (backgroundPlaying || (!m_pop && !mainPlayerPlaying))
-          m_pBackgroundPlayer->player.Render(destRect);
+          m_pBackgroundPlayer->player.Render(m_pRenderer, destRect);
    }
 
    if (mainPlayerPlaying || (!m_pop && !backgroundPlaying)) {
-      m_pMainPlayer->player.Render(destRect);
+      m_pMainPlayer->player.Render(m_pRenderer, destRect);
    }
 
    if (m_pBackgroundPlayer)

--- a/standalone/inc/pup/PUPMediaManager.h
+++ b/standalone/inc/pup/PUPMediaManager.h
@@ -17,19 +17,18 @@ class PUPMediaManager
 private:
    PUPMediaManagerPlayer m_player1;
    PUPMediaManagerPlayer m_player2;
-
    PUPMediaManagerPlayer* m_pMainPlayer;
    PUPMediaManagerPlayer* m_pBackgroundPlayer;
-
    PUPScreen* m_pScreen;
    bool m_pop;
+   SDL_Renderer* m_pRenderer;
 
 public:
    PUPMediaManager(PUPScreen* pScreen);
    ~PUPMediaManager() {};
 
    void SetRenderer(SDL_Renderer* pRenderer);
-   void Play(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority);
+   void Play(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority, int length);
    void SetBG(bool isBackground);
    void SetLoop(bool isLoop);
    void Stop();

--- a/standalone/inc/pup/PUPMediaPlayer.cpp
+++ b/standalone/inc/pup/PUPMediaPlayer.cpp
@@ -17,58 +17,16 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-constexpr size_t MAX_BUFFERED_FRAMES = 60;
-
 PUPMediaPlayer::PUPMediaPlayer()
 {
-   m_loop = false;
-   m_volume = 100.0f;
-   m_priority = -1;
-   m_pRenderer = NULL;
-   m_pTexture = NULL;
-   m_pFormatContext = NULL;
-   m_videoStream = -1;
-   m_pVideoContext = NULL;
-   m_pVideoConversionContext = NULL;
-   m_videoFormat = SDL_PIXELFORMAT_UNKNOWN;
-   m_videoWidth = 0;
-   m_videoHeight = 0;
-   m_audioStream = -1;
-   m_pAudioContext = NULL;
-   m_pAudioConversionContext = NULL;
-   m_audioFormat = AV_SAMPLE_FMT_NONE;
    m_pPinSound = new PinSound(nullptr);
    m_pPinSound->StreamInit(44100, 2, 0.0f);
-   m_running = false;
-   m_paused = false;
 }
 
 PUPMediaPlayer::~PUPMediaPlayer()
 {
    Stop();
-
-   if (m_pFormatContext)
-      avformat_close_input(&m_pFormatContext);
-
-   if (m_pVideoContext)
-      avcodec_free_context(&m_pVideoContext);
-
-   if (m_pVideoConversionContext)
-      sws_freeContext(m_pVideoConversionContext);
-
-   if (m_pAudioContext)
-      avcodec_free_context(&m_pAudioContext);
-
-   if (m_pAudioConversionContext)
-      swr_free(&m_pAudioConversionContext);
-
    delete m_pPinSound;
-}
-
-void PUPMediaPlayer::SetRenderer(SDL_Renderer* pRenderer)
-{
-   std::lock_guard<std::mutex> lock(m_mutex);
-   m_pRenderer = pRenderer;
 }
 
 void PUPMediaPlayer::Play(const string& szFilename)
@@ -80,49 +38,39 @@ void PUPMediaPlayer::Play(const string& szFilename)
    m_szFilename = szFilename;
    m_volume = 0.0f;
    m_loop = false;
-
-   if (m_pFormatContext)
-      avformat_close_input(&m_pFormatContext);
-
-   m_videoStream = -1;
-
-   if (m_pVideoContext)
-      avcodec_free_context(&m_pVideoContext);
-
-   m_videoFormat = SDL_PIXELFORMAT_UNKNOWN;
-   m_videoWidth = 0;
-   m_videoHeight = 0;
-
-   m_audioStream = -1;
-
-   if (m_pAudioContext)
-      avcodec_free_context(&m_pAudioContext);
-
-   m_audioFormat = AV_SAMPLE_FMT_NONE;
+   m_startTimestamp = SDL_GetTicks();
 
    // Open file
-
    if (avformat_open_input(&m_pFormatContext, szFilename.c_str(), NULL, NULL) != 0) {
       PLOGE.printf("Unable to open: filename=%s", szFilename.c_str());
       return;
    }
 
-   // Find video stream
+   // For image files, this will make sure width and height are set
+   if (avformat_find_stream_info(m_pFormatContext, nullptr) < 0) {
+      PLOGE.printf("Could not find stream info: filename=%s", szFilename.c_str());
+      return;
+   }
 
-   for (int i = 0; i < m_pFormatContext->nb_streams; i++) {
-      if (m_pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
-         !(m_pFormatContext->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC)) {
-         m_videoStream = i;
-         break;
+   // Find video stream
+   for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++) {
+      auto* pStream = m_pFormatContext->streams[i];
+      if (pStream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+          !(pStream->disposition & AV_DISPOSITION_ATTACHED_PIC)) {
+          m_videoStream = i;
+          break;
       }
    }
 
-   // Open video stream
+   bool singleFrame = false;
 
+   // Open video stream
    if (m_videoStream >= 0) {
       AVStream* pStream = m_pFormatContext->streams[m_videoStream];
       AVCodecParameters* pCodecParameters = pStream->codecpar;
       m_pVideoContext = OpenStream(m_pFormatContext, m_videoStream);
+      // Detect single-frame streams (static images)
+      singleFrame = pStream->nb_frames == 0;
       if (m_pVideoContext) {
          PLOGD.printf("Video stream: %s %dx%d", avcodec_get_name(m_pVideoContext->codec_id), pCodecParameters->width, pCodecParameters->height);
       }
@@ -134,16 +82,49 @@ void PUPMediaPlayer::Play(const string& szFilename)
       m_videoStream = -1;
    }
 
-   // Find audio stream
+   // Create video frame conversion context and frame queue
+   if (m_pVideoContext)
+   {
+      const AVPixelFormat targetFormat = AV_PIX_FMT_RGBA;
+      const int targetWidth = m_pVideoContext->width; // TODO we could also apply downscaling to the expected render size
+      const int targetHeight = m_pVideoContext->height;
+      m_nRgbFrames = singleFrame ? 1 : 3; // TODO shouldn't the queue size be adapted to the video characteristics ?
 
+      m_rgbFrames = new AVFrame*[m_nRgbFrames];
+      m_rgbFrameBuffers = new uint8_t*[m_nRgbFrames];
+      int rgbFrameSize = av_image_get_buffer_size(targetFormat, targetWidth, targetHeight, 1);
+      for (int i = 0; i < m_nRgbFrames; i++)
+      {
+         m_rgbFrames[i] = av_frame_alloc();
+         if (m_rgbFrames[i] == nullptr)
+         {
+            PLOGE.printf("Failed to create RGB buffer frame");
+            Stop();
+            return;
+         }
+         m_rgbFrameBuffers[i] = static_cast<uint8_t*>(av_malloc(rgbFrameSize * sizeof(uint8_t)));
+         if (m_rgbFrameBuffers[i] == nullptr)
+         {
+            PLOGE.printf("Failed to allocate RGB buffer");
+            Stop();
+            return;
+         }
+         m_rgbFrames[i]->width = targetWidth;
+         m_rgbFrames[i]->height = targetHeight;
+         m_rgbFrames[i]->format = targetFormat;
+         av_image_fill_arrays(m_rgbFrames[i]->data, m_rgbFrames[i]->linesize, m_rgbFrameBuffers[i], targetFormat, targetWidth, targetHeight, 1);
+      }
+   }
+
+   // Find audio stream
    if (m_videoStream >= 0) {
       m_audioStream = av_find_best_stream(m_pFormatContext, AVMEDIA_TYPE_AUDIO, -1, m_videoStream, NULL, 0);
       if (m_audioStream == AVERROR_DECODER_NOT_FOUND) {
-         PLOGW.printf("No audio stream found: filename=%s", szFilename.c_str());
+         PLOGE.printf("No audio stream found: filename=%s", szFilename.c_str());
       }
    }
    else {
-      for (int i = 0; i < m_pFormatContext->nb_streams; i++) {
+      for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++) {
          if (m_pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
             m_audioStream = i;
             break;
@@ -152,7 +133,6 @@ void PUPMediaPlayer::Play(const string& szFilename)
    }
 
    // Open audio stream
-
    if (m_audioStream >= 0) {
       AVStream* pStream = m_pFormatContext->streams[m_audioStream];
       AVCodecParameters* pCodecParameters = pStream->codecpar;
@@ -167,6 +147,7 @@ void PUPMediaPlayer::Play(const string& szFilename)
 
    if (!m_pVideoContext && !m_pAudioContext) {
       PLOGE.printf("No video or audio stream found: filename=%s", szFilename.c_str());
+      Stop();
       return;
    }
 
@@ -185,24 +166,31 @@ bool PUPMediaPlayer::IsPlaying()
 
 void PUPMediaPlayer::Pause(bool pause)
 {
-   std::lock_guard<std::mutex> lock(m_mutex);
-   m_paused = pause;
+   if (m_paused != pause)
+   {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_paused = pause;
+      if (m_paused)
+         m_pauseTimestamp = static_cast<double>(SDL_GetTicks() - m_startTimestamp) / 1000.0; // Freeze at the current playing time
+      else
+         m_startTimestamp = SDL_GetTicks() - static_cast<Uint64>(1000.0 * m_pauseTimestamp); // Adjust start time to restart from freeze point
+   }
 }
 
 void PUPMediaPlayer::Stop()
 {
-   if (IsPlaying()) {
+   if (IsPlaying())
+   {
       PLOGD.printf("Stop: %s", m_szFilename.c_str());
    }
 
+   // Stop decoder thread and flush queue
    {
       std::lock_guard<std::mutex> lock(m_mutex);
       m_running = false;
    }
-
    if (m_thread.joinable())
       m_thread.join();
-
    {
       std::lock_guard<std::mutex> lock(m_mutex);
       while (!m_queue.empty()) {
@@ -211,158 +199,54 @@ void PUPMediaPlayer::Stop()
          m_queue.pop();
       }
    }
-}
 
-void PUPMediaPlayer::Run()
-{
-   AVPacket* pPacket = av_packet_alloc();
-   if (!pPacket) {
-      PLOGE.printf("Unable to allocate packet");
-      return;
-   }
+   if (m_pFormatContext)
+      avformat_close_input(&m_pFormatContext);
+   m_pFormatContext = nullptr;
 
-   AVFrame* pFrame = av_frame_alloc();
-   if (!pFrame) {
-      PLOGE.printf("Unable to allocate frame");
-      av_packet_free(&pPacket);
-      return;
-   }
+   if (m_pVideoContext)
+      avcodec_free_context(&m_pVideoContext);
+   m_pVideoContext = nullptr;
+   m_videoStream = -1;
 
-   bool flushing = false;
-
-   Uint64 videoStart = 0;
-   double videoFirstPTS = -1.0;
-   int count = 0;
-   SDL_Renderer* pRenderer = nullptr;
-
-   while (true) {
-      {
-         std::lock_guard<std::mutex> lock(m_mutex);
-         if (!m_running)
-            break;
-
-         if (!pRenderer)
-            pRenderer = m_pRenderer;
-
-         m_pPinSound->StreamVolume(m_volume / 100.0f);
-      }
-
-      {
-         std::unique_lock<std::mutex> lock(m_mutex);
-         if (m_paused) {
-            lock.unlock();
-            SDL_Delay(100);
-            continue;
-         }
-      }
-
-      if (!flushing) {
-         if (av_read_frame(m_pFormatContext, pPacket) < 0) {
-            if (count == 0)  {
-               PLOGD.printf("End of stream, finishing decode: %s", m_szFilename.c_str());
-            }
-
-            if (m_pAudioContext)
-               avcodec_flush_buffers(m_pAudioContext);
-
-            if (m_pVideoContext)
-               avcodec_flush_buffers(m_pVideoContext);
-
-            flushing = true;
-         }
-         else {
-            if (pPacket->stream_index == m_audioStream) {
-               if (avcodec_send_packet(m_pAudioContext, pPacket) != 0) {
-                  PLOGE.printf("Unable to send audio packet");
-               }
-            }
-            else if (pPacket->stream_index == m_videoStream) {
-               if (avcodec_send_packet(m_pVideoContext, pPacket) != 0) {
-                  PLOGE.printf("Unable to send video packet");
-               }
-            }
-            av_packet_unref(pPacket);
-         }
-      }
-
-      bool decoded = false;
-
-      if (m_pAudioContext) {
-         while (avcodec_receive_frame(m_pAudioContext, pFrame) >= 0) {
-            HandleAudioFrame(pFrame);
-            decoded = true;
-         }
-         if (flushing)
-            SDL_Delay(100);
-      }
-
-      if (m_pVideoContext) {
-         while (avcodec_receive_frame(m_pVideoContext, pFrame) >= 0) {
-            double pts = ((double)pFrame->pts * m_pVideoContext->pkt_timebase.num) / m_pVideoContext->pkt_timebase.den;
-            if (videoFirstPTS < 0.0)
-               videoFirstPTS = pts;
-            pts -= videoFirstPTS;
-
-            if (pRenderer) {
-               AVFrame* pClonedFrame = av_frame_clone(pFrame);
-               if (pClonedFrame) {
-                  std::lock_guard<std::mutex> lock(m_mutex);
-                  if (m_queue.size() >= MAX_BUFFERED_FRAMES) {
-                     AVFrame* pOldFrame = m_queue.front();
-                     av_frame_free(&pOldFrame);
-                     m_queue.pop();
-                  }
-                  m_queue.push(pClonedFrame);
-               }
-            }
-
-            if (!videoStart)
-               videoStart = SDL_GetTicks();
-
-            double now = (double)(SDL_GetTicks() - videoStart) / 1000.0;
-            while (now < pts - 0.001) {
-               SDL_Delay(8);
-               now = (double)(SDL_GetTicks() - videoStart) / 1000.0;
-            }
-            decoded = true;
-         }
-      }
-
-      if (flushing && !decoded) {
-         SDL_Delay(100);
-
-         {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            if (!m_loop)
-               break;
-         }
-
-         if (m_pVideoContext) {
-            if (av_seek_frame(m_pFormatContext, m_videoStream, 0, 0) < 0) {
-               PLOGE.printf("Unable to seek video stream");
-            }
-            videoFirstPTS = -1.0;
-            videoStart = 0;
-         }
-
-         if (m_pAudioContext) {
-            if (av_seek_frame(m_pFormatContext, m_audioStream, 0, 0) < 0) {
-               PLOGE.printf("Unable to seek audio stream");
-            }
-         }
-
-         count++;
-         flushing = false;
-      }
-   }
-
-   av_frame_free(&pFrame);
-   av_packet_free(&pPacket);
-
+   if (m_rgbFrames)
    {
-      std::lock_guard<std::mutex> lock(m_mutex);
-      m_running = false;
+      for (int i = 0; i < m_nRgbFrames; i++)
+         if (m_rgbFrames[i])
+            av_frame_free(&m_rgbFrames[i]);
+      delete[] m_rgbFrames;
+      m_rgbFrames = nullptr;
    }
+   if (m_rgbFrames)
+   {
+      for (int i = 0; i < m_nRgbFrames; i++)
+         if (m_rgbFrameBuffers[i])
+            av_freep(&m_rgbFrameBuffers[i]);
+      delete[] m_rgbFrameBuffers;
+      m_rgbFrameBuffers = nullptr;
+   }
+   m_nRgbFrames = 0;
+   m_activeRgbFrame = 0;
+
+   if (m_swsContext)
+      sws_freeContext(m_swsContext);
+   m_swsContext = nullptr;
+
+   if (m_videoTexture)
+      SDL_DestroyTexture(m_videoTexture);
+
+   m_videoTexture = nullptr;
+   m_videoTextureId = 0xFFFFFF;
+
+   if (m_pAudioContext)
+      avcodec_free_context(&m_pAudioContext);
+   m_pAudioContext = nullptr;
+   m_audioFormat = AV_SAMPLE_FMT_NONE;
+   m_audioStream = -1;
+
+   if (m_pAudioConversionContext)
+      swr_free(&m_pAudioConversionContext);
+   m_pAudioConversionContext = nullptr;
 }
 
 void PUPMediaPlayer::SetLoop(bool loop)
@@ -383,81 +267,235 @@ void PUPMediaPlayer::SetVolume(float volume)
    }
 }
 
-void PUPMediaPlayer::Render(const SDL_Rect& destRect)
+void PUPMediaPlayer::SetLength(int length)
 {
-   AVFrame* pFrame = NULL;
+   std::lock_guard<std::mutex> lock(m_mutex);
+   if (m_length != length) {
+       PLOGD.printf("setting length: length=%d", length);
+       m_length = length;
+   }
+}
+
+void PUPMediaPlayer::Run()
+{
+   AVPacket* pPacket = av_packet_alloc();
+   if (!pPacket) {
+      PLOGE.printf("Unable to allocate packet");
+      return;
+   }
+
+   AVFrame* pFrame = av_frame_alloc();
+   if (!pFrame) {
+      PLOGE.printf("Unable to allocate frame");
+      av_packet_free(&pPacket);
+      return;
+   }
+
+   // Main loop which loops over read/decode/convert and handle video seeking/looping
+   while (true)
+   {
+      // Interact with main thread
+      bool loop;
+      {
+         std::lock_guard<std::mutex> lock(m_mutex);
+         if (!m_running)
+            break;
+         if (m_paused)
+         {
+            SDL_Delay(100);
+            continue;
+         }
+
+         double elapsed = (static_cast<double>(SDL_GetTicks() - m_startTimestamp) / 1000.0);
+         if (m_length != 0 && elapsed >= m_length)
+            break;
+
+         loop = m_loop;
+         m_pPinSound->StreamVolume(m_volume / 100.0f);
+      }
+
+      // Read next frame from source
+      const int rfRet = av_read_frame(m_pFormatContext, pPacket);
+      if (rfRet == AVERROR_EOF)
+      {
+         // End of stream, loop or stop
+         if (!loop)
+            break;
+         if (m_pVideoContext)
+         {
+            if (av_seek_frame(m_pFormatContext, m_videoStream, 0, 0) < 0)
+            {
+               PLOGE.printf("Unable to seek video stream. Aborting loop");
+               break;
+            }
+            avcodec_flush_buffers(m_pVideoContext);
+         }
+         if (m_pAudioContext)
+         {
+            if (av_seek_frame(m_pFormatContext, m_audioStream, 0, 0) < 0)
+            {
+               PLOGE.printf("Unable to seek audio stream. Aborting loop");
+            }
+            avcodec_flush_buffers(m_pAudioContext);
+         }
+         m_playIndex++;
+         m_startTimestamp = SDL_GetTicks();
+         continue;
+      }
+      else if (rfRet < 0)
+      {
+         // Error reading file, stop playing
+         PLOGE.printf("Error while reading video frame");
+         break;
+      }
+
+      // Send to decoder
+      if (pPacket->stream_index == m_audioStream)
+      {
+         if (avcodec_send_packet(m_pAudioContext, pPacket) != 0)
+         {
+            PLOGE.printf("Unable to send audio packet");
+         }
+      }
+      else if (pPacket->stream_index == m_videoStream)
+      {
+         if (avcodec_send_packet(m_pVideoContext, pPacket) != 0)
+         {
+            PLOGE.printf("Unable to send video packet");
+         }
+      }
+      av_packet_unref(pPacket);
+
+      // Process decoded frames
+      // TODO This should be done on anciliary threads to improve synchronization and better balance the load between CPU cores
+      // Here, the synchronization entirely rely on the fact that HandleVideoFrame will block, waiting for a free slot in the circular frame buffer
+      // This can causes audio overflow if there are no video (the stream is directly fully decoded) or audio glitches if the muxing is not great
+      // (video waiting for frame while audio buffer is exhausted, this one being unlikely).
+      if (m_pAudioContext)
+      {
+         while (avcodec_receive_frame(m_pAudioContext, pFrame) >= 0)
+            HandleAudioFrame(pFrame);
+      }
+      if (m_pVideoContext)
+      {
+         while (avcodec_receive_frame(m_pVideoContext, pFrame) >= 0)
+         {
+            pFrame->opaque = reinterpret_cast<void*>(static_cast<uintptr_t>(m_playIndex));
+            HandleVideoFrame(pFrame);
+         }
+      }
+   }
+
+   av_frame_free(&pFrame);
+   av_packet_free(&pPacket);
 
    {
       std::lock_guard<std::mutex> lock(m_mutex);
-      if (!m_queue.empty()) {
-         pFrame = m_queue.front();
-         m_queue.pop();
+      m_running = false;
+   }
+}
+
+void PUPMediaPlayer::HandleVideoFrame(AVFrame* frame)
+{
+   // Unknown frame format, don't process frame (would crash in getContext)
+   if (frame->format < 0)
+      return;
+
+   // m_activeRgbFrame points to the last frame (the one with the highest presentation timestamp)
+   int nextFrame = (m_activeRgbFrame + 1) % m_nRgbFrames;
+   AVFrame* rgbFrame = m_rgbFrames[nextFrame];
+
+   // Create/Update conversion context when source format is known (so after decoding at least one frame)
+   m_swsContext = sws_getCachedContext(m_swsContext, 
+      frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
+      rgbFrame->width, rgbFrame->height, static_cast<AVPixelFormat>(rgbFrame->format),
+      SWS_BILINEAR, NULL, NULL, NULL
+   );
+   if (m_swsContext == nullptr)
+      return;
+
+   // Wait for the buffer slot to be outdated (do not overwrite a frame that is waiting to be displayed), but only in the same play sequence (stored in the opaque field of the frame. if we looped or seek, skip)
+   if (rgbFrame->opaque == frame->opaque)
+   {
+      const double oldPts = (static_cast<double>(rgbFrame->pts) * m_pVideoContext->pkt_timebase.num) / m_pVideoContext->pkt_timebase.den;
+      while (m_running && (static_cast<double>(SDL_GetTicks() - m_startTimestamp) / 1000.0) < oldPts)
+         SDL_Delay(8);
+   }
+
+   // Convert to a renderable format (we do not lock as the consumer thread is not supposed to be accessing an outdated frame, and this operation can be a bit lengthy)
+   const bool resized = sws_scale(m_swsContext, frame->data, frame->linesize, 0, m_pVideoContext->height, rgbFrame->data, rgbFrame->linesize) == m_pVideoContext->height;
+
+   // Update frame PTS and pointer to latest frame under a lock as this modification impacts the consumer thread frame selection
+   {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      av_frame_copy_props(rgbFrame, frame);
+      m_activeRgbFrame++;
+   }
+}
+
+void PUPMediaPlayer::Render(SDL_Renderer* pRenderer, const SDL_Rect& destRect)
+{
+   if (!pRenderer)
+      return;
+
+   double elapsed = (static_cast<double>(SDL_GetTicks() - m_startTimestamp) / 1000.0);
+   if (m_length != 0 && elapsed >= m_length)
+      return;
+
+   if (m_nRgbFrames == 1) {
+      AVFrame* rgbFrame = m_rgbFrames[0];
+      if (m_videoTexture && (m_videoTexture->w != rgbFrame->width || m_videoTexture->h != rgbFrame->height)) {
+         SDL_DestroyTexture(m_videoTexture);
+         m_videoTexture = nullptr;
+      }
+      if (!m_videoTexture)
+         m_videoTexture = SDL_CreateTexture(pRenderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING, rgbFrame->width, rgbFrame->height);
+      if (m_videoTexture)
+         SDL_UpdateTexture(m_videoTexture, NULL, rgbFrame->data[0], rgbFrame->linesize[0]);
+   }
+   else if (m_running) {
+      // Search for the best frame to display and update the video texture accordingly (if needed)
+      const double playPts = m_paused ? m_pauseTimestamp : static_cast<double>(SDL_GetTicks() - m_startTimestamp) / 1000.0;
+      {
+         std::lock_guard<std::mutex> lock(m_mutex);
+         unsigned int m_renderFrameId = m_videoTextureId;
+         for (int i = 0; i < m_nRgbFrames; i++)
+         {
+            if (m_activeRgbFrame >= i)
+            {
+               const AVFrame* rgbFrame = m_rgbFrames[(m_activeRgbFrame + m_nRgbFrames - i) % m_nRgbFrames];
+               const double framePts = (static_cast<double>(rgbFrame->pts) * m_pVideoContext->pkt_timebase.num) / m_pVideoContext->pkt_timebase.den;
+               if (playPts <= framePts) // We select the first frame after (or at) the current play timestamp
+                  m_renderFrameId = m_activeRgbFrame - i;
+            }
+         }
+         if (m_videoTextureId != m_renderFrameId)
+         {
+            m_videoTextureId = m_renderFrameId;
+            AVFrame* rgbFrame = m_rgbFrames[m_renderFrameId % m_nRgbFrames];
+            if (m_videoTexture && (m_videoTexture->w != rgbFrame->width || m_videoTexture->h != rgbFrame->height)) {
+               SDL_DestroyTexture(m_videoTexture);
+               m_videoTexture = nullptr;
+            }
+            if (!m_videoTexture)
+               m_videoTexture = SDL_CreateTexture(pRenderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING, rgbFrame->width, rgbFrame->height);
+            if (m_videoTexture)
+               SDL_UpdateTexture(m_videoTexture, NULL, rgbFrame->data[0], rgbFrame->linesize[0]);
+
+            //const double framePts = (static_cast<double>(rgbFrame->pts) * m_pVideoContext->pkt_timebase.num) / m_pVideoContext->pkt_timebase.den;
+            //PLOGD.printf("Video tex update: play time: %8.3fs / frame pts: %8.3fs / delta: %8.3fs  [%s]", playPts, framePts, framePts - playPts, m_szFilename.c_str());
+         }
       }
    }
 
-   if (pFrame) {
-      SDL_PixelFormat format = GetVideoFormat((enum AVPixelFormat)pFrame->format);
-      if (!m_pTexture || format != m_videoFormat || pFrame->width != m_videoWidth || pFrame->height != m_videoHeight) {
-         if (m_pTexture)
-             SDL_DestroyTexture(m_pTexture);
-
-         if (format == SDL_PIXELFORMAT_UNKNOWN)
-            m_pTexture = SDL_CreateTexture(m_pRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, pFrame->width,pFrame->height);
-         else
-            m_pTexture = SDL_CreateTexture(m_pRenderer, format, SDL_TEXTUREACCESS_STREAMING, pFrame->width, pFrame->height);
-
-         m_videoFormat = format;
-         m_videoWidth = pFrame->width;
-         m_videoHeight = pFrame->height;
-      }
-
-      SDL_FlipMode flip = SDL_FLIP_NONE;
-
-      switch (format) {
-         case SDL_PIXELFORMAT_UNKNOWN:
-            m_pVideoConversionContext = sws_getCachedContext(m_pVideoConversionContext,
-               pFrame->width, pFrame->height, (enum AVPixelFormat)pFrame->format, pFrame->width, pFrame->height,
-               AV_PIX_FMT_BGRA, SWS_POINT, NULL, NULL, NULL);
-            if (m_pVideoConversionContext != NULL) {
-               uint8_t* pPixels[4];
-               int pitch[4];
-               if (SDL_LockTexture(m_pTexture, NULL, (void **)pPixels, pitch)) {
-                  sws_scale(m_pVideoConversionContext, (const uint8_t * const *)pFrame->data, pFrame->linesize, 0, pFrame->height, pPixels, pitch);
-                  SDL_UnlockTexture(m_pTexture);
-               }
-            }
-            break;
-         case SDL_PIXELFORMAT_IYUV:
-            if (pFrame->linesize[0] > 0 && pFrame->linesize[1] > 0 && pFrame->linesize[2] > 0) {
-               SDL_UpdateYUVTexture(m_pTexture, NULL, pFrame->data[0], pFrame->linesize[0],
-                  pFrame->data[1], pFrame->linesize[1], pFrame->data[2], pFrame->linesize[2]);
-            }
-            else if (pFrame->linesize[0] < 0 && pFrame->linesize[1] < 0 && pFrame->linesize[2] < 0) {
-               SDL_UpdateYUVTexture(m_pTexture, NULL, pFrame->data[0] + pFrame->linesize[0] * (pFrame->height - 1), -pFrame->linesize[0],
-                  pFrame->data[1] + pFrame->linesize[1] * (AV_CEIL_RSHIFT(pFrame->height, 1) - 1), -pFrame->linesize[1],
-                  pFrame->data[2] + pFrame->linesize[2] * (AV_CEIL_RSHIFT(pFrame->height, 1) - 1), -pFrame->linesize[2]);
-               flip = SDL_FLIP_VERTICAL;
-            }
-            SetYUVConversionMode(pFrame);
-            break;
-         default:
-            if (pFrame->linesize[0] < 0) {
-               SDL_UpdateTexture(m_pTexture, NULL, pFrame->data[0] + pFrame->linesize[0] * (pFrame->height - 1), -pFrame->linesize[0]);
-               flip = SDL_FLIP_VERTICAL;
-            }
-            else
-               SDL_UpdateTexture(m_pTexture, NULL, pFrame->data[0], pFrame->linesize[0]);
-      }
-      av_frame_free(&pFrame);
-   }
-
-   if (m_pTexture) {
+   // Render image
+   if (m_videoTexture) {
       SDL_FRect fDestRect;
       fDestRect.x = static_cast<float>(destRect.x);
       fDestRect.y = static_cast<float>(destRect.y);
       fDestRect.w = static_cast<float>(destRect.w);
       fDestRect.h = static_cast<float>(destRect.h);
-      SDL_RenderTexture(m_pRenderer, m_pTexture, NULL, &fDestRect);
+      SDL_RenderTexture(pRenderer, m_videoTexture, NULL, &fDestRect);
    }
 }
 
@@ -554,49 +592,6 @@ void PUPMediaPlayer::HandleAudioFrame(AVFrame* pFrame)
    m_pPinSound->StreamUpdate(pBuffer, resampledDataSize);
 
    av_free(pBuffer);
-}
-
-SDL_PixelFormat PUPMediaPlayer::GetVideoFormat(enum AVPixelFormat format)
-{
-   switch (format) {
-      case AV_PIX_FMT_RGB8: return SDL_PIXELFORMAT_RGB332;
-      case AV_PIX_FMT_RGB444: return SDL_PIXELFORMAT_XRGB4444;
-      case AV_PIX_FMT_RGB555: return SDL_PIXELFORMAT_XRGB1555;
-      case AV_PIX_FMT_BGR555: return SDL_PIXELFORMAT_XBGR1555;
-      case AV_PIX_FMT_RGB565: return SDL_PIXELFORMAT_RGB565;
-      case AV_PIX_FMT_BGR565: return SDL_PIXELFORMAT_BGR565;
-      case AV_PIX_FMT_RGB24: return SDL_PIXELFORMAT_RGB24;
-      case AV_PIX_FMT_BGR24: return SDL_PIXELFORMAT_BGR24;
-      case AV_PIX_FMT_0RGB32: return SDL_PIXELFORMAT_XRGB8888;
-      case AV_PIX_FMT_0BGR32: return SDL_PIXELFORMAT_XBGR8888;
-      case AV_PIX_FMT_NE(RGB0, 0BGR): return SDL_PIXELFORMAT_RGBX8888;
-      case AV_PIX_FMT_NE(BGR0, 0RGB): return SDL_PIXELFORMAT_BGRX8888;
-      case AV_PIX_FMT_RGB32: return SDL_PIXELFORMAT_ARGB8888;
-      case AV_PIX_FMT_RGB32_1: return SDL_PIXELFORMAT_RGBA8888;
-      case AV_PIX_FMT_BGR32: return SDL_PIXELFORMAT_ABGR8888;
-      case AV_PIX_FMT_BGR32_1: return SDL_PIXELFORMAT_BGRA8888;
-      case AV_PIX_FMT_YUV420P: return SDL_PIXELFORMAT_IYUV;
-      case AV_PIX_FMT_YUYV422: return SDL_PIXELFORMAT_YUY2;
-      case AV_PIX_FMT_UYVY422: return SDL_PIXELFORMAT_UYVY;
-      default: return SDL_PIXELFORMAT_UNKNOWN;
-   }
-}
-
-void PUPMediaPlayer::SetYUVConversionMode(AVFrame *frame)
-{
-   // JSM174 - Switch to Colorspace - https://github.com/libsdl-org/SDL/blob/main/test/testffmpeg.c
-   /*
-   SDL_YUV_CONVERSION_MODE mode = SDL_YUV_CONVERSION_AUTOMATIC;
-   if (frame && (frame->format == AV_PIX_FMT_YUV420P || frame->format == AV_PIX_FMT_YUYV422 || frame->format == AV_PIX_FMT_UYVY422)) {
-      if (frame->color_range == AVCOL_RANGE_JPEG)
-         mode = SDL_YUV_CONVERSION_JPEG;
-      else if (frame->colorspace == AVCOL_SPC_BT709)
-         mode = SDL_YUV_CONVERSION_BT709;
-      else if (frame->colorspace == AVCOL_SPC_BT470BG || frame->colorspace == AVCOL_SPC_SMPTE170M)
-         mode = SDL_YUV_CONVERSION_BT601;
-   }
-   SDL_SetYUVConversionMode(mode);
-   */
 }
 
 #if defined(__clang__)

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -342,10 +342,10 @@ void PUPScreen::SetOverlay(PUPPlaylist* pPlaylist, const string& szPlayFile)
    LoadRenderable(&m_overlay, pPlaylist->GetPlayFilePath(szPlayFile));
 }
 
-void PUPScreen::SetMedia(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority)
+void PUPScreen::SetMedia(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority, int length)
 {
    std::lock_guard<std::mutex> lock(m_renderMutex);
-   m_pMediaPlayerManager->Play(pPlaylist, szPlayFile, m_pParent ? (volume / 100.0f) * m_pParent->GetVolume() : volume, priority, skipSamePriority);
+   m_pMediaPlayerManager->Play(pPlaylist, szPlayFile, m_pParent ? (volume / 100.0f) * m_pParent->GetVolume() : volume, priority, skipSamePriority, length);
 }
 
 void PUPScreen::StopMedia()
@@ -527,7 +527,7 @@ void PUPScreen::ProcessPinDisplayRequest(PUPPinDisplayRequest* pRequest)
       case PUP_PINDISPLAY_REQUEST_TYPE_NORMAL:
          switch (pRequest->pPlaylist->GetFunction()) {
             case PUP_PLAYLIST_FUNCTION_DEFAULT:
-               SetMedia(pRequest->pPlaylist, pRequest->szPlayFile, pRequest->volume, pRequest->priority, false);
+               SetMedia(pRequest->pPlaylist, pRequest->szPlayFile, pRequest->volume, pRequest->priority, false, 0);
                break;
             case PUP_PLAYLIST_FUNCTION_FRAMES:
                StopMedia();
@@ -566,7 +566,7 @@ void PUPScreen::ProcessTriggerRequest(PUPTriggerRequest* pRequest)
       case PUP_TRIGGER_PLAY_ACTION_NORMAL:
          switch (pTrigger->GetPlaylist()->GetFunction()) {
             case PUP_PLAYLIST_FUNCTION_DEFAULT:
-               SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), false);
+               SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), false, pTrigger->GetLength());
                break;
             case PUP_PLAYLIST_FUNCTION_FRAMES:
                StopMedia();
@@ -583,15 +583,15 @@ void PUPScreen::ProcessTriggerRequest(PUPTriggerRequest* pRequest)
          }
          break;
       case PUP_TRIGGER_PLAY_ACTION_LOOP:
-         SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), false);
+         SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), false, pTrigger->GetLength());
          SetLoop(1);
          break;
       case PUP_TRIGGER_PLAY_ACTION_SET_BG:
-         SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), false);
+         SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), false, pTrigger->GetLength());
          SetBG(1);
          break;
       case PUP_TRIGGER_PLAY_ACTION_SKIP_SAME_PRTY:
-         SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), true);
+         SetMedia(pTrigger->GetPlaylist(), pTrigger->GetPlayFile(), pTrigger->GetVolume(), pTrigger->GetPriority(), true, pTrigger->GetLength());
          break;
       case PUP_TRIGGER_PLAY_ACTION_STOP_PLAYER:
          StopMedia(pTrigger->GetPriority());

--- a/standalone/inc/pup/PUPScreen.h
+++ b/standalone/inc/pup/PUPScreen.h
@@ -114,7 +114,7 @@ public:
    void SetBackground(PUPPlaylist* pPlaylist, const string& szPlayFile);
    void SetCustomPos(const string& string);
    void SetOverlay(PUPPlaylist* pPlaylist, const string& szPlayFile);
-   void SetMedia(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority);
+   void SetMedia(PUPPlaylist* pPlaylist, const string& szPlayFile, float volume, int priority, bool skipSamePriority, int length);
    void StopMedia();
    void StopMedia(int priority);
    void StopMedia(PUPPlaylist* pPlaylist, const string& szPlayFile);

--- a/standalone/inc/pup/PUPTrigger.h
+++ b/standalone/inc/pup/PUPTrigger.h
@@ -37,7 +37,7 @@ public:
    int GetPriority() const { return m_priority; }
    int GetLength() const { return m_length; }
    int GetCounter() const { return m_counter; }
-   int GetRestSeconds() const { return m_restSeconds; }
+   int GetRestMs() const { return m_restMs; }
    PUP_TRIGGER_PLAY_ACTION GetPlayAction() const { return m_playAction; }
    bool Evaluate(PUPManager* pManager, const PUPTriggerData& data);
    string ToString() const;
@@ -55,7 +55,7 @@ private:
    int m_priority;
    int m_length;
    int m_counter;
-   int m_restSeconds;
+   int m_restMs;
    PUP_TRIGGER_PLAY_ACTION m_playAction;
    Uint64 m_lastTriggered;
 };


### PR DESCRIPTION
- Fixed not sending D0=1 on start up
- Updated to use media player code from new pup plugin
- Updated media player to handle single frame video (png) (will wait for more proper fix)
- Continue to render texture even after `m_running` (last frame needs to display unless `PUP_SCREEN_MODE_FORCE_POP`,  `PUP_SCREEN_MODE_FORCE_POP_BACK`)
- Add support for trigger length, video will stop rendering after length (regardless of  `PUP_SCREEN_MODE_FORCE_POP`,  `PUP_SCREEN_MODE_FORCE_POP_BACK`)
- Updated trigger rest to be in ms. Absolute value of rest seconds <= 99 is treated as seconds, otherwise millis (confirmed with @nailbuster) 

Note: rest seconds < 0 should be treated as a delay, still need to implement this.