### PR TITLE
Use ref counting to manage texture data lifecycle

### DIFF
--- a/plugins/pup/PUPPlugin.cpp
+++ b/plugins/pup/PUPPlugin.cpp
@@ -136,13 +136,6 @@ VPXTexture CreateTexture(SDL_Surface* surf)
    return texture;
 }
 
-VPXTexture CreateTexture(uint8_t* rawData, int size)
-{
-   if (vpxApi)
-      return vpxApi->CreateTexture(rawData, size);
-   return nullptr;
-}
-
 void GetTextureInfo(VPXTexture texture, int* width, int* height)
 {
    if (vpxApi)

--- a/plugins/pup/common.h
+++ b/plugins/pup/common.h
@@ -59,7 +59,6 @@ PSC_USE_ERROR();
 
 // Rendering provided through plugin messages
 extern VPXTexture CreateTexture(SDL_Surface* surf);
-extern VPXTexture CreateTexture(uint8_t *rawData, int size);
 extern void GetTextureInfo(VPXTexture texture, int *width, int *height);
 extern void UpdateTexture(VPXTexture* texture, int width, int height, VPXTextureFormat format, const uint8_t *image);
 extern void DeleteTexture(VPXTexture texture);

--- a/src/core/VPXPluginAPIImpl.h
+++ b/src/core/VPXPluginAPIImpl.h
@@ -32,6 +32,8 @@ public:
    string ApplyScriptCOMObjectOverrides(string& script) const;
    IDispatch* CreateCOMPluginObject(const string& classId);
 
+   std::shared_ptr<BaseTexture> GetTexture(VPXTexture texture) const;
+
 private:
    VPXPluginAPIImpl();
 

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -367,7 +367,7 @@ public:
    // External DMD and displays, defined from script or captured
    bool m_capExtDMD = false; // frame capturing (hack for VR)
    int2 m_dmdSize = int2(0, 0); // DMD defined through VPX API DMDWidth/DMDHeight/DMDPixels/DMDColoredPixels
-   BaseTexture* m_dmdFrame = nullptr;
+   std::shared_ptr<BaseTexture> m_dmdFrame = nullptr;
    int m_dmdFrameId = 0;
 
    ResURIResolver m_resURIResolver;
@@ -375,7 +375,7 @@ public:
 
 public:
    bool m_capPUP = false;
-   BaseTexture *m_texPUP = nullptr;
+   std::shared_ptr<BaseTexture> m_texPUP = nullptr;
 
    unsigned int m_overall_frames = 0; // amount of rendered frames since start
 

--- a/src/parts/ball.cpp
+++ b/src/parts/ball.cpp
@@ -231,7 +231,7 @@ void Ball::RenderSetup(RenderDevice *device)
 
    if (m_d.m_useTableRenderSettings && g_pplayer->m_renderer->m_overwriteBallImages && g_pplayer->m_renderer->m_ballImage)
    {
-      m_pinballEnv = g_pplayer->m_renderer->m_ballImage;
+      m_pinballEnv = g_pplayer->m_renderer->m_ballImage.get();
       m_d.m_pinballEnvSphericalMapping = true;
    }
    else if (m_d.m_szImage.empty())
@@ -243,7 +243,7 @@ void Ball::RenderSetup(RenderDevice *device)
       m_pinballEnv = m_ptable->GetImage(m_d.m_szImage) ? m_ptable->GetImage(m_d.m_szImage) : nullptr;
 
    if (m_d.m_useTableRenderSettings && g_pplayer->m_renderer->m_overwriteBallImages && g_pplayer->m_renderer->m_decalImage)
-      m_pinballDecal = g_pplayer->m_renderer->m_decalImage;
+      m_pinballDecal = g_pplayer->m_renderer->m_decalImage.get();
    else if (m_d.m_imageDecal.empty())
       m_pinballDecal = nullptr;
    else

--- a/src/parts/decal.cpp
+++ b/src/parts/decal.cpp
@@ -728,7 +728,6 @@ void Decal::RenderSetup(RenderDevice *device)
 void Decal::RenderRelease()
 {
    assert(m_rd != nullptr);
-   delete m_textImg;
    delete m_meshBuffer;
    m_textImg = nullptr;
    m_meshBuffer = nullptr;
@@ -766,7 +765,7 @@ void Decal::Render(const unsigned int renderMask)
          m_rd->m_basicShader->SetTechniqueMaterial(SHADER_TECHNIQUE_basic_with_texture, *mat, false);
       else
          m_rd->m_basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-      m_rd->m_basicShader->SetTexture(SHADER_tex_base_color, m_textImg);
+      m_rd->m_basicShader->SetTexture(SHADER_tex_base_color, m_textImg.get());
    }
    else
    {

--- a/src/parts/decal.h
+++ b/src/parts/decal.h
@@ -75,7 +75,7 @@ private:
 
    RenderDevice *m_rd = nullptr;
    MeshBuffer *m_meshBuffer = nullptr;
-   BaseTexture *m_textImg = nullptr;
+   std::shared_ptr<BaseTexture> m_textImg = nullptr;
    float m_leading = 0.0f, m_descent = 0.0f;
    float m_realwidth = 0.0f, m_realheight = 0.0f;
 

--- a/src/parts/flasher.h
+++ b/src/parts/flasher.h
@@ -155,8 +155,6 @@ public:
       m_d.m_filterAmount = max(value,0);
    }
 
-   //BaseTexture* GetVideoCap(const string& szName);
-
    void setInPlayState(const bool newVal);
 
    FlasherData m_d;
@@ -164,7 +162,7 @@ public:
    bool m_lockedByLS = false;
    bool m_inPlayState = false;
 
-   BaseTexture *m_dmdFrame = nullptr;
+   std::shared_ptr<BaseTexture> m_dmdFrame = nullptr;
 
 private:
    void InitShape();
@@ -191,7 +189,7 @@ private:
    int m_videoCapHeight = 0;
    RECT m_videoSourceRect { 0 };
    HWND m_videoCapHwnd = nullptr;
-   BaseTexture* m_videoCapTex = nullptr;
+   std::shared_ptr<BaseTexture> m_videoCapTex = nullptr;
 
    int2 m_dmdSize = int2(0,0);
 

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1044,10 +1044,7 @@ STDMETHODIMP ScriptGlobalTable::put_DMDPixels(VARIANT pVal) // assumes VT_UI1 as
        || g_pplayer->m_dmdFrame->m_format != BaseTexture::BW)
    {
       if (g_pplayer->m_dmdFrame)
-      {
-         g_pplayer->m_renderer->m_renderDevice->m_texMan.UnloadTexture(g_pplayer->m_dmdFrame);
-         delete g_pplayer->m_dmdFrame;
-      }
+         g_pplayer->m_renderer->m_renderDevice->m_texMan.UnloadTexture(g_pplayer->m_dmdFrame.get());
       g_pplayer->m_dmdFrame = BaseTexture::Create(g_pplayer->m_dmdSize.x * scale, g_pplayer->m_dmdSize.y * scale, BaseTexture::BW);
    }
    const int size = g_pplayer->m_dmdSize.x * g_pplayer->m_dmdSize.y;
@@ -1073,7 +1070,7 @@ STDMETHODIMP ScriptGlobalTable::put_DMDPixels(VARIANT pVal) // assumes VT_UI1 as
    }
    SafeArrayUnaccessData(psa);
    g_pplayer->m_dmdFrameId++;
-   g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(g_pplayer->m_dmdFrame);
+   g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(g_pplayer->m_dmdFrame.get());
    return S_OK;
 }
 
@@ -1100,10 +1097,7 @@ STDMETHODIMP ScriptGlobalTable::put_DMDColoredPixels(VARIANT pVal) //!! assumes 
        || g_pplayer->m_dmdFrame->m_format != BaseTexture::SRGBA)
    {
       if (g_pplayer->m_dmdFrame)
-      {
-         g_pplayer->m_renderer->m_renderDevice->m_texMan.UnloadTexture(g_pplayer->m_dmdFrame);
-         delete g_pplayer->m_dmdFrame;
-      }
+         g_pplayer->m_renderer->m_renderDevice->m_texMan.UnloadTexture(g_pplayer->m_dmdFrame.get());
       g_pplayer->m_dmdFrame = BaseTexture::Create(g_pplayer->m_dmdSize.x * scale, g_pplayer->m_dmdSize.y * scale, BaseTexture::SRGBA);
    }
    const int size = g_pplayer->m_dmdSize.x * g_pplayer->m_dmdSize.y;
@@ -1116,7 +1110,7 @@ STDMETHODIMP ScriptGlobalTable::put_DMDColoredPixels(VARIANT pVal) //!! assumes 
    if (g_pplayer->m_scaleFX_DMD)
       upscale(data, g_pplayer->m_dmdSize, false);
    g_pplayer->m_dmdFrameId++;
-   g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(g_pplayer->m_dmdFrame);
+   g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(g_pplayer->m_dmdFrame.get());
    return S_OK;
 }
 

--- a/src/parts/primitive.cpp
+++ b/src/parts/primitive.cpp
@@ -1273,7 +1273,7 @@ void Primitive::Render(const unsigned int renderMask)
    float pinAlphaTest;
    if (g_pplayer->m_texPUP && m_isBackGlassImage)
    {
-      pin = g_pplayer->m_texPUP;
+      pin = g_pplayer->m_texPUP.get();
       pinAlphaTest = 0.f;
    }
    else

--- a/src/parts/textbox.cpp
+++ b/src/parts/textbox.cpp
@@ -438,7 +438,6 @@ void Textbox::RenderSetup(RenderDevice *device)
 void Textbox::RenderRelease()
 {
    assert(m_rd != nullptr);
-   delete m_texture;
    m_texture = nullptr;
    SAFE_RELEASE(m_pIFontPlay);
    m_rd = nullptr;
@@ -517,7 +516,7 @@ void Textbox::Render(const unsigned int renderMask)
       ResURIResolver::DisplayState dmd = g_pplayer->m_resURIResolver.GetDisplayState("ctrl://default/display");
       if (dmd.state.frame == nullptr)
          return;
-      BaseTexture::Update(&m_texture, dmd.source->width, dmd.source->height, 
+      BaseTexture::Update(m_texture, dmd.source->width, dmd.source->height, 
               dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM8    ? BaseTexture::BW
             : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? BaseTexture::SRGB565
                                                                       : BaseTexture::SRGB,
@@ -672,12 +671,12 @@ void Textbox::Render(const unsigned int renderMask)
             SDL_DestroySurface(pSurface);
          }
 #endif
-         m_rd->m_texMan.SetDirty(m_texture);
+         m_rd->m_texMan.SetDirty(m_texture.get());
       }
 
       m_rd->ResetRenderState();
       m_rd->m_DMDShader->SetFloat(SHADER_alphaTestValue, (float)(128.0 / 255.0));
-      g_pplayer->m_renderer->DrawSprite(x, y, w, h, 0xFFFFFFFF, m_rd->m_texMan.LoadTexture(m_texture, false), m_d.m_intensity_scale);
+      g_pplayer->m_renderer->DrawSprite(x, y, w, h, 0xFFFFFFFF, m_rd->m_texMan.LoadTexture(m_texture.get(), false), m_d.m_intensity_scale);
       m_rd->m_DMDShader->SetFloat(SHADER_alphaTestValue, 1.0f);
    }
 }

--- a/src/parts/textbox.h
+++ b/src/parts/textbox.h
@@ -101,7 +101,7 @@ private:
    
    RenderDevice *m_rd = nullptr;
    bool m_textureDirty = true;
-   BaseTexture *m_texture = nullptr;
+   std::shared_ptr<BaseTexture> m_texture = nullptr;
    IFont *m_pIFontPlay = nullptr; // Our font, scaled to match play window resolution
 
 #ifdef __STANDALONE__

--- a/src/renderer/Backglass.cpp
+++ b/src/renderer/Backglass.cpp
@@ -185,7 +185,7 @@ BackGlass::BackGlass(RenderDevice* const pd3dDevice, Texture * backgroundFallbac
                   size_t size = decode_base64(val, data, val_size, data_len);
                   if ((size > 0) && (strcmp(imagesNode->Name(), "BackglassImage") == 0)) {
                      m_loaded_image = BaseTexture::CreateFromData(data, size, true, g_pplayer->m_ptable->m_settings.LoadValueInt(Settings::Player, "MaxTexDimension"s));
-                     m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(m_loaded_image, false);
+                     m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(m_loaded_image.get(), false);
                      m_backglass_width = m_backgroundTexture->GetWidth();
                      m_backglass_height = m_backgroundTexture->GetHeight();
                   }
@@ -229,14 +229,13 @@ BackGlass::BackGlass(RenderDevice* const pd3dDevice, Texture * backgroundFallbac
 
 BackGlass::~BackGlass()
 {
-   delete m_loaded_image;
 }
 
 void BackGlass::Render()
 {
    if (g_pplayer->m_texPUP)
    {
-      m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, false);
+      m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP.get(), false);
       m_backglass_width = g_pplayer->m_texPUP->width();
       m_backglass_height = g_pplayer->m_texPUP->height();
       float tableWidth, glassHeight;

--- a/src/renderer/Backglass.h
+++ b/src/renderer/Backglass.h
@@ -16,7 +16,7 @@ public:
 
 private:
    RenderDevice* m_pd3dDevice;
-   BaseTexture* m_loaded_image; 
+   std::shared_ptr<BaseTexture> m_loaded_image; 
    Texture* m_backgroundFallback;
    std::shared_ptr<Sampler> m_backgroundTexture;
    int2 m_backglass_dmd;

--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -933,7 +933,7 @@ RenderDevice::RenderDevice(VPX::Window* const wnd, const bool isVR, const int nE
    int n_tex_units = min(max_frag_unit, max_combined_unit);
    for (int i = 0; i < n_tex_units; i++)
    {
-      SamplerBinding* binding = new SamplerBinding();
+      Sampler::SamplerBinding* binding = new Sampler::SamplerBinding();
       binding->unit = i;
       binding->use_rank = i;
       binding->sampler = nullptr;
@@ -1574,11 +1574,10 @@ void RenderDevice::Flip()
 void RenderDevice::UploadAndSetSMAATextures()
 {
    // TODO use standard BaseTexture / Sampler code instead
-   /* BaseTexture* searchBaseTex = BaseTexture::Create(SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT, BaseTexture::BW);
+   /* std::shared_ptr<BaseTexture> searchBaseTex = BaseTexture::Create(SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT, BaseTexture::BW);
    memcpy(searchBaseTex->data(), searchTexBytes, SEARCHTEX_SIZE);
    m_SMAAsearchTexture = std::make_shared<Sampler>(this, "SMAA Search"s, searchBaseTex, true);
-   m_SMAAsearchTexture->SetName("SMAA Search"s);
-   delete searchBaseTex;*/
+   m_SMAAsearchTexture->SetName("SMAA Search"s); */
 
 #if defined(ENABLE_BGFX)
    bgfx::TextureHandle smaaAreaTex = bgfx::createTexture2D(AREATEX_WIDTH, AREATEX_HEIGHT, false, 1, bgfx::TextureFormat::RG8, BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP, bgfx::makeRef(areaTexBytes, AREATEX_SIZE));

--- a/src/renderer/RenderDevice.h
+++ b/src/renderer/RenderDevice.h
@@ -294,7 +294,7 @@ private:
 public:
    int getGLVersion() const { return m_GLversion; }
    vector<MeshBuffer::SharedVAO*> m_sharedVAOs;
-   vector<SamplerBinding*> m_samplerBindings;
+   vector<Sampler::SamplerBinding*> m_samplerBindings;
    GLuint m_curVAO = 0;
    SDL_GLContext m_sdl_context = nullptr;
    #ifndef __STANDALONE__

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -57,7 +57,7 @@ public:
    };
    void SetupSegmentRenderer(int profile, const bool isBackdrop, const vec3& color, const float brightness, const SegmentFamily family, const SegElementType type, const float* segs, const ColorSpace colorSpace, Vertex3D_NoTex2* vertices,
       const vec4& emitterPad, const vec3& glassTint, const float glassRougness, ITexManCacheable* const glassTex, const vec4& glassArea, const vec3& glassAmbient);
-   void SetupDMDRender(int profile, const bool isBackdrop, const vec3& color, const float brightness, BaseTexture* dmd, const float alpha, const ColorSpace colorSpace, Vertex3D_NoTex2 *vertices,
+   void SetupDMDRender(int profile, const bool isBackdrop, const vec3& color, const float brightness, std::shared_ptr<BaseTexture> dmd, const float alpha, const ColorSpace colorSpace, Vertex3D_NoTex2 *vertices,
       const vec4& emitterPad, const vec3& glassTint, const float glassRougness, ITexManCacheable* const glassTex, const vec4& glassArea, const vec3& glassAmbient);
    void DrawStatics();
    void DrawDynamics(bool onlyBalls);
@@ -98,8 +98,8 @@ public:
    bool m_trailForBalls = false;
    float m_ballTrailStrength = 0.5f;
    bool m_overwriteBallImages = false;
-   BaseTexture* m_ballImage = nullptr;
-   BaseTexture* m_decalImage = nullptr;
+   std::shared_ptr<BaseTexture> m_ballImage = nullptr;
+   std::shared_ptr<BaseTexture> m_decalImage = nullptr;
 
    // Post processing
    void SetScreenOffset(const float x, const float y); // set render offset in screen coordinates, e.g., for the nudge shake
@@ -151,7 +151,7 @@ private:
    bool IsBloomEnabled() const;
    void Bloom();
    void SSRefl();
-   BaseTexture* EnvmapPrecalc(std::shared_ptr<const BaseTexture> envTex, const unsigned int rad_env_xres, const unsigned int rad_env_yres);
+   std::shared_ptr<BaseTexture> EnvmapPrecalc(std::shared_ptr<const BaseTexture> envTex, const unsigned int rad_env_xres, const unsigned int rad_env_yres);
 
    bool m_shaderDirty = true;
    void SetupShaders();
@@ -228,7 +228,7 @@ private:
    Texture* m_tonemapLUT = nullptr;
 
    #if defined(ENABLE_DX9) || defined(__OPENGLES__) || defined(__APPLE__)
-   BaseTexture* m_envRadianceTexture = nullptr;
+   std::shared_ptr<BaseTexture> m_envRadianceTexture = nullptr;
    #else
    RenderTarget* m_envRadianceTexture = nullptr;
    #endif

--- a/src/renderer/Sampler.h
+++ b/src/renderer/Sampler.h
@@ -35,17 +35,6 @@ enum SurfaceType
    RT_CUBEMAP // Cubemap texture (6 layers)
 };
 
-class Sampler;
-struct SamplerBinding
-{
-   int unit;
-   int use_rank;
-   std::shared_ptr<const Sampler> sampler;
-   SamplerFilter filter;
-   SamplerAddressMode clamp_u;
-   SamplerAddressMode clamp_v;
-};
-
 class Sampler final
 {
 public:
@@ -97,6 +86,15 @@ private:
    GLuint m_texture = 0;
    GLuint CreateTexture(std::shared_ptr<const BaseTexture> surf, unsigned int Levels, colorFormat Format, int stereo);
 public:
+   struct SamplerBinding
+   {
+      int unit;
+      int use_rank;
+      std::shared_ptr<const Sampler> sampler;
+      SamplerFilter filter;
+      SamplerAddressMode clamp_u;
+      SamplerAddressMode clamp_v;
+   };
    mutable ankerl::unordered_dense::set<SamplerBinding*> m_bindings;
 #elif defined(ENABLE_DX9)
    IDirect3DTexture9* m_texture = nullptr;

--- a/src/renderer/Shader.cpp
+++ b/src/renderer/Shader.cpp
@@ -1191,7 +1191,7 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
          #elif defined(ENABLE_OPENGL)
          // DX9 implementation uses preaffected texture units, not samplers, so these can not be used for OpenGL. This would cause some collisions.
          m_renderDevice->m_curParameterChanges--;
-         SamplerBinding* tex_unit = nullptr;
+         Sampler::SamplerBinding* tex_unit = nullptr;
          for (auto binding : texel->m_bindings)
          {
             if (binding->filter == filter && binding->clamp_u == clampu && binding->clamp_v == clampv)

--- a/src/renderer/captureExt.cpp
+++ b/src/renderer/captureExt.cpp
@@ -34,7 +34,7 @@ ExtCaptureManager::CaptureState ExtCaptureManager::GetState(const string& name) 
    return CS_Undeclared;
 }
 
-void ExtCaptureManager::StartCapture(const string& name, BaseTexture** targetTexture, const vector<string>& windowlist)
+void ExtCaptureManager::StartCapture(const string& name, std::shared_ptr<BaseTexture>* targetTexture, const vector<string>& windowlist)
 {
    m_captureMutex.lock();
    Capture* const capture = new Capture();
@@ -84,8 +84,7 @@ void ExtCaptureManager::Update()
          const std::lock_guard<std::mutex> guard(m_captureMutex);
          if (*capture->m_targetTexture != nullptr)
          {
-            g_pplayer->m_renderer->m_renderDevice->m_texMan.UnloadTexture(*capture->m_targetTexture);
-            delete *capture->m_targetTexture;
+            g_pplayer->m_renderer->m_renderDevice->m_texMan.UnloadTexture(capture->m_targetTexture->get());
             *capture->m_targetTexture = nullptr;
          }
          // Sleaze alert! - ec creates a HBitmap, but we hijack ec's data pointer to dump its data directly into VP's texture
@@ -109,7 +108,7 @@ void ExtCaptureManager::Update()
       {
          // We do not lock wait on the update thread when pushing the update information to the texture manager to limit the performance impact
          capture->m_updated = false;
-         g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(*capture->m_targetTexture);
+         g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(capture->m_targetTexture->get());
       }
    }
 

--- a/src/renderer/captureExt.h
+++ b/src/renderer/captureExt.h
@@ -178,7 +178,7 @@ public:
       CS_Failure // Failed (no going back)
    };
    CaptureState GetState(const string& name) const;
-   void StartCapture(const string& name, BaseTexture** targetTexture, const vector<string>& windowlist);
+   void StartCapture(const string& name, std::shared_ptr<BaseTexture>* targetTexture, const vector<string>& windowlist);
    void Update();
    void Stop();
 
@@ -202,7 +202,7 @@ private:
       CaptureState m_state = CS_Uninitialized;
       vector<string> m_searchWindows;
       Duplication* m_duplication;
-      BaseTexture** m_targetTexture;
+      std::shared_ptr<BaseTexture>* m_targetTexture;
       HWND m_window;
       HBITMAP m_hBitmap;
       void* m_data = nullptr;


### PR DESCRIPTION
This allows to remove the data copy for each update on the BGFX platform