### PR TITLE
plugins: simplify DMDOverlay to be added to base form. Fix autopos.

### DIFF
--- a/plugins/b2slegacy/Server.cpp
+++ b/plugins/b2slegacy/Server.cpp
@@ -26,10 +26,7 @@ Server::Server(MsgPluginAPI* msgApi, uint32_t endpointId, VPXPluginAPI* vpxApi)
    : m_msgApi(msgApi),
      m_vpxApi(vpxApi),
      m_endpointId(endpointId),
-     m_pinmameApi(nullptr),
-     m_resURIResolver(*msgApi, endpointId, true, false, false, false),
-     m_scoreviewDmdOverlay(m_resURIResolver, m_dmdTex, nullptr, vpxApi),
-     m_backglassDmdOverlay(m_resURIResolver, m_dmdTex, nullptr, vpxApi)
+     m_pinmameApi(nullptr)
 {
    m_pB2SSettings = new B2SSettings(m_msgApi);
    m_pB2SData = new B2SData(this, m_pB2SSettings, m_vpxApi);
@@ -61,9 +58,6 @@ Server::Server(MsgPluginAPI* msgApi, uint32_t endpointId, VPXPluginAPI* vpxApi)
    m_nLamps = 0;
    m_mechIndex = -1;
    m_nMechs = 0;
-
-   m_scoreviewDmdOverlay.LoadSettings(msgApi, "B2SLegacy"s, "Scoreview"s);
-   m_backglassDmdOverlay.LoadSettings(msgApi, "B2SLegacy"s, "Backglass"s);
 }
 
 Server::~Server()
@@ -1614,7 +1608,7 @@ void Server::Startup()
 void Server::ShowBackglassForm()
 {
    if (!m_pFormBackglass)
-      m_pFormBackglass = new FormBackglass(m_msgApi, m_vpxApi, m_pB2SData);
+      m_pFormBackglass = new FormBackglass(m_vpxApi, m_msgApi, m_endpointId, m_pB2SData);
 
    m_pFormBackglass->Show();
    m_pFormBackglass->SetTopMost(true);

--- a/plugins/b2slegacy/Server.h
+++ b/plugins/b2slegacy/Server.h
@@ -5,7 +5,6 @@
 #include "forms/FormBackglass.h"
 #include "classes/B2SCollectData.h"
 #include "core/ResURIResolver.h"
-#include "utils/DMDOverlay.h"
 
 namespace B2SLegacy {
 
@@ -98,8 +97,7 @@ public:
    B2SSettings* GetB2SSettings() const { return m_pB2SSettings; }
    PinMAMEAPI* GetPinMAMEApi() const { return m_pinmameApi; }
    void SetPinMAMEApi(PinMAMEAPI* pinmameApi) { m_pinmameApi = pinmameApi; }
-   DMDOverlay& GetScoreviewDmdOverlay() { return m_scoreviewDmdOverlay; }
-   DMDOverlay& GetBackglassDmdOverlay() { return m_backglassDmdOverlay; }
+   uint32_t GetEndpointId() const { return m_endpointId; }
    void GetChangedLamps();
    void GetChangedLamps(ScriptVariant* pRet);
    void GetChangedSolenoids();
@@ -181,10 +179,7 @@ private:
    const uint32_t m_endpointId;
    PinMAMEAPI* m_pinmameApi;
 
-   ResURIResolver m_resURIResolver;
    VPXTexture m_dmdTex = nullptr;
-   DMDOverlay m_scoreviewDmdOverlay;
-   DMDOverlay m_backglassDmdOverlay;
 
    bool m_ready = false;
    bool m_canRenderBackglass = false;

--- a/plugins/b2slegacy/forms/Form.cpp
+++ b/plugins/b2slegacy/forms/Form.cpp
@@ -1,19 +1,33 @@
 #include "../common.h"
 
 #include "Form.h"
+#include "../utils/DMDOverlay.h"
 #include "../Server.h"
 
 namespace B2SLegacy {
 
-Form::Form(MsgPluginAPI* msgApi, VPXPluginAPI* vpxApi, B2SData* pB2SData) :
-   Control(vpxApi), m_msgApi(msgApi), m_pB2SData(pB2SData)
+Form::Form(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi, uint32_t endpointId, B2SData* pB2SData, const string& overlayType) 
+   : Control(vpxApi), 
+     m_msgApi(msgApi), 
+     m_endpointId(endpointId),
+     m_pB2SData(pB2SData)
 {
+   if (!overlayType.empty()) {
+      m_pResURIResolver = new ResURIResolver(*msgApi, m_endpointId, true, false, false, false);
+      m_dmdTex = nullptr;
+
+      m_pDmdOverlay = new DMDOverlay(*m_pResURIResolver, m_dmdTex, nullptr, m_vpxApi);
+      m_pDmdOverlay->LoadSettings(msgApi, "B2SLegacy", overlayType);
+   }
 }
 
 Form::~Form()
 {
+   delete m_pDmdOverlay;
+   delete m_pResURIResolver;
+   if (m_dmdTex && m_vpxApi)
+      m_vpxApi->DeleteTexture(m_dmdTex);
 }
-
 
 void Form::Show()
 {
@@ -21,6 +35,15 @@ void Form::Show()
 
 void Form::Hide()
 {
+}
+
+void Form::OnPaint(VPXRenderContext2D* const ctx)
+{
+   if (m_pDmdOverlay) {
+      m_pDmdOverlay->UpdateBackgroundImage(GetBackgroundImage());
+      m_pDmdOverlay->Render(ctx);
+   }
+   Control::OnPaint(ctx);
 }
 
 }

--- a/plugins/b2slegacy/forms/Form.h
+++ b/plugins/b2slegacy/forms/Form.h
@@ -1,16 +1,18 @@
 #pragma once
 
 #include "../controls/Control.h"
+#include "core/ResURIResolver.h"
 
 namespace B2SLegacy {
 
 class B2SData;
 class Server;
+class DMDOverlay;
 
 class Form : public Control
 {
 public:
-   Form(MsgPluginAPI* msgApi, VPXPluginAPI* vpxApi, B2SData* pB2SData);
+   Form(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi, uint32_t endpointId, B2SData* pB2SData, const string& overlayType = "");
    ~Form();
 
    void Show();
@@ -18,12 +20,17 @@ public:
    void SetTopMost(bool topMost) { m_topMost = topMost; }
    bool IsTopMost() const { return m_topMost; }
    B2SData* GetB2SData() const { return m_pB2SData; }
+   void OnPaint(VPXRenderContext2D* const ctx) override;
 
 protected:
    MsgPluginAPI* m_msgApi = nullptr;
    B2SData* m_pB2SData = nullptr;
+   uint32_t m_endpointId = 0;
 
 private:
+   ResURIResolver* m_pResURIResolver = nullptr;
+   VPXTexture m_dmdTex = nullptr;
+   DMDOverlay* m_pDmdOverlay = nullptr;
    bool m_topMost = false;
 };
 

--- a/plugins/b2slegacy/forms/FormBackglass.cpp
+++ b/plugins/b2slegacy/forms/FormBackglass.cpp
@@ -7,6 +7,7 @@
 #include "FormDMD.h"
 #include "../common.h"
 #include "../Server.h"
+#include "../utils/DMDOverlay.h"
 #include "../classes/B2SVersionInfo.h"
 #include "../classes/B2SScreen.h"
 #include "../classes/B2SAnimation.h"
@@ -27,8 +28,8 @@ namespace B2SLegacy {
 
 #include <exception>
 
-FormBackglass::FormBackglass(MsgPluginAPI* msgApi, VPXPluginAPI* vpxApi, B2SData* pB2SData)
-   : Form(msgApi, vpxApi, pB2SData),
+FormBackglass::FormBackglass(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi,uint32_t endpointId, B2SData* pB2SData)
+   : Form(vpxApi, msgApi, endpointId, pB2SData, "Backglass"),
      m_pB2SSettings(pB2SData->GetB2SSettings())
 {
    SetName("formBackglass"s);
@@ -157,13 +158,7 @@ void FormBackglass::OnPaint(VPXRenderContext2D* const ctx)
       }
    }
 
-   Server* server = m_pB2SData->GetServer();
-   if (server) {
-      server->GetBackglassDmdOverlay().UpdateBackgroundImage(GetBackgroundImage());
-      server->GetBackglassDmdOverlay().Render(ctx);
-   }
-
-   Control::OnPaint(ctx);
+   Form::OnPaint(ctx);
 }
 
 
@@ -1405,7 +1400,7 @@ void FormBackglass::RotateImage(B2SPictureBox* pPicbox, int rotationsteps, eSnip
 void FormBackglass::CheckDMDForm()
 {
    if (!m_pFormDMD && !m_pB2SSettings->IsHideB2SDMD())
-      m_pFormDMD = new FormDMD(m_msgApi, m_vpxApi, m_pB2SData);
+      m_pFormDMD = new FormDMD(m_vpxApi, m_msgApi, m_endpointId, m_pB2SData);
 }
 
 VPXTexture FormBackglass::CreateLightImage(VPXTexture image, eDualMode dualmode, const string& firstromkey_)

--- a/plugins/b2slegacy/forms/FormBackglass.h
+++ b/plugins/b2slegacy/forms/FormBackglass.h
@@ -15,7 +15,7 @@ class Server;
 class FormBackglass final : public Form
 {
 public:
-   FormBackglass(MsgPluginAPI* msgApi, VPXPluginAPI* vpxApi, B2SData* pB2SData);
+   FormBackglass(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi, uint32_t endpointId, B2SData* pB2SData);
    ~FormBackglass();
 
    void Start();

--- a/plugins/b2slegacy/forms/FormDMD.cpp
+++ b/plugins/b2slegacy/forms/FormDMD.cpp
@@ -4,12 +4,13 @@
 #include "../Server.h"
 #include "../controls/B2SPictureBox.h"
 #include "../utils/VPXGraphics.h"
+#include "../utils/DMDOverlay.h"
 #include "LoggingPlugin.h"
 
 namespace B2SLegacy {
 
-FormDMD::FormDMD(MsgPluginAPI* msgApi, VPXPluginAPI* vpxApi, B2SData* pB2SData) :
-   Form(msgApi, vpxApi, pB2SData)
+FormDMD::FormDMD(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi, uint32_t endpointId, B2SData* pB2SData)
+   : Form(vpxApi, msgApi, endpointId, pB2SData, "Scoreview")
 {
    SetName("formDMD");
 }
@@ -51,13 +52,7 @@ void FormDMD::OnPaint(VPXRenderContext2D* const ctx)
       }
    }
 
-   Server* server = m_pB2SData->GetServer();
-   if (server) {
-      server->GetScoreviewDmdOverlay().UpdateBackgroundImage(GetBackgroundImage());
-      server->GetScoreviewDmdOverlay().Render(ctx);
-   }
-
-   Control::OnPaint(ctx);
+   Form::OnPaint(ctx);
 }
 
 

--- a/plugins/b2slegacy/forms/FormDMD.h
+++ b/plugins/b2slegacy/forms/FormDMD.h
@@ -13,7 +13,7 @@ class Server;
 class FormDMD final : public Form
 {
 public:
-   FormDMD(MsgPluginAPI* msgApi, VPXPluginAPI* vpxApi, B2SData* pB2SData);
+   FormDMD(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi, uint32_t endpointId, B2SData* pB2SData);
    ~FormDMD();
 
    void OnPaint(VPXRenderContext2D* const ctx) override;

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -67,6 +67,30 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
          dmd.state.frame);
    }
 
+   float scaledX, scaledY, scaledW, scaledH;
+   
+   if (m_detectDmdFrame) {
+      // Autodetection: Scale from background image space to window space
+      const VPXTextureInfo* const texInfo = m_vpxApi->GetTextureInfo(m_backImage);
+      float scaleX = static_cast<float>(ctx->outWidth) / static_cast<float>(texInfo->width);
+      float scaleY = static_cast<float>(ctx->outHeight) / static_cast<float>(texInfo->height);
+
+      scaledX = static_cast<float>(m_frame.x) * scaleX;
+      scaledY = static_cast<float>(m_frame.y) * scaleY;
+      scaledW = static_cast<float>(m_frame.z) * scaleX;
+      scaledH = static_cast<float>(m_frame.w) * scaleY;
+   }
+   else {
+      // Manual coordinates: scale from logical window space to physical render space
+      float scaleX = ctx->outWidth / ctx->wndWidth;
+      float scaleY = ctx->outHeight / ctx->wndHeight;
+
+      scaledX = static_cast<float>(m_frame.x) * scaleX;
+      scaledY = static_cast<float>(m_frame.y) * scaleY;
+      scaledW = static_cast<float>(m_frame.z) * scaleX;
+      scaledH = static_cast<float>(m_frame.w) * scaleY;
+   }
+
    vec4 glassArea, glassAmbient(1.f, 1.f, 1.f, 1.f), glassTint(1.f, 1.f, 1.f, 1.f), glassPad;
    vec4 dmdTint(1.f, 1.f, 1.f, 1.f);
    ctx->DrawDisplay(ctx, VPXDisplayRenderStyle::VPXDMDStyle_Plasma,
@@ -78,7 +102,7 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
       m_dmdTex, dmdTint.x, dmdTint.y, dmdTint.z, 1.f, 1.f, // DMD emitter, emitter tint, emitter brightness, emitter alpha
       glassPad.x, glassPad.y, glassPad.z, glassPad.w, // Emitter padding (from glass border)
       // Render quad
-      static_cast<float>(m_frame.x), static_cast<float>(m_frame.y), static_cast<float>(m_frame.z), static_cast<float>(m_frame.w));
+      scaledX, scaledY, scaledW, scaledH);
 }
 
 ivec4 DMDOverlay::SearchDmdSubFrame(VPXTexture image, float dmdAspectRatio)

--- a/src/assets/Default_VPinballX.ini
+++ b/src/assets/Default_VPinballX.ini
@@ -134,7 +134,7 @@ BackglassDisplay =
 BackglassFullScreen = 
 ; Output mode
 ; 0 - Disabled
-; 1 - Embedded in another output
+; 1 - Embedded in playfield output
 ; 2 - Native system window (maybe a window, exclusive fullscreen, VR headset,...)
 BackglassOutput = 
 BackglassWndX = 
@@ -154,7 +154,7 @@ ScoreViewDisplay =
 ScoreViewFullScreen = 
 ; Output mode
 ; 0 - Disabled
-; 1 - Embedded in another output
+; 1 - Embedded in playfield output
 ; 2 - Native system window (maybe a window, exclusive fullscreen, VR headset,...)
 ScoreViewOutput = 
 ScoreViewWndX = 
@@ -173,7 +173,7 @@ TopperDisplay =
 TopperFullScreen = 
 ; Output mode
 ; 0 - Disabled
-; 1 - Embedded in another output
+; 1 - Embedded in playfield output
 ; 2 - Native system window (maybe a window, exclusive fullscreen, VR headset,...)
 TopperOutput = 
 TopperWndX = 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2236,10 +2236,20 @@ RenderTarget *Player::RenderAnciliaryWindow(VPXAnciliaryWindow window, RenderTar
    if (output.GetMode() == VPX::RenderOutput::OM_EMBEDDED)
    {
       outputRT = embedRT;
-      m_outputW = output.GetEmbeddedWindow()->GetWidth();
-      m_outputH = output.GetEmbeddedWindow()->GetHeight();
-      output.GetEmbeddedWindow()->GetPos(m_outputX, m_outputY);
-      m_outputY = outputRT->GetHeight() - m_outputY - m_outputH;
+
+      const float displayScaleX = static_cast<float>(m_playfieldWnd->GetPixelWidth()) / static_cast<float>(m_playfieldWnd->GetWidth());
+      const float displayScaleY = static_cast<float>(m_playfieldWnd->GetPixelHeight()) / static_cast<float>(m_playfieldWnd->GetHeight());
+
+      const int wndW = output.GetEmbeddedWindow()->GetWidth();
+      const int wndH = output.GetEmbeddedWindow()->GetHeight();
+      int wndX;
+      int wndY;
+      output.GetEmbeddedWindow()->GetPos(wndX, wndY);
+
+      m_outputW = static_cast<int>(wndW * displayScaleX);
+      m_outputH = static_cast<int>(wndH * displayScaleY);
+      m_outputX = static_cast<int>(wndX * displayScaleX);
+      m_outputY = static_cast<int>(wndY * displayScaleY);
    }
    #ifdef ENABLE_BGFX
    else if (output.GetMode() == VPX::RenderOutput::OM_WINDOW)
@@ -2305,6 +2315,24 @@ RenderTarget *Player::RenderAnciliaryWindow(VPXAnciliaryWindow window, RenderTar
       bool isLinearOutput;
    };
 
+   int wndW;
+   int wndH;
+   if (output.GetMode() == VPX::RenderOutput::OM_EMBEDDED)
+   {
+      wndW = output.GetEmbeddedWindow()->GetWidth();
+      wndH = output.GetEmbeddedWindow()->GetHeight();
+   }
+   else if (output.GetMode() == VPX::RenderOutput::OM_WINDOW)
+   {
+      wndW = output.GetWindow()->GetWidth();
+      wndH = output.GetWindow()->GetHeight();
+   }
+   else
+   {
+      wndW = m_outputW;
+      wndH = m_outputH;
+   }
+
    PlayerRenderContext2D context
    {
       {
@@ -2312,6 +2340,7 @@ RenderTarget *Player::RenderAnciliaryWindow(VPXAnciliaryWindow window, RenderTar
          static_cast<float>(m_outputW), static_cast<float>(m_outputH),
          1, // 2D render
          static_cast<float>(m_outputW), static_cast<float>(m_outputH),
+         static_cast<float>(wndW), static_cast<float>(wndH),
          // Draw an image
          [](VPXRenderContext2D *ctx, VPXTexture texture,
             const float tintR, const float tintG, const float tintB, const float alpha,

--- a/src/plugins/VPXPlugin.h
+++ b/src/plugins/VPXPlugin.h
@@ -109,6 +109,8 @@ typedef struct VPXRenderContext2D
    int is2D;                  // If true, the rendering is done in 2D mode, otherwise in 3D mode
    float outWidth;            // Target surface width for 2D render, otherwise hint to be used for aspect ratio computation, LOD and layout
    float outHeight;           // Target surface height for 2D render, otherwise hint to be used for apsect ratio computation, LOD and layout
+   float wndWidth;            // Logical window width
+   float wndHeight;           // Logical window height
    void(MSGPIAPI* DrawImage)(VPXRenderContext2D* ctx, VPXTexture texture,
       const float tintR, const float tintG, const float tintB, const float alpha, // tint color and alpha (0..1)
       const float texX, const float texY, const float texW, const float texH,  // coordinates in texture surface (0..tex.width, 0..tex.height)


### PR DESCRIPTION
This PR fixes autopos for the DMDOverlay for the `B2SLegacyPlugin`

I didn't have much choice but to added the window's width and height to the `VPXRenderContext2D`. 

On MacOS, if a person defines the backglass window as 300x300, since it's retina, the buffer is 600x600. If they are manually trying position it, and say, leave a 20 pixel gap on each side, they might do:

```
[Backglass]
BackglassDisplay =
BackglassFullScreen = 0
; Output mode
; 0 - Disabled
; 1 - Embedded in playfield output
; 2 - Native system window (maybe a window, exclusive fullscreen, VR headset,...)
BackglassOutput = 2
BackglassWndX = 0
BackglassWndY = 0
BackglassWidth = 300
BackglassHeight = 300

[Plugin.B2SLegacy]
.
.
BackglassDMDOverlay = 1
BackglassDMDAutoPos = 0
BackglassDMDX = 20
BackglassDMDY = 20
BackglassDMDWidth = 260
BackglassDMDHeight = 260
```

They aren't not going to realize it got upscaled to 600x600 so it would be offset.

I've tested on mobile as well, and everything is working well.

![Screenshot 2025-08-17 at 2 36 52 PM](https://github.com/user-attachments/assets/5b0dcb87-f6d0-4d32-a6fa-fa738ee70a50)