### PR TITLE
Standalone: Fix -listres/-listsnd and add -listctrl/-listall options

### DIFF
--- a/src/core/VPApp.h
+++ b/src/core/VPApp.h
@@ -34,6 +34,10 @@ private:
    
 #ifdef __STANDALONE__
    bool m_displayId = false;
+   bool m_listSnd = false;
+   bool m_listRes = false;
+   bool m_listCtrl = false;
+   bool m_listAll = false;
 #endif
    string m_tableFileName;
    string m_tableIniFileName;


### PR DESCRIPTION
## Summary
- Fix `-listres` and `-listsnd` commands that were not working (SDL not initialized)
- Add `-listctrl` to list controllers with detailed info (axes, buttons, vendor/product, serial)
- Add `-listall` to list all devices at once
- Display platform and SDL version in list output

## Test plan
- [ ] Run `./VPinballX_BGFX -listres` and verify displays are listed
- [ ] Run `./VPinballX_BGFX -listsnd` and verify sound devices are listed
- [ ] Run `./VPinballX_BGFX -listctrl` and verify controllers are listed with details
- [ ] Run `./VPinballX_BGFX -listall` and verify all devices are listed

🤖 Generated with [Claude Code](https://claude.ai/code)