### PR TITLE
cli: also show density for listres

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -996,7 +996,7 @@ public:
          for (int display = 0; display < displays.size(); display++) {
             const SDL_DisplayMode* displayMode = SDL_GetDesktopDisplayMode(displays.at(display).adapter);
             PLOGI << "display " << displays.at(display).adapter << ": " << displayMode->w << 'x' << displayMode->h
-                  << " (refreshRate=" << displayMode->refresh_rate << ')';
+                  << " (refreshRate=" << displayMode->refresh_rate << ", pixelDensity=" << displayMode->pixel_density << ')';
          }
 
          PLOGI << "Available external window renderers:";


### PR DESCRIPTION
On linux when using the SDL3 X11 or Wayland driver you get a different resolution. This shows why.


X11

```
❯ SDL_VIDEO_DRIVER=x11 ./build/VPinballX_BGFX -listres
...
INFO  [308304] [VPApp::InitInstance@995] Available window fullscreen desktop resolutions:
INFO  [308304] [VPApp::InitInstance@998] display 1: 3840x2160 (refreshRate=59.98, pixeldensity=1)
INFO  [308304] [VPApp::InitInstance@998] display 2: 3840x2160 (refreshRate=59.98, pixeldensity=1)

```

Wayland

```
❯ SDL_VIDEO_DRIVER=wayland ./build/VPinballX_BGFX -listres
...
INFO  [308007] [VPApp::InitInstance@995] Available window fullscreen desktop resolutions:
INFO  [308007] [VPApp::InitInstance@998] display 3: 1920x1080 (refreshRate=59.99, pixeldensity=2)
INFO  [308007] [VPApp::InitInstance@998] display 4: 1920x1080 (refreshRate=59.99, pixeldensity=2)
```