### PR TITLE
standalone: fix B2S segment leak. backport pup plugin changes

### DIFF
--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -193,6 +193,7 @@ void PUPManager::LoadPlaylists()
             }
             else {
                LOGE("Duplicate playlist: playlist=%s", pPlaylist->ToString().c_str());
+               delete pPlaylist;
             }
          }
       }

--- a/plugins/pup/PUPMediaPlayer.cpp
+++ b/plugins/pup/PUPMediaPlayer.cpp
@@ -181,14 +181,6 @@ void PUPMediaPlayer::Stop()
    }
    if (m_thread.joinable())
       m_thread.join();
-   {
-      std::lock_guard<std::mutex> lock(m_mutex);
-      while (!m_queue.empty()) {
-         AVFrame* pFrame = m_queue.front();
-         av_frame_free(&pFrame);
-         m_queue.pop();
-      }
-   }
 
    if (m_pFormatContext)
       avformat_close_input(&m_pFormatContext);

--- a/plugins/pup/PUPMediaPlayer.h
+++ b/plugins/pup/PUPMediaPlayer.h
@@ -66,7 +66,6 @@ private:
    AVSampleFormat m_audioFormat = AV_SAMPLE_FMT_NONE;
    //PinSound* m_pPinSound = nullptr;
 
-   std::queue<AVFrame*> m_queue;
    std::mutex m_mutex;
    std::thread m_thread;
    bool m_running = false;

--- a/standalone/inc/b2s/dream7/Dream7Display.cpp
+++ b/standalone/inc/b2s/dream7/Dream7Display.cpp
@@ -24,6 +24,9 @@ Dream7Display::Dream7Display() : Control()
 Dream7Display::~Dream7Display()
 {
    delete m_pMatrix;
+
+   for (auto& pSegmentNumber : m_segmentNumbers)
+      delete pSegmentNumber;
 }
 
 void Dream7Display::OnPaint(VP::RendererGraphics* pGraphics)

--- a/standalone/inc/b2s/dream7/Segment.cpp
+++ b/standalone/inc/b2s/dream7/Segment.cpp
@@ -55,7 +55,6 @@ Segment::Segment(float x, float y, float radius)
 
 Segment::~Segment()
 {
-   delete m_pStyle;
    delete m_pGlassPath;
    delete m_pLightPath;
    delete m_pExternMatrix;
@@ -269,5 +268,7 @@ void Segment::SetTransform(VP::RendererGraphics* pGraphics)
 
 void Segment::Transform(VP::Matrix* pMatrix)
 {
+   if (m_pExternMatrix)
+      delete m_pExternMatrix;
    m_pExternMatrix = pMatrix->Clone();
 }

--- a/standalone/inc/b2s/dream7/SegmentNumber.cpp
+++ b/standalone/inc/b2s/dream7/SegmentNumber.cpp
@@ -87,7 +87,10 @@ void SegmentNumber::SetCharacter(const string& szCharacter)
 
 void SegmentNumber::InitSegments(const SegmentNumberType type, const float thickness)
 {
+   for (Segment* pSegment : m_segments)
+      delete pSegment;
    m_segments.clear();
+
    float TH = thickness;
    float T4 = TH / 4.0f;
    float T2 = TH / 2.0f;
@@ -151,6 +154,8 @@ void SegmentNumber::InitSegments(const SegmentNumberType type, const float thick
 
 void SegmentNumber::InitMatrix(const SDL_FPoint& location, VP::Matrix* pMatrix)
 {
+   if (m_pNumberMatrix != NULL)
+      delete m_pNumberMatrix;
    m_pNumberMatrix = pMatrix->Clone();
    m_pNumberMatrix->Translate(location.x, location.y);
    m_segments.Transform(m_pNumberMatrix);

--- a/standalone/inc/common/Matrix.h
+++ b/standalone/inc/common/Matrix.h
@@ -27,7 +27,7 @@ public:
     Matrix();
     Matrix(const Matrix& matrix);
     Matrix(float m11, float m12, float m21, float m22, float dx, float dy);
-    
+
     void Rotate(float angle);
     void Multiply(const Matrix& other);
     void Translate(float x, float y);

--- a/standalone/inc/pup/PUPLabel.cpp
+++ b/standalone/inc/pup/PUPLabel.cpp
@@ -323,8 +323,9 @@ void PUPLabel::Render(SDL_Renderer* pRenderer, SDL_Rect& rect, int pagenum)
          else if (m_type == PUP_LABEL_TYPE_GIF) {
             m_pAnimation = IMG_LoadAnimation(m_szPath.c_str());
             if (m_pAnimation) {
-               m_frame = 0;
-               m_pTexture = SDL_CreateTextureFromSurface(pRenderer, m_pAnimation->frames[m_frame]);
+               m_animationFrame = -1;
+               m_animationStart = SDL_GetTicks();
+               m_pTexture = SDL_CreateTextureFromSurface(pRenderer, m_pAnimation->frames[0]);
                m_dirty = false;
             }
             else {
@@ -342,9 +343,11 @@ void PUPLabel::Render(SDL_Renderer* pRenderer, SDL_Rect& rect, int pagenum)
       return;
 
    if (m_pAnimation) {
-      if (++m_frame >= m_pAnimation->count)
-         m_frame = 0;
-      SDL_UpdateTexture(m_pTexture, nullptr, m_pAnimation->frames[m_frame]->pixels, m_pAnimation->frames[m_frame]->pitch);
+      int expectedFrame = static_cast<int>(static_cast<float>(SDL_GetTicks() - m_animationStart) * 60.f / 1000.f) % m_pAnimation->count;
+      if (expectedFrame != m_animationFrame) {
+         m_animationFrame = expectedFrame;
+         SDL_UpdateTexture(m_pTexture, nullptr, m_pAnimation->frames[m_animationFrame]->pixels, m_pAnimation->frames[m_animationFrame]->pitch);
+      }
    }
 
    float width;

--- a/standalone/inc/pup/PUPLabel.h
+++ b/standalone/inc/pup/PUPLabel.h
@@ -70,6 +70,7 @@ private:
    PUP_LABEL_TYPE m_type;
    IMG_Animation* m_pAnimation;
    string m_szPath;
-   int m_frame;
+   int m_animationFrame;
+   Uint64 m_animationStart;
    std::mutex m_mutex;
 };

--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -125,7 +125,8 @@ void PUPManager::LoadPlaylists()
       while (std::getline(playlistsFile, line)) {
          if (++i == 1)
             continue;
-         if (PUPPlaylist* pPlaylist = PUPPlaylist::CreateFromCSV(line)) {
+         PUPPlaylist* pPlaylist = PUPPlaylist::CreateFromCSV(line);
+         if (pPlaylist) {
             string folderNameLower = lowerCase(pPlaylist->GetFolder());
             if (lowerPlaylistNames.find(folderNameLower) == lowerPlaylistNames.end()) {
                m_playlists.push_back(pPlaylist);
@@ -133,6 +134,7 @@ void PUPManager::LoadPlaylists()
             }
             else {
                PLOGW.printf("Duplicate playlist: playlist=%s", pPlaylist->ToString().c_str());
+               delete pPlaylist;
             }
          }
       }

--- a/standalone/inc/pup/PUPMediaPlayer.h
+++ b/standalone/inc/pup/PUPMediaPlayer.h
@@ -68,7 +68,6 @@ private:
    AVSampleFormat m_audioFormat = AV_SAMPLE_FMT_NONE;
    PinSound* m_pPinSound = nullptr;
 
-   std::queue<AVFrame*> m_queue;
    std::mutex m_mutex;
    std::thread m_thread;
    bool m_running = false;


### PR DESCRIPTION
- fixed leak when duplicate playlist error logic was added
- remove unused queue from PUP media players
- fixed large b2s leak with games using Dream7 segments
- ported gif pup label fix from plugin into standalone
- test adding built in ffmpeg thread decoding in standalone pup media player