### PR TITLE
misc: fix MusicDirectory returning path without separator

### DIFF
--- a/src/core/ScriptGlobalTable.cpp
+++ b/src/core/ScriptGlobalTable.cpp
@@ -404,7 +404,8 @@ STDMETHODIMP ScriptGlobalTable::get_MusicDirectory(VARIANT pSubDir, BSTR *pVal)
       path = path / MakeString(V_BSTR(&pSubDir));
    if (!DirExists(path))
       return E_FAIL;
-   *pVal = SysAllocStringLen(path.wstring().data(), static_cast<UINT>(path.wstring().length()));
+   path /= "";
+   *pVal = MakeWideBSTR(path.string());
    return S_OK;
 }
 


### PR DESCRIPTION
`MusicDirectory` wasn't returning paths with path separators after https://github.com/vpinball/vpinball/commit/a447f7c9460c53283d4ab11d70196c62b0c09b94. 

This would cause:

`/Users/jmillard/tables/batocera/userdata/roms/vpinball/ag/music/AGsfx_RadioScan.mp3`

instead of 

`/Users/jmillard/tables/batocera/userdata/roms/vpinball/ag/music/AG/sfx_RadioScan.mp3`

Also replaced `SysAllocStringLen` to `MakeWideBSTR` to match other functions.

Fixes https://github.com/vpinball/vpinball/issues/3191 and could be related to https://github.com/vpinball/vpinball/issues/3159