### PR TITLE
Fix MacOS build, cleanup av dependencies

### DIFF
--- a/make/CMakeLists_bgfx-macos-arm64.txt
+++ b/make/CMakeLists_bgfx-macos-arm64.txt
@@ -118,8 +118,6 @@ target_link_libraries(vpinball PUBLIC
    dmdutil
    dof
    avcodec
-   avdevice
-   avfilter
    avformat
    avutil
    swresample

--- a/make/CMakeLists_bgfx-macos-x64.txt
+++ b/make/CMakeLists_bgfx-macos-x64.txt
@@ -118,8 +118,6 @@ target_link_libraries(vpinball PUBLIC
    dmdutil
    dof
    avcodec
-   avdevice
-   avfilter
    avformat
    avutil
    swresample

--- a/make/CMakeLists_bgfx_lib.txt
+++ b/make/CMakeLists_bgfx_lib.txt
@@ -145,8 +145,6 @@ target_link_libraries(vpinball PUBLIC
    sockpp
    dof
    avcodec
-   avdevice
-   avfilter
    avformat
    avutil
    swresample

--- a/make/CMakeLists_gl-macos-arm64.txt
+++ b/make/CMakeLists_gl-macos-arm64.txt
@@ -123,8 +123,6 @@ target_link_libraries(vpinball PUBLIC
    dmdutil
    dof
    avcodec
-   avdevice
-   avfilter
    avformat
    avutil
    swresample

--- a/make/CMakeLists_gl-macos-x64.txt
+++ b/make/CMakeLists_gl-macos-x64.txt
@@ -124,8 +124,6 @@ target_link_libraries(vpinball PUBLIC
    dmdutil
    dof
    avcodec
-   avdevice
-   avfilter
    avformat
    avutil
    swresample

--- a/make/CMakeLists_plugin_FlexDMD.txt
+++ b/make/CMakeLists_plugin_FlexDMD.txt
@@ -139,10 +139,6 @@ if(BUILD_SHARED)
          target_link_libraries(FlexDMDPlugin
             SDL364.lib
             SDL3_image64.lib
-            AVCODEC64.lib
-            AVFORMAT64.lib
-            AVUTIL64.lib
-            SWSCALE64.lib
          )
       else()
          set_target_properties(FlexDMDPlugin PROPERTIES
@@ -152,10 +148,6 @@ if(BUILD_SHARED)
          target_link_libraries(FlexDMDPlugin
             SDL3.lib
             SDL3_image.lib
-            AVCODEC.lib
-            AVFORMAT.lib
-            AVUTIL.lib
-            SWSCALE.lib
          )
       endif()
    else()
@@ -177,6 +169,7 @@ if(BUILD_SHARED)
          avcodec
          avformat
          avutil
+         swresample
          swscale
       )
    endif()

--- a/make/CMakeLists_plugin_PUP.txt
+++ b/make/CMakeLists_plugin_PUP.txt
@@ -8,6 +8,7 @@ set(CMAKE_C_STANDARD 99)
 set(PUP_PLUGIN_SOURCES
    plugins/pup/common.h
    plugins/pup/common.cpp
+   plugins/pup/common.cpp
    plugins/pup/LibAv.h
    plugins/pup/PUPPlugin.cpp
    plugins/pup/PUPCustomPos.h
@@ -114,8 +115,6 @@ if(BUILD_SHARED)
          SDL3_image
          SDL3_ttf
          avcodec
-         avdevice
-         avfilter
          avformat
          avutil
          swresample

--- a/src/input/pininput.cpp
+++ b/src/input/pininput.cpp
@@ -634,6 +634,8 @@ void PinInput::FireActionEvent(EnumAssignKeys action, bool isPressed)
          g_pplayer->m_vrDevice->TableDown();
       break;
    #endif
+   
+   default: break;
    }
 
    if (!g_pplayer->m_liveUI->IsTweakMode() && isPressed && (action == eLeftFlipperKey || action == eRightFlipperKey || action == eStagedLeftFlipperKey || action == eStagedRightFlipperKey))

--- a/src/parts/trigger.cpp
+++ b/src/parts/trigger.cpp
@@ -1140,7 +1140,7 @@ STDMETHODIMP Trigger::DestroyBall(int *pVal)
          if (it != ball->m_d.m_vpVolObjs->end())
          {
             if (pVal)
-               *pVal++;
+               (*pVal) = (*pVal) + 1;
             ball->m_d.m_vpVolObjs->erase(it);
             g_pplayer->DestroyBall(ball); // inside trigger volume?
          }

--- a/src/renderer/Texture.cpp
+++ b/src/renderer/Texture.cpp
@@ -553,6 +553,7 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
             return nullptr;
          copy_rgb_rgba<false>((unsigned int*)tex->data(), datac(), (size_t)width() * height());
          break;
+      default: break;
       }
       break;
 
@@ -565,6 +566,7 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
             return nullptr;
          copy_rgb_rgba<false>((unsigned int*)tex->data(), datac(), (size_t)width() * height());
          break;
+      default: break;
       }
       break;
 
@@ -587,6 +589,7 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
             }
          }
          break;
+      default: break;
       }
       break;
 
@@ -612,6 +615,7 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
             tex->SetIsOpaque(true);
          }
          break;
+      default: break;
       }
       break;
 
@@ -635,6 +639,7 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
             }
          }
          break;
+         default: break;
       }
       break;
    
@@ -658,8 +663,12 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
             }
          }
          break;
+         default: break;
       }
       break;
+
+   default: break;
+
    }
 
    // Copy without conversion

--- a/src/ui/live/EditorUI.cpp
+++ b/src/ui/live/EditorUI.cpp
@@ -887,6 +887,7 @@ bool EditorUI::GetSelectionTransform(Matrix3D& transform) const
       transform = Matrix3D::MatrixTranslate(center.x, center.y, 0.5f * (obj->m_d.m_heightbottom + obj->m_d.m_heighttop));
       return true;
    }
+   default: break; // Unsupported item type
    }
 
    return false;
@@ -1007,6 +1008,7 @@ void EditorUI::SetSelectionTransform(const Matrix3D &newTransform, bool clearPos
       obj->m_d.m_heighttop += posZ - pz;
       break;
    }
+   default: break; // Unsupported item type
    }
 }
 


### PR DESCRIPTION
Note that swresample is added to FlexDMD as it will be needed when implementing sound rendering