### PR TITLE
Win32 UI: disable accelerators in Edit controls

### DIFF
--- a/src/core/VPApp.cpp
+++ b/src/core/VPApp.cpp
@@ -1031,6 +1031,24 @@ BOOL VPApp::OnIdle(LONG count)
    return TRUE;
 }
 
+BOOL VPApp::PreTranslateMessage(MSG& msg)
+{
+#ifndef __STANDALONE__
+   if ((msg.message >= WM_KEYFIRST && msg.message <= WM_KEYLAST) /* && (msg.wParam == VK_DELETE) */)
+   {
+      HWND hwndFocus = GetFocus();
+      TCHAR className[256];
+      if (hwndFocus && GetClassName(hwndFocus, className, 256))
+      {
+         // If it's an Edit control, skip accelerators
+         if (_tcscmp(className, _T("Edit")) == 0)
+            return FALSE;
+      }
+   }
+   return __super::PreTranslateMessage(msg);
+#endif
+}
+
 bool VPApp::StepMsgLoop()
 {
 #ifndef __STANDALONE__

--- a/src/core/VPApp.h
+++ b/src/core/VPApp.h
@@ -19,6 +19,7 @@ public:
 
 protected:
    BOOL OnIdle(LONG count) OVERRIDE;
+   virtual BOOL PreTranslateMessage(MSG& msg);
 
 private:
    string GetPathFromArg(const string& arg, bool setCurrentPath);


### PR DESCRIPTION
Avoid deleting objects when pressing delete in an edit, ...