### PR TITLE
pup: improve screen line error reporting

### DIFF
--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -74,7 +74,8 @@ void PUPManager::LoadConfig(const string& szRomName)
          while (std::getline(screensFile, line)) {
             if (++i == 1)
                continue;
-            AddScreen(PUPScreen::CreateFromCSV(this, line, m_playlists));
+            if (PUPScreen* pScreen = PUPScreen::CreateFromCSV(this, line, m_playlists))
+               AddScreen(pScreen);
          }
       }
       else {

--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -125,7 +125,7 @@ PUPScreen* PUPScreen::CreateFromCSV(PUPManager* manager, const string& line, con
 {
    vector<string> parts = parse_csv_line(line);
    if (parts.size() != 8) {
-      LOGD("Invalid screen: %s", line.c_str());
+      LOGE("Failed to parse screen line, expected 8 columns but got %d: %s", parts.size(), line.c_str());
       return nullptr;
    }
 

--- a/standalone/inc/pup/PUPManager.cpp
+++ b/standalone/inc/pup/PUPManager.cpp
@@ -56,7 +56,8 @@ void PUPManager::LoadConfig(const string& szRomName)
          while (std::getline(screensFile, line)) {
             if (++i == 1)
                continue;
-            AddScreen(PUPScreen::CreateFromCSV(this, line, m_playlists));
+            if (PUPScreen* pScreen = PUPScreen::CreateFromCSV(this, line, m_playlists))
+               AddScreen(pScreen);
          }
       }
       else {

--- a/standalone/inc/pup/PUPScreen.cpp
+++ b/standalone/inc/pup/PUPScreen.cpp
@@ -127,7 +127,7 @@ PUPScreen* PUPScreen::CreateFromCSV(PUPManager* pManager, const string& line, co
 {
    vector<string> parts = parse_csv_line(line);
    if (parts.size() != 8) {
-      PLOGD.printf("Invalid screen: %s", line.c_str());
+      PLOGE.printf("Failed to parse screen line, expected 8 columns but got %d: %s", parts.size(), line.c_str());
       return nullptr;
    }
 


### PR DESCRIPTION
https://vpuniverse.com/files/file/19352-godfather/

Before:

```
2025-05-23 10:49:43.037 ERROR [389724] [PUPManager::AddScreen@167] Null screen argument
```

With this applied

```
2025-05-23 11:22:04.025 ERROR [400351] [PUPScreen::CreateFromCSV@130] Failed to parse screen line, expected 8 columns but got 9: 0,Topper,,,,0,off,,
```

*I wanted to trim the `line` before passing it to the CreateFromCSV because it contains a trailing `\r` but could not find such function?*