### PR TITLE
Remove PinSim::FrontEndControls

### DIFF
--- a/src/ui/win/WinEditor.h
+++ b/src/ui/win/WinEditor.h
@@ -175,13 +175,6 @@ public:
 
    ULONG m_cref;
 
-   // registered window message ID for PinSim::FrontEndControls
-   // (http://mjrnet.org/pinscape/PinSimFrontEndControls/PinSimFrontEndControls.htm)
-   UINT m_pinSimFrontEndControlsMsg;
-
-   // handler for PinSim::FrontEndControls messages
-   LRESULT OnFrontEndControlsMsg(WPARAM wParam, LPARAM lParam);
-
    vector<PinTableWnd*> m_vtable;
    CComObject<PinTable> *m_ptableActive = nullptr;
 


### PR DESCRIPTION
In the end, PinSim does not provide any feature over standard window messaging while it would need to hack SDL event processing, adding some complexity, non portable and hacks to VPX.

If a Front End want to implement these messages, it should use CreateProcess then dwProcessId for listing windows and sending close messages.

For some discussion, see: https://github.com/vpinball/vpinball/issues/3142#issuecomment-3910299100