### PR TITLE
ci: fix pipeline to build with supported windows runners

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
       tag: ${{ steps.version.outputs.tag }}
@@ -37,7 +37,7 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   prerelease:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ version ]
     steps:
       - id: download

--- a/.github/workflows/vpinball.yml
+++ b/.github/workflows/vpinball.yml
@@ -12,7 +12,7 @@ defaults:
 jobs:
   version:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version_short: ${{ steps.version.outputs.version_short }}
       revision: ${{ steps.version.outputs.revision }}
@@ -38,7 +38,7 @@ jobs:
 
   dxsdk:
     name: DirectX SDK
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       - id: cache
         uses: actions/cache@v4
@@ -57,7 +57,7 @@ jobs:
 
   build:
     name: Build VPinballX-${{ matrix.config }}-${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2025
     needs: [ version, dxsdk ]
     strategy:
       fail-fast: false
@@ -78,11 +78,11 @@ jobs:
           export DXSDK_DIR="${GITHUB_WORKSPACE}/DXSDK"
           cp cmake/CMakeLists_${{ matrix.platform}}.txt CMakeLists.txt
           # cmake can't find fxc.exe so copy one into the a directory in the path
-          cp "/c/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/fxc.exe" /mingw64/bin
+          cp "/c/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x86/fxc.exe" /mingw64/bin
           if [[ "${{ matrix.platform }}" == "win-x64" ]]; then
-            cmake -T v141_xp -G "Visual Studio 16 2019" -A x64 -B build
+            cmake -G "Visual Studio 17 2022" -A x64 -B build
           else
-            cmake -T v141_xp -G "Visual Studio 16 2019" -A Win32 -B build
+            cmake -G "Visual Studio 17 2022" -A Win32 -B build
           fi
           cmake --build build --config ${{ matrix.config }}
       - run: |
@@ -104,7 +104,7 @@ jobs:
 
   build-gl:
     name: Build VPinballX_GL-${{ matrix.config }}-${{ matrix.platform }}
-    runs-on: windows-2022
+    runs-on: windows-2025
     needs: [ version, dxsdk ]
     strategy:
       fail-fast: false


### PR DESCRIPTION
10.8.0 pipelines are failing. This fixes that.

Unfortunately this prevents us from using `v141_xp` flag. Not sure if this is an issue @toxieainc @JockeJarre ...
