### PR TITLE
Add tables directory configuration from CLI

### DIFF
--- a/src/core/AppCommands.cpp
+++ b/src/core/AppCommands.cpp
@@ -253,6 +253,7 @@ enum option_names
    OPTION_CUSTOM8,
    OPTION_CUSTOM9,
    OPTION_PREFPATH,
+   OPTION_TABLESPATH,
    OPTION_INVALID,
 };
 struct CommandLineOption
@@ -301,6 +302,7 @@ static const CommandLineOption options[] = {
    { OPTION_CUSTOM8, "c8"s, "Custom value 8"s },
    { OPTION_CUSTOM9, "c9"s, "Custom value 9"s },
    { OPTION_PREFPATH, "PrefPath"s, "[path]  Use a custom preferences path instead of default"s },
+   { OPTION_TABLESPATH, "TablesPath"s, "[path]  Use a custom tables path instead of default"s },
 };
 
 string CommandLineProcessor::GetPathFromArg(const string& arg, bool setCurrentPath)
@@ -521,6 +523,19 @@ void CommandLineProcessor::ProcessCommandLine(int nArgs, const char* szArglist[]
             }
          }
          g_app->m_fileLocator.SetPrefPath(path);
+         i++;
+         break;
+      }
+
+      case OPTION_TABLESPATH:
+      {
+         if (i + 1 >= nArgs)
+         {
+            OnCommandLineError("Command Line Error"s, "Option '"s + szArglist[i] + "' must be followed by a valid folder path");
+            exit(1);
+         }
+         string path = GetPathFromArg(szArglist[i + 1], false);
+         g_app->m_fileLocator.SetTablesPath(path);
          i++;
          break;
       }

--- a/src/core/FileLocator.h
+++ b/src/core/FileLocator.h
@@ -55,6 +55,7 @@ public:
 
    // Allow to change the preference r/w folder used for user settings
    void SetPrefPath(const std::filesystem::path& path);
+   void SetTablesPath(const std::filesystem::path& path);
 
 private:
    FileLayoutMode m_fileLayoutMode = FileLayoutMode::AppOnly;
@@ -64,5 +65,6 @@ private:
 
    void SetupPrefPath();
    std::filesystem::path m_prefPath; // The preferences path where user settings and all sort of dynamic datas are stored
+   std::filesystem::path m_tablesPath;  // Used to override the default table path
 };
 


### PR DESCRIPTION
On Linux systems where no Documents directory is configured (e.g. removed from xdg-user-dirs), SDL_GetUserFolder(SDL_FOLDER_DOCUMENTS) returns  nullptr.
This gets passed straight into std::filesystem::path(), causing a segfault at startup.

This PR fixes that null pointer crash with a proper error message, and adds a -TablesPath CLI parameter so users can explicitly set the tables  directory — which also serves as a workaround for systems without a Documents folder.

I ran the application with these changes but could not fully validate the feature since I hit a second, unrelated crash in StandaloneMsgLoop::MainMsgLoop where m_vpxEditor is null.