### PR TITLE
misc: set table iniPath even if ini file doesn't exist

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1463,10 +1463,11 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
    m_filename = filename;
 
    // Load user custom settings before actually loading the table for settings applying during load
-   if (const std::filesystem::path iniPath = GetSettingsFileName(); FileExists(iniPath))
+   if (const std::filesystem::path iniPath = GetSettingsFileName(); !iniPath.empty())
    {
       m_settings.SetIniPath(iniPath);
-      m_settings.Load(false);
+      if (FileExists(iniPath))
+         m_settings.Load(false);
    }
 
    HRESULT hr;


### PR DESCRIPTION
When loading a table that has no table.ini file, and then exiting the table I was seeing:

```
2026-02-25 07:42:03.297 ERROR [14554149] [VPX::Properties::LayeredINIPropertyStore::Save@218] Failed to save settings file to '' 
```

I believe this should fix https://github.com/vpinball/vpinball/issues/3176 and reports I've been getting on Discord.