### PR TITLE
build: fix macos-x64 linker issue with libswresample (chained fixups)

### DIFF
--- a/platforms/macos-arm64/external.sh
+++ b/platforms/macos-arm64/external.sh
@@ -302,7 +302,7 @@ fi
 # build ffmpeg
 #
 
-FFMPEG_EXPECTED_SHA="${FFMPEG_SHA}"
+FFMPEG_EXPECTED_SHA="${FFMPEG_SHA}_002"
 FFMPEG_FOUND_SHA="$([ -f ffmpeg/cache.txt ] && cat ffmpeg/cache.txt || echo "")"
 
 if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
@@ -327,8 +327,7 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
       --prefix=. \
       --libdir=@rpath \
       --arch=arm64 \
-      --cc='clang -arch arm64' \
-      --extra-ldflags='-Wl,-ld_classic'
+      --cc='clang -arch arm64'
    make -j${NUM_PROCS}
    cd ..
 

--- a/platforms/macos-x64/external.sh
+++ b/platforms/macos-x64/external.sh
@@ -302,7 +302,7 @@ fi
 # build ffmpeg
 #
 
-FFMPEG_EXPECTED_SHA="${FFMPEG_SHA}"
+FFMPEG_EXPECTED_SHA="${FFMPEG_SHA}_002"
 FFMPEG_FOUND_SHA="$([ -f ffmpeg/cache.txt ] && cat ffmpeg/cache.txt || echo "")"
 
 if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
@@ -328,7 +328,7 @@ if [ "${FFMPEG_EXPECTED_SHA}" != "${FFMPEG_FOUND_SHA}" ]; then
       --libdir=@rpath \
       --arch=x86_64 \
       --cc='clang -arch x86_64' \
-      --extra-ldflags='-Wl,-ld_classic'
+      --extra-ldflags='-Wl,-no_fixup_chains'
    make -j${NUM_PROCS}
    cd ..
 


### PR DESCRIPTION
We started get this error a few days ago while compiling for macos-x64:

```
ld: chained fixups, seg_count exceeds number of segments in '/Users/runner/work/vpinball/vpinball/third-party/runtime-libs/macos-x64/libswresample.dylib'
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```