### PR TITLE
mobile: better mvc design for iOS and Android, cleanup

### DIFF
--- a/platforms/ios-arm64/SDL/SDL_uikitappdelegate.m
+++ b/platforms/ios-arm64/SDL/SDL_uikitappdelegate.m
@@ -1,0 +1,687 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2026 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+#ifdef SDL_VIDEO_DRIVER_UIKIT
+
+#include "../SDL_sysvideo.h"
+
+#import "SDL_uikitappdelegate.h"
+#import "SDL_uikitmodes.h"
+#import "SDL_uikitwindow.h"
+
+#include "../../events/SDL_events_c.h"
+#include "../../main/SDL_main_callbacks.h"
+
+#ifdef main
+#undef main
+#endif
+
+static SDL_main_func forward_main;
+static int forward_argc;
+static char **forward_argv;
+static int exit_status;
+
+int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserved)
+{
+    // store arguments
+    forward_main = mainFunction;
+    forward_argc = argc;
+    forward_argv = argv;
+
+    // Give over control to run loop, SDLUIKitDelegate will handle most things from here
+    @autoreleasepool {
+        NSString *name = nil;
+
+        if (@available(iOS 13.0, tvOS 13.0, *)) {
+            name = [SDLUIKitSceneDelegate getSceneDelegateClassName];
+        }
+        if (!name) {
+            name = [SDLUIKitDelegate getAppDelegateClassName];
+        }
+        UIApplicationMain(argc, argv, nil, name);
+    }
+
+    return exit_status;
+}
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+// Load a launch image using the old UILaunchImageFile-era naming rules.
+static UIImage *SDL_LoadLaunchImageNamed(NSString *name, int screenh)
+{
+    UIInterfaceOrientation curorient = [UIApplication sharedApplication].statusBarOrientation;
+    UIUserInterfaceIdiom idiom = [UIDevice currentDevice].userInterfaceIdiom;
+    UIImage *image = nil;
+
+    if (idiom == UIUserInterfaceIdiomPhone && screenh == 568) {
+        // The image name for the iPhone 5 uses its height as a suffix.
+        image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-568h", name]];
+    } else if (idiom == UIUserInterfaceIdiomPad) {
+        // iPad apps can launch in any orientation.
+        if (UIInterfaceOrientationIsLandscape(curorient)) {
+            if (curorient == UIInterfaceOrientationLandscapeLeft) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-LandscapeLeft", name]];
+            } else {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-LandscapeRight", name]];
+            }
+            if (!image) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-Landscape", name]];
+            }
+        } else {
+            if (curorient == UIInterfaceOrientationPortraitUpsideDown) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-PortraitUpsideDown", name]];
+            }
+            if (!image) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-Portrait", name]];
+            }
+        }
+    }
+
+    if (!image) {
+        image = [UIImage imageNamed:name];
+    }
+
+    return image;
+}
+
+@interface SDLLaunchStoryboardViewController : UIViewController
+@property(nonatomic, strong) UIViewController *storyboardViewController;
+- (instancetype)initWithStoryboardViewController:(UIViewController *)storyboardViewController;
+@end
+
+@implementation SDLLaunchStoryboardViewController
+
+- (instancetype)initWithStoryboardViewController:(UIViewController *)storyboardViewController
+{
+    self = [super init];
+    self.storyboardViewController = storyboardViewController;
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    [self addChildViewController:self.storyboardViewController];
+    [self.view addSubview:self.storyboardViewController.view];
+    self.storyboardViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.storyboardViewController.view.frame = self.view.bounds;
+    [self.storyboardViewController didMoveToParentViewController:self];
+
+#ifndef SDL_PLATFORM_VISIONOS
+    UIApplication.sharedApplication.statusBarHidden = self.prefersStatusBarHidden;
+    UIApplication.sharedApplication.statusBarStyle = self.preferredStatusBarStyle;
+#endif
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+    return [[NSBundle.mainBundle objectForInfoDictionaryKey:@"UIStatusBarHidden"] boolValue];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    NSString *statusBarStyle = [NSBundle.mainBundle objectForInfoDictionaryKey:@"UIStatusBarStyle"];
+    if ([statusBarStyle isEqualToString:@"UIStatusBarStyleLightContent"]) {
+        return UIStatusBarStyleLightContent;
+    }
+    if (@available(iOS 13.0, *)) {
+        if ([statusBarStyle isEqualToString:@"UIStatusBarStyleDarkContent"]) {
+            return UIStatusBarStyleDarkContent;
+        }
+    }
+    return UIStatusBarStyleDefault;
+}
+
+@end
+#endif // !SDL_PLATFORM_TVOS
+
+
+@interface SDLLaunchScreenController ()
+
+#ifndef SDL_PLATFORM_TVOS
+- (NSUInteger)supportedInterfaceOrientations;
+#endif
+
+@end
+
+@implementation SDLLaunchScreenController
+
+- (instancetype)init
+{
+    return [self initWithNibName:nil bundle:[NSBundle mainBundle]];
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    if (!(self = [super initWithNibName:nil bundle:nil])) {
+        return nil;
+    }
+
+    NSString *screenname = nibNameOrNil;
+    NSBundle *bundle = nibBundleOrNil;
+
+    // A launch screen may not exist. Fall back to launch images in that case.
+    if (screenname) {
+        @try {
+            self.view = [bundle loadNibNamed:screenname owner:self options:nil][0];
+        }
+        @catch (NSException *exception) {
+            /* If a launch screen name is specified but it fails to load, iOS
+             * displays a blank screen rather than falling back to an image. */
+            return nil;
+        }
+    }
+
+    if (!self.view) {
+        NSArray *launchimages = [bundle objectForInfoDictionaryKey:@"UILaunchImages"];
+        NSString *imagename = nil;
+        UIImage *image = nil;
+
+#ifdef SDL_PLATFORM_VISIONOS
+        int screenw = SDL_XR_SCREENWIDTH;
+        int screenh = SDL_XR_SCREENHEIGHT;
+#else
+        int screenw = (int)([UIScreen mainScreen].bounds.size.width + 0.5);
+        int screenh = (int)([UIScreen mainScreen].bounds.size.height + 0.5);
+#endif
+
+
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+        UIInterfaceOrientation curorient = [UIApplication sharedApplication].statusBarOrientation;
+
+        // We always want portrait-oriented size, to match UILaunchImageSize.
+        if (screenw > screenh) {
+            int width = screenw;
+            screenw = screenh;
+            screenh = width;
+        }
+#endif
+
+        // Xcode 5 introduced a dictionary of launch images in Info.plist.
+        if (launchimages) {
+            for (NSDictionary *dict in launchimages) {
+                NSString *minversion = dict[@"UILaunchImageMinimumOSVersion"];
+                NSString *sizestring = dict[@"UILaunchImageSize"];
+
+                // Ignore this image if the current version is too low.
+                if (minversion && !UIKit_IsSystemVersionAtLeast(minversion.doubleValue)) {
+                    continue;
+                }
+
+                // Ignore this image if the size doesn't match.
+                if (sizestring) {
+                    CGSize size = CGSizeFromString(sizestring);
+                    if ((int)(size.width + 0.5) != screenw || (int)(size.height + 0.5) != screenh) {
+                        continue;
+                    }
+                }
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+                UIInterfaceOrientationMask orientmask = UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+                NSString *orientstring = dict[@"UILaunchImageOrientation"];
+
+                if (orientstring) {
+                    if ([orientstring isEqualToString:@"PortraitUpsideDown"]) {
+                        orientmask = UIInterfaceOrientationMaskPortraitUpsideDown;
+                    } else if ([orientstring isEqualToString:@"Landscape"]) {
+                        orientmask = UIInterfaceOrientationMaskLandscape;
+                    } else if ([orientstring isEqualToString:@"LandscapeLeft"]) {
+                        orientmask = UIInterfaceOrientationMaskLandscapeLeft;
+                    } else if ([orientstring isEqualToString:@"LandscapeRight"]) {
+                        orientmask = UIInterfaceOrientationMaskLandscapeRight;
+                    }
+                }
+
+                // Ignore this image if the orientation doesn't match.
+                if ((orientmask & (1 << curorient)) == 0) {
+                    continue;
+                }
+#endif
+
+                imagename = dict[@"UILaunchImageName"];
+            }
+
+            if (imagename) {
+                image = [UIImage imageNamed:imagename];
+            }
+        }
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+        else {
+            imagename = [bundle objectForInfoDictionaryKey:@"UILaunchImageFile"];
+
+            if (imagename) {
+                image = SDL_LoadLaunchImageNamed(imagename, screenh);
+            }
+
+            if (!image) {
+                image = SDL_LoadLaunchImageNamed(@"Default", screenh);
+            }
+        }
+#endif
+
+        if (image) {
+#ifdef SDL_PLATFORM_VISIONOS
+            CGRect viewFrame = CGRectMake(0, 0, screenw, screenh);
+#else
+            CGRect viewFrame = [UIScreen mainScreen].bounds;
+#endif
+            UIImageView *view = [[UIImageView alloc] initWithFrame:viewFrame];
+            UIImageOrientation imageorient = UIImageOrientationUp;
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+            // Bugs observed / workaround tested in iOS 8.3.
+            if (UIInterfaceOrientationIsLandscape(curorient)) {
+                if (image.size.width < image.size.height) {
+                    /* On iOS 8, portrait launch images displayed in forced-
+                     * landscape mode (e.g. a standard Default.png on an iPhone
+                     * when Info.plist only supports landscape orientations) need
+                     * to be rotated to display in the expected orientation. */
+                    if (curorient == UIInterfaceOrientationLandscapeLeft) {
+                        imageorient = UIImageOrientationRight;
+                    } else if (curorient == UIInterfaceOrientationLandscapeRight) {
+                        imageorient = UIImageOrientationLeft;
+                    }
+                }
+            }
+#endif
+
+            // Create the properly oriented image.
+            view.image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:imageorient];
+
+            self.view = view;
+        }
+    }
+
+    return self;
+}
+
+- (void)loadView
+{
+    // Do nothing.
+}
+
+#ifndef SDL_PLATFORM_TVOS
+- (BOOL)shouldAutorotate
+{
+    // If YES, the launch image will be incorrectly rotated in some cases.
+    return NO;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    /* We keep the supported orientations unrestricted to avoid the case where
+     * there are no common orientations between the ones set in Info.plist and
+     * the ones set here (it will cause an exception in that case.) */
+    return UIInterfaceOrientationMaskAll;
+}
+#endif // !SDL_PLATFORM_TVOS
+
+@end // SDLLaunchScreenController
+
+
+API_AVAILABLE(ios(13.0))
+@implementation SDLUIKitSceneDelegate
+{
+    UIWindow *launchWindow;
+    NSMutableArray<NSURL *> *launchURLs;
+}
+
++ (NSString *)getSceneDelegateClassName
+{
+    return @"SDLUIKitSceneDelegate";
+}
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+        return;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    windowScene.delegate = self;
+
+    NSBundle *bundle = [NSBundle mainBundle];
+
+#ifdef SDL_IPHONE_LAUNCHSCREEN
+    UIViewController *vc = nil;
+    NSString *screenname = nil;
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+    screenname = [bundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
+
+    if (screenname) {
+        @try {
+            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:screenname bundle:bundle];
+            __auto_type storyboardVc = [storyboard instantiateInitialViewController];
+            vc = [[SDLLaunchStoryboardViewController alloc] initWithStoryboardViewController:storyboardVc];
+        }
+        @catch (NSException *exception) {
+            // Do nothing (there's more code to execute below).
+        }
+    }
+#endif
+
+    if (vc == nil) {
+        vc = [[SDLLaunchScreenController alloc] initWithNibName:screenname bundle:bundle];
+    }
+
+    if (vc.view) {
+#ifdef SDL_PLATFORM_VISIONOS
+        CGRect viewFrame = CGRectMake(0, 0, SDL_XR_SCREENWIDTH, SDL_XR_SCREENHEIGHT);
+#else
+        CGRect viewFrame = windowScene.coordinateSpace.bounds;
+#endif
+        launchWindow = [[UIWindow alloc] initWithWindowScene:windowScene];
+        launchWindow.frame = viewFrame;
+
+        launchWindow.windowLevel = UIWindowLevelNormal + 1.0;
+        launchWindow.hidden = NO;
+        launchWindow.rootViewController = vc;
+    }
+#endif
+
+    // Set working directory to resource path
+    [[NSFileManager defaultManager] changeCurrentDirectoryPath:[bundle resourcePath]];
+
+    // Handle any connection options (like opening URLs)
+    launchURLs = [[NSMutableArray alloc] init];
+
+    for (NSUserActivity *activity in connectionOptions.userActivities) {
+        if (activity.webpageURL) {
+            [launchURLs addObject:activity.webpageURL];
+        }
+    }
+
+    for (UIOpenURLContext *urlContext in connectionOptions.URLContexts) {
+        [launchURLs addObject:urlContext.URL];
+    }
+
+    SDL_SetMainReady();
+    [self performSelector:@selector(postFinishLaunch) withObject:nil afterDelay:0.0];
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+    for (UIOpenURLContext *context in URLContexts) {
+        [self handleURL:context.URL];
+    }
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene
+{
+    SDL_OnApplicationDidEnterForeground();
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene
+{
+    SDL_OnApplicationWillEnterBackground();
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene
+{
+    SDL_OnApplicationWillEnterForeground();
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+    SDL_OnApplicationDidEnterBackground();
+}
+
+- (void)handleURL:(NSURL *)url
+{
+    const char *sourceApplicationCString = NULL;
+    NSURL *fileURL = url.filePathURL;
+    if (fileURL != nil) {
+        SDL_SendDropFile(NULL, sourceApplicationCString, fileURL.path.UTF8String);
+    } else {
+        SDL_SendDropFile(NULL, sourceApplicationCString, url.absoluteString.UTF8String);
+    }
+    SDL_SendDropComplete(NULL);
+}
+
+- (void)hideLaunchScreen
+{
+    UIWindow *window = launchWindow;
+
+    if (!window || window.hidden) {
+        return;
+    }
+
+    launchWindow = nil;
+
+    [UIView animateWithDuration:0.2
+        animations:^{
+          window.alpha = 0.0;
+        }
+        completion:^(BOOL finished) {
+          window.hidden = YES;
+          UIKit_ForceUpdateHomeIndicator();
+        }];
+}
+
+- (void)postFinishLaunch
+{
+    [self performSelector:@selector(hideLaunchScreen) withObject:nil afterDelay:0.0];
+    [self performSelector:@selector(processLaunchURLs) withObject:nil afterDelay:0.0];
+
+    SDL_SetiOSEventPump(true);
+    exit_status = SDL_CallMainFunction(forward_argc, forward_argv, forward_main);
+    SDL_SetiOSEventPump(false);
+
+    if (launchWindow) {
+        launchWindow.hidden = YES;
+        launchWindow = nil;
+    }
+}
+
+- (void)processLaunchURLs
+{
+    for (NSURL *url in launchURLs) {
+        [self handleURL:url];
+    }
+    launchURLs = nil;
+}
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options API_AVAILABLE(ios(13.0))
+{
+    // This doesn't appear to be called, but it needs to be implemented to signal that we support the UIScene life cycle
+    UISceneConfiguration *config = [[UISceneConfiguration alloc] initWithName:@"SDLSceneConfiguration" sessionRole:connectingSceneSession.role];
+    config.delegateClass = [SDLUIKitSceneDelegate class];
+    return config;
+}
+
+@end // SDLUIKitSceneDelegate
+
+
+@implementation SDLUIKitDelegate
+{
+    UIWindow *launchWindow;
+}
+
+// convenience method
++ (id)sharedAppDelegate
+{
+    /* the delegate is set in UIApplicationMain(), which is guaranteed to be
+     * called before this method */
+    return [UIApplication sharedApplication].delegate;
+}
+
++ (NSString *)getAppDelegateClassName
+{
+    /* subclassing notice: when you subclass this appdelegate, make sure to add
+     * a category to override this method and return the actual name of the
+     * delegate */
+    return @"SDLUIKitDelegate";
+}
+
+- (void)hideLaunchScreen
+{
+    UIWindow *window = launchWindow;
+
+    if (!window || window.hidden) {
+        return;
+    }
+
+    launchWindow = nil;
+
+    // Do a nice animated fade-out (roughly matches the real launch behavior.)
+    [UIView animateWithDuration:0.2
+        animations:^{
+          window.alpha = 0.0;
+        }
+        completion:^(BOOL finished) {
+          window.hidden = YES;
+          UIKit_ForceUpdateHomeIndicator(); // Wait for launch screen to hide so settings are applied to the actual view controller.
+        }];
+}
+
+- (void)postFinishLaunch
+{
+    /* Hide the launch screen the next time the run loop is run. SDL apps will
+     * have a chance to load resources while the launch screen is still up. */
+    [self performSelector:@selector(hideLaunchScreen) withObject:nil afterDelay:0.0];
+
+    // run the user's application, passing argc and argv
+    SDL_SetiOSEventPump(true);
+    exit_status = SDL_CallMainFunction(forward_argc, forward_argv, forward_main);
+    SDL_SetiOSEventPump(false);
+
+    if (launchWindow) {
+        launchWindow.hidden = YES;
+        launchWindow = nil;
+    }
+
+    // exit, passing the return status from the user's application
+    /* We don't actually exit to support applications that do setup in their
+     * main function and then allow the Cocoa event loop to run. */
+    // exit(exit_status);
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    NSBundle *bundle = [NSBundle mainBundle];
+
+#ifdef SDL_IPHONE_LAUNCHSCREEN
+    /* The normal launch screen is displayed until didFinishLaunching returns,
+     * but SDL_main is called after that happens and there may be a noticeable
+     * delay between the start of SDL_main and when the first real frame is
+     * displayed (e.g. if resources are loaded before SDL_GL_SwapWindow is
+     * called), so we show the launch screen programmatically until the first
+     * time events are pumped. */
+    UIViewController *vc = nil;
+    NSString *screenname = nil;
+
+    // tvOS only uses a plain launch image.
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+    screenname = [bundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
+
+    if (screenname) {
+        @try {
+            /* The launch storyboard is actually a nib in some older versions of
+             * Xcode. We'll try to load it as a storyboard first, as it's more
+             * modern. */
+            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:screenname bundle:bundle];
+            __auto_type storyboardVc = [storyboard instantiateInitialViewController];
+            vc = [[SDLLaunchStoryboardViewController alloc] initWithStoryboardViewController:storyboardVc];
+        }
+        @catch (NSException *exception) {
+            // Do nothing (there's more code to execute below).
+        }
+    }
+#endif
+
+    if (vc == nil) {
+        vc = [[SDLLaunchScreenController alloc] initWithNibName:screenname bundle:bundle];
+    }
+
+    if (vc.view) {
+#ifdef SDL_PLATFORM_VISIONOS
+        CGRect viewFrame = CGRectMake(0, 0, SDL_XR_SCREENWIDTH, SDL_XR_SCREENHEIGHT);
+#else
+        CGRect viewFrame = [UIScreen mainScreen].bounds;
+#endif
+        launchWindow = [[UIWindow alloc] initWithFrame:viewFrame];
+
+        /* We don't want the launch window immediately hidden when a real SDL
+         * window is shown - we fade it out ourselves when we're ready. */
+        launchWindow.windowLevel = UIWindowLevelNormal + 1.0;
+
+        /* Show the window but don't make it key. Events should always go to
+         * other windows when possible. */
+        launchWindow.hidden = NO;
+
+        launchWindow.rootViewController = vc;
+    }
+#endif
+
+    // Set working directory to resource path
+    [[NSFileManager defaultManager] changeCurrentDirectoryPath:[bundle resourcePath]];
+
+    SDL_SetMainReady();
+    [self performSelector:@selector(postFinishLaunch) withObject:nil afterDelay:0.0];
+
+    return YES;
+}
+
+- (UIWindow *)window
+{
+    SDL_VideoDevice *_this = SDL_GetVideoDevice();
+    if (_this) {
+        SDL_Window *window = NULL;
+        for (window = _this->windows; window != NULL; window = window->next) {
+            SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
+            if (data != nil) {
+                return data.uiwindow;
+            }
+        }
+    }
+    return nil;
+}
+
+- (void)setWindow:(UIWindow *)window
+{
+    // Do nothing.
+}
+
+- (void)sendDropFileForURL:(NSURL *)url fromSourceApplication:(NSString *)sourceApplication
+{
+    NSURL *fileURL = url.filePathURL;
+    const char *sourceApplicationCString = sourceApplication ? [sourceApplication UTF8String] : NULL;
+    if (fileURL != nil) {
+        SDL_SendDropFile(NULL, sourceApplicationCString, fileURL.path.UTF8String);
+    } else {
+        SDL_SendDropFile(NULL, sourceApplicationCString, url.absoluteString.UTF8String);
+    }
+    SDL_SendDropComplete(NULL);
+}
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    // TODO: Handle options
+    [self sendDropFileForURL:url fromSourceApplication:NULL];
+    return YES;
+}
+
+@end // SDLUIKitDelegate
+
+#endif // SDL_VIDEO_DRIVER_UIKIT

--- a/platforms/ios-arm64/external.sh
+++ b/platforms/ios-arm64/external.sh
@@ -41,6 +41,7 @@ if [ "${SDL3_EXPECTED_SHA}" != "${SDL3_FOUND_SHA}" ]; then
    tar xzf SDL-${SDL_SHA}.tar.gz
    mv SDL-${SDL_SHA} SDL
    cd SDL
+   cp ../../../../../platforms/ios-arm64/SDL/SDL_uikitappdelegate.m src/video/uikit/SDL_uikitappdelegate.m
    cmake \
       -DSDL_SHARED=OFF \
       -DSDL_STATIC=ON \

--- a/platforms/ios-simulator-arm64/SDL/SDL_uikitappdelegate.m
+++ b/platforms/ios-simulator-arm64/SDL/SDL_uikitappdelegate.m
@@ -1,0 +1,687 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2026 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+#ifdef SDL_VIDEO_DRIVER_UIKIT
+
+#include "../SDL_sysvideo.h"
+
+#import "SDL_uikitappdelegate.h"
+#import "SDL_uikitmodes.h"
+#import "SDL_uikitwindow.h"
+
+#include "../../events/SDL_events_c.h"
+#include "../../main/SDL_main_callbacks.h"
+
+#ifdef main
+#undef main
+#endif
+
+static SDL_main_func forward_main;
+static int forward_argc;
+static char **forward_argv;
+static int exit_status;
+
+int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserved)
+{
+    // store arguments
+    forward_main = mainFunction;
+    forward_argc = argc;
+    forward_argv = argv;
+
+    // Give over control to run loop, SDLUIKitDelegate will handle most things from here
+    @autoreleasepool {
+        NSString *name = nil;
+
+        if (@available(iOS 13.0, tvOS 13.0, *)) {
+            name = [SDLUIKitSceneDelegate getSceneDelegateClassName];
+        }
+        if (!name) {
+            name = [SDLUIKitDelegate getAppDelegateClassName];
+        }
+        UIApplicationMain(argc, argv, nil, name);
+    }
+
+    return exit_status;
+}
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+// Load a launch image using the old UILaunchImageFile-era naming rules.
+static UIImage *SDL_LoadLaunchImageNamed(NSString *name, int screenh)
+{
+    UIInterfaceOrientation curorient = [UIApplication sharedApplication].statusBarOrientation;
+    UIUserInterfaceIdiom idiom = [UIDevice currentDevice].userInterfaceIdiom;
+    UIImage *image = nil;
+
+    if (idiom == UIUserInterfaceIdiomPhone && screenh == 568) {
+        // The image name for the iPhone 5 uses its height as a suffix.
+        image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-568h", name]];
+    } else if (idiom == UIUserInterfaceIdiomPad) {
+        // iPad apps can launch in any orientation.
+        if (UIInterfaceOrientationIsLandscape(curorient)) {
+            if (curorient == UIInterfaceOrientationLandscapeLeft) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-LandscapeLeft", name]];
+            } else {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-LandscapeRight", name]];
+            }
+            if (!image) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-Landscape", name]];
+            }
+        } else {
+            if (curorient == UIInterfaceOrientationPortraitUpsideDown) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-PortraitUpsideDown", name]];
+            }
+            if (!image) {
+                image = [UIImage imageNamed:[NSString stringWithFormat:@"%@-Portrait", name]];
+            }
+        }
+    }
+
+    if (!image) {
+        image = [UIImage imageNamed:name];
+    }
+
+    return image;
+}
+
+@interface SDLLaunchStoryboardViewController : UIViewController
+@property(nonatomic, strong) UIViewController *storyboardViewController;
+- (instancetype)initWithStoryboardViewController:(UIViewController *)storyboardViewController;
+@end
+
+@implementation SDLLaunchStoryboardViewController
+
+- (instancetype)initWithStoryboardViewController:(UIViewController *)storyboardViewController
+{
+    self = [super init];
+    self.storyboardViewController = storyboardViewController;
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    [self addChildViewController:self.storyboardViewController];
+    [self.view addSubview:self.storyboardViewController.view];
+    self.storyboardViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.storyboardViewController.view.frame = self.view.bounds;
+    [self.storyboardViewController didMoveToParentViewController:self];
+
+#ifndef SDL_PLATFORM_VISIONOS
+    UIApplication.sharedApplication.statusBarHidden = self.prefersStatusBarHidden;
+    UIApplication.sharedApplication.statusBarStyle = self.preferredStatusBarStyle;
+#endif
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+    return [[NSBundle.mainBundle objectForInfoDictionaryKey:@"UIStatusBarHidden"] boolValue];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    NSString *statusBarStyle = [NSBundle.mainBundle objectForInfoDictionaryKey:@"UIStatusBarStyle"];
+    if ([statusBarStyle isEqualToString:@"UIStatusBarStyleLightContent"]) {
+        return UIStatusBarStyleLightContent;
+    }
+    if (@available(iOS 13.0, *)) {
+        if ([statusBarStyle isEqualToString:@"UIStatusBarStyleDarkContent"]) {
+            return UIStatusBarStyleDarkContent;
+        }
+    }
+    return UIStatusBarStyleDefault;
+}
+
+@end
+#endif // !SDL_PLATFORM_TVOS
+
+
+@interface SDLLaunchScreenController ()
+
+#ifndef SDL_PLATFORM_TVOS
+- (NSUInteger)supportedInterfaceOrientations;
+#endif
+
+@end
+
+@implementation SDLLaunchScreenController
+
+- (instancetype)init
+{
+    return [self initWithNibName:nil bundle:[NSBundle mainBundle]];
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    if (!(self = [super initWithNibName:nil bundle:nil])) {
+        return nil;
+    }
+
+    NSString *screenname = nibNameOrNil;
+    NSBundle *bundle = nibBundleOrNil;
+
+    // A launch screen may not exist. Fall back to launch images in that case.
+    if (screenname) {
+        @try {
+            self.view = [bundle loadNibNamed:screenname owner:self options:nil][0];
+        }
+        @catch (NSException *exception) {
+            /* If a launch screen name is specified but it fails to load, iOS
+             * displays a blank screen rather than falling back to an image. */
+            return nil;
+        }
+    }
+
+    if (!self.view) {
+        NSArray *launchimages = [bundle objectForInfoDictionaryKey:@"UILaunchImages"];
+        NSString *imagename = nil;
+        UIImage *image = nil;
+
+#ifdef SDL_PLATFORM_VISIONOS
+        int screenw = SDL_XR_SCREENWIDTH;
+        int screenh = SDL_XR_SCREENHEIGHT;
+#else
+        int screenw = (int)([UIScreen mainScreen].bounds.size.width + 0.5);
+        int screenh = (int)([UIScreen mainScreen].bounds.size.height + 0.5);
+#endif
+
+
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+        UIInterfaceOrientation curorient = [UIApplication sharedApplication].statusBarOrientation;
+
+        // We always want portrait-oriented size, to match UILaunchImageSize.
+        if (screenw > screenh) {
+            int width = screenw;
+            screenw = screenh;
+            screenh = width;
+        }
+#endif
+
+        // Xcode 5 introduced a dictionary of launch images in Info.plist.
+        if (launchimages) {
+            for (NSDictionary *dict in launchimages) {
+                NSString *minversion = dict[@"UILaunchImageMinimumOSVersion"];
+                NSString *sizestring = dict[@"UILaunchImageSize"];
+
+                // Ignore this image if the current version is too low.
+                if (minversion && !UIKit_IsSystemVersionAtLeast(minversion.doubleValue)) {
+                    continue;
+                }
+
+                // Ignore this image if the size doesn't match.
+                if (sizestring) {
+                    CGSize size = CGSizeFromString(sizestring);
+                    if ((int)(size.width + 0.5) != screenw || (int)(size.height + 0.5) != screenh) {
+                        continue;
+                    }
+                }
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+                UIInterfaceOrientationMask orientmask = UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+                NSString *orientstring = dict[@"UILaunchImageOrientation"];
+
+                if (orientstring) {
+                    if ([orientstring isEqualToString:@"PortraitUpsideDown"]) {
+                        orientmask = UIInterfaceOrientationMaskPortraitUpsideDown;
+                    } else if ([orientstring isEqualToString:@"Landscape"]) {
+                        orientmask = UIInterfaceOrientationMaskLandscape;
+                    } else if ([orientstring isEqualToString:@"LandscapeLeft"]) {
+                        orientmask = UIInterfaceOrientationMaskLandscapeLeft;
+                    } else if ([orientstring isEqualToString:@"LandscapeRight"]) {
+                        orientmask = UIInterfaceOrientationMaskLandscapeRight;
+                    }
+                }
+
+                // Ignore this image if the orientation doesn't match.
+                if ((orientmask & (1 << curorient)) == 0) {
+                    continue;
+                }
+#endif
+
+                imagename = dict[@"UILaunchImageName"];
+            }
+
+            if (imagename) {
+                image = [UIImage imageNamed:imagename];
+            }
+        }
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+        else {
+            imagename = [bundle objectForInfoDictionaryKey:@"UILaunchImageFile"];
+
+            if (imagename) {
+                image = SDL_LoadLaunchImageNamed(imagename, screenh);
+            }
+
+            if (!image) {
+                image = SDL_LoadLaunchImageNamed(@"Default", screenh);
+            }
+        }
+#endif
+
+        if (image) {
+#ifdef SDL_PLATFORM_VISIONOS
+            CGRect viewFrame = CGRectMake(0, 0, screenw, screenh);
+#else
+            CGRect viewFrame = [UIScreen mainScreen].bounds;
+#endif
+            UIImageView *view = [[UIImageView alloc] initWithFrame:viewFrame];
+            UIImageOrientation imageorient = UIImageOrientationUp;
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+            // Bugs observed / workaround tested in iOS 8.3.
+            if (UIInterfaceOrientationIsLandscape(curorient)) {
+                if (image.size.width < image.size.height) {
+                    /* On iOS 8, portrait launch images displayed in forced-
+                     * landscape mode (e.g. a standard Default.png on an iPhone
+                     * when Info.plist only supports landscape orientations) need
+                     * to be rotated to display in the expected orientation. */
+                    if (curorient == UIInterfaceOrientationLandscapeLeft) {
+                        imageorient = UIImageOrientationRight;
+                    } else if (curorient == UIInterfaceOrientationLandscapeRight) {
+                        imageorient = UIImageOrientationLeft;
+                    }
+                }
+            }
+#endif
+
+            // Create the properly oriented image.
+            view.image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:imageorient];
+
+            self.view = view;
+        }
+    }
+
+    return self;
+}
+
+- (void)loadView
+{
+    // Do nothing.
+}
+
+#ifndef SDL_PLATFORM_TVOS
+- (BOOL)shouldAutorotate
+{
+    // If YES, the launch image will be incorrectly rotated in some cases.
+    return NO;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    /* We keep the supported orientations unrestricted to avoid the case where
+     * there are no common orientations between the ones set in Info.plist and
+     * the ones set here (it will cause an exception in that case.) */
+    return UIInterfaceOrientationMaskAll;
+}
+#endif // !SDL_PLATFORM_TVOS
+
+@end // SDLLaunchScreenController
+
+
+API_AVAILABLE(ios(13.0))
+@implementation SDLUIKitSceneDelegate
+{
+    UIWindow *launchWindow;
+    NSMutableArray<NSURL *> *launchURLs;
+}
+
++ (NSString *)getSceneDelegateClassName
+{
+    return @"SDLUIKitSceneDelegate";
+}
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+        return;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    windowScene.delegate = self;
+
+    NSBundle *bundle = [NSBundle mainBundle];
+
+#ifdef SDL_IPHONE_LAUNCHSCREEN
+    UIViewController *vc = nil;
+    NSString *screenname = nil;
+
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+    screenname = [bundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
+
+    if (screenname) {
+        @try {
+            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:screenname bundle:bundle];
+            __auto_type storyboardVc = [storyboard instantiateInitialViewController];
+            vc = [[SDLLaunchStoryboardViewController alloc] initWithStoryboardViewController:storyboardVc];
+        }
+        @catch (NSException *exception) {
+            // Do nothing (there's more code to execute below).
+        }
+    }
+#endif
+
+    if (vc == nil) {
+        vc = [[SDLLaunchScreenController alloc] initWithNibName:screenname bundle:bundle];
+    }
+
+    if (vc.view) {
+#ifdef SDL_PLATFORM_VISIONOS
+        CGRect viewFrame = CGRectMake(0, 0, SDL_XR_SCREENWIDTH, SDL_XR_SCREENHEIGHT);
+#else
+        CGRect viewFrame = windowScene.coordinateSpace.bounds;
+#endif
+        launchWindow = [[UIWindow alloc] initWithWindowScene:windowScene];
+        launchWindow.frame = viewFrame;
+
+        launchWindow.windowLevel = UIWindowLevelNormal + 1.0;
+        launchWindow.hidden = NO;
+        launchWindow.rootViewController = vc;
+    }
+#endif
+
+    // Set working directory to resource path
+    [[NSFileManager defaultManager] changeCurrentDirectoryPath:[bundle resourcePath]];
+
+    // Handle any connection options (like opening URLs)
+    launchURLs = [[NSMutableArray alloc] init];
+
+    for (NSUserActivity *activity in connectionOptions.userActivities) {
+        if (activity.webpageURL) {
+            [launchURLs addObject:activity.webpageURL];
+        }
+    }
+
+    for (UIOpenURLContext *urlContext in connectionOptions.URLContexts) {
+        [launchURLs addObject:urlContext.URL];
+    }
+
+    SDL_SetMainReady();
+    [self performSelector:@selector(postFinishLaunch) withObject:nil afterDelay:0.0];
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+    for (UIOpenURLContext *context in URLContexts) {
+        [self handleURL:context.URL];
+    }
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene
+{
+    SDL_OnApplicationDidEnterForeground();
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene
+{
+    SDL_OnApplicationWillEnterBackground();
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene
+{
+    SDL_OnApplicationWillEnterForeground();
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+    SDL_OnApplicationDidEnterBackground();
+}
+
+- (void)handleURL:(NSURL *)url
+{
+    const char *sourceApplicationCString = NULL;
+    NSURL *fileURL = url.filePathURL;
+    if (fileURL != nil) {
+        SDL_SendDropFile(NULL, sourceApplicationCString, fileURL.path.UTF8String);
+    } else {
+        SDL_SendDropFile(NULL, sourceApplicationCString, url.absoluteString.UTF8String);
+    }
+    SDL_SendDropComplete(NULL);
+}
+
+- (void)hideLaunchScreen
+{
+    UIWindow *window = launchWindow;
+
+    if (!window || window.hidden) {
+        return;
+    }
+
+    launchWindow = nil;
+
+    [UIView animateWithDuration:0.2
+        animations:^{
+          window.alpha = 0.0;
+        }
+        completion:^(BOOL finished) {
+          window.hidden = YES;
+          UIKit_ForceUpdateHomeIndicator();
+        }];
+}
+
+- (void)postFinishLaunch
+{
+    [self performSelector:@selector(hideLaunchScreen) withObject:nil afterDelay:0.0];
+    [self performSelector:@selector(processLaunchURLs) withObject:nil afterDelay:0.0];
+
+    SDL_SetiOSEventPump(true);
+    exit_status = SDL_CallMainFunction(forward_argc, forward_argv, forward_main);
+    SDL_SetiOSEventPump(false);
+
+    if (launchWindow) {
+        launchWindow.hidden = YES;
+        launchWindow = nil;
+    }
+}
+
+- (void)processLaunchURLs
+{
+    for (NSURL *url in launchURLs) {
+        [self handleURL:url];
+    }
+    launchURLs = nil;
+}
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options API_AVAILABLE(ios(13.0))
+{
+    // This doesn't appear to be called, but it needs to be implemented to signal that we support the UIScene life cycle
+    UISceneConfiguration *config = [[UISceneConfiguration alloc] initWithName:@"SDLSceneConfiguration" sessionRole:connectingSceneSession.role];
+    config.delegateClass = [SDLUIKitSceneDelegate class];
+    return config;
+}
+
+@end // SDLUIKitSceneDelegate
+
+
+@implementation SDLUIKitDelegate
+{
+    UIWindow *launchWindow;
+}
+
+// convenience method
++ (id)sharedAppDelegate
+{
+    /* the delegate is set in UIApplicationMain(), which is guaranteed to be
+     * called before this method */
+    return [UIApplication sharedApplication].delegate;
+}
+
++ (NSString *)getAppDelegateClassName
+{
+    /* subclassing notice: when you subclass this appdelegate, make sure to add
+     * a category to override this method and return the actual name of the
+     * delegate */
+    return @"SDLUIKitDelegate";
+}
+
+- (void)hideLaunchScreen
+{
+    UIWindow *window = launchWindow;
+
+    if (!window || window.hidden) {
+        return;
+    }
+
+    launchWindow = nil;
+
+    // Do a nice animated fade-out (roughly matches the real launch behavior.)
+    [UIView animateWithDuration:0.2
+        animations:^{
+          window.alpha = 0.0;
+        }
+        completion:^(BOOL finished) {
+          window.hidden = YES;
+          UIKit_ForceUpdateHomeIndicator(); // Wait for launch screen to hide so settings are applied to the actual view controller.
+        }];
+}
+
+- (void)postFinishLaunch
+{
+    /* Hide the launch screen the next time the run loop is run. SDL apps will
+     * have a chance to load resources while the launch screen is still up. */
+    [self performSelector:@selector(hideLaunchScreen) withObject:nil afterDelay:0.0];
+
+    // run the user's application, passing argc and argv
+    SDL_SetiOSEventPump(true);
+    exit_status = SDL_CallMainFunction(forward_argc, forward_argv, forward_main);
+    SDL_SetiOSEventPump(false);
+
+    if (launchWindow) {
+        launchWindow.hidden = YES;
+        launchWindow = nil;
+    }
+
+    // exit, passing the return status from the user's application
+    /* We don't actually exit to support applications that do setup in their
+     * main function and then allow the Cocoa event loop to run. */
+    // exit(exit_status);
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    NSBundle *bundle = [NSBundle mainBundle];
+
+#ifdef SDL_IPHONE_LAUNCHSCREEN
+    /* The normal launch screen is displayed until didFinishLaunching returns,
+     * but SDL_main is called after that happens and there may be a noticeable
+     * delay between the start of SDL_main and when the first real frame is
+     * displayed (e.g. if resources are loaded before SDL_GL_SwapWindow is
+     * called), so we show the launch screen programmatically until the first
+     * time events are pumped. */
+    UIViewController *vc = nil;
+    NSString *screenname = nil;
+
+    // tvOS only uses a plain launch image.
+#if !defined(SDL_PLATFORM_TVOS) && !defined(SDL_PLATFORM_VISIONOS)
+    screenname = [bundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
+
+    if (screenname) {
+        @try {
+            /* The launch storyboard is actually a nib in some older versions of
+             * Xcode. We'll try to load it as a storyboard first, as it's more
+             * modern. */
+            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:screenname bundle:bundle];
+            __auto_type storyboardVc = [storyboard instantiateInitialViewController];
+            vc = [[SDLLaunchStoryboardViewController alloc] initWithStoryboardViewController:storyboardVc];
+        }
+        @catch (NSException *exception) {
+            // Do nothing (there's more code to execute below).
+        }
+    }
+#endif
+
+    if (vc == nil) {
+        vc = [[SDLLaunchScreenController alloc] initWithNibName:screenname bundle:bundle];
+    }
+
+    if (vc.view) {
+#ifdef SDL_PLATFORM_VISIONOS
+        CGRect viewFrame = CGRectMake(0, 0, SDL_XR_SCREENWIDTH, SDL_XR_SCREENHEIGHT);
+#else
+        CGRect viewFrame = [UIScreen mainScreen].bounds;
+#endif
+        launchWindow = [[UIWindow alloc] initWithFrame:viewFrame];
+
+        /* We don't want the launch window immediately hidden when a real SDL
+         * window is shown - we fade it out ourselves when we're ready. */
+        launchWindow.windowLevel = UIWindowLevelNormal + 1.0;
+
+        /* Show the window but don't make it key. Events should always go to
+         * other windows when possible. */
+        launchWindow.hidden = NO;
+
+        launchWindow.rootViewController = vc;
+    }
+#endif
+
+    // Set working directory to resource path
+    [[NSFileManager defaultManager] changeCurrentDirectoryPath:[bundle resourcePath]];
+
+    SDL_SetMainReady();
+    [self performSelector:@selector(postFinishLaunch) withObject:nil afterDelay:0.0];
+
+    return YES;
+}
+
+- (UIWindow *)window
+{
+    SDL_VideoDevice *_this = SDL_GetVideoDevice();
+    if (_this) {
+        SDL_Window *window = NULL;
+        for (window = _this->windows; window != NULL; window = window->next) {
+            SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
+            if (data != nil) {
+                return data.uiwindow;
+            }
+        }
+    }
+    return nil;
+}
+
+- (void)setWindow:(UIWindow *)window
+{
+    // Do nothing.
+}
+
+- (void)sendDropFileForURL:(NSURL *)url fromSourceApplication:(NSString *)sourceApplication
+{
+    NSURL *fileURL = url.filePathURL;
+    const char *sourceApplicationCString = sourceApplication ? [sourceApplication UTF8String] : NULL;
+    if (fileURL != nil) {
+        SDL_SendDropFile(NULL, sourceApplicationCString, fileURL.path.UTF8String);
+    } else {
+        SDL_SendDropFile(NULL, sourceApplicationCString, url.absoluteString.UTF8String);
+    }
+    SDL_SendDropComplete(NULL);
+}
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    // TODO: Handle options
+    [self sendDropFileForURL:url fromSourceApplication:NULL];
+    return YES;
+}
+
+@end // SDLUIKitDelegate
+
+#endif // SDL_VIDEO_DRIVER_UIKIT

--- a/platforms/ios-simulator-arm64/external.sh
+++ b/platforms/ios-simulator-arm64/external.sh
@@ -27,7 +27,7 @@ cd "external/ios-simulator-arm64/${BUILD_TYPE}"
 #
 # build SDL3, SDL3_image, SDL3_ttf#
 
-SDL3_EXPECTED_SHA="${SDL_SHA}-${SDL_IMAGE_SHA}-${SDL_TTF_SHA}"
+SDL3_EXPECTED_SHA="${SDL_SHA}-${SDL_IMAGE_SHA}-${SDL_TTF_SHA}_001"
 SDL3_FOUND_SHA="$([ -f SDL3/cache.txt ] && cat SDL3/cache.txt || echo "")"
 
 if [ "${SDL3_EXPECTED_SHA}" != "${SDL3_FOUND_SHA}" ]; then
@@ -41,6 +41,7 @@ if [ "${SDL3_EXPECTED_SHA}" != "${SDL3_FOUND_SHA}" ]; then
    tar xzf SDL-${SDL_SHA}.tar.gz
    mv SDL-${SDL_SHA} SDL
    cd SDL
+   cp ../../../../../platforms/ios-simulator-arm64/SDL/SDL_uikitappdelegate.m src/video/uikit/SDL_uikitappdelegate.m
    cmake \
       -DSDL_SHARED=OFF \
       -DSDL_STATIC=ON \

--- a/src/core/Settings_properties.inl
+++ b/src/core/Settings_properties.inl
@@ -1355,7 +1355,7 @@ PropBoolDyn(PluginWMP, Enable, "Enable"s, "Enable WMP plugin"s, g_isStandalone);
 PropBoolDyn(PluginVNI, Enable, "Enable"s, "Enable VNI plugin"s, g_isStandalone);
 
 // Standalone
-PropEnumWithMin(Standalone, RenderingModeOverride, "Override rendering mode"s, ""s, int, -1, g_isMobile ? 2 : -1, "Default"s, "2D"s, "Stereo 3D"s, "VR"s);
+PropEnumWithMin(Standalone, RenderingModeOverride, "Override rendering mode"s, ""s, int, -1, -1, "Default"s, "2D"s, "Stereo 3D"s, "VR"s);
 PropBool(Standalone, Haptics, "Haptics"s, ""s, g_isMobile);
 PropBool(Standalone, ResetLogOnPlay, "Reset Log on Play"s, ""s, g_isMobile);
 

--- a/standalone/android/app/build.gradle.kts
+++ b/standalone/android/app/build.gradle.kts
@@ -129,7 +129,7 @@ android {
 }
 
 base {
-    archivesName.set("VPinball_BGFX-$versionFilename")
+    archivesName.set("VPinballX_BGFX-$versionFilename")
 }
 
 kotlin {

--- a/standalone/android/app/src/main/java/org/vpinball/app/Enums.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/Enums.kt
@@ -30,7 +30,7 @@ enum class Link(val url: String) {
 enum class Credit(val displayName: String, val authors: String? = null, val link: Link? = null) {
     VPINBALL(
         "Visual Pinball",
-        "toxieainc, vbousquet, fuzzelhjb, jsm174, c-f-h, francisdb, bcd, cupidsf, djrobx, brandrew2, mjrgh, koadic76, shagendo, Nicals, horseyhorsey, CraftedCart, superhac, snail_gary, Matthias Buecher, Le-Syl21, baxelrod-bdai, YellowLabrador, claytgreene, markmon, JockeJarre, WildCoder, ScaryG, nkissebe, mkalkbrenner, freezy, Wylted1, WizardsHat, RandyDavis2000, ntleverenz, latsao, Chickenzilla, Yuki, teamsuperpanda, surtarso, RockfordRoe, ravarcade, poiuyterry, omigeot, manofwar32, LeHaine, KutsuyaYuki, kaicherry, joni999, jmarzka, droscoe, cschmidtpxc, CapitaineSheridan, Billiam, andremichi",
+        "toxieainc, vbousquet, fuzzelhjb, jsm174, c-f-h, francisdb, bcd, cupidsf, djrobx, brandrew2, mjrgh, koadic76, shagendo, Nicals, horseyhorsey, CraftedCart, superhac, snail_gary, Matthias Buecher, Le-Syl21, baxelrod-bdai, YellowLabrador, claytgreene, markmon, JockeJarre, WildCoder, ScaryG, nkissebe, mkalkbrenner, freezy, Wylted1, WizardsHat, RandyDavis2000, ntleverenz, latsao, Chickenzilla, Yuki, teamsuperpanda, surtarso, RockfordRoe, ravarcade, poiuyterry, omigeot, manofwar32, LeHaine, KutsuyaYuki, kaicherry, joni999, jmarzka, droscoe, cschmidtpxc, CapitaineSheridan, Billiam, andremichi, evilwraith",
         Link.VPINBALL,
     ),
     PINMAME(
@@ -43,7 +43,7 @@ enum class Credit(val displayName: String, val authors: String? = null, val link
     LIBZEDMD("libzedmd", "mkalkbrenner, jsm174, zesinger, Cpasjuste, bartdesign", Link.LIBZEDMD),
     LIBSERUM("libserum", "zesinger, mkalkbrenner, pinballpower, jsm174, vbousquet, toxieainc", Link.LIBSERUM),
     LIBDOF("libdof", "jsm174, dekay", Link.LIBDOF),
-    LIBVNI("libvni", "mkalkbrenner, freezy", Link.LIBVNI),
+    LIBVNI("libvni", "mkalkbrenner, freezy, jsm174", Link.LIBVNI),
     ARTWORK("Artwork", "smillard316 (Table placeholder), adam.co (App icon enhancements)"),
     OTHER("Other third party libraries", link = Link.THIRDPARTY),
 }

--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballActivity.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballActivity.kt
@@ -6,15 +6,14 @@ import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.vpinball.app.ui.VPinballContent
+import org.vpinball.app.ui.screens.landing.LandingScreenViewModel
 
 class VPinballActivity : ComponentActivity() {
-    val viewModel: VPinballViewModel by viewModel()
+    val viewModel: VPinballModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,21 +27,13 @@ class VPinballActivity : ComponentActivity() {
         handleIntent(intent)
 
         setContent {
-            val state by viewModel.state.collectAsStateWithLifecycle()
-
             LaunchedEffect(Unit) { viewModel.startSplashTimer() }
 
-            LaunchedEffect(state.loading, state.table) {
-                if (state.loading && state.table != null) {
-                    val table = state.table!!
+            LaunchedEffect(viewModel.showHUD, viewModel.activeTable) {
+                if (viewModel.showHUD && viewModel.activeTable != null) {
+                    val table = viewModel.activeTable!!
 
-                    val success =
-                        VPinballManager.load(table) { progress, status ->
-                            lifecycleScope.launch {
-                                viewModel.progress(progress)
-                                viewModel.status(status)
-                            }
-                        }
+                    val success = VPinballManager.load(table) { progress, status -> lifecycleScope.launch { viewModel.updateHUD(progress, status) } }
 
                     if (success) {
                         val intent = Intent(this@VPinballActivity, VPinballPlayerActivity::class.java)
@@ -68,6 +59,6 @@ class VPinballActivity : ComponentActivity() {
 
     private fun handleIntent(intent: Intent?) {
         val uri = intent?.data ?: return
-        viewModel.openUri(uri)
+        LandingScreenViewModel.triggerOpenUri(uri)
     }
 }

--- a/standalone/android/app/src/main/java/org/vpinball/app/VPinballModel.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/VPinballModel.kt
@@ -1,0 +1,63 @@
+package org.vpinball.app
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class VPinballModel : ViewModel() {
+    var tables by mutableStateOf(emptyList<Table>())
+    var activeTable: Table? = null
+    var isPlaying by mutableStateOf(false)
+    var webServerURL by mutableStateOf<String?>(null)
+    var hudTitle by mutableStateOf<String?>(null)
+    var hudProgress by mutableIntStateOf(0)
+    var hudStatus by mutableStateOf<String?>(null)
+    var showSplash by mutableStateOf(true)
+    var showHUD by mutableStateOf(false)
+
+    private var splashTimerStarted = false
+
+    fun startSplashTimer() {
+        if (!splashTimerStarted) {
+            splashTimerStarted = true
+            viewModelScope.launch {
+                delay(SPLASH_DELAY_DURATION)
+                showSplash = false
+            }
+        }
+    }
+
+    fun showHUD(title: String, status: String) {
+        hudTitle = title
+        hudProgress = 0
+        hudStatus = status
+        showHUD = true
+    }
+
+    fun updateHUD(progress: Int, status: String) {
+        hudProgress = progress
+        hudStatus = status
+    }
+
+    fun updateHUD(progress: Int) {
+        hudProgress = progress
+    }
+
+    fun hideHUD() {
+        showHUD = false
+    }
+
+    fun launchInViewModelScope(block: suspend () -> Unit) {
+        viewModelScope.launch { block() }
+    }
+
+    companion object {
+        private val SPLASH_DELAY_DURATION = 2000.milliseconds
+    }
+}

--- a/standalone/android/app/src/main/java/org/vpinball/app/di/Modules.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/di/Modules.kt
@@ -2,12 +2,12 @@ package org.vpinball.app.di
 
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
-import org.vpinball.app.VPinballViewModel
+import org.vpinball.app.VPinballModel
 import org.vpinball.app.ui.screens.landing.LandingScreenViewModel
 import org.vpinball.app.ui.screens.settings.SettingsViewModel
 
 val appModule = module {
-    viewModelOf(::VPinballViewModel)
+    viewModelOf(::VPinballModel)
     viewModelOf(::SettingsViewModel)
     viewModelOf(::LandingScreenViewModel)
 }

--- a/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballInterop.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/jni/VPinballInterop.kt
@@ -39,16 +39,6 @@ enum class VPinballSettingsSection(val value: String) {
     }
 }
 
-enum class VPinballViewMode(val value: Int, override val text: String) : VPinballDisplayText {
-    DESKTOP_FSS(0, "Desktop & FSS"),
-    CABINET(1, "Cabinet"),
-    DESKTOP_NO_FSS(2, "Desktop (no FSS)");
-
-    companion object {
-        @JvmStatic fun fromInt(value: Int): VPinballViewMode = entries.firstOrNull { it.value == value } ?: DESKTOP_FSS
-    }
-}
-
 enum class VPinballMaxTexDimension(val value: Int, override val text: String) : VPinballDisplayText {
     MAX_256(256, "256"),
     MAX_384(384, "384"),

--- a/standalone/android/app/src/main/java/org/vpinball/app/ui/VPinballContent.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/ui/VPinballContent.kt
@@ -3,82 +3,39 @@ package org.vpinball.app.ui
 import android.content.Intent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.core.content.FileProvider
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.io.File
 import org.vpinball.app.CodeLanguage
-import org.vpinball.app.Link
-import org.vpinball.app.VPinballViewModel
+import org.vpinball.app.VPinballModel
 import org.vpinball.app.ui.screens.common.CodeWebViewDialog
 import org.vpinball.app.ui.screens.landing.LandingScreen
 import org.vpinball.app.ui.screens.loading.LoadingScreen
 import org.vpinball.app.ui.screens.splash.SplashScreen
 import org.vpinball.app.ui.theme.VPinballTheme
-import org.vpinball.app.ui.theme.VpxRed
 import org.vpinball.app.ui.util.koinActivityViewModel
 
 @Composable
-fun VPinballContent(viewModel: VPinballViewModel = koinActivityViewModel()) {
+fun VPinballContent(viewModel: VPinballModel = koinActivityViewModel()) {
     val context = LocalContext.current
-    val state by viewModel.state.collectAsStateWithLifecycle()
     var codeFile by remember { mutableStateOf<File?>(null) }
 
     VPinballTheme {
-        if (state.splash) {
+        if (viewModel.showSplash) {
             SplashScreen()
         } else {
             Box(modifier = Modifier.fillMaxSize()) {
                 LandingScreen(onViewFile = { file -> codeFile = file })
 
-                if (state.loading) {
-                    state.table?.let { table -> LoadingScreen(table, state.progress, state.status) }
+                if (viewModel.showHUD) {
+                    viewModel.activeTable?.let { table -> LoadingScreen(table, viewModel.hudProgress, viewModel.hudStatus) }
                 }
-            }
-
-            if (state.error != null) {
-                AlertDialog(
-                    title = { Text(text = "TILT!", style = MaterialTheme.typography.titleMedium) },
-                    text = { Text(state.error!!) },
-                    onDismissRequest = {},
-                    confirmButton = {
-                        TextButton(onClick = { viewModel.clearError() }) {
-                            Text(
-                                text = "OK",
-                                color = Color.VpxRed,
-                                fontSize = MaterialTheme.typography.titleMedium.fontSize,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                        }
-                    },
-                    dismissButton = {
-                        TextButton(
-                            onClick = {
-                                viewModel.clearError()
-                                Link.TROUBLESHOOTING.open(context = context)
-                            }
-                        ) {
-                            Text(
-                                text = "Learn More",
-                                color = Color.VpxRed,
-                                fontSize = MaterialTheme.typography.titleMedium.fontSize,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                        }
-                    },
-                )
             }
 
             codeFile?.let {

--- a/standalone/android/app/src/main/java/org/vpinball/app/ui/screens/settings/SettingsScreen.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/ui/screens/settings/SettingsScreen.kt
@@ -83,7 +83,6 @@ import org.vpinball.app.jni.VPinballGfxBackend
 import org.vpinball.app.jni.VPinballMaxTexDimension
 import org.vpinball.app.jni.VPinballPath
 import org.vpinball.app.jni.VPinballStorageMode
-import org.vpinball.app.jni.VPinballViewMode
 import org.vpinball.app.ui.screens.common.RoundedCard
 import org.vpinball.app.ui.theme.VPinballTheme
 import org.vpinball.app.ui.theme.VpxRed
@@ -126,34 +125,23 @@ fun SettingsScreen(
                     SectionHeader(title = "General")
 
                     RoundedCard {
-                        SwitchRow(
-                            label = "Haptics",
-                            isChecked = viewModel.haptics,
-                            onCheckedChange = { viewModel.handleHaptics(value = it) },
-                            description = "Provide haptic feedback when balls collide with flippers, bumpers, and slingshots.",
-                        )
-
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
-                        SwitchRow(
-                            label = "Force VR Rendering Mode",
-                            isChecked = viewModel.renderingModeOverride,
-                            onCheckedChange = { viewModel.handleRenderingModeOverride(value = it) },
-                            description =
-                                "Provide table scripts with `RenderingMode=2` " +
-                                    "so backbox and cabinet are rendered. Useful for tables that do not provide FSS support.",
-                        )
-
                         if (!BuildConfig.IS_QUEST) {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
                             EnumMenuRow(
                                 label = "Graphics Backend",
                                 options = VPinballGfxBackend.entries.toList(),
                                 option = viewModel.gfxBackend,
                                 onOptionChanged = { viewModel.handleGfxBackend(value = it) },
                             )
+
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                         }
+
+                        SwitchRow(
+                            label = "Haptics",
+                            isChecked = viewModel.haptics,
+                            onCheckedChange = { viewModel.handleHaptics(value = it) },
+                            description = "Provide haptic feedback when balls collide with flippers, bumpers, and slingshots.",
+                        )
                     }
                 }
 
@@ -189,17 +177,6 @@ fun SettingsScreen(
                                 )
                             }
                         }
-                    }
-                }
-
-                item {
-                    RoundedCard {
-                        EnumMenuRow(
-                            label = "Display",
-                            options = VPinballViewMode.entries.toList(),
-                            option = viewModel.bgSet,
-                            onOptionChanged = { viewModel.handleBGSet(value = it) },
-                        )
                     }
                 }
 
@@ -311,6 +288,21 @@ fun SettingsScreen(
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp),
+                        )
+                    }
+                }
+
+                item {
+                    SectionHeader(title = "Miscellaneous")
+
+                    RoundedCard {
+                        SwitchRow(
+                            label = "Force VR Rendering Mode",
+                            isChecked = viewModel.renderingModeOverride,
+                            onCheckedChange = { viewModel.handleRenderingModeOverride(value = it) },
+                            description =
+                                "Provide table scripts with `RenderingMode=2` " +
+                                    "so backbox and cabinet are rendered. Useful for tables that do not provide FSS support.",
                         )
                     }
                 }

--- a/standalone/android/app/src/main/java/org/vpinball/app/ui/screens/settings/SettingsViewModel.kt
+++ b/standalone/android/app/src/main/java/org/vpinball/app/ui/screens/settings/SettingsViewModel.kt
@@ -18,7 +18,6 @@ import org.vpinball.app.jni.VPinballSettingsSection.PLAYER
 import org.vpinball.app.jni.VPinballSettingsSection.PLUGIN_DMDUTIL
 import org.vpinball.app.jni.VPinballSettingsSection.STANDALONE
 import org.vpinball.app.jni.VPinballStorageMode
-import org.vpinball.app.jni.VPinballViewMode
 import org.vpinball.app.ui.screens.landing.LandingScreenViewModel
 
 class SettingsViewModel : ViewModel() {
@@ -40,9 +39,6 @@ class SettingsViewModel : ViewModel() {
         private set
 
     // Display
-
-    var bgSet by mutableStateOf(VPinballViewMode.DESKTOP_FSS)
-        private set
 
     // Performance
 
@@ -83,7 +79,7 @@ class SettingsViewModel : ViewModel() {
         // General
 
         haptics = VPinballManager.loadValue(STANDALONE, "Haptics", true)
-        renderingModeOverride = (VPinballManager.loadValue(STANDALONE, "RenderingModeOverride", 2) == 2)
+        renderingModeOverride = (VPinballManager.loadValue(STANDALONE, "RenderingModeOverride", -1) == 2)
         gfxBackend = VPinballGfxBackend.fromString(VPinballManager.loadValue(PLAYER, "GfxBackend", VPinballGfxBackend.OPENGLES.value))
 
         val savedSAFPath = VPinballManager.loadValue(STANDALONE, "SAFPath", "")
@@ -101,10 +97,6 @@ class SettingsViewModel : ViewModel() {
                     }
                 }
             }
-
-        // Display
-
-        bgSet = VPinballViewMode.fromInt(VPinballManager.loadValue(PLAYER, "BGSet", VPinballViewMode.DESKTOP_FSS.value))
 
         // Performance
 
@@ -185,11 +177,6 @@ class SettingsViewModel : ViewModel() {
     }
 
     // Display
-
-    fun handleBGSet(value: VPinballViewMode) {
-        bgSet = value
-        VPinballManager.saveValue(PLAYER, "BGSet", bgSet.value)
-    }
 
     // Performance
 

--- a/standalone/ios/VPinball.xcodeproj/project.pbxproj
+++ b/standalone/ios/VPinball.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		C145FE1E2C5B4ADB0049D313 /* SettingsExternalDMDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C145FE1A2C5B4ADB0049D313 /* SettingsExternalDMDView.swift */; };
 		C145FE202C5B4ADB0049D313 /* SettingsPerformanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C145FE1C2C5B4ADB0049D313 /* SettingsPerformanceView.swift */; };
 		C15528C42EA016BA005CBB91 /* TableFileOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15528C32EA016BA005CBB91 /* TableFileOperations.swift */; };
-		C15DE5762C7257F1001F1D13 /* VPinballViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15DE5752C7257F1001F1D13 /* VPinballViewModel.swift */; };
+		C15DE5762C7257F1001F1D13 /* VPinballModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15DE5752C7257F1001F1D13 /* VPinballModel.swift */; };
 		C15DE57C2C75A324001F1D13 /* CodeWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15DE57B2C75A324001F1D13 /* CodeWebView.swift */; };
 		C1610F1C2C4BE8930049ED87 /* ViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1610F1B2C4BE8930049ED87 /* ViewModifiers.swift */; };
 		C1610F202C4D31350049ED87 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1610F1F2C4D31350049ED87 /* Enums.swift */; };
@@ -40,6 +40,7 @@
 		C19E19C92F38DCB900B9030B /* TableContextPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E19C32F38DCB900B9030B /* TableContextPreview.swift */; };
 		C1A292E32C4720090056A3C0 /* MailComposeViewControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A292E22C4720090056A3C0 /* MailComposeViewControllerView.swift */; };
 		C1A292E92C4751C20056A3C0 /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A292E82C4751C20056A3C0 /* CodeView.swift */; };
+		C1AA00012F3A000000000001 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA00002F3A000000000001 /* MainViewModel.swift */; };
 		C1B20FC92DF1F0110012E33F /* SettingsWebServerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B20FC82DF1F0110012E33F /* SettingsWebServerView.swift */; };
 		C1D5C4042E9B52750059F90F /* VPinballIOSStartup.m in Sources */ = {isa = PBXBuildFile; fileRef = C1D5C4022E9B52750059F90F /* VPinballIOSStartup.m */; };
 		C1D5C4052E9B52750059F90F /* VPinballIOSStartup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D5C4032E9B52750059F90F /* VPinballIOSStartup.swift */; };
@@ -89,7 +90,7 @@
 		C145FE1A2C5B4ADB0049D313 /* SettingsExternalDMDView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsExternalDMDView.swift; sourceTree = "<group>"; };
 		C145FE1C2C5B4ADB0049D313 /* SettingsPerformanceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsPerformanceView.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		C15528C32EA016BA005CBB91 /* TableFileOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableFileOperations.swift; sourceTree = "<group>"; };
-		C15DE5752C7257F1001F1D13 /* VPinballViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VPinballViewModel.swift; sourceTree = "<group>"; };
+		C15DE5752C7257F1001F1D13 /* VPinballModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VPinballModel.swift; sourceTree = "<group>"; };
 		C15DE57B2C75A324001F1D13 /* CodeWebView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeWebView.swift; sourceTree = "<group>"; };
 		C1610F1B2C4BE8930049ED87 /* ViewModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModifiers.swift; sourceTree = "<group>"; };
 		C1610F1F2C4D31350049ED87 /* Enums.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
@@ -108,6 +109,7 @@
 		C19E19C52F38DCB900B9030B /* TableGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableGridView.swift; sourceTree = "<group>"; };
 		C1A292E22C4720090056A3C0 /* MailComposeViewControllerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailComposeViewControllerView.swift; sourceTree = "<group>"; };
 		C1A292E82C4751C20056A3C0 /* CodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
+		C1AA00002F3A000000000001 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		C1B20FC82DF1F0110012E33F /* SettingsWebServerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWebServerView.swift; sourceTree = "<group>"; };
 		C1D5C4022E9B52750059F90F /* VPinballIOSStartup.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VPinballIOSStartup.m; sourceTree = "<group>"; };
 		C1D5C4032E9B52750059F90F /* VPinballIOSStartup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPinballIOSStartup.swift; sourceTree = "<group>"; };
@@ -206,9 +208,10 @@
 		C162663F2C29955E0002FD15 /* models */ = {
 			isa = PBXGroup;
 			children = (
-				C15DE5752C7257F1001F1D13 /* VPinballViewModel.swift */,
+				C1AA00002F3A000000000001 /* MainViewModel.swift */,
 				C1D90AE42C9A6007006CB735 /* SettingsModel.swift */,
 				C104D1C92E52744800FD86CC /* Table.swift */,
+				C15DE5752C7257F1001F1D13 /* VPinballModel.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -374,7 +377,8 @@
 				C1610F1C2C4BE8930049ED87 /* ViewModifiers.swift in Sources */,
 				C1D90AE52C9A6007006CB735 /* SettingsModel.swift in Sources */,
 				C11419052C277D9800582B6F /* VPinballApp.swift in Sources */,
-				C15DE5762C7257F1001F1D13 /* VPinballViewModel.swift in Sources */,
+				C1AA00012F3A000000000001 /* MainViewModel.swift in Sources */,
+				C15DE5762C7257F1001F1D13 /* VPinballModel.swift in Sources */,
 				C145FE202C5B4ADB0049D313 /* SettingsPerformanceView.swift in Sources */,
 				C16266452C29955E0002FD15 /* SplashView.swift in Sources */,
 				C1920AFC2C6A281A00483104 /* TableImagePlaceholderView.swift in Sources */,

--- a/standalone/ios/VPinball/VPinballApp.swift
+++ b/standalone/ios/VPinball/VPinballApp.swift
@@ -2,30 +2,30 @@ import Foundation
 import SwiftUI
 
 struct VPinballAppView: View {
-    @ObservedObject var vpinballViewModel = VPinballViewModel.shared
+    @ObservedObject var vpinballModel = VPinballModel.shared
 
     var body: some View {
         ZStack {
-            if vpinballViewModel.showSplash {
+            if vpinballModel.showSplash {
                 SplashView()
                     .onAppear {
                         handleAppear()
                     }
             } else {
                 MainView()
-                    .opacity(vpinballViewModel.showMainView ? 1 : 0)
+                    .opacity(vpinballModel.showMainView ? 1 : 0)
             }
         }
-        .onChange(of: vpinballViewModel.isPlaying) {
-            vpinballViewModel.showMainView = !vpinballViewModel.isPlaying
+        .onChange(of: vpinballModel.isPlaying) {
+            vpinballModel.showMainView = !vpinballModel.isPlaying
 
-            StatusBarManager.shared.setHidden(!vpinballViewModel.showMainView,
+            StatusBarManager.shared.setHidden(!vpinballModel.showMainView,
                                               animated: false)
         }
     }
 
     func handleAppear() {
         VPinballManager.shared.startup()
-        vpinballViewModel.startSplashTimer()
+        vpinballModel.startSplashTimer()
     }
 }

--- a/standalone/ios/VPinball/VPinballIOSStartup.swift
+++ b/standalone/ios/VPinball/VPinballIOSStartup.swift
@@ -50,11 +50,19 @@ func VPinball_IOSStartup(window: UnsafeMutableRawPointer?) {
 
 @_silgen_name("VPinball_IOSOpenURL")
 func VPinball_IOSOpenURL(url: UnsafePointer<CChar>?) {
-    if let url = url {
-        let urlString = String(cString: url)
-        let path = urlString.removingPercentEncoding ?? urlString
-        DispatchQueue.main.async {
-            VPinballViewModel.shared.openURL = URL(fileURLWithPath: path)
+    if let ptr = url {
+        let raw = String(cString: ptr)
+        var fileURL: URL?
+        if let url = URL(string: raw), url.scheme == "file" {
+            fileURL = url
+        } else if raw.hasPrefix("/") {
+            let path = raw.removingPercentEncoding ?? raw
+            fileURL = URL(fileURLWithPath: path)
+        }
+        if let fileURL = fileURL {
+            DispatchQueue.main.async {
+                MainViewModel.shared.openURL = fileURL
+            }
         }
     }
 }

--- a/standalone/ios/VPinball/models/MainViewModel.swift
+++ b/standalone/ios/VPinball/models/MainViewModel.swift
@@ -1,0 +1,281 @@
+import PhotosUI
+import SwiftUI
+
+@MainActor
+class MainViewModel: ObservableObject {
+    static let shared = MainViewModel()
+
+    enum ActionType {
+        case play
+        case stopped
+        case rename
+        case tableImage
+        case viewScript
+        case share
+        case reset
+        case delete
+    }
+
+    @Published var selectedTable: Table?
+
+    @Published var showSettings = false
+
+    @Published var confirmImportTableURL: URL?
+    @Published var showConfirmImportTable = false
+
+    @Published var importTableURL: URL? {
+        didSet { handleImportTableURL() }
+    }
+
+    @Published var showImportTable = false
+
+    @Published var tableListSearchText = ""
+
+    @Published var shareItems: [Any] = []
+    @Published var showShare = false
+
+    @Published var renameTableName = ""
+    @Published var showRenameTable = false
+
+    @Published var showTableImage = false
+    @Published var tableImagePhotoItem: PhotosPickerItem?
+    @Published var showTableImagePhotoPicker = false
+
+    @Published var showScript = false
+
+    @Published var errorMessage = ""
+    @Published var showError = false
+
+    @Published var openURL: URL? {
+        didSet { handleOpenURL() }
+    }
+
+    @Published var scrollToTable: Table?
+
+    @Published var tableViewMode: TableViewMode = .grid {
+        didSet { VPinballManager.shared.saveValue(.standalone, "TableViewMode", tableViewMode.rawValue) }
+    }
+
+    @Published var tableGridSize: TableGridSize = .medium {
+        didSet { VPinballManager.shared.saveValue(.standalone, "TableGridSize", tableGridSize.rawValue) }
+    }
+
+    @Published var tableListSortOrder: SortOrder = .forward {
+        didSet { VPinballManager.shared.saveValue(.standalone, "TableListSort", tableListSortOrder == .forward ? 1 : 0) }
+    }
+
+    func loadSettings() {
+        let manager = VPinballManager.shared
+        tableViewMode = TableViewMode(rawValue: manager.loadValue(.standalone,
+                                                                  "TableViewMode",
+                                                                  TableViewMode.grid.rawValue)) ?? .grid
+        tableGridSize = TableGridSize(rawValue: manager.loadValue(.standalone,
+                                                                  "TableGridSize",
+                                                                  TableGridSize.medium.rawValue)) ?? .medium
+        tableListSortOrder = manager.loadValue(.standalone, "TableListSort", 1) == 1 ? .forward : .reverse
+    }
+
+    func setAction(_ type: ActionType, table: Table? = nil) {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                        to: nil,
+                                        from: nil,
+                                        for: nil)
+
+        selectedTable = table
+
+        switch type {
+        case .play:
+            handlePlayTable()
+        case .rename:
+            handleShowRenameTable()
+        case .tableImage:
+            handleShowTableImage()
+        case .viewScript:
+            handleViewTableScript()
+        case .share:
+            handleShareTable()
+        case .reset:
+            handleResetTable()
+        case .delete:
+            handleDeleteTable()
+        case .stopped:
+            break
+        }
+    }
+
+    func handleAppear() {
+        loadSettings()
+
+        Task {
+            await TableManager.shared.refresh()
+        }
+
+        handleOpenURL()
+    }
+
+    func handleOpenURL() {
+        if let url = openURL {
+            openURL = nil
+            handleShowConfirmImportTable(url: url)
+        }
+    }
+
+    func handleImportTableURL() {
+        handleShowConfirmImportTable(url: importTableURL)
+    }
+
+    func handleShowConfirmImportTable(url: URL?) {
+        if let url = url {
+            importTableURL = nil
+            confirmImportTableURL = url
+            showConfirmImportTable = true
+        }
+    }
+
+    func handleConfirmImportTable() {
+        if let url = confirmImportTableURL {
+            handleImportTable(url: url)
+        }
+        confirmImportTableURL = nil
+    }
+
+    func handleImportTable(url: URL?) {
+        if let url = url {
+            Task {
+                _ = await TableManager.shared.importTable(from: url)
+            }
+        }
+    }
+
+    func handleShowRenameTable() {
+        if let selectedTable = selectedTable {
+            renameTableName = selectedTable.name
+            showRenameTable = true
+            scrollToTable = nil
+        }
+    }
+
+    func handleRenameTable() {
+        if let selectedTable = selectedTable {
+            Task {
+                _ = await TableManager.shared.renameTable(table: selectedTable,
+                                                          newName: renameTableName)
+                scrollToTable = selectedTable
+            }
+        }
+    }
+
+    func handleShowTableImage() {
+        tableImagePhotoItem = nil
+        showTableImage = true
+    }
+
+    func handleTableImagePhotoItem() {
+        if let selectedTable = selectedTable {
+            if let item = tableImagePhotoItem {
+                item.loadTransferable(type: Data.self) { result in
+                    switch result {
+                    case let .success(data?):
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            if let image = UIImage(data: data) {
+                                Task {
+                                    await TableManager.shared.setTableImage(table: selectedTable,
+                                                                            image: image)
+                                }
+                            } else {
+                                Task {
+                                    await TableManager.shared.setTableImage(table: selectedTable,
+                                                                            imagePath: "")
+                                }
+                            }
+                        }
+                    default:
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    func handleTableImageReset() {
+        if let selectedTable = selectedTable {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                Task {
+                    await TableManager.shared.setTableImage(table: selectedTable,
+                                                            imagePath: "")
+                }
+            }
+        }
+    }
+
+    func handleViewTableScript() {
+        if let selectedTable = selectedTable {
+            Task {
+                let hasScript = await selectedTable.hasScriptFileAsync()
+                if hasScript {
+                    await MainActor.run {
+                        showScript = true
+                    }
+                    return
+                }
+
+                if await TableManager.shared.extractTableScript(table: selectedTable) {
+                    await MainActor.run {
+                        showScript = true
+                    }
+                } else {
+                    await MainActor.run {
+                        handleShowError(message: "Unable to extract script")
+                    }
+                }
+            }
+        }
+    }
+
+    func handleShareTable() {
+        if let selectedTable = selectedTable {
+            Task {
+                if let path = await TableManager.shared.exportTable(table: selectedTable) {
+                    shareItems = [URL(fileURLWithPath: path)]
+                    showShare = true
+                }
+            }
+        }
+    }
+
+    func handleResetTable() {
+        if let selectedTable = selectedTable {
+            _ = TableManager.shared.resetTableIni(table: selectedTable)
+        }
+    }
+
+    func handleDeleteTable() {
+        if let selectedTable = selectedTable {
+            Task {
+                await TableManager.shared.deleteTable(table: selectedTable)
+            }
+        }
+    }
+
+    func handlePlayTable() {
+        if VPinballModel.shared.activeTable != nil {
+            return
+        }
+
+        if let selectedTable = selectedTable {
+            Task {
+                if await VPinballManager.shared.play(table: selectedTable) != true {
+                    VPinballModel.shared.activeTable = nil
+                    handleShowError(message: "Unable to load table")
+                }
+            }
+        }
+    }
+
+    func handleShowError(message: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.errorMessage = message
+            self.showError = true
+        }
+    }
+}

--- a/standalone/ios/VPinball/models/SettingsModel.swift
+++ b/standalone/ios/VPinball/models/SettingsModel.swift
@@ -6,7 +6,6 @@ class SettingsModel: ObservableObject {
 
     @Published var haptics: Bool = false
     @Published var renderingModeOverride: Bool = false
-    @Published var viewMode: VPinballViewMode = .desktopFSS
     @Published var resetLogOnPlay: Bool = false
 
     // External DMD
@@ -40,7 +39,7 @@ class SettingsModel: ObservableObject {
         } else {
             haptics = vpinballManager.loadValue(.standalone, "Haptics", true)
         }
-        renderingModeOverride = (vpinballManager.loadValue(.standalone, "RenderingModeOverride", 2) == 2)
+        renderingModeOverride = (vpinballManager.loadValue(.standalone, "RenderingModeOverride", -1) == 2)
 
         // External DMD
 
@@ -55,10 +54,6 @@ class SettingsModel: ObservableObject {
         dmdServerAddr = vpinballManager.loadValue(.pluginDMDUtil, "DMDServerAddr", "0.0.0.0")
         dmdServerPort = vpinballManager.loadValue(.pluginDMDUtil, "DMDServerPort", 6789)
         zedmdWiFiAddr = vpinballManager.loadValue(.pluginDMDUtil, "ZeDMDWiFiAddr", "zedmd-wifi.local")
-
-        // Display
-
-        viewMode = VPinballViewMode(rawValue: vpinballManager.loadValue(.player, "BGSet", VPinballViewMode.desktopFSS.rawValue)) ?? .desktopFSS
 
         // Performance
 
@@ -87,10 +82,6 @@ class SettingsModel: ObservableObject {
 
     func handleRenderingModeOverride() {
         vpinballManager.saveValue(.standalone, "RenderingModeOverride", renderingModeOverride ? 2 : -1)
-    }
-
-    func handleViewMode() {
-        vpinballManager.saveValue(.player, "BGSet", viewMode.rawValue)
     }
 
     func handleResetLogOnPlay() {

--- a/standalone/ios/VPinball/models/VPinballModel.swift
+++ b/standalone/ios/VPinball/models/VPinballModel.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+@MainActor
+class VPinballModel: ObservableObject {
+    static let shared = VPinballModel()
+
+    @Published var tables: [Table] = []
+    @Published var activeTable: Table?
+    @Published var isPlaying = false
+    @Published var webServerURL: String?
+    @Published var hudTitle: String?
+    @Published var hudProgress: Int = 0
+    @Published var hudStatus: String?
+    @Published var showSplash = true
+    @Published var showMainView = true
+    @Published var showHUD = false
+
+    func showHUD(title: String, status: String) {
+        hudTitle = title
+        hudProgress = 0
+        hudStatus = status
+        showHUD = true
+    }
+
+    func updateHUD(progress: Int, status: String) {
+        hudProgress = progress
+        hudStatus = status
+    }
+
+    func updateHUD(progress: Int) {
+        hudProgress = progress
+    }
+
+    func hideHUD() {
+        showHUD = false
+    }
+
+    func startSplashTimer() {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            withAnimation {
+                self.showSplash = false
+            }
+        }
+    }
+}

--- a/standalone/ios/VPinball/utils/Enums.swift
+++ b/standalone/ios/VPinball/utils/Enums.swift
@@ -107,7 +107,7 @@ enum Credit {
     var authors: String? {
         switch self {
         case .vpinball:
-            return "toxieainc, vbousquet, fuzzelhjb, jsm174, c-f-h, francisdb, bcd, cupidsf, djrobx, brandrew2, mjrgh, koadic76, shagendo, Nicals, horseyhorsey, CraftedCart, superhac, snail_gary, Matthias Buecher, Le-Syl21, baxelrod-bdai, YellowLabrador, claytgreene, markmon, JockeJarre, WildCoder, ScaryG, nkissebe, mkalkbrenner, freezy, Wylted1, WizardsHat, RandyDavis2000, ntleverenz, latsao, Chickenzilla, Yuki, teamsuperpanda, surtarso, RockfordRoe, ravarcade, poiuyterry, omigeot, manofwar32, LeHaine, KutsuyaYuki, kaicherry, joni999, jmarzka, droscoe, cschmidtpxc, CapitaineSheridan, Billiam, andremichi"
+            return "toxieainc, vbousquet, fuzzelhjb, jsm174, c-f-h, francisdb, bcd, cupidsf, djrobx, brandrew2, mjrgh, koadic76, shagendo, Nicals, horseyhorsey, CraftedCart, superhac, snail_gary, Matthias Buecher, Le-Syl21, baxelrod-bdai, YellowLabrador, claytgreene, markmon, JockeJarre, WildCoder, ScaryG, nkissebe, mkalkbrenner, freezy, Wylted1, WizardsHat, RandyDavis2000, ntleverenz, latsao, Chickenzilla, Yuki, teamsuperpanda, surtarso, RockfordRoe, ravarcade, poiuyterry, omigeot, manofwar32, LeHaine, KutsuyaYuki, kaicherry, joni999, jmarzka, droscoe, cschmidtpxc, CapitaineSheridan, Billiam, andremichi, evilwraith"
         case .pinmame:
             return "toxieainc, volkenborn, Steve Ellenoff, bcd, Tom, Haukap, wpcmame, Matthias Buecher, jsm174, vbousquet, mkalkbrenner, droscoe, djrobx, Thomas Behrens, bontango, tomlogic, mjrgh, Oliver, Kaegi, syllebra, JockeJarre, Randall, Perlow, gstellenberg, Netsplits, gnulnulf, Sunnucks, mattwalsh, Mark, freezy, uid68989, Sereda, Pavel, noflip95, No, francisdb, diego-link-eggy"
         case .libaltsound:

--- a/standalone/ios/VPinball/utils/VPinballInterop.swift
+++ b/standalone/ios/VPinball/utils/VPinballInterop.swift
@@ -27,27 +27,6 @@ enum VPinballSettingsSection: String {
     case pluginDMDUtil = "Plugin.DMDUtil"
 }
 
-enum VPinballViewMode: CInt {
-    case desktopFSS
-    case cabinet
-    case desktopNoFSS
-
-    static let all: [VPinballViewMode] = [.desktopFSS,
-                                          .cabinet,
-                                          .desktopNoFSS]
-
-    var name: String {
-        switch self {
-        case .desktopFSS:
-            return "Desktop & FSS"
-        case .cabinet:
-            return "Cabinet"
-        case .desktopNoFSS:
-            return "Desktop (no FSS)"
-        }
-    }
-}
-
 enum VPinballMaxTexDimension: CInt {
     case unlimited = 0
     case max256 = 256

--- a/standalone/ios/VPinball/views/HUDOverlayView.swift
+++ b/standalone/ios/VPinball/views/HUDOverlayView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct HUDOverlayView: View {
-    @ObservedObject var vpinballViewModel = VPinballViewModel.shared
+    @ObservedObject var vpinballModel = VPinballModel.shared
 
     var body: some View {
         ZStack {
@@ -12,20 +12,20 @@ struct HUDOverlayView: View {
                 Spacer()
 
                 VStack(spacing: 20) {
-                    Text(vpinballViewModel.hudTitle ?? " ")
+                    Text(vpinballModel.hudTitle ?? " ")
                         .multilineTextAlignment(.center)
                         .font(.headline)
                         .bold()
                         .foregroundStyle(Color.white)
 
-                    ProgressView(value: Double(vpinballViewModel.hudProgress),
+                    ProgressView(value: Double(vpinballModel.hudProgress),
                                  total: 100)
                         .progressViewStyle(.linear)
                         .tint(Color.vpxDarkYellow)
                         .background(Color.black)
                         .cornerRadius(2)
 
-                    Text(vpinballViewModel.hudStatus ?? " ")
+                    Text(vpinballModel.hudStatus ?? " ")
                         .font(.caption)
                         .bold()
                         .foregroundStyle(Color.white)

--- a/standalone/ios/VPinball/views/SettingsExternalDMDView.swift
+++ b/standalone/ios/VPinball/views/SettingsExternalDMDView.swift
@@ -2,11 +2,8 @@ import SwiftUI
 
 struct SettingsExternalDMDView: View {
     @ObservedObject var settingsModel: SettingsModel
-    @ObservedObject var vpinballViewModel = VPinballViewModel.shared
 
     var showInput: (String, String, UIKeyboardType, @escaping (String) -> Void) -> Void
-
-    let vpinballManager = VPinballManager.shared
 
     var body: some View {
         Section {

--- a/standalone/ios/VPinball/views/SettingsPerformanceView.swift
+++ b/standalone/ios/VPinball/views/SettingsPerformanceView.swift
@@ -2,9 +2,6 @@ import SwiftUI
 
 struct SettingsPerformanceView: View {
     @ObservedObject var settingsModel: SettingsModel
-    @ObservedObject var vpinballViewModel = VPinballViewModel.shared
-
-    let vpinballManager = VPinballManager.shared
 
     var body: some View {
         Section("Performance") {

--- a/standalone/ios/VPinball/views/SettingsWebServerView.swift
+++ b/standalone/ios/VPinball/views/SettingsWebServerView.swift
@@ -2,11 +2,9 @@ import SwiftUI
 
 struct SettingsWebServerView: View {
     @ObservedObject var settingsModel: SettingsModel
-    @ObservedObject var vpinballViewModel = VPinballViewModel.shared
+    @ObservedObject var vpinballModel = VPinballModel.shared
 
     var showInput: (String, String, UIKeyboardType, @escaping (String) -> Void) -> Void
-
-    let vpinballManager = VPinballManager.shared
 
     var body: some View {
         Section {
@@ -33,7 +31,7 @@ struct SettingsWebServerView: View {
             Text("Web Server")
         }
         footer: {
-            if let url = vpinballViewModel.webServerURL, !url.isEmpty {
+            if let url = vpinballModel.webServerURL, !url.isEmpty {
                 Text(.init("Web Server is running and can be accessed at: \(url)."))
             } else {
                 Text("Web Server is not running.")

--- a/standalone/ios/VPinball/views/TableContextMenu.swift
+++ b/standalone/ios/VPinball/views/TableContextMenu.swift
@@ -49,9 +49,9 @@ struct TableContextMenu: View {
         }
     }
 
-    private func handleAction(_ type: VPinballViewModel.ActionType, delay: TimeInterval = 0.5) {
+    private func handleAction(_ type: MainViewModel.ActionType, delay: TimeInterval = 0.5) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            VPinballViewModel.shared.setAction(type, table: table)
+            MainViewModel.shared.setAction(type, table: table)
         }
     }
 }

--- a/standalone/ios/VPinball/views/TableGridView.swift
+++ b/standalone/ios/VPinball/views/TableGridView.swift
@@ -12,9 +12,9 @@ enum TableGridSize: Int, Hashable {
 }
 
 struct TableGridView: View {
-    @ObservedObject var vpinballViewModel = VPinballViewModel.shared
-    @ObservedObject var tableManager = TableManager.shared
+    @ObservedObject var mainViewModel = MainViewModel.shared
 
+    var tables: [Table]
     var viewMode: TableViewMode
     var gridSize: TableGridSize
     var sortOrder: SortOrder
@@ -27,16 +27,14 @@ struct TableGridView: View {
     private let rowHorizontalPadding: CGFloat = 12
     private let rowOuterPadding: CGFloat = 10
 
-    init(viewMode: TableViewMode = .grid, gridSize: TableGridSize = .medium, sortOrder: SortOrder = .reverse, searchText: String = "", scrollToTable: Binding<Table?> = .constant(nil)) {
-        self.viewMode = viewMode
-        self.gridSize = gridSize
-        self.sortOrder = sortOrder
-        self.searchText = searchText
-        _scrollToTable = scrollToTable
-    }
-
     var filteredTables: [Table] {
-        return tableManager.filteredTables(searchText: searchText, sortOrder: sortOrder)
+        tables
+            .filter { searchText.isEmpty || $0.name.localizedCaseInsensitiveContains(searchText) }
+            .sorted {
+                sortOrder == .forward
+                    ? $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                    : $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedDescending
+            }
     }
 
     var body: some View {
@@ -133,8 +131,8 @@ struct TableGridView: View {
             selectedTable = nil
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                vpinballViewModel.setAction(.play,
-                                            table: table)
+                mainViewModel.setAction(.play,
+                                        table: table)
             }
         }
     }


### PR DESCRIPTION
This PR does more cleanup to the mobile apps. I'm still learning and working my way though better mvc design. iOS now has a separate `MainViewModel` instead of cramming everything into `VPinballViewModel`. `VPinballViewModel` is now `VPinballModel` and contains core app state: `tables`, `activeTable`, `isPlaying`,  etc. Android was updated with similarly with the misleading `UiState` being deleted and moved into `VPinballModel` 

Other updates:

- Provided a patch for SDL on iOS that will allow cold start to still show the "Confirm Import Table" alert. See https://github.com/libsdl-org/SDL/issues/15093
- Removed `downloadUbiquitousItem` from iOS, as iCloud progress was unreliable and would lock app up
- Moved `Graphics Backend` to top setting on Android
- Removed the ability to change the `Display` (BGSet) from the Settings menu since this can be done in LiveUI
- Moved `Force VR Rendering Mode` to a new `Miscellaneous` section in Setting and defaulted to Off. (This provides consistent out of the box experience on all platforms.)
- Updated Credits
- Fixed android archive names from `VPinball_BGFX` to `VPinballX_BGFX`