### PR TITLE
fix: resolve -listsnd and -listres command line options not working

### DIFF
--- a/src/core/VPApp.cpp
+++ b/src/core/VPApp.cpp
@@ -672,8 +672,8 @@ void VPApp::ProcessCommandLine(int nArgs, char* szArglist[])
    m_extractScript = false;
    m_audit = false;
    m_tournament = false;
-   m_listSnd = false;  // NOUVEAU: initialisation du flag
-   m_listRes = false;  // NOUVEAU: initialisation du flag
+   m_listSnd = false;  // Initialize flag for deferred sound device enumeration
+   m_listRes = false;  // Initialize flag for deferred display resolution enumeration
 #ifdef __STANDALONE__
    m_prefPath.clear();
    m_displayId = false;
@@ -872,14 +872,14 @@ void VPApp::ProcessCommandLine(int nArgs, char* szArglist[])
          break;
 
       case OPTION_LISTSND:
-         // MODIFICATION: marquer le flag au lieu de traiter immédiatement
+         // Set flag instead of processing immediately - device enumeration requires SDL initialization
          m_listSnd = true;
          m_run = false;
          break;
 
       #ifdef ENABLE_SDL_VIDEO
       case OPTION_LISTRES:
-         // MODIFICATION: marquer le flag au lieu de traiter immédiatement
+         // Set flag instead of processing immediately - display enumeration requires SDL initialization
          m_listRes = true;
          m_run = false;
          break;
@@ -1019,7 +1019,7 @@ BOOL VPApp::InitInstance()
 
 int VPApp::Run()
 {
-   // NOUVEAU: traiter les options qui nécessitent une initialisation complète
+   // Process options that require complete SDL initialization
    if (m_listSnd)
    {
       PLOGI << "Available sound devices:";

--- a/src/core/VPApp.h
+++ b/src/core/VPApp.h
@@ -32,8 +32,8 @@ private:
    bool m_extractScript = false;
    bool m_audit = false;
    bool m_tournament = false;
-   bool m_listSnd = false;    // NOUVEAU: flag pour -listsnd
-   bool m_listRes = false;    // NOUVEAU: flag pour -listres
+   bool m_listSnd = false;    // Flag for -listsnd option to defer sound device enumeration
+   bool m_listRes = false;    // Flag for -listres option to defer display resolution enumeration
 #ifdef __STANDALONE__
    bool m_displayId = false;
    string m_prefPath;

--- a/src/core/VPApp.h
+++ b/src/core/VPApp.h
@@ -32,6 +32,8 @@ private:
    bool m_extractScript = false;
    bool m_audit = false;
    bool m_tournament = false;
+   bool m_listSnd = false;    // NOUVEAU: flag pour -listsnd
+   bool m_listRes = false;    // NOUVEAU: flag pour -listres
 #ifdef __STANDALONE__
    bool m_displayId = false;
    string m_prefPath;


### PR DESCRIPTION
The -listsnd and -listres options were failing because they attempted to enumerate audio/video devices before SDL subsystems were properly initialized, causing the application to exit without displaying any information.

Changes:
- Add m_listSnd and m_listRes flags to VPApp class
- Defer device enumeration until after InitInstance() completes
- Move enumeration logic from ProcessCommandLine() to Run()
- Ensure SDL audio/video subsystems are initialized before querying devices
- Return proper exit code (0) after displaying device information

This fix ensures that:
- -listsnd displays available sound devices with channel information
- -listres shows fullscreen resolutions, desktop modes, and renderers
- Both options work reliably across different system configurations

Fixes command line functionality that was broken in recent SDL3 migration.