### PR TITLE
plugins: move pupvideos path detection (fixes voodoo carnival)

### DIFF
--- a/plugins/pinmame/PinMAMEPlugin.cpp
+++ b/plugins/pinmame/PinMAMEPlugin.cpp
@@ -418,13 +418,22 @@ MSGPI_EXPORT void MSGPIAPI PinMAMEPluginLoad(const uint32_t sessionId, const Msg
       }
       if (pinmamePath.empty())
       {
-         // FIXME implement a last resort or just ask the user to define its path setup in the settings ?
          #if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
-            //pinmamePath = find_directory_case_insensitive(g_pvp->m_szMyPath, "pinmame"s);
+            if (vpxApi != nullptr)
+            { 
+               VPXInfo vpxInfo;
+               vpxApi->GetVpxInfo(&vpxInfo);
+               pinmamePath = find_case_insensitive_directory_path(vpxInfo.prefPath + "pinmame"s);
+            }
+            else {
+               LOGE("PinMAME path is not defined.");
+            }
+         #elif defined(__APPLE__) || defined(__linux__)
+            pinmamePath = string(getenv("HOME")) + PATH_SEPARATOR_CHAR + ".pinmame" + PATH_SEPARATOR_CHAR;
          #else
-            //pinmamePath = string(getenv("HOME")) + PATH_SEPARATOR_CHAR + ".pinmame" + PATH_SEPARATOR_CHAR;
+            // FIXME implement a last resort or just ask the user to define its path setup in the settings ?
+            LOGE("PinMAME path is not defined.");
          #endif
-         LOGE("PinMAME path is not defined.");
       }
       strncpy_s(const_cast<char*>(config.vpmPath), PINMAME_MAX_PATH, pinmamePath.c_str());
 

--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -42,6 +42,25 @@ PUPManager::~PUPManager()
 
 void PUPManager::SetGameDir(const string& szRomName)
 {
+   // If root path is not defined, look next to table like we do for pinmame folder
+   if (m_szRootPath.empty()) {
+      VPXPluginAPI* vpxApi = nullptr;
+      unsigned int getVpxApiId = m_msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_MSG_GET_API);
+      m_msgApi->BroadcastMsg(m_endpointId, getVpxApiId, &vpxApi);
+      m_msgApi->ReleaseMsgID(getVpxApiId);
+      if (vpxApi != nullptr)
+      {
+         VPXTableInfo tableInfo;
+         vpxApi->GetTableInfo(&tableInfo);
+         std::filesystem::path tablePath = tableInfo.path;
+         m_szRootPath = find_case_insensitive_directory_path(tablePath.parent_path().string() + PATH_SEPARATOR_CHAR + "pupvideos"s);
+
+         if (!m_szRootPath.empty()) {
+            LOGI("PUP folder was found at '%s'", m_szRootPath.c_str());
+         }
+      }
+   }
+
    const string path = find_case_insensitive_directory_path(m_szRootPath + szRomName);
    if (path.empty())
    {
@@ -63,25 +82,6 @@ void PUPManager::SetGameDir(const string& szRomName)
 void PUPManager::LoadConfig(const string& szRomName)
 {
    Unload();
-
-   // If root path is not defined, look next to table like we do for pinmame folder
-   if (m_szRootPath.empty()) {
-      VPXPluginAPI* vpxApi = nullptr;
-      unsigned int getVpxApiId = m_msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_MSG_GET_API);
-      m_msgApi->BroadcastMsg(m_endpointId, getVpxApiId, &vpxApi);
-      m_msgApi->ReleaseMsgID(getVpxApiId);
-      if (vpxApi != nullptr)
-      {
-         VPXTableInfo tableInfo;
-         vpxApi->GetTableInfo(&tableInfo);
-         std::filesystem::path tablePath = tableInfo.path;
-         m_szRootPath = find_case_insensitive_directory_path(tablePath.parent_path().string() + PATH_SEPARATOR_CHAR + "pupvideos"s);
-
-         if (!m_szRootPath.empty()) {
-            LOGI("PUP folder was found at '%s'", m_szRootPath.c_str());
-         }
-      }
-   }
 
    SetGameDir(szRomName);
 

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -29,9 +29,9 @@ PUPPinDisplay::~PUPPinDisplay()
    m_pupManager.Unload();
 }
 
-void PUPPinDisplay::Init(int screenNum, const string& RootDir)
+void PUPPinDisplay::Init(int screenNum, const string& romName)
 {
-   m_pupManager.SetGameDir(RootDir);
+   m_pupManager.SetGameDir(romName);
    m_pupManager.AddScreen(screenNum);
 }
 

--- a/plugins/pup/PUPPinDisplay.h
+++ b/plugins/pup/PUPPinDisplay.h
@@ -14,7 +14,7 @@ public:
 
    PSC_IMPLEMENT_REFCOUNT()
 
-   void Init(int screenNum, const string& rootDir);
+   void Init(int screenNum, const string& romName);
    void playlistadd(int screenNum, const string& folder, int sort, int restSeconds);
    void playlistplay(int screenNum, const string& playlist);
    void playlistplayex(int screenNum, const string& playlist, const string& playfilename, int volume, int forceplay);


### PR DESCRIPTION
@superhac reported that 220286584_VoodoosCarnivalPinball is crashing. 

It doesn't seem to crash on MacOS, however, this one does use a `PUPPinDisplay`. 

Since the `PUPPinDisplay` doesn't trigger `LoadConfig` in the `PUPManager`, it doesn't have a chance to calculate the `pupvideos` path next to the table. 

This PR just moves the logic to the `SetGameDir` since all tables set that.  

I'm guessing pin display might have some other problems and we will have to revisit in the future, but this did get the videos playing on MacOS.

This PR also updates apple and linux paths to default to the home directory for pinmame, if nothing is set at all. Some users in discord were getting tripped up on this. Since it's in an #ifdef, windows will still work like it did. 

