### PR TITLE
Delayed hiding of window so B2S.Server can find the VPX window name

### DIFF
--- a/src/core/vpinball.cpp
+++ b/src/core/vpinball.cpp
@@ -1048,7 +1048,6 @@ void VPinball::DoPlay(const int playMode)
       return;
 
    PLOGI << "Starting Play mode [table: " << table->m_tableName << ", play mode: " << playMode << ']';
-   ShowWindow(SW_HIDE);
    bool initError = false;
    if (false)
    {
@@ -1212,6 +1211,8 @@ void VPinball::DoPlay(const int playMode)
       #else
       auto processWindowMessages = []() {};
       #endif
+      ShowWindow(SW_HIDE);
+
       g_pplayer->GameLoop(processWindowMessages);
 
       #if (defined(__APPLE__) && (defined(TARGET_OS_IOS) && TARGET_OS_IOS))
@@ -1221,9 +1222,9 @@ void VPinball::DoPlay(const int playMode)
 
       delete g_pplayer;
       g_pplayer = nullptr;
-   }
 
-   ShowWindow(SW_SHOW);
+     ShowWindow(SW_SHOW);
+   }
 
    if (initError)
    {


### PR DESCRIPTION
This should fix [https://github.com/vpinball/vpinball/issues/2516](url)
Introduced by [https://github.com/vpinball/vpinball/commit/1a6b1120392f08fa89b17b26c7dcaea1bc66fe1f](url)
Although, Im not 100% sure as there still may be a timing issue where B2S Backglass Server make take a little more time to load and then still not find the window. I've tested this build in Debug and Release environments.

The hiding of the window changed behavior that b2sbackglassserver was relying on.
In this file [https://github.com/vpinball/b2s-backglass/blob/master/b2sbackglassserver/b2sbackglassserver/Classes/Processes.vb](url), the follow code below determines the name of the directb2s file based on the window name of the running Visual Pinball editor window. See snippet of code below:

This code enumerates all "IsWindowVisible()" windows. Due to hiding the window, this function no longer finds the VPX window
`    Private Function EnumWinProc(ByVal hwnd As IntPtr, ByVal lParam As Int32) As Boolean
        If IsWindowVisible(hwnd) AndAlso GetParent(hwnd) = IntPtr.Zero AndAlso GetWindowLong(hwnd, GWL_HWNDPARENT) = 0 Then
            Dim str As String = String.Empty.PadLeft(GetWindowTextLength(hwnd) + 1)
            GetWindowText(hwnd, str, str.Length)
            If Not String.IsNullOrEmpty(str.Substring(0, str.Length - 1)) Then windowlist.Add(New ProcInfo(str.Substring(0, str.Length - 1), hwnd))
        End If
        EnumWinProc = True
    End Function
    Private Sub RefreshWindowList()
        windowlist = New List(Of ProcInfo)
        EnumWindows(AddressOf EnumWinProc, CInt(True))
    End Sub
`

Then during startup of the B2S Backglass Server, the following code is run which looks for "Visual Pinball - <TABLE_NAME>".
`	    Public Sub New()
        RefreshWindowList()
        For Each proc As ProcInfo In windowlist
            If Not String.IsNullOrEmpty(proc.Name) Then
                If proc.Name.StartsWith("Visual Pinball - ", StringComparison.CurrentCultureIgnoreCase) Then
                    'Visual Pinball - [Tom and Jerry (Original 2019) v 1.33]
                    If String.IsNullOrEmpty(_tablename) Then
                        _tablename = proc.Name.Substring(17)
                        '[Tom and Jerry (Original 2019) v 1.33]___
                        If _tablename.StartsWith("[") AndAlso Not _tablename.EndsWith("]") Then
	`