### PR TITLE
Linux: Fix compilation with non-BFD linkers

### DIFF
--- a/make/CMakeLists_bgfx-linux-aarch64.txt
+++ b/make/CMakeLists_bgfx-linux-aarch64.txt
@@ -118,7 +118,6 @@ target_link_libraries(vpinball PUBLIC
 
 set_target_properties(vpinball PROPERTIES
    RUNTIME_OUTPUT_NAME "${APP_NAME}"
-   LINK_FLAGS "-Wl,--copy-dt-needed-entries"
 )
 
 add_custom_command(TARGET vpinball POST_BUILD

--- a/make/CMakeLists_bgfx-linux-x64.txt
+++ b/make/CMakeLists_bgfx-linux-x64.txt
@@ -107,7 +107,6 @@ target_link_libraries(vpinball PUBLIC
 
 set_target_properties(vpinball PROPERTIES
    RUNTIME_OUTPUT_NAME "${APP_NAME}"
-   LINK_FLAGS "-Wl,--copy-dt-needed-entries"
 )
 
 add_custom_command(TARGET vpinball POST_BUILD

--- a/make/CMakeLists_gl-linux-aarch64.txt
+++ b/make/CMakeLists_gl-linux-aarch64.txt
@@ -124,7 +124,6 @@ target_link_libraries(vpinball PUBLIC
 
 set_target_properties(vpinball PROPERTIES
    RUNTIME_OUTPUT_NAME "${APP_NAME}"
-   LINK_FLAGS "-Wl,--copy-dt-needed-entries"
 )
 
 add_custom_command(TARGET vpinball POST_BUILD

--- a/make/CMakeLists_gl-linux-x64.txt
+++ b/make/CMakeLists_gl-linux-x64.txt
@@ -112,7 +112,6 @@ target_link_libraries(vpinball PUBLIC
 
 set_target_properties(vpinball PROPERTIES
    RUNTIME_OUTPUT_NAME "${APP_NAME}"
-   LINK_FLAGS "-Wl,--copy-dt-needed-entries"
 )
 
 add_custom_command(TARGET vpinball POST_BUILD


### PR DESCRIPTION
`-Wl,--copy-dt-needed-entries` breaks non-bfd linkers (i.e. lld & mold) and is unnecessary in modern versions of bfd/gcc