### PR TITLE
android: keep screen enabled for main activity (@syd711)

### DIFF
--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballActivity.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballActivity.kt
@@ -2,6 +2,7 @@ package org.vpinball.app
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +18,8 @@ class VPinballActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        window.addFlags(FLAG_KEEP_SCREEN_ON)
 
         VPinballManager.onActivityReady(this)
 


### PR DESCRIPTION
This will prevent the web server from stopping during long file transfers.

Thanks to @syd711 for reporting this on Discord!