### PR TITLE
plugins: copy flexdmd assets for static plugins

### DIFF
--- a/plugins/flexdmd/FlexDMD.cpp
+++ b/plugins/flexdmd/FlexDMD.cpp
@@ -16,11 +16,12 @@
 
 namespace Flex {
 
-FlexDMD::FlexDMD()
+FlexDMD::FlexDMD(VPXPluginAPI* vpxApi) :
+   m_vpxApi(vpxApi)
 {
    m_pStage = new Group(this, "Stage"s);
    m_pStage->SetSize(static_cast<float>(m_width), static_cast<float>(m_height));
-   m_pAssetManager = new AssetManager();
+   m_pAssetManager = new AssetManager(m_vpxApi);
 }
 
 FlexDMD::~FlexDMD()

--- a/plugins/flexdmd/FlexDMD.h
+++ b/plugins/flexdmd/FlexDMD.h
@@ -38,7 +38,7 @@ typedef enum
 class FlexDMD final
 {
 public:
-   FlexDMD();
+   FlexDMD(VPXPluginAPI* vpxApi);
    ~FlexDMD();
 
    PSC_IMPLEMENT_REFCOUNT()
@@ -127,6 +127,8 @@ private:
       m_rgbaFrame.clear();
       m_lumFrame.clear();
    }
+
+   VPXPluginAPI* m_vpxApi = nullptr;
 
    uint8_t* m_rgbFrame = nullptr;
    bool m_rgbFrameDirty = true;

--- a/plugins/flexdmd/FlexDMDPlugin.cpp
+++ b/plugins/flexdmd/FlexDMDPlugin.cpp
@@ -321,6 +321,7 @@ PSC_CLASS_END(FlexDMD)
 // Plugin interface
 
 static MsgPluginAPI* msgApi = nullptr;
+static VPXPluginAPI* vpxApi = nullptr;
 static ScriptablePluginAPI* scriptApi = nullptr;
 
 static uint32_t endpointId, nextDmdId;
@@ -633,6 +634,10 @@ MSGPI_EXPORT void MSGPIAPI FlexDMDPluginLoad(const uint32_t sessionId, MsgPlugin
    onSegSrcChangedId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_SEG_ON_SRC_CHG_MSG);
    getSegSrcId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_SEG_GET_SRC_MSG);
 
+   unsigned int getVpxApiId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_MSG_GET_API);
+   msgApi->BroadcastMsg(endpointId, getVpxApiId, &vpxApi);
+   msgApi->ReleaseMsgID(getVpxApiId);
+
    // Contribute our API to the script engine
    const unsigned int getScriptApiId = msgApi->GetMsgID(SCRIPTPI_NAMESPACE, SCRIPTPI_MSG_GET_API);
    msgApi->BroadcastMsg(endpointId, getScriptApiId, &scriptApi);
@@ -683,7 +688,7 @@ MSGPI_EXPORT void MSGPIAPI FlexDMDPluginLoad(const uint32_t sessionId, MsgPlugin
 
    nextDmdId = 0;
    FlexDMD_SCD->CreateObject = []() {
-      FlexDMD* pFlex = new FlexDMD();
+      FlexDMD* pFlex = new FlexDMD(vpxApi);
       pFlex->SetId(nextDmdId);
       pFlex->SetOnDMDChangedHandler(OnShowChanged);
       pFlex->SetOnDestroyHandler(OnFlexDestroyed);
@@ -712,4 +717,5 @@ MSGPI_EXPORT void MSGPIAPI FlexDMDPluginUnload()
    scriptApi->SetCOMObjectOverride("FlexDMD.FlexDMD", nullptr);
    scriptApi = nullptr;
    msgApi = nullptr;
+   vpxApi = nullptr;
 }

--- a/plugins/flexdmd/common.h
+++ b/plugins/flexdmd/common.h
@@ -4,6 +4,20 @@
 #include <cstdarg>
 #include <cstdio>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <tchar.h>
+#include <locale>
+#include <codecvt>
+#endif
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#include <limits.h>
+#include <unistd.h>
+#endif
+
 #include <string>
 using namespace std::string_literals;
 using std::string;
@@ -56,5 +70,6 @@ bool try_parse_color(const string& str, ColorRGBA32& value);
 string normalize_path_separators(const string& szPath);
 string extension_from_path(const string& path);
 string find_case_insensitive_file_path(const string& szPath);
+string GetPluginPath();
 
 }

--- a/plugins/flexdmd/resources/AssetManager.cpp
+++ b/plugins/flexdmd/resources/AssetManager.cpp
@@ -16,19 +16,21 @@
 
 #include <sstream>
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #if SDL_PLATFORM_WINDOWS
-   #define WIN32_LEAN_AND_MEAN
    #undef RGB
    #undef GetRValue
    #undef GetGValue
    #undef GetBValue
-   #include <Windows.h>
-   #include <tchar.h>
 #endif
 
 namespace Flex {
 
-AssetManager::AssetManager() {
+AssetManager::AssetManager(VPXPluginAPI* vpxApi) :
+   m_vpxApi(vpxApi) {
    m_szBasePath = "./";
 }
 
@@ -249,30 +251,16 @@ void* AssetManager::Open(AssetSrc* pSrc)
       break;
       case AssetSrcType_FlexResource:
       {
-         string path = SDL_GetBasePath() + "plugins/flexdmd/assets"s + PATH_SEPARATOR_CHAR + pSrc->GetPath();
-         #if SDL_PLATFORM_WINDOWS
-            HMODULE hModule = nullptr;
-            if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, _T("Open"), &hModule))
-            {
-               TCHAR dllPath[MAX_PATH];
-               if (GetModuleFileName(hModule, dllPath, MAX_PATH))
-               {
-                  #ifdef _UNICODE
-                  std::wstring fullpath(dllPath);
-                  #else
-                  std::string fullpath(dllPath);
-                  #endif
-                  fullpath = fullpath.substr(0, fullpath.find_last_of(_T("\\/"))) + _T('\\');
-                  #ifdef _UNICODE
-                  path = POLE::UTF16toUTF8(fullpath);
-                  #else
-                  path = fullpath;
-                  #endif
-                  path += "assets"s + PATH_SEPARATOR_CHAR + pSrc->GetPath();
-               }
-            }
+         // Load assets provided with plugin
+         string path;
+         #if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
+         VPXInfo vpxInfo;
+         m_vpxApi->GetVpxInfo(&vpxInfo);
+         path = string(vpxInfo.path) + PATH_SEPARATOR_CHAR + "plugins"s + PATH_SEPARATOR_CHAR + "flexdmd"s + PATH_SEPARATOR_CHAR;
+         #else
+         path = GetPluginPath();
          #endif
-         path = find_case_insensitive_file_path(path);
+         path = find_case_insensitive_file_path(path + "assets"s + PATH_SEPARATOR_CHAR + pSrc->GetPath());
          if (!path.empty()) {
             if (pSrc->GetAssetType() == AssetType_BMFont)
                pAsset = BitmapFont::Create(path);

--- a/plugins/flexdmd/resources/AssetManager.h
+++ b/plugins/flexdmd/resources/AssetManager.h
@@ -14,7 +14,7 @@ class VPXFile;
 class AssetManager final
 {
 public:
-   AssetManager();
+   AssetManager(VPXPluginAPI* vpxApi);
    ~AssetManager();
 
    const string& GetBasePath() { return m_szBasePath; }
@@ -29,6 +29,8 @@ public:
    void ClearAll();
 
 private:
+   VPXPluginAPI* m_vpxApi = nullptr;
+
    ankerl::unordered_dense::map<string, Bitmap*> m_cachedBitmaps;
    ankerl::unordered_dense::map<string, Font*> m_cachedFonts;
 

--- a/plugins/scoreview/ScoreViewPlugin.cpp
+++ b/plugins/scoreview/ScoreViewPlugin.cpp
@@ -14,13 +14,6 @@
 
 #include "ScoreView.h"
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <tchar.h>
-#include <locale>
-#include <codecvt>
-#endif
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
@@ -51,33 +44,16 @@ int OnRender(VPXRenderContext2D* ctx, void*)
       if (!scoreview->HasLayouts())
       {
          // Load default layouts provided with plugin
-         // TODO this is implemented in a platform dependent manner as platforms like Android or iOS may need special handling (as plugins are statically linked, and we may embbed layouts in ressources or define a custom path scheme)
-         string fullpath;
-         #ifdef _WIN32
-         HMODULE hm = nullptr;
-         if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, _T("PluginLoad"), &hm) == 0)
-            return false;
-         TCHAR path[MAX_PATH];
-         if (GetModuleFileName(hm, path, MAX_PATH) == 0)
-            return false;
-         #ifdef _UNICODE
-         int size_needed = WideCharToMultiByte(CP_UTF8, 0, path, -1, NULL, 0, NULL, NULL);
-         fullpath.resize(size_needed, 0);
-         WideCharToMultiByte(CP_UTF8, 0, path, -1, fullpath.data(), size_needed, NULL, NULL);
-         #else
-         fullpath = string(path);
-         #endif
-         fullpath = PathFromFilename(fullpath) + PATH_SEPARATOR_CHAR;
-         #else
+         string path;
          #if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
          VPXInfo vpxInfo;
-         vpxApi->GetVpxInfo(&vpxInfo);
-         fullpath = string(vpxInfo.path) + PATH_SEPARATOR_CHAR + "plugins"s + PATH_SEPARATOR_CHAR + "scoreview"s + PATH_SEPARATOR_CHAR;
+         m_vpxApi->GetVpxInfo(&vpxInfo);
+         path = string(vpxInfo.path) + PATH_SEPARATOR_CHAR + "plugins"s + PATH_SEPARATOR_CHAR + "flexdmd"s + PATH_SEPARATOR_CHAR;
          #else
-         fullpath = PathFromFilename(GetLibraryPath());
+         path = GetPluginPath();
          #endif
-         #endif
-         scoreview->Load(fullpath + "layouts" + PATH_SEPARATOR_CHAR);
+         path = path + "layouts"s + PATH_SEPARATOR_CHAR;
+         scoreview->Load(path);
       }
    }
    return scoreview->Render(ctx) ? 1 : 0;

--- a/plugins/scoreview/common.cpp
+++ b/plugins/scoreview/common.cpp
@@ -143,18 +143,49 @@ string PathFromFilename(const string& szfilename)
    return szpath;
 }
 
-#ifndef _WIN32
-string GetLibraryPath()
+string GetPluginPath()
 {
-   Dl_info info{};
-   if (dladdr((void*)&GetLibraryPath, &info) == 0 || !info.dli_fname)
-      return "";
-   char buf[PATH_MAX];
-   if (!realpath(info.dli_fname, buf))
-      return "";
-   return string(buf);
-}
+    string pathBuf;
+#ifdef _WIN32
+    HMODULE hm = nullptr;
+    if (GetModuleHandleEx(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            _T("ScoreViewPluginLoad"), &hm) == 0)
+        return string();
+
+    TCHAR buf[MAX_PATH];
+    if (GetModuleFileName(hm, buf, MAX_PATH) == 0)
+        return string();
+
+#ifdef _UNICODE
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, buf, -1, NULL, 0, NULL, NULL);
+    pathBuf.resize(size_needed, 0);
+    WideCharToMultiByte(CP_UTF8, 0, buf, -1, pathBuf.data(), size_needed, NULL, NULL);
+#else
+    pathBuf = string(buf);
 #endif
+#else
+    Dl_info info{};
+    if (dladdr((void*)&GetPluginPath, &info) == 0 || !info.dli_fname)
+        return string();
+
+    char realBuf[PATH_MAX];
+    if (!realpath(info.dli_fname, realBuf))
+        return string();
+
+    pathBuf = string(realBuf);
+#endif
+
+    if (pathBuf.empty())
+        return string();
+
+    size_t lastSep = pathBuf.find_last_of(PATH_SEPARATOR_CHAR);
+    if (lastSep == string::npos)
+        return string();
+
+    return pathBuf.substr(0, lastSep + 1);
+}
 
 }
 

--- a/plugins/scoreview/common.h
+++ b/plugins/scoreview/common.h
@@ -4,6 +4,17 @@
 #include <cstdarg>
 #include <cstdio>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#include <tchar.h>
+#include <locale>
+#include <codecvt>
+#endif
+
 #ifndef _WIN32
 #include <dlfcn.h>
 #include <limits.h>
@@ -45,7 +56,6 @@ bool try_parse_float(const string& str, float& value);
 bool try_parse_int(const string& str, int& value);
 string find_case_insensitive_file_path(const string& szPath);
 string PathFromFilename(const string& szfilename);
-#ifndef _WIN32
-string GetLibraryPath();
-#endif
+string GetPluginPath();
+
 }

--- a/standalone/android/app/build.gradle.kts
+++ b/standalone/android/app/build.gradle.kts
@@ -55,11 +55,14 @@ tasks {
         from("${layout.buildDirectory}/../../../../scripts") {
             into("scripts")
         }
-        from("${layout.buildDirectory}/../../../../standalone/inc/flexdmd/resources") {
-            into("flexdmd")
-        }
         from("${layout.buildDirectory}/../../../../plugins/scoreview/layouts") {
            into("plugins/scoreview/layouts")
+        }
+        from("${layout.buildDirectory}/../../../../plugins/flexdmd/assets") {
+           into("plugins/flexdmd/assets")
+        }
+        from("${layout.buildDirectory}/../../../../standalone/inc/flexdmd/resources") {
+            into("flexdmd")
         }
         into(destinationDir)
     }

--- a/standalone/ios/VPinball.xcodeproj/project.pbxproj
+++ b/standalone/ios/VPinball.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "BUNDLE_RESOURCES=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}\"\n\nrm -rf \"${BUNDLE_RESOURCES}/scripts\"\ncp -r \"$PROJECT_DIR/../../scripts\" \"${BUNDLE_RESOURCES}\"\n\nrm -rf \"${BUNDLE_RESOURCES}/assets\"\ncp -r \"$PROJECT_DIR/../../src/assets\" \"${BUNDLE_RESOURCES}\"\n\nrm -rf \"${BUNDLE_RESOURCES}/flexdmd\"\ncp -r \"$PROJECT_DIR/../../standalone/inc/flexdmd/resources\" \"${BUNDLE_RESOURCES}/flexdmd\"\n\nrm -rf \"${BUNDLE_RESOURCES}/plugins\"\nmkdir -p \"${BUNDLE_RESOURCES}/plugins/scoreview\"\ncp -r \"$PROJECT_DIR/../../plugins/scoreview/layouts\" \"${BUNDLE_RESOURCES}/plugins/scoreview\"\n";
+			shellScript = "BUNDLE_RESOURCES=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}\"\n\nrm -rf \"${BUNDLE_RESOURCES}/scripts\"\ncp -r \"$PROJECT_DIR/../../scripts\" \"${BUNDLE_RESOURCES}\"\n\nrm -rf \"${BUNDLE_RESOURCES}/assets\"\ncp -r \"$PROJECT_DIR/../../src/assets\" \"${BUNDLE_RESOURCES}\"\n\nrm -rf \"${BUNDLE_RESOURCES}/flexdmd\"\ncp -r \"$PROJECT_DIR/../../standalone/inc/flexdmd/resources\" \"${BUNDLE_RESOURCES}/flexdmd\"\n\nrm -rf \"${BUNDLE_RESOURCES}/plugins\"\n\nmkdir -p \"${BUNDLE_RESOURCES}/plugins/scoreview\"\ncp -r \"$PROJECT_DIR/../../plugins/scoreview/layouts\" \"${BUNDLE_RESOURCES}/plugins/scoreview\"\n\nmkdir -p \"${BUNDLE_RESOURCES}/plugins/flexdmd\"\ncp -r \"$PROJECT_DIR/../../plugins/flexdmd/assets\" \"${BUNDLE_RESOURCES}/plugins/flexdmd\"\n";
 		};
 		C1FF3F472CB8DD67004D238B /* Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Also consolidates the library path logic into one function: GetPluginPath. I think this could still be optimized further to do the mobile path directly.