### PR TITLE
standalone: fix MakeChar segfault. Prevent LiveUI assertions

### DIFF
--- a/src/core/def.cpp
+++ b/src/core/def.cpp
@@ -287,7 +287,7 @@ wstring MakeWString(const char * const sz)
 char *MakeChar(const WCHAR* const wz)
 {
    const int len = WideCharToMultiByte(CP_ACP, 0, wz, -1, nullptr, 0, nullptr, nullptr); //(int)wcslen(wz) + 1; // include null termination
-   if (len <= 1)
+   if (len == 0)
       return nullptr;
    char * const szT = new char[len];
    WideCharToMultiByte(CP_ACP, 0, wz, -1, szT, len, nullptr, nullptr);

--- a/src/ui/LiveUI.cpp
+++ b/src/ui/LiveUI.cpp
@@ -1024,8 +1024,11 @@ void LiveUI::Update(const int width, const int height)
    ImGuiIO &io = ImGui::GetIO();
    const bool isInteractiveUI = m_ShowUI || m_ShowSplashModal || m_ShowBAMModal;
    const bool isVR = m_renderer->m_stereo3D == STEREO_VR;
+#ifndef __STANDALONE__
+   // io.DisplaySize already contains the correct width and height for MacOS (and Wayland) 
    io.DisplaySize.x = static_cast<float>(width);
    io.DisplaySize.y = static_cast<float>(height);
+#endif
    // If we are only showing overlays (no mouse interaction), apply main camera rotation
    m_rotate = (isInteractiveUI || isVR) ? 0 : ((int)(m_player->m_ptable->mViewSetups[m_player->m_ptable->m_BG_current_set].GetRotation((int)io.DisplaySize.x, (int)io.DisplaySize.y) / 90.0f));
    if (m_rotate == 1 || m_rotate == 3)

--- a/standalone/inc/wmp/WMPCore.cpp
+++ b/standalone/inc/wmp/WMPCore.cpp
@@ -52,7 +52,9 @@ STDMETHODIMP WMPCore::put_URL(BSTR pbstrURL)
 
    PLOGI.printf("player=%p, URL=%s", this, m_szURL.c_str());
 
-   if (m_pAudioPlayer->PlayMusic(m_szURL))
+   m_szURL = find_case_insensitive_file_path(m_szURL);
+
+   if (!m_szURL.empty() && m_pAudioPlayer->PlayMusic(m_szURL))
    {
       m_pAudioPlayer->PauseMusic();
       m_playState = wmppsReady;


### PR DESCRIPTION
@toxieainc, @vbousquet - not sure if I made the correct fix, but `SortAgainstValue` calls `MakeChar` with L"", which then returns `null` which segfaults `lstrcmp`. All the other `Make*` seem to return an empty string, so I made it do the same.
 
```
int CodeViewDispatch::SortAgainstValue(const wstring& pv) const
{
   const char* szName1 = MakeChar(pv.c_str());
   const char* szName2 = MakeChar(m_wName.c_str());
   int ret = lstrcmp(szName1, szName2);
   delete[] szName1;
   delete[] szName2;
   return ret;
}
```

`standalone/inc/wine/wine.c:`

```
__forceinline INT WINAPI lstrcmpA(LPCSTR str1, LPCSTR str2)
{
   return strcmp(str1, str2);
}
```


