### PR TITLE
PuP-Plugin: Fix label positioning so it matches windows pup implemention

### DIFF
--- a/plugins/pup/PUPLabel.cpp
+++ b/plugins/pup/PUPLabel.cpp
@@ -437,9 +437,6 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
 
    SDL_FRect dest = { static_cast<float>(rect.x), static_cast<float>(rect.y), width, height };
 
-   // --- Anchor-based positioning (PinUP compatible) ---
-
-   // X
    float xposPercent = m_xPos / 100.0f;
    if (m_xPos == 0.f && m_xAlign == PUP_LABEL_XALIGN_CENTER)
       xposPercent = 0.5f;
@@ -451,7 +448,6 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    else if (m_xAlign == PUP_LABEL_XALIGN_RIGHT)
       dest.x -= width;
 
-   // Y
    float yposPercent = m_yPos / 100.0f;
    if (m_yPos == 0.f && m_yAlign == PUP_LABEL_YALIGN_CENTER)
       yposPercent = 0.5f;


### PR DESCRIPTION
The plugin was treating xpos and ypos as the top-left draw position, while the real PuP (Windows) behavior treats them as an anchor point that gets shifted by xalign and yalign.

Because that alignment offset wasn’t being applied correctly:

    yalign=2 (bottom) didn’t move the label up by its height
    xalign=1 (center) didn’t shift it left by half its width

so (0,0) always rendered as top-left, forcing you to fake placement with ypos=100

The fix: apply the alignment offsets to the final draw position:

    subtract width/2 or width for horizontal center/right alignment
    subtract height/2 or height for vertical center/bottom alignment

After that change, (xpos,ypos) is correctly treated as the anchor point and (0,0) works like Windows PuP (bottom-center with your align settings).

The behavior can been seen in issue https://github.com/vpinball/vpinball/issues/3178