### PR TITLE
quest: add support for meta quest builds

### DIFF
--- a/.github/workflows/vpinball-mobile.yml
+++ b/.github/workflows/vpinball-mobile.yml
@@ -108,13 +108,18 @@ jobs:
           path: tmp
 
   build-android:
-    name: Build VPinballX_BGFX-android-${{ matrix.config }}
+    name: Build VPinballX_BGFX-android-${{ matrix.flavor }}-${{ matrix.config }}
     runs-on: ubuntu-24.04
     needs: [ version ]
     strategy:
       fail-fast: false
       matrix:
         config: [ Release ]
+        flavor: [ quest, mobile ]
+    env:
+      ANDROID_NDK: /usr/local/lib/android/sdk/ndk/28.2.13676358
+      ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/28.2.13676358
+      ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/28.2.13676358
     steps:
       - run: |
           sudo apt install bison
@@ -130,9 +135,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: external
-          key: BGFX-android-arm64-v8a-${{ matrix.config }}-external-${{ env.TIMESTAMP }}
+          key: BGFX-android-arm64-v8a-${{ matrix.flavor }}-${{ matrix.config }}-external-${{ env.TIMESTAMP }}
           restore-keys: |
-            BGFX-android-arm64-v8a-${{ matrix.config }}-external-
+            BGFX-android-arm64-v8a-${{ matrix.flavor }}-${{ matrix.config }}-external-
       - name: Build external cache
         run: |
           BUILD_TYPE=${{ matrix.config }} ./platforms/android-arm64-v8a/external.sh
@@ -141,7 +146,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: external
-          key: BGFX-android-arm64-v8a-${{ matrix.config }}-external-${{ env.TIMESTAMP }}
+          key: BGFX-android-arm64-v8a-${{ matrix.flavor }}-${{ matrix.config }}-external-${{ env.TIMESTAMP }}
       - name: Set version
         run: |
           perl -i -pe"s/9999/${{ needs.version.outputs.revision }}/g" src/core/git_version.h
@@ -149,11 +154,20 @@ jobs:
       - name: Build libvpinball
         run: |
           cp make/CMakeLists_bgfx_lib.txt CMakeLists.txt
-          cmake \
-                -DPLATFORM=android \
-                -DARCH=arm64-v8a \
-                -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-                -B build/android-arm64-v8a
+          if [[ "${{ matrix.flavor }}" == "quest" ]]; then
+            cmake \
+                  -DPLATFORM=android \
+                  -DARCH=arm64-v8a \
+                  -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+                  -DENABLE_XR=ON \
+                  -B build/android-arm64-v8a
+          else
+            cmake \
+                  -DPLATFORM=android \
+                  -DARCH=arm64-v8a \
+                  -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+                  -B build/android-arm64-v8a
+          fi
           cmake --build build/android-arm64-v8a -- -j$(nproc)
       - if: github.repository == 'vpinball/vpinball'
         name: Build app
@@ -164,9 +178,11 @@ jobs:
         run: |
           cd standalone/android
           echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 --decode > app/vpinball.jks
+          FLAVOR="${{ matrix.flavor }}"
+          FLAVOR_CAPITALIZED="$(echo "${FLAVOR:0:1}" | tr '[:lower:]' '[:upper:]')${FLAVOR:1}"
           ./gradlew \
-            assemble${{ matrix.config }} \
-            bundle${{ matrix.config }} \
+            assemble${FLAVOR_CAPITALIZED}${{ matrix.config }} \
+            bundle${FLAVOR_CAPITALIZED}${{ matrix.config }} \
             -PversionName="${{ needs.version.outputs.version_full }}" \
             -Psha7="${{ needs.version.outputs.sha7 }}"
       - if: github.repository != 'vpinball/vpinball'
@@ -182,21 +198,24 @@ jobs:
                 -keypass "$ANDROID_KEY_PASSWORD" \
                 -alias "$ANDROID_KEY_ALIAS" \
                 -dname "CN=VPinball Android, O=VPinball, C=XX"
+          FLAVOR="${{ matrix.flavor }}"
+          FLAVOR_CAPITALIZED="$(echo "${FLAVOR:0:1}" | tr '[:lower:]' '[:upper:]')${FLAVOR:1}"
           ./gradlew \
-            assemble${{ matrix.config }} \
-            bundle${{ matrix.config }} \
+            assemble${FLAVOR_CAPITALIZED}${{ matrix.config }} \
+            bundle${FLAVOR_CAPITALIZED}${{ matrix.config }} \
             -PversionName="${{ needs.version.outputs.version_full }}" \
             -Psha7="${{ needs.version.outputs.sha7 }}"
       - name: Stage apk/aab artifacts
         run: |
           CONFIG_LC=$(echo "${{ matrix.config }}" | tr '[:upper:]' '[:lower:]')
+          FLAVOR_LC=$(echo "${{ matrix.flavor }}" | tr '[:upper:]' '[:lower:]')
           mkdir tmp
-          cp standalone/android/app/build/outputs/apk/${CONFIG_LC}/*.apk tmp
+          cp standalone/android/app/build/outputs/apk/${FLAVOR_LC}/${CONFIG_LC}/*.apk tmp
           if [[ "${{ github.repository }}" == "vpinball/vpinball" ]]; then
-             cp standalone/android/app/build/outputs/bundle/${CONFIG_LC}/*.aab tmp
+             cp standalone/android/app/build/outputs/bundle/${FLAVOR_LC}${{ matrix.config }}/*.aab tmp
           fi
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: VPinballX_BGFX-${{ needs.version.outputs.tag }}-${{ matrix.config }}-android
+          name: VPinballX_BGFX-${{ needs.version.outputs.tag }}-${{ matrix.flavor }}-${{ matrix.config }}-android
           path: tmp

--- a/lib/bindings/java/jni/VPinballLib_JNI.cpp
+++ b/lib/bindings/java/jni/VPinballLib_JNI.cpp
@@ -8,6 +8,12 @@
 #include <SDL3/SDL_system.h>
 #include <jni.h>
 
+#ifdef ENABLE_XR
+#define XR_USE_PLATFORM_ANDROID
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+#endif
+
 using namespace VPinballLib;
 
 static jobject gJNICallbackObject = nullptr;
@@ -172,5 +178,29 @@ JNIEXPORT jint JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballStop(JNIEnv
 {
    return VPinballStop();
 }
+
+#ifdef ENABLE_XR
+JNIEXPORT jboolean JNICALL Java_org_vpinball_app_jni_VPinballJNI_VPinballInitOpenXR(JNIEnv* env, jobject obj, jobject activity)
+{
+   JavaVM* vm;
+   env->GetJavaVM(&vm);
+
+   jobject globalActivity = env->NewGlobalRef(activity);
+
+   XrLoaderInitInfoAndroidKHR loaderInitInfo = {XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR};
+   loaderInitInfo.applicationVM = vm;
+   loaderInitInfo.applicationContext = globalActivity;
+
+   PFN_xrInitializeLoaderKHR xrInitializeLoaderKHR;
+   xrGetInstanceProcAddr(XR_NULL_HANDLE, "xrInitializeLoaderKHR", (PFN_xrVoidFunction*)&xrInitializeLoaderKHR);
+
+   if (xrInitializeLoaderKHR != nullptr)
+   {
+      XrResult result = xrInitializeLoaderKHR((const XrLoaderInitInfoBaseHeaderKHR*)&loaderInitInfo);
+      return result == XR_SUCCESS;
+   }
+   return false;
+}
+#endif
 
 }

--- a/lib/src/VPinballLib.cpp
+++ b/lib/src/VPinballLib.cpp
@@ -120,7 +120,7 @@ void VPinballLib::AppIterate()
 
                if (success) {
                   PLOGI.printf("Screenshot saved: %s", imagePath.c_str());
-               } 
+               }
                else {
                   PLOGE.printf("Failed to save screenshot: %s", imagePath.c_str());
                }
@@ -301,6 +301,11 @@ void VPinballLib::SendEvent(VPINBALL_EVENT event, void* data)
 
 void VPinballLib::LoadPlugins()
 {
+   static bool pluginsLoaded = false;
+   if (pluginsLoaded)
+      return;
+   pluginsLoaded = true;
+
    static constexpr struct {
       const char* id;
       void (*load)(uint32_t, const MsgPluginAPI*);
@@ -321,10 +326,9 @@ void VPinballLib::LoadPlugins()
    };
 
    for (size_t i = 0; i < std::size(plugins); ++i) {
-      char buf[256];
-      MsgPI::MsgPluginManager::GetInstance().GetMsgAPI().GetSetting(plugins[i].id, "Enable", buf, 256);
-      if (buf[0] == '1') {
-         auto& p = plugins[i];
+      auto& p = plugins[i];
+      string sectionName = string("Plugin.") + p.id;
+      if (LoadValueBool(sectionName, "Enable", false)) {
          auto plugin = MsgPI::MsgPluginManager::GetInstance().RegisterPlugin(
             p.id, p.id, p.id,
             "", "", "",

--- a/make/CMakeLists_bgfx_lib.txt
+++ b/make/CMakeLists_bgfx_lib.txt
@@ -3,8 +3,11 @@ cmake_minimum_required(VERSION 3.25)
 set(PLATFORM "ios" CACHE STRING "Platform")
 set(ARCH "arm64" CACHE STRING "Arch")
 
+option(ENABLE_XR "Enable OpenXR support" OFF)
+
 message(STATUS "PLATFORM: ${PLATFORM}")
 message(STATUS "ARCH: ${ARCH}")
+message(STATUS "ENABLE_XR: ${ENABLE_XR}")
 
 if(PLATFORM STREQUAL "ios" OR PLATFORM STREQUAL "ios-simulator")
    set(CMAKE_SYSTEM_NAME iOS)
@@ -16,6 +19,10 @@ elseif(PLATFORM STREQUAL "android")
    set(CMAKE_SYSTEM_NAME Android)
    set(CMAKE_SYSTEM_VERSION 30)
    set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
+endif()
+
+if((PLATFORM STREQUAL "ios" OR PLATFORM STREQUAL "ios-simulator") AND ENABLE_XR)
+   message(FATAL_ERROR "iOS does not support ENABLE_XR")
 endif()
 
 file(READ src/core/vpversion.h version)
@@ -94,6 +101,7 @@ target_compile_definitions(vpinball PRIVATE
     __LIBVPINBALL__
 
     ENABLE_BGFX
+    $<$<BOOL:${ENABLE_XR}>:ENABLE_XR>
 
     __WINESRC__
     WINE_UNICODE_NATIVE
@@ -201,7 +209,12 @@ elseif(PLATFORM STREQUAL "android")
       GLESv3
       android
       log
+      vulkan
    )
+endif()
+
+if(ENABLE_XR)
+   target_link_libraries(vpinball PUBLIC openxr_loader)
 endif()
 
 add_custom_command(TARGET vpinball POST_BUILD

--- a/make/README.md
+++ b/make/README.md
@@ -142,7 +142,7 @@ open standalone/ios/VPinball.xcodeproj
 </details>
 
 <details>
-<summary>android-arm64-v8a</summary>
+<summary>android-arm64-v8a (Mobile)</summary>
 
 ```
 brew install cmake bison curl
@@ -156,7 +156,26 @@ cp make/CMakeLists_bgfx_lib.txt CMakeLists.txt
 cmake -DPLATFORM=android -DARCH=arm64-v8a -DCMAKE_BUILD_TYPE=Release -B build/android-arm64-v8a
 cmake --build build/android-arm64-v8a -- -j$(sysctl -n hw.ncpu)
 cd standalone/android
-./gradlew assembleDebug
+./gradlew assembleMobileDebug
+```
+</details>
+
+<details>
+<summary>android-arm64-v8a (Quest)</summary>
+
+```
+brew install cmake bison curl
+export PATH="$(brew --prefix bison)/bin:$PATH"
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+export ANDROID_HOME=/Users/jmillard/Library/Android/sdk
+export ANDROID_NDK=/Users/jmillard/Library/Android/sdk/ndk/28.2.13676358
+export ANDROID_NDK_HOME=/Users/jmillard/Library/Android/sdk/ndk/28.2.13676358
+platforms/android-arm64-v8a/external.sh
+cp make/CMakeLists_bgfx_lib.txt CMakeLists.txt
+cmake -DPLATFORM=android -DARCH=arm64-v8a -DENABLE_XR=ON -DCMAKE_BUILD_TYPE=Release -B build/android-arm64-v8a
+cmake --build build/android-arm64-v8a -- -j$(sysctl -n hw.ncpu)
+cd standalone/android
+./gradlew assembleQuestDebug
 ```
 </details>
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1928,7 +1928,7 @@ void Player::FinishFrame()
    if (m_closing == CS_USER_INPUT)
    {
       m_closing = CS_PLAYING;
-      if (g_pvp->m_disable_pause_menu || m_renderer->m_stereo3D == STEREO_VR)
+      if (g_pvp->m_disable_pause_menu)
          m_closing = CS_STOP_PLAY;
       else {
          m_liveUI->OpenMainSplash();

--- a/src/core/vpversion.h
+++ b/src/core/vpversion.h
@@ -24,7 +24,11 @@
 #endif
 #elif defined(ENABLE_BGFX)
 #define VP_FLAVOUR "BGFX"
+#if defined(ENABLE_XR) && defined(__ANDROID__)
+#define VP_FLAVOUR_SHORT "BGFX XR"
+#else
 #define VP_FLAVOUR_SHORT "BGFX"
+#endif
 #else
 #define VP_FLAVOUR "DirectX"
 #define VP_FLAVOUR_SHORT "DX"

--- a/src/renderer/VRDevice.h
+++ b/src/renderer/VRDevice.h
@@ -148,6 +148,7 @@ private:
       XrCompositionLayerProjection layerProjection = { XR_TYPE_COMPOSITION_LAYER_PROJECTION };
       std::vector<XrCompositionLayerProjectionView> layerProjectionViews;
       std::vector<XrCompositionLayerDepthInfoKHR> depthInfoViews;
+      XrCompositionLayerPassthroughFB layerPassthrough = { XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB };
    };
 
    bool m_depthExtensionSupported = false;
@@ -168,6 +169,11 @@ private:
    PFN_xrGetVisibilityMaskKHR xrGetVisibilityMaskKHR;
    bool m_visibilityMaskDirty = true;
    MeshBuffer* m_visibilityMask = nullptr;
+
+   bool m_passthroughExtensionSupported = false;
+   XrPassthroughFB m_passthrough = XR_NULL_HANDLE;
+   XrPassthroughLayerFB m_passthroughLayer = XR_NULL_HANDLE;
+   bool m_passthroughEnabled = false;
 
    class XRGraphicBackend* m_backend = nullptr;
 

--- a/standalone/android/app/build.gradle.kts
+++ b/standalone/android/app/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 
     defaultConfig {
         applicationId = "org.vpinball.vpinball_bgfx"
-        minSdk = 30
+        minSdk = 34
         targetSdk = 35
         versionCode = versionCodeValue
         versionName = versionNameValue
@@ -84,6 +84,18 @@ android {
         vectorDrawables { useSupportLibrary = true }
 
         ndk { abiFilters += "arm64-v8a" }
+    }
+
+    flavorDimensions += "platform"
+    productFlavors {
+        create("quest") {
+            dimension = "platform"
+            buildConfigField("boolean", "IS_QUEST", "true")
+        }
+        create("mobile") {
+            dimension = "platform"
+            buildConfigField("boolean", "IS_QUEST", "false")
+        }
     }
 
     signingConfigs {
@@ -111,7 +123,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions { jvmTarget = "17" }
-    buildFeatures { compose = true }
+    buildFeatures {
+        buildConfig = true
+        compose = true
+    }
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
 }
 

--- a/standalone/android/app/src/main/AndroidManifest.xml
+++ b/standalone/android/app/src/main/AndroidManifest.xml
@@ -58,7 +58,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
@@ -86,7 +85,7 @@
          -->
 
         <activity android:name="VPinballActivity"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:configChanges="layoutDirection|locale|grammaticalGender|fontScale|fontWeightAdjustment|orientation|uiMode|screenLayout|screenSize|smallestScreenSize"
             android:theme="@style/Theme.VPinball"
             android:exported="true"
@@ -120,15 +119,13 @@
 
         <activity android:name="VPinballPlayerActivity"
             android:alwaysRetainTaskState="true"
+            android:launchMode="singleTop"
             android:configChanges="layoutDirection|locale|grammaticalGender|fontScale|fontWeightAdjustment|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
-            android:documentLaunchMode="never"
-            android:excludeFromRecents="true"
-            android:exported="false"
-            android:launchMode="singleTask"
             android:preferMinimalPostProcessing="true"
             android:theme="@style/Theme.VPinball.Fullscreen"
+            android:exported="false"
+            android:excludeFromRecents="true"
             >
-
         </activity>
 
         <provider

--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballManager.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballManager.kt
@@ -186,6 +186,8 @@ object VPinballManager : KoinComponent {
                                     }
 
                                     viewModel.loading(false)
+                                    viewModel.progress(0)
+                                    viewModel.status(null)
                                 } else {
                                     withContext(Dispatchers.IO) { TableManager.getInstance().cleanupLoadedTable(table) }
                                 }

--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballPlayerActivity.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballPlayerActivity.kt
@@ -6,10 +6,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.libsdl.app.SDLActivity
+import org.vpinball.app.jni.VPinballLogLevel
 
 class VPinballPlayerActivity : SDLActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (BuildConfig.IS_QUEST) {
+            VPinballManager.vpinballJNI.VPinballInitOpenXR(this)
+        }
 
         VPinballManager.setPlayerActivity(this)
 
@@ -26,8 +31,18 @@ class VPinballPlayerActivity : SDLActivity() {
         }
     }
 
+    override fun onStop() {
+        VPinballManager.log(VPinballLogLevel.INFO, "VPinballPlayerActivity: onStop: isFinishing=$isFinishing")
+
+        if (!isFinishing) {
+            VPinballManager.log(VPinballLogLevel.INFO, "VPinballPlayerActivity: force quit detected, exiting")
+            System.exit(0)
+        }
+
+        super.onStop()
+    }
+
     override fun onDestroy() {
-        VPinballManager.stop()
         VPinballManager.setPlayerActivity(null)
         super.onDestroy()
     }

--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballViewModel.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballViewModel.kt
@@ -66,7 +66,7 @@ class VPinballViewModel : ViewModel() {
     }
 
     fun stopped() {
-        _state.update { it.copy(loading = false, playing = false, table = null) }
+        _state.update { it.copy(loading = false, playing = false, table = null, progress = 0, status = null) }
     }
 
     fun launchInViewModelScope(block: suspend () -> Unit) {

--- a/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballJNI.java
+++ b/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballJNI.java
@@ -19,4 +19,5 @@ public class VPinballJNI {
     public native int VPinballExtractTableScript();
     public native int VPinballPlay();
     public native void VPinballStop();
+    public native boolean VPinballInitOpenXR(Object activity);
 }

--- a/standalone/android/app/src/main/java/org/vpinball/app/ui/screens/settings/SettingsScreen.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/ui/screens/settings/SettingsScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.unit.dp
 import java.io.File
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
+import org.vpinball.app.BuildConfig
 import org.vpinball.app.Credit
 import org.vpinball.app.Link
 import org.vpinball.app.R
@@ -142,14 +143,16 @@ fun SettingsScreen(
                                     "so backbox and cabinet are rendered. Useful for tables that do not provide FSS support.",
                         )
 
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                        if (!BuildConfig.IS_QUEST) {
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
-                        EnumMenuRow(
-                            label = "Graphics Backend",
-                            options = VPinballGfxBackend.entries.toList(),
-                            option = viewModel.gfxBackend,
-                            onOptionChanged = { viewModel.handleGfxBackend(value = it) },
-                        )
+                            EnumMenuRow(
+                                label = "Graphics Backend",
+                                options = VPinballGfxBackend.entries.toList(),
+                                option = viewModel.gfxBackend,
+                                onOptionChanged = { viewModel.handleGfxBackend(value = it) },
+                            )
+                        }
                     }
                 }
 

--- a/standalone/android/app/src/mobile/AndroidManifest.xml
+++ b/standalone/android/app/src/mobile/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity android:name="VPinballActivity"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name="VPinballPlayerActivity"
+            tools:node="merge">
+        </activity>
+    </application>
+
+</manifest>

--- a/standalone/android/app/src/quest/AndroidManifest.xml
+++ b/standalone/android/app/src/quest/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" />
+    <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+
+    <application>
+        <activity android:name="VPinballActivity"
+            android:resizeableActivity="true"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="com.oculus.intent.category.2D" />
+            </intent-filter>
+            <layout android:defaultHeight="800dp" android:defaultWidth="1200dp" />
+        </activity>
+
+        <activity android:name="VPinballPlayerActivity"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="com.oculus.intent.category.VR" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>


### PR DESCRIPTION
This adds two build flavors to the android app: `mobile`, `quest`.

Before this can be merged, we need to get a patch into our bgfx fork.