### PR TITLE
plugins: add dmd overlay support for B2SLegacy

### DIFF
--- a/make/CMakeLists_plugin_B2SLegacy.txt
+++ b/make/CMakeLists_plugin_B2SLegacy.txt
@@ -11,6 +11,8 @@ set(B2SLEGACY_PLUGIN_SOURCES
    plugins/b2slegacy/B2SLegacyPlugin.cpp
    plugins/b2slegacy/Server.h
    plugins/b2slegacy/Server.cpp
+   plugins/b2slegacy/utils/DMDOverlay.h
+   plugins/b2slegacy/utils/DMDOverlay.cpp
    plugins/b2slegacy/utils/Timer.h
    plugins/b2slegacy/utils/Timer.cpp
    plugins/b2slegacy/utils/Matrix.h
@@ -100,6 +102,8 @@ set(B2SLEGACY_PLUGIN_SOURCES
    plugins/b2slegacy/forms/FormBackglass.cpp
    plugins/b2slegacy/forms/FormDMD.h
    plugins/b2slegacy/forms/FormDMD.cpp
+   src/core/ResURIResolver.h
+   src/core/ResURIResolver.cpp
 
    third-party/include/tinyxml2/tinyxml2.h
    third-party/include/tinyxml2/tinyxml2.cpp

--- a/plugins/b2slegacy/Server.cpp
+++ b/plugins/b2slegacy/Server.cpp
@@ -2,6 +2,8 @@
 #include "Server.h"
 #include "LoggingPlugin.h"
 
+using namespace std::string_literals;
+
 #include "forms/FormBackglass.h"
 #include "forms/FormDMD.h"
 
@@ -24,7 +26,10 @@ Server::Server(MsgPluginAPI* msgApi, uint32_t endpointId, VPXPluginAPI* vpxApi)
    : m_msgApi(msgApi),
      m_vpxApi(vpxApi),
      m_endpointId(endpointId),
-     m_pinmameApi(nullptr)
+     m_pinmameApi(nullptr),
+     m_resURIResolver(*msgApi, endpointId, true, false, false, false),
+     m_scoreviewDmdOverlay(m_resURIResolver, m_dmdTex, nullptr, vpxApi),
+     m_backglassDmdOverlay(m_resURIResolver, m_dmdTex, nullptr, vpxApi)
 {
    m_pB2SSettings = new B2SSettings(m_msgApi);
    m_pB2SData = new B2SData(this, m_pB2SSettings, m_vpxApi);
@@ -56,6 +61,9 @@ Server::Server(MsgPluginAPI* msgApi, uint32_t endpointId, VPXPluginAPI* vpxApi)
    m_nLamps = 0;
    m_mechIndex = -1;
    m_nMechs = 0;
+
+   m_scoreviewDmdOverlay.LoadSettings(msgApi, "B2SLegacy"s, "Scoreview"s);
+   m_backglassDmdOverlay.LoadSettings(msgApi, "B2SLegacy"s, "Backglass"s);
 }
 
 Server::~Server()

--- a/plugins/b2slegacy/Server.h
+++ b/plugins/b2slegacy/Server.h
@@ -4,6 +4,8 @@
 #include <functional>
 #include "forms/FormBackglass.h"
 #include "classes/B2SCollectData.h"
+#include "core/ResURIResolver.h"
+#include "utils/DMDOverlay.h"
 
 namespace B2SLegacy {
 
@@ -96,6 +98,8 @@ public:
    B2SSettings* GetB2SSettings() const { return m_pB2SSettings; }
    PinMAMEAPI* GetPinMAMEApi() const { return m_pinmameApi; }
    void SetPinMAMEApi(PinMAMEAPI* pinmameApi) { m_pinmameApi = pinmameApi; }
+   DMDOverlay& GetScoreviewDmdOverlay() { return m_scoreviewDmdOverlay; }
+   DMDOverlay& GetBackglassDmdOverlay() { return m_backglassDmdOverlay; }
    void GetChangedLamps();
    void GetChangedLamps(ScriptVariant* pRet);
    void GetChangedSolenoids();
@@ -176,6 +180,11 @@ private:
    VPXPluginAPI* const m_vpxApi;
    const uint32_t m_endpointId;
    PinMAMEAPI* m_pinmameApi;
+
+   ResURIResolver m_resURIResolver;
+   VPXTexture m_dmdTex = nullptr;
+   DMDOverlay m_scoreviewDmdOverlay;
+   DMDOverlay m_backglassDmdOverlay;
 
    bool m_ready = false;
    bool m_canRenderBackglass = false;

--- a/plugins/b2slegacy/common.h
+++ b/plugins/b2slegacy/common.h
@@ -230,3 +230,21 @@ string title_and_path_from_filename(const string& filename);
 bool is_string_numeric(const string& str);
 
 }
+
+class vec4
+{
+public:
+   vec4() { }
+   vec4(float px, float py, float pz, float pw) : x(px), y(py), z(pz), w(pw) { }
+
+   float x = 0.f, y = 0.f, z = 0.f, w = 0.f;
+};
+
+class ivec4
+{
+public:
+   ivec4() { }
+   ivec4(int px, int py, int pz, int pw) : x(px), y(py), z(pz), w(pw) { }
+
+   int x = 0, y = 0, z = 0, w = 0;
+};

--- a/plugins/b2slegacy/forms/FormBackglass.cpp
+++ b/plugins/b2slegacy/forms/FormBackglass.cpp
@@ -157,6 +157,12 @@ void FormBackglass::OnPaint(VPXRenderContext2D* const ctx)
       }
    }
 
+   Server* server = m_pB2SData->GetServer();
+   if (server) {
+      server->GetBackglassDmdOverlay().UpdateBackgroundImage(GetBackgroundImage());
+      server->GetBackglassDmdOverlay().Render(ctx);
+   }
+
    Control::OnPaint(ctx);
 }
 

--- a/plugins/b2slegacy/forms/FormDMD.cpp
+++ b/plugins/b2slegacy/forms/FormDMD.cpp
@@ -51,6 +51,12 @@ void FormDMD::OnPaint(VPXRenderContext2D* const ctx)
       }
    }
 
+   Server* server = m_pB2SData->GetServer();
+   if (server) {
+      server->GetScoreviewDmdOverlay().UpdateBackgroundImage(GetBackgroundImage());
+      server->GetScoreviewDmdOverlay().Render(ctx);
+   }
+
    Control::OnPaint(ctx);
 }
 

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -1,0 +1,162 @@
+#include "../common.h"
+
+#include "DMDOverlay.h"
+#include "VPXGraphics.h"
+
+#include <cmath>
+#include <vector>
+#include <stack>
+#include <algorithm>
+
+namespace B2SLegacy {
+
+DMDOverlay::DMDOverlay(ResURIResolver& resURIResolver, VPXTexture& dmdTex, VPXTexture backImage, VPXPluginAPI* vpxApi)
+   : m_resURIResolver(resURIResolver)
+   , m_dmdTex(dmdTex)
+   , m_backImage(backImage)
+   , m_vpxApi(vpxApi)
+{
+}
+
+void DMDOverlay::LoadSettings(MsgPluginAPI* const msgApi, const string& pluginId, const string& prefix)
+{
+   char buf[32];
+   msgApi->GetSetting(pluginId.c_str(), (prefix + "DMDOverlay").c_str(), buf, sizeof(buf));
+   m_enable = atoi(buf) != 0;
+   msgApi->GetSetting(pluginId.c_str(), (prefix + "DMDAutoPos").c_str(), buf, sizeof(buf));
+   m_detectDmdFrame = atoi(buf) != 0;
+   msgApi->GetSetting(pluginId.c_str(), (prefix + "DMDX").c_str(), buf, sizeof(buf));
+   m_frame.x = atoi(buf);
+   msgApi->GetSetting(pluginId.c_str(), (prefix + "DMDY").c_str(), buf, sizeof(buf));
+   m_frame.y = atoi(buf);
+   msgApi->GetSetting(pluginId.c_str(), (prefix + "DMDWidth").c_str(), buf, sizeof(buf));
+   m_frame.z = atoi(buf);
+   msgApi->GetSetting(pluginId.c_str(), (prefix + "DMDHeight").c_str(), buf, sizeof(buf));
+   m_frame.w = atoi(buf);
+}
+
+void DMDOverlay::Render(VPXRenderContext2D* ctx)
+{
+   if (!m_enable)
+      return;
+
+   ResURIResolver::DisplayState dmd = m_resURIResolver.GetDisplayState("ctrl://default/display");
+   if (dmd.state.frame == nullptr)
+      return;
+
+   // When DMD source change, search for the DMD sub frame as it depends on the DMD source aspect ratio
+   if (m_detectDmdFrame && m_backImage && m_detectSrcId.id != dmd.source->id.id)
+   {
+      m_frame = ivec4();
+      m_detectSrcId.id = dmd.source->id.id;
+      const float ar = static_cast<float>(dmd.source->width) / static_cast<float>(dmd.source->height);
+      m_frameSearch = std::async(std::launch::async, [this, ar]() { return SearchDmdSubFrame(m_backImage, ar); });
+   }
+
+   if (m_frameSearch.valid() && m_frameSearch.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+      m_frame = m_frameSearch.get();
+
+   if (m_frame.z == 0.f || m_frame.w == 0.f)
+      return;
+
+   if (m_vpxApi) {
+      m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height,
+         dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM8         ? VPXTextureFormat::VPXTEXFMT_BW
+            : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? VPXTextureFormat::VPXTEXFMT_sRGB565
+                                                                      : VPXTextureFormat::VPXTEXFMT_sRGB8,
+         dmd.state.frame);
+   }
+
+   vec4 glassArea, glassAmbient(1.f, 1.f, 1.f, 1.f), glassTint(1.f, 1.f, 1.f, 1.f), glassPad;
+   vec4 dmdTint(1.f, 1.f, 1.f, 1.f);
+   ctx->DrawDisplay(ctx, VPXDisplayRenderStyle::VPXDMDStyle_Plasma,
+      // First layer: glass
+      nullptr, glassTint.x, glassTint.y, glassTint.z, 0.f, // Glass texture, tint and roughness
+      glassArea.x, glassArea.y, glassArea.z, glassArea.w, // Glass texture coordinates (inside overall glass texture)
+      glassAmbient.x, glassAmbient.y, glassAmbient.z, // Glass lighting from room
+      // Second layer: emitter
+      m_dmdTex, dmdTint.x, dmdTint.y, dmdTint.z, 1.f, 1.f, // DMD emitter, emitter tint, emitter brightness, emitter alpha
+      glassPad.x, glassPad.y, glassPad.z, glassPad.w, // Emitter padding (from glass border)
+      // Render quad
+      static_cast<float>(m_frame.x), static_cast<float>(m_frame.y), static_cast<float>(m_frame.z), static_cast<float>(m_frame.w));
+}
+
+ivec4 DMDOverlay::SearchDmdSubFrame(VPXTexture image, float dmdAspectRatio)
+{
+   ivec4 subFrame;
+
+   if (!m_vpxApi)
+      return subFrame;
+   
+   VPXTextureInfo* texInfo = m_vpxApi->GetTextureInfo(image);
+   if (texInfo == nullptr)
+      return subFrame;
+
+   // Find the largest dark rectangle in the background image
+   float maxHeuristic = 0.f;
+   float selectedAspectRatio = 1.f;
+   std::stack<int> st;
+   vector<int> heights(texInfo->width, 0); // height of empty columns above each pixels in the row as we scan them downward
+   for (unsigned int y = 0; y < texInfo->height; ++y)
+   {
+      for (unsigned int x = 0; x < texInfo->width; ++x)
+      {
+         uint8_t lum = 0;
+         const int pos = y * texInfo->width + x;
+         switch (texInfo->format)
+         {
+         case VPXTEXFMT_BW: lum = texInfo->data[pos]; break;
+         case VPXTEXFMT_sRGB8: lum = static_cast<uint8_t>(0.299f * texInfo->data[pos * 3] + 0.587f * texInfo->data[pos * 3 + 1] + 0.114f * texInfo->data[pos * 3 + 2]); break;
+         case VPXTEXFMT_sRGBA8: lum = static_cast<uint8_t>(0.299f * texInfo->data[pos * 4] + 0.587f * texInfo->data[pos * 4 + 1] + 0.114f * texInfo->data[pos * 4 + 2]); break;
+         default: return subFrame;
+         }
+         if (lum < 8)
+            heights[x] += 1;
+         else
+            heights[x] = 0;
+      }
+
+      // Evaluate each rectangle that can be formed with the heights of the columns
+      for (unsigned int x = 0; x <= texInfo->width; ++x)
+      {
+         while (!st.empty() && (x == texInfo->width || heights[st.top()] > heights[x]))
+         {
+            const int height = heights[st.top()];
+            st.pop();
+            const int width = st.empty() ? x : x - st.top() - 1;
+            const float aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+            const float arMatch = aspectRatio < dmdAspectRatio ? aspectRatio / dmdAspectRatio : dmdAspectRatio / aspectRatio;
+            const float heuristic = height * width * powf(arMatch, 0.5f);
+            if (heuristic > maxHeuristic)
+            {
+               maxHeuristic = heuristic;
+               subFrame.x = st.empty() ? 0 : st.top() + 1;
+               subFrame.y = texInfo->height - y - 1;
+               subFrame.z = width;
+               subFrame.w = height;
+            }
+         }
+         if (x < texInfo->width)
+            st.push(x);
+      }
+   }
+
+   // Do not select a too small area
+   if (static_cast<unsigned int>(subFrame.z * subFrame.w) < texInfo->width * texInfo->height / 16)
+      subFrame = ivec4();
+
+   return subFrame;
+}
+
+void DMDOverlay::UpdateBackgroundImage(VPXTexture backImage)
+{
+   if (m_backImage != backImage) {
+      m_backImage = backImage;
+      if (m_detectDmdFrame) {
+         m_frame = ivec4();
+         m_detectSrcId.id = 0;
+      }
+   }
+}
+
+}

--- a/plugins/b2slegacy/utils/DMDOverlay.h
+++ b/plugins/b2slegacy/utils/DMDOverlay.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <future>
+
+#include "../common.h"
+#include "core/ResURIResolver.h"
+
+namespace B2SLegacy {
+   
+class DMDOverlay final
+{
+public:
+   DMDOverlay(ResURIResolver& resURIResolver, VPXTexture& dmdTex, VPXTexture backImage, VPXPluginAPI* vpxApi);
+   void LoadSettings(MsgPluginAPI* const msgApi, const string& pluginId, const string& prefix);
+   void Render(VPXRenderContext2D* context);
+   void UpdateBackgroundImage(VPXTexture backImage);
+
+private:
+   ivec4 SearchDmdSubFrame(VPXTexture image, float dmdAspectRatio);
+
+   ResURIResolver& m_resURIResolver;
+   VPXTexture& m_dmdTex;
+   VPXPluginAPI* m_vpxApi;
+
+   bool m_enable = false;
+   ivec4 m_frame;
+
+   bool m_detectDmdFrame = false;
+   VPXTexture m_backImage;
+   CtlResId m_detectSrcId { 0 };
+   std::future<ivec4> m_frameSearch;
+};
+
+}

--- a/src/assets/Default_VPinballX.ini
+++ b/src/assets/Default_VPinballX.ini
@@ -36,6 +36,20 @@ Enable =
 
 [Plugin.B2S]
 Enable = 
+# ScoreView DMD Overlay Settings
+ScoreviewDMDOverlay = 
+ScoreviewDMDAutoPos = 
+ScoreviewDMDX = 
+ScoreviewDMDY = 
+ScoreviewDMDWidth = 
+ScoreviewDMDHeight = 
+# Backglass DMD Overlay Settings
+BackglassDMDOverlay = 
+BackglassDMDAutoPos = 
+BackglassDMDX = 
+BackglassDMDY = 
+BackglassDMDWidth = 
+BackglassDMDHeight = 
 
 [Plugin.B2SLegacy]
 Enable = 
@@ -48,6 +62,20 @@ B2SHideB2SBackglass =
 B2SHideDMD = 
 B2SDualMode = 
 B2SDMDFlipY = 
+# ScoreView DMD Overlay Settings
+ScoreviewDMDOverlay = 
+ScoreviewDMDAutoPos = 
+ScoreviewDMDX = 
+ScoreviewDMDY = 
+ScoreviewDMDWidth = 
+ScoreviewDMDHeight = 
+# Backglass DMD Overlay Settings
+BackglassDMDOverlay = 
+BackglassDMDAutoPos = 
+BackglassDMDX = 
+BackglassDMDY = 
+BackglassDMDWidth = 
+BackglassDMDHeight = 
 
 [Plugin.DMDUtil]
 Enable = 


### PR DESCRIPTION
This implements #2630, #2629, #2628 into the B2SLegacy plugin as discussed in https://github.com/vpinball/vpinball/issues/2622#issuecomment-3193481862

Unfortunately autodetection is not working, probably due to B2SLegacy's rescaling of controls. Until I can figure out the issue, you will need to use:

```
[Plugin.B2SLegacy]
Enable = 
# 0 to show grill (if it exists), 1 to hide grill
B2SHideGrill = 
# 0 to show extra DMD frame (if it exists), 1 to hide extra DMD frame
B2SHideB2SDMD = 
# 0 to show backglass, 1 to hide backglass
B2SHideB2SBackglass = 
B2SHideDMD = 
B2SDualMode = 
B2SDMDFlipY = 
# ScoreView DMD Overlay Settings
ScoreviewDMDOverlay = 
ScoreviewDMDAutoPos = 
ScoreviewDMDX = 
ScoreviewDMDY = 
ScoreviewDMDWidth = 
ScoreviewDMDHeight = 
# Backglass DMD Overlay Settings
BackglassDMDOverlay = 
BackglassDMDAutoPos = 
BackglassDMDX = 
BackglassDMDY = 
BackglassDMDWidth = 
BackglassDMDHeight = 
```