### PR TITLE
plugins: update B2SLegacy Plugin to have custom coordinate system

### DIFF
--- a/plugins/b2slegacy/Server.cpp
+++ b/plugins/b2slegacy/Server.cpp
@@ -80,37 +80,29 @@ int Server::OnRender(VPXRenderContext2D* const renderCtx, void* context)
       return 0;
 
    if (!m_ready) {
-      if (renderCtx->window == VPXAnciliaryWindow::VPXWINDOW_Backglass) {
-         m_pFormBackglass->GetB2SScreen()->SetBackglassSize({ 0, 0, static_cast<int>(renderCtx->outWidth), static_cast<int>(renderCtx->outHeight) });
-         m_canRenderBackglass = true;
-      }
-      else if (renderCtx->window == VPXAnciliaryWindow::VPXWINDOW_ScoreView) {
-         m_pFormBackglass->GetB2SScreen()->SetDMDSize({ 0, 0, static_cast<int>(renderCtx->outWidth), static_cast<int>(renderCtx->outHeight) });
-         m_canRenderDMD = true;
-      }
+      if (!m_pFormBackglass->IsValid())
+         return 0;
 
-      m_renderTimeout++;
+      m_pFormBackglass->Start();
+      m_ready = true;
+   }
 
-      if ((m_canRenderBackglass && m_canRenderDMD) ||
-          (m_renderTimeout >= 60 && (m_canRenderBackglass || m_canRenderDMD))) {
-         if (m_pFormBackglass->IsValid()) {
-            m_pFormBackglass->Start();
-            m_ready = true;
-         }
+   if (renderCtx->window == VPXAnciliaryWindow::VPXWINDOW_Backglass) {
+      if (!m_pB2SSettings->IsHideB2SBackglass()) {
+         SDL_Rect& size = m_pFormBackglass->GetB2SScreen()->GetBackglassSize();
+         renderCtx->srcWidth = static_cast<float>(size.w);
+         renderCtx->srcHeight = static_cast<float>(size.h);
+         m_pFormBackglass->OnPaint(renderCtx);
+         return 1;
       }
    }
-   else {
-      if (renderCtx->window == VPXAnciliaryWindow::VPXWINDOW_Backglass) {
-         if (!m_pB2SSettings->IsHideB2SBackglass()) {
-            m_pFormBackglass->OnPaint(renderCtx);
-            return 1;
-         }
-      }
-      else if (renderCtx->window == VPXAnciliaryWindow::VPXWINDOW_ScoreView) {
-         if (m_pFormBackglass->GetFormDMD()) {
-            m_pFormBackglass->GetFormDMD()->OnPaint(renderCtx);
-            return 1;
-         }
+   else if (renderCtx->window == VPXAnciliaryWindow::VPXWINDOW_ScoreView) {
+      if (m_pFormBackglass->GetFormDMD()) {
+         SDL_Rect& size = m_pFormBackglass->GetB2SScreen()->GetDMDSize();
+         renderCtx->srcWidth = static_cast<float>(size.w);
+         renderCtx->srcHeight = static_cast<float>(size.h);
+         m_pFormBackglass->GetFormDMD()->OnPaint(renderCtx);
+         return 1;
       }
    }
 

--- a/plugins/b2slegacy/Server.h
+++ b/plugins/b2slegacy/Server.h
@@ -182,9 +182,6 @@ private:
    VPXTexture m_dmdTex = nullptr;
 
    bool m_ready = false;
-   bool m_canRenderBackglass = false;
-   bool m_canRenderDMD = false;
-   int m_renderTimeout = 0;
 };
 
 }

--- a/plugins/b2slegacy/classes/B2SScreen.cpp
+++ b/plugins/b2slegacy/classes/B2SScreen.cpp
@@ -82,16 +82,16 @@ void B2SScreen::Start(Form* pFormBackglass, Form* pFormDMD, SDL_Point defaultDMD
 
 void B2SScreen::ReadB2SSettingsFromFile()
 {
-   int backglassWidth = m_pB2SData->GetB2SSettings()->GetSettingInt("BackglassWidth", 0);
-   int backglassHeight = m_pB2SData->GetB2SSettings()->GetSettingInt("BackglassHeight", 0);
+   int backglassWidth = m_pB2SData->GetB2SSettings()->GetSettingInt("B2SBackglassWidth", 512);
+   int backglassHeight = m_pB2SData->GetB2SSettings()->GetSettingInt("B2SBackglassHeight", 384);
    int backglassX = m_pB2SData->GetB2SSettings()->GetSettingInt("BackglassX", 0);
    int backglassY = m_pB2SData->GetB2SSettings()->GetSettingInt("BackglassY", 0);
 
    m_backglassSize = { 0, 0, backglassWidth, backglassHeight };
    m_backglassLocation = { backglassX, backglassY };
 
-   int dmdWidth = m_pB2SData->GetB2SSettings()->GetSettingInt("DMDWidth", 0);
-   int dmdHeight = m_pB2SData->GetB2SSettings()->GetSettingInt("DMDHeight", 0);
+   int dmdWidth = m_pB2SData->GetB2SSettings()->GetSettingInt("B2SDMDWidth", 375);
+   int dmdHeight = m_pB2SData->GetB2SSettings()->GetSettingInt("B2SDMDHeight", 225);
    int dmdX = m_pB2SData->GetB2SSettings()->GetSettingInt("DMDX", 0);
    int dmdY = m_pB2SData->GetB2SSettings()->GetSettingInt("DMDY", 0);
 

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -70,10 +70,10 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
    float scaledX, scaledY, scaledW, scaledH;
    
    if (m_detectDmdFrame) {
-      // Autodetection: Scale from background image space to window space
+      // Autodetection: Scale from background image space to source space
       const VPXTextureInfo* const texInfo = m_vpxApi->GetTextureInfo(m_backImage);
-      float scaleX = static_cast<float>(ctx->outWidth) / static_cast<float>(texInfo->width);
-      float scaleY = static_cast<float>(ctx->outHeight) / static_cast<float>(texInfo->height);
+      float scaleX = static_cast<float>(ctx->srcWidth) / static_cast<float>(texInfo->width);
+      float scaleY = static_cast<float>(ctx->srcHeight) / static_cast<float>(texInfo->height);
 
       scaledX = static_cast<float>(m_frame.x) * scaleX;
       scaledY = static_cast<float>(m_frame.y) * scaleY;
@@ -81,14 +81,11 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
       scaledH = static_cast<float>(m_frame.w) * scaleY;
    }
    else {
-      // Manual coordinates: scale from logical window space to physical render space
-      float scaleX = ctx->outWidth / ctx->wndWidth;
-      float scaleY = ctx->outHeight / ctx->wndHeight;
-
-      scaledX = static_cast<float>(m_frame.x) * scaleX;
-      scaledY = static_cast<float>(m_frame.y) * scaleY;
-      scaledW = static_cast<float>(m_frame.z) * scaleX;
-      scaledH = static_cast<float>(m_frame.w) * scaleY;
+      // Manual coordinates: use direct frame coordinates, flip Y to start from top
+      scaledX = static_cast<float>(m_frame.x);
+      scaledY = ctx->srcHeight - static_cast<float>(m_frame.y) - static_cast<float>(m_frame.w);
+      scaledW = static_cast<float>(m_frame.z);
+      scaledH = static_cast<float>(m_frame.w);
    }
 
    vec4 glassArea, glassAmbient(1.f, 1.f, 1.f, 1.f), glassTint(1.f, 1.f, 1.f, 1.f), glassPad;

--- a/plugins/b2slegacy/utils/VPXGraphics.cpp
+++ b/plugins/b2slegacy/utils/VPXGraphics.cpp
@@ -559,8 +559,8 @@ void VPXGraphics::DrawImage(VPXPluginAPI* vpxApi, VPXRenderContext2D* ctx, VPXTe
 
    float srcX = destRect ? (float)destRect->x : 0.0f;
    float srcY = destRect ? (float)destRect->y : 0.0f;
-   float srcW = destRect ? (float)destRect->w : ctx->outWidth;
-   float srcH = destRect ? (float)destRect->h : ctx->outHeight;
+   float srcW = destRect ? (float)destRect->w : ctx->srcWidth;
+   float srcH = destRect ? (float)destRect->h : ctx->srcHeight;
 
    ctx->DrawImage(ctx, texture, tintR, tintG, tintB, alpha,
                   texX, texY, texW, texH, pivotX, pivotY, rotation,

--- a/src/assets/Default_VPinballX.ini
+++ b/src/assets/Default_VPinballX.ini
@@ -62,20 +62,24 @@ B2SHideB2SBackglass =
 B2SHideDMD = 
 B2SDualMode = 
 B2SDMDFlipY = 
-# ScoreView DMD Overlay Settings
-ScoreviewDMDOverlay = 
-ScoreviewDMDAutoPos = 
-ScoreviewDMDX = 
-ScoreviewDMDY = 
-ScoreviewDMDWidth = 
-ScoreviewDMDHeight = 
-# Backglass DMD Overlay Settings
+B2SBackglassWidth = 
+B2SBackglassHeight = 
+B2SDMDWidth = 
+B2SDMDHeight = 
+# Backglass DMD Overlay (relative to B2SBackglassWidth/B2SBackglassHeight)
 BackglassDMDOverlay = 
 BackglassDMDAutoPos = 
 BackglassDMDX = 
 BackglassDMDY = 
 BackglassDMDWidth = 
 BackglassDMDHeight = 
+# ScoreView DMD Overlay (relative to B2SDMDWidth/B2SDMDHeight)
+ScoreviewDMDOverlay = 
+ScoreviewDMDAutoPos = 
+ScoreviewDMDX = 
+ScoreviewDMDY = 
+ScoreviewDMDWidth = 
+ScoreviewDMDHeight = 
 
 [Plugin.DMDUtil]
 Enable = 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2315,24 +2315,6 @@ RenderTarget *Player::RenderAnciliaryWindow(VPXAnciliaryWindow window, RenderTar
       bool isLinearOutput;
    };
 
-   int wndW;
-   int wndH;
-   if (output.GetMode() == VPX::RenderOutput::OM_EMBEDDED)
-   {
-      wndW = output.GetEmbeddedWindow()->GetWidth();
-      wndH = output.GetEmbeddedWindow()->GetHeight();
-   }
-   else if (output.GetMode() == VPX::RenderOutput::OM_WINDOW)
-   {
-      wndW = output.GetWindow()->GetWidth();
-      wndH = output.GetWindow()->GetHeight();
-   }
-   else
-   {
-      wndW = m_outputW;
-      wndH = m_outputH;
-   }
-
    PlayerRenderContext2D context
    {
       {
@@ -2340,7 +2322,6 @@ RenderTarget *Player::RenderAnciliaryWindow(VPXAnciliaryWindow window, RenderTar
          static_cast<float>(m_outputW), static_cast<float>(m_outputH),
          1, // 2D render
          static_cast<float>(m_outputW), static_cast<float>(m_outputH),
-         static_cast<float>(wndW), static_cast<float>(wndH),
          // Draw an image
          [](VPXRenderContext2D *ctx, VPXTexture texture,
             const float tintR, const float tintG, const float tintB, const float alpha,

--- a/src/plugins/VPXPlugin.h
+++ b/src/plugins/VPXPlugin.h
@@ -109,8 +109,6 @@ typedef struct VPXRenderContext2D
    int is2D;                  // If true, the rendering is done in 2D mode, otherwise in 3D mode
    float outWidth;            // Target surface width for 2D render, otherwise hint to be used for aspect ratio computation, LOD and layout
    float outHeight;           // Target surface height for 2D render, otherwise hint to be used for apsect ratio computation, LOD and layout
-   float wndWidth;            // Logical window width
-   float wndHeight;           // Logical window height
    void(MSGPIAPI* DrawImage)(VPXRenderContext2D* ctx, VPXTexture texture,
       const float tintR, const float tintG, const float tintB, const float alpha, // tint color and alpha (0..1)
       const float texX, const float texY, const float texW, const float texH,  // coordinates in texture surface (0..tex.width, 0..tex.height)


### PR DESCRIPTION
This PR addresses comments from https://github.com/vpinball/vpinball/pull/2639 and https://github.com/vpinball/vpinball/issues/2622.

We've added `B2SBackglassWidth`, `B2SBackglassHeight`, `B2SDMDWidth`, `B2SDMDHeight` and reverted the additional members we added to `VPXRenderContext2D`

```ini
[Plugin.B2SLegacy]
Enable = 
# 0 to show grill (if it exists), 1 to hide grill
B2SHideGrill = 
# 0 to show extra DMD frame (if it exists), 1 to hide extra DMD frame
B2SHideB2SDMD = 
# 0 to show backglass, 1 to hide backglass
B2SHideB2SBackglass = 
B2SHideDMD = 
B2SDualMode = 
B2SDMDFlipY = 
B2SBackglassWidth = 
B2SBackglassHeight = 
B2SDMDWidth = 
B2SDMDHeight = 
# Backglass DMD Overlay (relative to B2SBackglassWidth/B2SBackglassHeight)
BackglassDMDOverlay = 
BackglassDMDAutoPos = 
BackglassDMDX = 
BackglassDMDY = 
BackglassDMDWidth = 
BackglassDMDHeight = 
# ScoreView DMD Overlay (relative to B2SDMDWidth/B2SDMDHeight)
ScoreviewDMDOverlay = 
ScoreviewDMDAutoPos = 
ScoreviewDMDX = 
ScoreviewDMDY = 
ScoreviewDMDWidth = 
ScoreviewDMDHeight = 
```

@superhac - the manual DMD position also now starts from the top instead of the bottom.