### PR TITLE
ci: set xcode compiler to 16.4 to fix fastlane failure

### DIFF
--- a/.github/workflows/vpinball-mobile.yml
+++ b/.github/workflows/vpinball-mobile.yml
@@ -90,6 +90,7 @@ jobs:
           cmake --build build/ios-arm64 -- -j$(sysctl -n hw.ncpu)
       - name: Build app
         run: |
+          sudo xcode-select -switch /Applications/Xcode_16.4.app
           MARKETING_VERSION="${{ needs.version.outputs.version_ios }}"
           CURRENT_PROJECT_VERSION="${{ needs.version.outputs.version_full }}"
           cd standalone/ios


### PR DESCRIPTION
The CI started failing a few days ago for iOS, see [here](https://github.com/actions/runner-images/issues/12541).