### PR TITLE
standalone: fix table override vbs. display compile/runtime errors in liveui

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1128,12 +1128,17 @@ void Player::OnScriptError(ScriptInterpreter::ErrorType type, int line, int colu
    if (m_playMode == Player::PlayMode::CaptureAttract)
       SetCloseState(Player::CloseState::CS_STOP_PLAY);
 
-#ifdef __STANDALONE__
-   PLOGE << (type == ScriptInterpreter::ErrorType::Runtime ? "Runtime" : "Compile") << " error on line " << line << ", col " << column << ": " << description;
-#endif
-
    if (m_ptable->m_tableEditor)
       m_ptable->m_tableEditor->m_pcv->OnScriptError(type, line ,column, description, stackDump);
+
+   if (g_isStandalone)
+   {
+      const string errorType = (type == ScriptInterpreter::ErrorType::Runtime) ? "Runtime" : "Compile";
+      const string desc = string_from_utf8_or_iso8859_1(description.data(), description.size());
+      PLOGE << errorType << " error on line " << line << ", col " << column << ": " << desc;
+      if (g_pplayer && g_pplayer->m_liveUI)
+         g_pplayer->m_liveUI->PushNotification(errorType + " error: " + desc, 5000);
+   }
 }
 
 Ball *Player::CreateBall(const float x, const float y, const float z, const float vx, const float vy, const float vz, const float radius, const float mass)

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -2062,8 +2062,10 @@ void PinTable::LoadScriptOverride(const std::filesystem::path& scriptPath)
       return;
    }
 
+   m_script_text = string_from_utf8_or_iso8859_1(buffer.data(), buffer.size());
    if (m_tableEditor)
-      m_tableEditor->m_pcv->SetScript(string_from_utf8_or_iso8859_1(buffer.data(), buffer.size()));
+      m_tableEditor->m_pcv->SetScript(m_script_text);
+
    m_external_script_name = scriptPath;
 }
 


### PR DESCRIPTION
Fixes:

- Overridden table script was only being set when `m_tableEditor` which is now only for Windows builds
- Existing LiveUI compile/runtime error message was in `CodeView` path which is now only for Windows builds (would have simplified code, but `m_suppressErrorDialogs` factors in, and that's only in `CodeView`)