### PR TITLE
Use placeholder when b2s image fail to be interpreted.

### DIFF
--- a/standalone/inc/b2s/forms/FormBackglass.cpp
+++ b/standalone/inc/b2s/forms/FormBackglass.cpp
@@ -1625,11 +1625,24 @@ SDL_Surface* FormBackglass::CropImageToTransparency(SDL_Surface* pImage, SDL_Sur
 
 SDL_Surface* FormBackglass::Base64ToImage(const string& image)
 {
+   if (image.empty()) {
+      PLOGW.printf("Found empty image.");
+      return CreatePlaceholder();
+   }
+
    vector<unsigned char> imageData = base64_decode(image);
+
+   if (imageData.empty()) {
+      PLOGE.printf("Base 64 image decode failed or resulted in empty data.");
+      return CreatePlaceholder();
+   }
+
    SDL_IOStream* rwops = SDL_IOFromConstMem(imageData.data(), imageData.size());
 
-   if (!rwops)
-      return NULL;
+   if (!rwops) {
+      PLOGE.printf("Failed ton construct SDL buffer from %d bytes of image data: %s", imageData.size(), SDL_GetError());
+      return CreatePlaceholder();
+   }
 
    SDL_Surface* pImage = IMG_Load_IO(rwops, 0);
    if (!pImage) {
@@ -1660,4 +1673,10 @@ OLE_COLOR FormBackglass::String2Color(const string& color)
       return RGB(colorValues[0], colorValues[1], colorValues[2]);
 
    return RGB(0, 0, 0);
+}
+
+
+SDL_Surface* FormBackglass::CreatePlaceholder() const
+{
+   return SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_RGBA32);
 }

--- a/standalone/inc/b2s/forms/FormBackglass.h
+++ b/standalone/inc/b2s/forms/FormBackglass.h
@@ -78,6 +78,7 @@ private:
    OLE_COLOR String2Color(const string& color);
    SDL_Surface* ResizeSurface(SDL_Surface* original, int newWidth, int newHeight);
    SDL_Surface* RotateSurface(SDL_Surface* source, int angle);
+   SDL_Surface* CreatePlaceholder() const;
 
    static constexpr int minSize4Image = 300000;
 


### PR DESCRIPTION
When loading the "Die Hard Trilogy" table ([vpuniverse.com/files/file/17645](https://vpuniverse.com/files/file/17645-die-hard-trilogy-vpw-2023/)), VPinball crashes with a segmentation fault during DirectB2S file processing.

The crash occurs when FormBackglass::Base64ToImage() fails to decode base64 image data and returns nullptr.
This method currently returns NULL when something is wrong but there aren't any checks on NULL on the caller side.

The decode failure was traced to empty or placeholder "Image" attributes in the DirectB2S file (
[Die Hard Trilogy (VPW 2023) v0.98.directb2s.gz](https://github.com/user-attachments/files/20652031/Die.Hard.Trilogy.VPW.2023.v0.98.directb2s.gz)
).

This PR adds some validation in the Base64ToImage method, logs any error and returns a 1px placeholder if anything fails.
This way, we should have a degraded backglass in case of failure to decode an image but no more crash.

I'm not sure this is the best solution. I'm not familiar enough with B2S to properly interpret what represents an empty Image attribute.