### PR TITLE
Update orientation settings to handle Landscape (flipped) for tablet and gaming devices

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -506,12 +506,19 @@ public:
 #ifdef _MSC_VER
       // disable auto-rotate on tablets
 #if (_WIN32_WINNT <= 0x0601)
-      SetDisplayAutoRotationPreferences = (pSDARP)GetProcAddress(GetModuleHandle(TEXT("user32.dll")),
-         "SetDisplayAutoRotationPreferences");
+      pSDARP SetDisplayAutoRotationPreferences = (pSDARP)GetProcAddress(GetModuleHandle(TEXT("user32.dll")), "SetDisplayAutoRotationPreferences");
       if (SetDisplayAutoRotationPreferences)
-         SetDisplayAutoRotationPreferences(ORIENTATION_PREFERENCE_LANDSCAPE);
+      {
+         // Allow both normal and flipped landscape to honor system defaults
+         SetDisplayAutoRotationPreferences(static_cast<ORIENTATION_PREFERENCE>(ORIENTATION_PREFERENCE_LANDSCAPE | ORIENTATION_PREFERENCE_LANDSCAPE_FLIPPED));
+      }
 #else
-      SetDisplayAutoRotationPreferences(ORIENTATION_PREFERENCE_LANDSCAPE);
+      // Use the same API for newer Windows versions
+      pSDARP SetDisplayAutoRotationPreferences = (pSDARP)GetProcAddress(GetModuleHandle(TEXT("user32.dll")), "SetDisplayAutoRotationPreferences");
+      if (SetDisplayAutoRotationPreferences)
+      {
+         SetDisplayAutoRotationPreferences(static_cast<ORIENTATION_PREFERENCE>(ORIENTATION_PREFERENCE_LANDSCAPE | ORIENTATION_PREFERENCE_LANDSCAPE_FLIPPED));
+      }
 #endif
 
       //!! max(2u, std::thread::hardware_concurrency()) ??


### PR DESCRIPTION
This should fix Issue #1222 

I started using VPX only a few weeks ago and ran into the same issue mentioned on my Legion Go.  I've been a developer for several years but have done hardly anything in C, so full disclosure, I used AI tools to find the solution.  But it builds and plays properly on my Legion Go after making these changes.  Tested with Space Cadet, Terminator 2, Addams Family, and a Super Mario table, so it should be good to go.  The fix is also in the spot where a comment was added saying "disable auto-rotate on tablets" that was mentioned in the 1222 issue, so it should be the right place.

Feel free to make any adjustments or give me feedback and I will happily build and test on my Legion Go again.

Thanks!