### PR TITLE
misc: fix UpdateOpaque crash with GetRawBitmap returns null

### DIFF
--- a/src/renderer/Texture.cpp
+++ b/src/renderer/Texture.cpp
@@ -1155,7 +1155,8 @@ void Texture::UpdateOpaque() const
    if (!m_isOpaqueDirty)
       return;
    m_isOpaqueDirty = false;
-   m_isOpaque = GetRawBitmap(false, 0)->IsOpaque();
+   auto bitmap = GetRawBitmap(false, 0);
+   m_isOpaque = bitmap ? bitmap->IsOpaque() : false;
 }
 
 void Texture::SetIsOpaque(const bool v) const


### PR DESCRIPTION
@superhac asked me to look into why the [Accept (Germany) 1.2](https://vpuniverse.com/files/file/8472-accept-germany-12/) table would crash on standalone.

I'm not sure why, but the `CustomMetalTip.png` is unable to be decoded with FreeImage. (@toxieainc)

`UpdateOpaque` will blow up because it assumes `GetRawBitmap()` is not null.

This check matches a fews other in `Texture.cpp` where it looks for `GetRawBitmap()` not being `nullptr`.

Fwiw, I used @francisdb 's vpxtool to uncompress the table, and `CustomMetalTip.png` seems to be fine.

<img width="256" height="341" alt="CustomMetalTip" src="https://github.com/user-attachments/assets/863aaa32-5e92-4818-ad79-26d0938570e1" />

<img width="3680" height="2238" alt="image" src="https://github.com/user-attachments/assets/9c7e2d32-fd9b-4009-9a67-47d60206adb7" />

<img width="3680" height="2238" alt="image" src="https://github.com/user-attachments/assets/ccdcf6b5-2462-426b-8814-ad5bfefbc68a" />





