### PR TITLE
libvpinball: rework settings to use section name strings

### DIFF
--- a/plugins/scoreview/ScoreViewPlugin.cpp
+++ b/plugins/scoreview/ScoreViewPlugin.cpp
@@ -47,7 +47,7 @@ int OnRender(VPXRenderContext2D* ctx, void*)
          #if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
          VPXInfo vpxInfo;
          vpxApi->GetVpxInfo(&vpxInfo);
-         path = string(vpxInfo.path) + PATH_SEPARATOR_CHAR + "plugins" + PATH_SEPARATOR_CHAR + "flexdmd" + PATH_SEPARATOR_CHAR;
+         path = string(vpxInfo.path) + PATH_SEPARATOR_CHAR + "plugins" + PATH_SEPARATOR_CHAR + "scoreview" + PATH_SEPARATOR_CHAR;
          #else
          path = GetPluginPath();
          #endif

--- a/src/assets/Default_VPinballX.ini
+++ b/src/assets/Default_VPinballX.ini
@@ -427,6 +427,7 @@ SoftwareVertexProcessing =
 ;       OpenGLES on Android
 ;       Metal on Apple devices
 ;       Vulkan for everything else
+;     Note: Direct3D11 and Direct3D12 are Windows only, Metal is macOS and iOS only
 GfxBackend = 
 
 ; Stereo rendering (VR have its own dedicated section)

--- a/src/assets/vpx.html
+++ b/src/assets/vpx.html
@@ -1300,7 +1300,7 @@
       }
 
       var chunk = data.subarray(offset, offset + chunkSize) || "";
-      fetch(`/upload?offset=${offset}&q=${encodeURIComponent(directory)}&file=${encodeURIComponent(filename)}`, { method: "POST", body: chunk })
+      fetch(`/upload?offset=${offset}&q=${encodeURIComponent(directory)}&file=${encodeURIComponent(filename)}&length=${data.length}`, { method: "POST", body: chunk })
         .then((res) => {
           if (res.ok && chunk.length > 0) {
             sendChunk(filePath, data, offset + chunk.length, chunkSize, statusId, callback);

--- a/src/core/Settings.cpp
+++ b/src/core/Settings.cpp
@@ -220,13 +220,44 @@ void Settings::Validate(const bool addDefaults)
    SettingInt(Settings::Player, "JoyTweakKey"s, 0, 0x00, 0xFFFF, ""s);
 #endif
 
+   //////////////////////////////////////////////////////////////////////////
+   // GfxBackend section
+
+#ifdef __ANDROID__
+   SettingString(Section::Player, "GfxBackend"s, "OpenGLES"s, ""s);
+#endif
+
+   //////////////////////////////////////////////////////////////////////////
+   // Ball Rendering section
+
+#ifdef __STANDALONE__
+   SettingBool(Section::Player, "BallTrail"s, false, ""s);
+#endif
 
    //////////////////////////////////////////////////////////////////////////
    // Rendering section
 
    SettingFloat(Section::Player, "EmissionScale"s, 0.5f, 0.f, 1.f, ""s);
-   SettingInt(Section::Player, "MaxTexDimension"s, 0, 0, 16384, "Maximum texture dimension. Images sized above this limit will be automatically scaled down on load."s);
 
+#ifndef __LIBVPINBALL__
+   SettingInt(Section::Player, "MaxTexDimension"s, 0, 0, 16384, "Maximum texture dimension. Images sized above this limit will be automatically scaled down on load."s);
+#else
+   SettingInt(Section::Player, "MaxTexDimension"s, 1536, 0, 16384, "Maximum texture dimension. Images sized above this limit will be automatically scaled down on load."s);
+#endif
+
+   //////////////////////////////////////////////////////////////////////////
+   // Plugin.ScoreView
+
+#ifdef __LIBVPINBALL__
+   SettingBool(GetSection("Plugin.ScoreView"), "Enable"s, true, ""s);
+#endif
+
+   //////////////////////////////////////////////////////////////////////////
+   // Standalone section
+
+#ifdef __LIBVPINBALL__
+   SettingInt(Section::Standalone, "RenderingModeOverride"s, 2, 0, 2, ""s);
+#endif
 
    //////////////////////////////////////////////////////////////////////////
    // VR Player section
@@ -234,7 +265,6 @@ void Settings::Validate(const bool addDefaults)
    SettingFloat(Settings::PlayerVR, "TableX"s, 0.f, -300.f, 300.f, "VR scene horizontal X offset (cm)."s);
    SettingFloat(Settings::PlayerVR, "TableY"s, 0.f, -300.f, 300.f, "VR scene horizontal Y offset (cm)."s);
    SettingFloat(Settings::PlayerVR, "TableZ"s, 0.f, -300.f, 300.f, "VR scene vertical offset (cm)s"s);
-
 
    //////////////////////////////////////////////////////////////////////////
    // Cabinet section
@@ -248,17 +278,33 @@ void Settings::Validate(const bool addDefaults)
    SettingFloat(Section::Player, "LockbarWidth"s, 70.f, 10.f, 150.f, "Lockbar width in centimeters (measured on the cabinet)."s);
    SettingFloat(Section::Player, "LockbarHeight"s, 85.f, 0.f, 250.f, "Lockbar height in centimeters (measured on the cabinet, from ground to top of lockbar)."s);
 
+   //////////////////////////////////////////////////////////////////////////
+   // Backglass section
+
+#ifdef __LIBVPINBALL__
+   SettingInt(Section::Backglass, "BackglassOutput"s, 1, 1, 1, ""s);
+   SettingInt(Section::Backglass, "BackglassWndX"s, 0, 0, 3000, ""s);
+   SettingInt(Section::Backglass, "BackglassWndY"s, 160, 0, 3000, ""s);
+   SettingInt(Section::Backglass, "BackglassWidth"s, 640, 0, 3000, ""s);
+   SettingInt(Section::Backglass, "BackglassHeight"s, 480, 0, 3000, ""s);
+#endif
 
    //////////////////////////////////////////////////////////////////////////
    // ScoreView section
 
+#ifdef __LIBVPINBALL__
+   SettingInt(Section::ScoreView, "ScoreViewOutput"s, 1, 1, 1, ""s);
+   SettingInt(Section::ScoreView, "ScoreViewWndX"s, 0, 0, 3000, ""s);
+   SettingInt(Section::ScoreView, "ScoreViewWndY"s, 0, 0, 3000, ""s);
+   SettingInt(Section::ScoreView, "ScoreViewWidth"s, 640, 0, 3000, ""s);
+   SettingInt(Section::ScoreView, "ScoreViewHeight"s, 160, 0, 3000, ""s);
+#endif
 
    //////////////////////////////////////////////////////////////////////////
    // Playfield view section
 
    SettingFloat(Section::Player, "MaxFramerate"s, -1.f, -1.f, 1000.f, "Maximum FPS of playfield view (minimum: 24FPS), 0 is unlimited, < 0 is limited to the display refresh rate."s);
    SettingInt(Section::Player, "SyncMode"s, VSM_NONE, VSM_NONE, VSM_FRAME_PACING, "Hardware video sync mode to use: None / Vertical Sync / Adaptative Sync / Frame Pacing."s);
-
 
    //////////////////////////////////////////////////////////////////////////
    // DMD section

--- a/standalone/VPinball.cpp
+++ b/standalone/VPinball.cpp
@@ -31,36 +31,36 @@ VPINBALLAPI void VPinballResetLog()
    s_vpinstance.ResetLog();
 }
 
-VPINBALLAPI int VPinballLoadValueInt(VPINBALL_SETTINGS_SECTION section, const char* pKey, int defaultValue)
+VPINBALLAPI int VPinballLoadValueInt(const char* pSectionName, const char* pKey, int defaultValue)
 {
-   return s_vpinstance.LoadValueInt((VPinballLib::SettingsSection)section, pKey, defaultValue);
+   return s_vpinstance.LoadValueInt(pSectionName, pKey, defaultValue);
 }
 
-VPINBALLAPI float VPinballLoadValueFloat(VPINBALL_SETTINGS_SECTION section, const char* pKey, float defaultValue)
+VPINBALLAPI float VPinballLoadValueFloat(const char* pSectionName, const char* pKey, float defaultValue)
 {
-   return s_vpinstance.LoadValueFloat((VPinballLib::SettingsSection)section, pKey, defaultValue);
+   return s_vpinstance.LoadValueFloat(pSectionName, pKey, defaultValue);
 }
 
-VPINBALLAPI const char* VPinballLoadValueString(VPINBALL_SETTINGS_SECTION section, const char* pKey, const char* pDefaultValue)
+VPINBALLAPI const char* VPinballLoadValueString(const char* pSectionName, const char* pKey, const char* pDefaultValue)
 {
    thread_local string value;
-   value = s_vpinstance.LoadValueString((VPinballLib::SettingsSection)section, pKey, pDefaultValue);
+   value = s_vpinstance.LoadValueString(pSectionName, pKey, pDefaultValue);
    return value.c_str();
 }
 
-VPINBALLAPI void VPinballSaveValueInt(VPINBALL_SETTINGS_SECTION section, const char* pKey, int value)
+VPINBALLAPI void VPinballSaveValueInt(const char* pSectionName, const char* pKey, int value)
 {
-   s_vpinstance.SaveValueInt((VPinballLib::SettingsSection)section, pKey, value);
+   s_vpinstance.SaveValueInt(pSectionName, pKey, value);
 }
 
-VPINBALLAPI void VPinballSaveValueFloat(VPINBALL_SETTINGS_SECTION section, const char* pKey, float value)
+VPINBALLAPI void VPinballSaveValueFloat(const char* pSectionName, const char* pKey, float value)
 {
-   s_vpinstance.SaveValueFloat((VPinballLib::SettingsSection)section, pKey, value);
+   s_vpinstance.SaveValueFloat(pSectionName, pKey, value);
 }
 
-VPINBALLAPI void VPinballSaveValueString(VPINBALL_SETTINGS_SECTION section, const char* pKey, const char* pValue)
+VPINBALLAPI void VPinballSaveValueString(const char* pSectionName, const char* pKey, const char* pValue)
 {
-   s_vpinstance.SaveValueString((VPinballLib::SettingsSection)section, pKey, pValue);
+   s_vpinstance.SaveValueString(pSectionName, pKey, pValue);
 }
 
 VPINBALLAPI VPINBALL_STATUS VPinballUncompress(const char* pSource)
@@ -170,7 +170,7 @@ VPINBALLAPI void VPinballGetCustomTableOption(int index, VPinballCustomTableOpti
 
    VPinballLib::CustomTableOption customTableOption;
    s_vpinstance.GetCustomTableOption(index, customTableOption);
-   pCustomTableOption->section = (VPINBALL_SETTINGS_SECTION)customTableOption.section;
+   pCustomTableOption->sectionName = customTableOption.sectionName;
    pCustomTableOption->id = customTableOption.id;
    pCustomTableOption->name = customTableOption.name;
    pCustomTableOption->showMask = customTableOption.showMask;
@@ -195,7 +195,7 @@ VPINBALLAPI void VPinballSetCustomTableOption(VPinballCustomTableOption* pCustom
 
       if (strcmp(existingOption.id, pCustomTableOption->id) == 0) {
          VPinballLib::CustomTableOption customTableOption;
-         customTableOption.section = (VPinballLib::SettingsSection)existingOption.section;
+         customTableOption.sectionName = existingOption.sectionName;
          customTableOption.id = existingOption.id;
          customTableOption.value = pCustomTableOption->value;
          s_vpinstance.SetCustomTableOption(customTableOption);

--- a/standalone/VPinball.h
+++ b/standalone/VPinball.h
@@ -23,18 +23,6 @@ typedef enum {
 } VPINBALL_STATUS;
 
 typedef enum {
-   VPINBALL_SETTINGS_SECTION_STANDALONE = 2,
-   VPINBALL_SETTINGS_SECTION_PLAYER = 3,
-   VPINBALL_SETTINGS_SECTION_DMD = 4,
-   VPINBALL_SETTINGS_SECTION_ALPHA = 5,
-   VPINBALL_SETTINGS_SECTION_BACKGLASS = 6,
-   VPINBALL_SETTINGS_SECTION_SCORE_VIEW = 7,
-   VPINBALL_SETTINGS_SECTION_TOPPER = 8,
-   VPINBALL_SETTINGS_SECTION_TABLE_OVERRIDE = 13,
-   VPINBALL_SETTINGS_SECTION_TABLE_OPTION = 14
-} VPINBALL_SETTINGS_SECTION;
-
-typedef enum {
    VPINBALL_SCRIPT_ERROR_TYPE_COMPILE,
    VPINBALL_SCRIPT_ERROR_TYPE_RUNTIME
 } VPINBALL_SCRIPT_ERROR_TYPE;
@@ -107,7 +95,7 @@ typedef struct {
 } VPinballTableOptions;
 
 typedef struct {
-   VPINBALL_SETTINGS_SECTION section;
+   const char* sectionName;
    const char* id;
    const char* name;
    int showMask;
@@ -148,12 +136,12 @@ VPINBALLAPI const char* VPinballGetVersionStringFull();
 VPINBALLAPI void VPinballInit(VPinballEventCallback callback);
 VPINBALLAPI void VPinballLog(VPINBALL_LOG_LEVEL level, const char* pMessage);
 VPINBALLAPI void VPinballResetLog();
-VPINBALLAPI int VPinballLoadValueInt(VPINBALL_SETTINGS_SECTION section, const char* pKey, int defaultValue);
-VPINBALLAPI float VPinballLoadValueFloat(VPINBALL_SETTINGS_SECTION section, const char* pKey, float defaultValue);
-VPINBALLAPI const char* VPinballLoadValueString(VPINBALL_SETTINGS_SECTION section, const char* pKey, const char* pDefaultValue);
-VPINBALLAPI void VPinballSaveValueInt(VPINBALL_SETTINGS_SECTION section, const char* pKey, int value);
-VPINBALLAPI void VPinballSaveValueFloat(VPINBALL_SETTINGS_SECTION section, const char* pKey, float value);
-VPINBALLAPI void VPinballSaveValueString(VPINBALL_SETTINGS_SECTION section, const char* pKey, const char* pValue);
+VPINBALLAPI int VPinballLoadValueInt(const char* pSectionName, const char* pKey, int defaultValue);
+VPINBALLAPI float VPinballLoadValueFloat(const char* pSectionName, const char* pKey, float defaultValue);
+VPINBALLAPI const char* VPinballLoadValueString(const char* pSectionName, const char* pKey, const char* pDefaultValue);
+VPINBALLAPI void VPinballSaveValueInt(const char* pSectionName, const char* pKey, int value);
+VPINBALLAPI void VPinballSaveValueFloat(const char* pSectionName, const char* pKey, float value);
+VPINBALLAPI void VPinballSaveValueString(const char* pSectionName, const char* pKey, const char* pValue);
 VPINBALLAPI VPINBALL_STATUS VPinballUncompress(const char* pSource);
 VPINBALLAPI VPINBALL_STATUS VPinballCompress(const char* pSource, const char* pDestination);
 VPINBALLAPI void VPinballUpdateWebServer();

--- a/standalone/VPinballJNI.cpp
+++ b/standalone/VPinballJNI.cpp
@@ -18,7 +18,6 @@ static jclass gJNICustomTableOptionClass = nullptr;
 static jclass gJNIViewSetupClass = nullptr;
 
 static jclass gJNIScriptErrorTypeClass = nullptr;
-static jclass gJNISettingsSectionClass = nullptr;
 static jclass gJNIOptionUnitClass = nullptr;
 static jclass gJNIToneMapperClass = nullptr;
 static jclass gJNIViewLayoutClass = nullptr;
@@ -163,7 +162,6 @@ JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballInit(JNIEnv
    gJNIViewSetupClass = (jclass)env->NewGlobalRef(env->FindClass("org/vpinball/app/jni/VPinballViewSetup"));
 
    gJNIScriptErrorTypeClass = (jclass)env->NewGlobalRef(env->FindClass("org/vpinball/app/jni/VPinballScriptErrorType"));
-   gJNISettingsSectionClass = (jclass)env->NewGlobalRef(env->FindClass("org/vpinball/app/jni/VPinballSettingsSection"));
    gJNIOptionUnitClass = (jclass)env->NewGlobalRef(env->FindClass("org/vpinball/app/jni/VPinballOptionUnit"));
    gJNIToneMapperClass = (jclass)env->NewGlobalRef(env->FindClass("org/vpinball/app/jni/VPinballToneMapper"));
    gJNIViewLayoutClass = (jclass)env->NewGlobalRef(env->FindClass("org/vpinball/app/jni/VPinballViewLayoutMode"));
@@ -183,53 +181,65 @@ JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballResetLog(JN
    VPinballResetLog();
 }
 
-JNIEXPORT jint JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballLoadValueInt(JNIEnv* env, jobject obj, jint section, jstring key, jint defaultValue)
+JNIEXPORT jint JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballLoadValueInt(JNIEnv* env, jobject obj, jstring sectionName, jstring key, jint defaultValue)
 {
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
    const char* pKey = env->GetStringUTFChars(key, nullptr);
-   int result = VPinballLoadValueInt(static_cast<VPINBALL_SETTINGS_SECTION>(section), pKey, defaultValue);
+   int result = VPinballLoadValueInt(pSectionName, pKey, defaultValue);
    env->ReleaseStringUTFChars(key, pKey);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
    return result;
 }
 
-JNIEXPORT jfloat JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballLoadValueFloat(JNIEnv* env, jobject obj, jint section, jstring key, jfloat defaultValue)
+JNIEXPORT jfloat JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballLoadValueFloat(JNIEnv* env, jobject obj, jstring sectionName, jstring key, jfloat defaultValue)
 {
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
    const char* pKey = env->GetStringUTFChars(key, nullptr);
-   float result = VPinballLoadValueFloat(static_cast<VPINBALL_SETTINGS_SECTION>(section), pKey, defaultValue);
+   float result = VPinballLoadValueFloat(pSectionName, pKey, defaultValue);
    env->ReleaseStringUTFChars(key, pKey);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
    return result;
 }
 
-JNIEXPORT jstring JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballLoadValueString(JNIEnv* env, jobject obj, jint section, jstring key, jstring defaultValue)
+JNIEXPORT jstring JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballLoadValueString(JNIEnv* env, jobject obj, jstring sectionName, jstring key, jstring defaultValue)
 {
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
    const char* pKey = env->GetStringUTFChars(key, nullptr);
    const char* pDefaultValue = env->GetStringUTFChars(defaultValue, nullptr);
-   const char* pResult = VPinballLoadValueString(static_cast<VPINBALL_SETTINGS_SECTION>(section), pKey, pDefaultValue);
-   env->ReleaseStringUTFChars(key, pKey);
+   const char* pResult = VPinballLoadValueString(pSectionName, pKey, pDefaultValue);
    env->ReleaseStringUTFChars(defaultValue, pDefaultValue);
+   env->ReleaseStringUTFChars(key, pKey);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
    return env->NewStringUTF(pResult);
 }
 
-JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSaveValueInt(JNIEnv* env, jobject obj, jint section, jstring key, jint value)
+JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSaveValueInt(JNIEnv* env, jobject obj, jstring sectionName, jstring key, jint value)
 {
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
    const char* pKey = env->GetStringUTFChars(key, nullptr);
-   VPinballSaveValueInt(static_cast<VPINBALL_SETTINGS_SECTION>(section), pKey, value);
+   VPinballSaveValueInt(pSectionName, pKey, value);
    env->ReleaseStringUTFChars(key, pKey);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
 }
 
-JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSaveValueFloat(JNIEnv* env, jobject obj, jint section, jstring key, jfloat value)
+JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSaveValueFloat(JNIEnv* env, jobject obj, jstring sectionName, jstring key, jfloat value)
 {
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
    const char* pKey = env->GetStringUTFChars(key, nullptr);
-   VPinballSaveValueFloat(static_cast<VPINBALL_SETTINGS_SECTION>(section), pKey, value);
+   VPinballSaveValueFloat(pSectionName, pKey, value);
    env->ReleaseStringUTFChars(key, pKey);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
 }
 
-JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSaveValueString(JNIEnv* env, jobject obj, jint section, jstring key, jstring value)
+JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSaveValueString(JNIEnv* env, jobject obj, jstring sectionName, jstring key, jstring value)
 {
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
    const char* pKey = env->GetStringUTFChars(key, nullptr);
    const char* pValue = env->GetStringUTFChars(value, nullptr);
-   VPinballSaveValueString(static_cast<VPINBALL_SETTINGS_SECTION>(section), pKey, pValue);
-   env->ReleaseStringUTFChars(key, pKey);
+   VPinballSaveValueString(pSectionName, pKey, pValue);
    env->ReleaseStringUTFChars(value, pValue);
+   env->ReleaseStringUTFChars(key, pKey);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
 }
 
 JNIEXPORT jint JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballUncompress(JNIEnv* env, jobject obj, jstring source)
@@ -368,7 +378,7 @@ JNIEXPORT jint JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballGetCustomTa
 
 JNIEXPORT jobject JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballGetCustomTableOption(JNIEnv* env, jobject obj, jint index)
 {
-   if (!gJNICustomTableOptionClass || !gJNISettingsSectionClass || !gJNIOptionUnitClass)
+   if (!gJNICustomTableOptionClass || !gJNIOptionUnitClass)
       return nullptr;
 
    VPinballCustomTableOption customTableOption = {};
@@ -379,14 +389,7 @@ JNIEXPORT jobject JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballGetCusto
    if (!constructor || !setupObject)
       return nullptr;
 
-   jfieldID sectionField = env->GetFieldID(gJNICustomTableOptionClass, "section", "Lorg/vpinball/app/jni/VPinballSettingsSection;");
-   jmethodID settingsSectionFromIntMethod = env->GetStaticMethodID(gJNISettingsSectionClass, "fromInt", "(I)Lorg/vpinball/app/jni/VPinballSettingsSection;");
-   if (sectionField && settingsSectionFromIntMethod) {
-      jobject settingsSectionObject = env->CallStaticObjectMethod(gJNISettingsSectionClass, settingsSectionFromIntMethod, (jint)customTableOption.section);
-      if (settingsSectionObject)
-         env->SetObjectField(setupObject, sectionField, settingsSectionObject);
-   }
-
+   env->SetObjectField(setupObject, env->GetFieldID(gJNICustomTableOptionClass, "sectionName", "Ljava/lang/String;"), env->NewStringUTF(customTableOption.sectionName ? customTableOption.sectionName : ""));
    env->SetObjectField(setupObject, env->GetFieldID(gJNICustomTableOptionClass, "id", "Ljava/lang/String;"), env->NewStringUTF(customTableOption.id ? customTableOption.id : ""));
    env->SetObjectField(setupObject, env->GetFieldID(gJNICustomTableOptionClass, "name", "Ljava/lang/String;"), env->NewStringUTF(customTableOption.name ? customTableOption.name : ""));
    env->SetIntField(setupObject, env->GetFieldID(gJNICustomTableOptionClass, "showMask", "I"), customTableOption.showMask);
@@ -416,14 +419,20 @@ JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballSetCustomTa
 
    VPinballCustomTableOption customTableOption = {};
 
+   jstring sectionName = (jstring)env->GetObjectField(setup, env->GetFieldID(gJNICustomTableOptionClass, "sectionName", "Ljava/lang/String;"));
+   const char* pSectionName = env->GetStringUTFChars(sectionName, nullptr);
+   customTableOption.sectionName = pSectionName;
+
    jstring id = (jstring)env->GetObjectField(setup, env->GetFieldID(gJNICustomTableOptionClass, "id", "Ljava/lang/String;"));
    const char* pId = env->GetStringUTFChars(id, nullptr);
    customTableOption.id = pId;
+
    customTableOption.value = env->GetFloatField(setup, env->GetFieldID(gJNICustomTableOptionClass, "value", "F"));
 
    VPinballSetCustomTableOption(&customTableOption);
 
    env->ReleaseStringUTFChars(id, pId);
+   env->ReleaseStringUTFChars(sectionName, pSectionName);
 }
 
 JNIEXPORT void JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballResetCustomTableOptions(JNIEnv* env, jobject obj)

--- a/standalone/VPinballLib.h
+++ b/standalone/VPinballLib.h
@@ -19,18 +19,6 @@ enum class VPinballStatus {
    Failure
 };
 
-enum class SettingsSection {
-   Standalone = 2,
-   Player = 3,
-   DMD = 4,
-   Alpha = 5,
-   Backglass = 6,
-   ScoreView = 7,
-   Topper = 8,
-   TableOverride = 13,
-   TableOption = 14
-};
-
 enum class ScriptErrorType {
    Compile,
    Runtime
@@ -104,7 +92,7 @@ struct TableOptions {
 };
 
 struct CustomTableOption {
-   SettingsSection section;
+   const char* sectionName;
    const char* id;
    const char* name;
    int showMask;
@@ -146,12 +134,12 @@ public:
    string GetVersionStringFull();
    void Log(LogLevel level, const string& message);
    void ResetLog();
-   int LoadValueInt(SettingsSection section, const string& key, int defaultValue);
-   float LoadValueFloat(SettingsSection section, const string& key, float defaultValue);
-   string LoadValueString(SettingsSection section, const string& key, const string& defaultValue);
-   void SaveValueInt(SettingsSection section, const string& key, int value);
-   void SaveValueFloat(SettingsSection section, const string& key, float value);
-   void SaveValueString(SettingsSection section, const string& key, const string& value);
+   int LoadValueInt(const string& sectionName, const string& key, int defaultValue);
+   float LoadValueFloat(const string& sectionName, const string& key, float defaultValue);
+   string LoadValueString(const string& sectionName, const string& key, const string& defaultValue);
+   void SaveValueInt(const string& sectionName, const string& key, int value);
+   void SaveValueFloat(const string& sectionName, const string& key, float value);
+   void SaveValueString(const string& sectionName, const string& key, const string& value);
    VPinballStatus Uncompress(const string& source);
    VPinballStatus Compress(const string& source, const string& destination);
    void UpdateWebServer();

--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballManager.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballManager.kt
@@ -187,7 +187,6 @@ object VPinballManager {
 
         CoroutineScope(Dispatchers.Main).launch {
             delay(500)
-            setIniDefaults()
             updateWebServer()
         }
     }
@@ -216,16 +215,6 @@ object VPinballManager {
                 }
             vibrator.vibrate(VibrationEffect.createOneShot(15, amplitude))
         }
-    }
-
-    private fun setIniDefaults() {
-        saveValue(PLAYER, "GfxBackend", loadValue(PLAYER, "GfxBackend", VPinballGfxBackend.OPENGLES.value))
-        saveValue(STANDALONE, "RenderingModeOverride", loadValue(STANDALONE, "RenderingModeOverride", 2))
-        saveValue(PLAYER, "MaxTexDimension", loadValue(PLAYER, "MaxTexDimension", 1024))
-        saveValue(PLAYER, "BallTrail", loadValue(PLAYER, "BallTrail", false))
-        saveValue(DMD, "DMDOutput", loadValue(DMD, "DMDOutput", 0))
-        saveValue(PLAYER, "ScreenWidth", loadValue(PLAYER, "ScreenWidth", 15.4f))
-        saveValue(PLAYER, "ScreenHeight", loadValue(PLAYER, "ScreenHeight", 7.1f))
     }
 
     fun updateWebServer() {
@@ -264,8 +253,6 @@ object VPinballManager {
 
     fun resetIni() {
         vpinballJNI.VPinballResetIni()
-
-        setIniDefaults()
     }
 
     fun toggleFPS() {

--- a/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballInterop.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballInterop.kt
@@ -18,22 +18,31 @@ enum class VPinballStatus(val value: Int) {
     FAILURE(1),
 }
 
-enum class VPinballSettingsSection(val value: Int) {
-    STANDALONE(2),
-    PLAYER(3),
-    DMD(4),
-    ALPHA(5),
-    BACKGLASS(6),
-    SCORE_VIEW(7),
-    TOPPER(8),
-    TABLE_OVERRIDE(13),
-    TABLE_OPTION(14);
+enum class VPinballSettingsSection(val value: String) {
+    STANDALONE("Standalone"),
+    PLAYER("Player"),
+    DMD("DMD"),
+    ALPHA("Alpha"),
+    BACKGLASS("Backglass"),
+    SCORE_VIEW("ScoreView"),
+    TOPPER("Topper"),
+    TABLE_OVERRIDE("TableOverride"),
+    TABLE_OPTION("TableOption"),
+    PLUGIN_ALPHA_DMD("Plugin.AlphaDMD"),
+    PLUGIN_B2S("Plugin.B2S"),
+    PLUGIN_FLEX_DMD("Plugin.FlexDMD"),
+    PLUGIN_PINMAME("Plugin.PinMAME"),
+    PLUGIN_PUP("Plugin.PUP"),
+    PLUGIN_REMOTE_CONTROL("Plugin.RemoteControl"),
+    PLUGIN_SERUM("Plugin.Serum"),
+    PLUGIN_SCORE_VIEW("Plugin.ScoreView"),
+    PLUGIN_DMD_UTIL("Plugin.DMDUtil");
 
     companion object {
         @JvmStatic
-        fun fromInt(value: Int): VPinballSettingsSection {
-            return VPinballSettingsSection.entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException("Unknown value: $value")
-        }
+        fun fromValue(value: String): VPinballSettingsSection =
+            entries.firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException("Unknown value: $value")
     }
 }
 
@@ -311,7 +320,7 @@ data class VPinballWebServerData(val url: String)
 data class VPinballCaptureScreenshotData(val success: Boolean)
 
 data class VPinballCustomTableOption(
-    var section: VPinballSettingsSection,
+    var sectionName: String,
     var id: String,
     var name: String,
     var showMask: Int,

--- a/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballJNI.java
+++ b/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballJNI.java
@@ -5,12 +5,12 @@ public class VPinballJNI {
     public native void VPinballInit(VPinballEventCallback callback);
     public native void VPinballLog(int level, String message);
     public native void VPinballResetLog();
-    public native int VPinballLoadValueInt(int section, String key, int defaultValue);
-    public native float VPinballLoadValueFloat(int section, String key, float defaultValue);
-    public native String VPinballLoadValueString(int section, String key, String defaultValue);
-    public native void VPinballSaveValueInt(int section, String key, int value);
-    public native void VPinballSaveValueFloat(int section, String key, float value);
-    public native void VPinballSaveValueString(int section, String key, String value);
+    public native int VPinballLoadValueInt(String sectionName, String key, int defaultValue);
+    public native float VPinballLoadValueFloat(String sectionName, String key, float defaultValue);
+    public native String VPinballLoadValueString(String sectionName, String key, String defaultValue);
+    public native void VPinballSaveValueInt(String sectionName, String key, int value);
+    public native void VPinballSaveValueFloat(String sectionName, String key, float value);
+    public native void VPinballSaveValueString(String sectionName, String key, String value);
     public native int VPinballUncompress(String source);
     public native int VPinballCompress(String source, String destination);
     public native void VPinballUpdateWebServer();

--- a/standalone/inc/webserver/WebServer.cpp
+++ b/standalone/inc/webserver/WebServer.cpp
@@ -245,11 +245,17 @@ void WebServer::Upload(struct mg_connection *c, struct mg_http_message* hm)
       PLOGI.printf("Uploading file: file=%s", file);
    }
 
+   char lengthStr[32];
+   mg_http_get_var(&hm->query, "length", lengthStr, sizeof(lengthStr));
+   long length = lengthStr[0] ? strtol(lengthStr, nullptr, 10) : 0;
+
    string path = g_pvp->m_myPrefPath + q;
 
-   if (!mg_http_upload(c, hm, &mg_fs_posix, path.c_str(), 1024 * 1024 * 500)) {
-      if (!strncmp(q, "VPinballX.ini", sizeof(q)))
-         g_pvp->m_settings.LoadFromFile(path, false);
+   if (mg_http_upload(c, hm, &mg_fs_posix, path.c_str(), 1024 * 1024 * 500) == length) {
+      if (*q == '\0' && !strcmp(file, "VPinballX.ini")) {
+         g_pvp->m_settings.LoadFromFile(path, true);
+         g_pvp->m_settings.Save();
+      }
    }
 }
 

--- a/standalone/ios/VPinball/utils/VPinballInterop.swift
+++ b/standalone/ios/VPinball/utils/VPinballInterop.swift
@@ -14,16 +14,24 @@ enum VPinballStatus: CInt {
     case failure
 }
 
-enum VPinballSettingsSection: CInt {
-    case standalone = 2
-    case player = 3
-    case dmd = 4
-    case alpha = 5
-    case backglass = 6
-    case scoreView = 7
-    case topper = 8
-    case tableOverride = 13
-    case tableOption = 14
+enum VPinballSettingsSection: String {
+    case standalone = "Standalone"
+    case player = "Player"
+    case alpha = "Alpha"
+    case backglass = "Backglass"
+    case scoreView = "ScoreView"
+    case topper = "Topper"
+    case tableOverride = "TableOverride"
+    case tableOption = "TableOption"
+    case pluginAlphaDMD = "Plugin.AlphaDMD"
+    case pluginB2S = "Plugin.B2S"
+    case pluginFlexDMD = "Plugin.FlexDMD"
+    case pluginPinMAME = "Plugin.PinMAME"
+    case pluginPUP = "Plugin.PUP"
+    case pluginRemoteControl = "Plugin.RemoteControl"
+    case pluginSerum = "Plugin.Serum"
+    case pluginScoreView = "Plugin.ScoreView"
+    case pluginDMDUtil = "Plugin.DMDUtil"
 }
 
 enum VPinballViewMode: CInt {
@@ -337,7 +345,7 @@ enum VPinballEvent: CInt {
     var name: String? {
         switch self {
         case .archiveUncompressing:
-            return "Ucompressing"
+            return "Uncompressing"
         case .archiveCompressing:
             return "Compressing"
         case .loadingItems:
@@ -508,7 +516,7 @@ struct VPinballTableOptions {
 }
 
 struct VPinballCustomTableOption {
-    var section: CInt = 0
+    var sectionName: UnsafePointer<CChar>?
     var id: UnsafePointer<CChar>?
     var name: UnsafePointer<CChar>?
     var showMask: CInt = 0
@@ -555,22 +563,22 @@ func VPinballLog(_ level: CInt, _ pMessage: UnsafePointer<CChar>)
 func VPinballResetLog()
 
 @_silgen_name("VPinballLoadValueInt")
-func VPinballLoadValueInt(_ section: CInt, _ pKey: UnsafePointer<CChar>, _ defaultValue: CInt) -> CInt
+func VPinballLoadValueInt(_ section: UnsafePointer<CChar>, _ pKey: UnsafePointer<CChar>, _ defaultValue: CInt) -> CInt
 
 @_silgen_name("VPinballLoadValueFloat")
-func VPinballLoadValueFloat(_ section: CInt, _ pKey: UnsafePointer<CChar>, _ defaultValue: Float) -> Float
+func VPinballLoadValueFloat(_ section: UnsafePointer<CChar>, _ pKey: UnsafePointer<CChar>, _ defaultValue: Float) -> Float
 
 @_silgen_name("VPinballLoadValueString")
-func VPinballLoadValueString(_ section: CInt, _ pKey: UnsafePointer<CChar>, _ defaultValue: UnsafePointer<CChar>) -> UnsafePointer<CChar>
+func VPinballLoadValueString(_ section: UnsafePointer<CChar>, _ pKey: UnsafePointer<CChar>, _ defaultValue: UnsafePointer<CChar>) -> UnsafePointer<CChar>
 
 @_silgen_name("VPinballSaveValueInt")
-func VPinballSaveValueInt(_ section: CInt, _ pKey: UnsafePointer<CChar>, _ value: CInt)
+func VPinballSaveValueInt(_ section: UnsafePointer<CChar>, _ pKey: UnsafePointer<CChar>, _ value: CInt)
 
 @_silgen_name("VPinballSaveValueFloat")
-func VPinballSaveValueFloat(_ section: CInt, _ pKey: UnsafePointer<CChar>, _ value: Float)
+func VPinballSaveValueFloat(_ section: UnsafePointer<CChar>, _ pKey: UnsafePointer<CChar>, _ value: Float)
 
 @_silgen_name("VPinballSaveValueString")
-func VPinballSaveValueString(_ section: CInt, _ pKey: UnsafePointer<CChar>, _ value: UnsafePointer<CChar>)
+func VPinballSaveValueString(_ section: UnsafePointer<CChar>, _ pKey: UnsafePointer<CChar>, _ value: UnsafePointer<CChar>)
 
 @_silgen_name("VPinballGetVersionStringFull")
 func VPinballGetVersionStringFull() -> UnsafePointer<CChar>

--- a/standalone/ios/VPinball/utils/VPinballManager.swift
+++ b/standalone/ios/VPinball/utils/VPinballManager.swift
@@ -196,7 +196,6 @@ class VPinballManager {
             }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.setIniDefaults()
             self.updateWebServer()
 
             if self.loadValue(.standalone, "LowMemoryNotice", -1) == 1 {
@@ -578,17 +577,6 @@ class VPinballManager {
 
     func resetIni() {
         _ = VPinballResetIni()
-
-        setIniDefaults()
-    }
-
-    func setIniDefaults() {
-        saveValue(.standalone, "RenderingModeOverride", loadValue(.standalone, "RenderingModeOverride", 2))
-        saveValue(.player, "MaxTexDimension", loadValue(.player, "MaxTexDimension", 1024))
-        saveValue(.player, "BallTrail", loadValue(.player, "BallTrail", false))
-        saveValue(.dmd, "DMDOutput", loadValue(.dmd, "DMDOutput", 0))
-        saveValue(.player, "ScreenWidth", loadValue(.player, "ScreenWidth", 15.4))
-        saveValue(.player, "ScreenHeight", loadValue(.player, "ScreenHeight", 7.1))
     }
 
     func updateWebServer() {


### PR DESCRIPTION
This updates mobile builds to use section name strings rather than ints for loading and saving settings.
This will allow setting and loading values for plugins, such as `[Plugin.ScoreView]` and `[Plugin.DMDUtil]` 

Also defaults for mobile were moved from the native apps, back to libvpinball using `Settings::Validate` (which I didn't realize existed, and is super awesome) 