### PR TITLE
standalone: fix incomplete var_cmp to avoid needing CInt

### DIFF
--- a/standalone/docs/changelog.md
+++ b/standalone/docs/changelog.md
@@ -4,6 +4,9 @@ To keep up with all the changes in master, and make it easier to rebase, this br
 
 The downside of this approach is not accurately keeping track of history:
 
+* 10/24/25
+    * Fix incomplete var_cmp to support avoid needing CInt
+
 * 07/26/25
     * Replaced standalone WMP player with new WMP Plugin (bloodm, ag)
     * Removed standalone PUP player in favor of PUP Plugin


### PR DESCRIPTION
@superhac and merlinrtp discovered an issue with vbs case statements failing to match when comparing strings and numbers:

For example:
      
```
        Dim x : x = "3"
        Select Case x
                Case 3
                       WScript.echo("HERE 3")
                Case 4
                       WScript.echo("HERE 4")
                Case 5
                       WScript.echo("HERE 5")
        End Select  
```

After debugging wine: 

```
static HRESULT var_cmp(exec_ctx_t *ctx, VARIANT *l, VARIANT *r)
{
    TRACE("%s %s\n", debugstr_variant(l), debugstr_variant(r));

    /* FIXME: Fix comparing string to number */

    return VarCmp(l, r, ctx->script->lcid, 0);
}
```

This avoids having to do work-arounds like using `CInt()`
