### PR TITLE
Follow executable path symlink on macos

### DIFF
--- a/src/core/FileLocator.cpp
+++ b/src/core/FileLocator.cpp
@@ -6,6 +6,13 @@
 
 #include "FileLocator.h"
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#include <mach-o/dyld.h>
+#endif
+#endif
+
 FileLocator::FileLocator()
    : m_appPath(EvaluateAppPath())
 {
@@ -26,6 +33,25 @@ std::filesystem::path FileLocator::EvaluateAppPath()
    appPath = SDL_GetUserFolder(SDL_FOLDER_DOCUMENTS);
 #else
    appPath = SDL_GetBasePath();
+#if defined(__APPLE__) && defined(TARGET_OS_OSX) && TARGET_OS_OSX
+   uint32_t exePathSize = 0;
+   _NSGetExecutablePath(nullptr, &exePathSize);
+   if (exePathSize > 0)
+   {
+      std::string exePath(exePathSize, '\0');
+      if (_NSGetExecutablePath(exePath.data(), &exePathSize) == 0)
+      {
+         // Get the canonical path, to be able to support users creating a symlink to the executable from another location,
+         // but still have the app working properly with files located with the real executable path. On macOS, the executable
+         // is located in 'AppBundle/Contents/MacOS/', but resources are located in 'AppBundle/Contents/Resources/'.
+         std::filesystem::path canonicalPath = std::filesystem::canonical(exePath).parent_path();
+         if (canonicalPath.filename() == "MacOS" && canonicalPath.parent_path().filename() == "Contents")
+         {
+            appPath = canonicalPath.parent_path() / "Resources";
+         }
+      }
+   }
+#endif
 #endif
    return appPath;
 }


### PR DESCRIPTION
Fixes #3228.

With symlink:
```sh
zsh❯ cd ~

zsh❯ ll VPinballX_BGFX
lrwxr-xr-x@ 1 sean  staff    81B 11 Mar 17:36 VPinballX_BGFX@ -> /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/MacOS/VPinballX_BGFX

zsh❯ ./VPinballX_BGFX -v
2026-03-11 19:31:03.904 INFO  [12990483] [VPApp::InitInstance@297] Starting VPX - v10.8.1 Beta (Rev. 9999 (unknown), macos BGFX 64bits)
2026-03-11 19:31:03.905 INFO  [12990483] [VPApp::InitInstance@298] Settings file was loaded from /Users/sean/Library/Application Support/VPinballX/10.8/VPinballX.ini
2026-03-11 19:31:03.905 INFO  [12990483] [VPApp::InitInstance@299] Number of logical CPU cores: 12
2026-03-11 19:31:03.905 INFO  [12990483] [VPApp::InitInstance@300] Application path: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources
2026-03-11 19:31:03.905 INFO  [12990483] [VPApp::InitInstance@301] Preference path: /Users/sean/Library/Application Support/VPinballX/10.8
2026-03-11 19:31:03.907 INFO  [12990483] [WinMain@244] Plugin HelloWorld was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/helloworld/plugin-helloworld.dylib)
2026-03-11 19:31:03.907 INFO  [12990483] [WinMain@244] Plugin B2S was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/b2s/plugin-b2s.dylib)
2026-03-11 19:31:03.908 INFO  [12990483] [WinMain@244] Plugin DOF was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/dof/plugin-dof.dylib)
2026-03-11 19:31:03.922 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin PinMAME loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/pinmame/plugin-pinmame.dylib)
2026-03-11 19:31:03.923 INFO  [12990483] [WinMain@244] Plugin UpscaleDMD was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/upscaledmd/plugin-upscaledmd.dylib)
2026-03-11 19:31:03.923 INFO  [12990483] [WinMain@244] Plugin HelloScript was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/helloscript/plugin-helloscript.dylib)
2026-03-11 19:31:03.923 INFO  [12990483] [WinMain@244] Plugin RemoteControl was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/remote-control/plugin-remote-control.dylib)
2026-03-11 19:31:03.937 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin ScoreView loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/scoreview/plugin-scoreview.dylib)
2026-03-11 19:31:03.939 INFO  [12990483] [WinMain@244] Plugin AlphaDMD was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/alphadmd/plugin-alphadmd.dylib)
2026-03-11 19:31:03.963 INFO  [12990483] [VPXPluginAPIImpl::PluginLog@239] WMP Plugin loaded successfully
2026-03-11 19:31:03.963 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin WMP loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/wmp/plugin-wmp.dylib)
2026-03-11 19:31:03.963 INFO  [12990483] [WinMain@244] Plugin DMDUtil was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/dmdutil/plugin-dmdutil.dylib)
2026-03-11 19:31:03.987 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin B2SLegacy loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/b2slegacy/plugin-b2slegacy.dylib)
2026-03-11 19:31:03.996 INFO  [12990483] [VPXPluginAPIImpl::PluginLog@239] AltSound Plugin loaded successfully
2026-03-11 19:31:03.996 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin AltSound loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/altsound/plugin-altsound.dylib)
2026-03-11 19:31:04.018 WARN  [12990483] [VPXPluginAPIImpl::PluginLog@240] PUP folder was not found (settings is '')
2026-03-11 19:31:04.018 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin PUP loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/pup/plugin-pup.dylib)
2026-03-11 19:31:04.027 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin Serum loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/serum/plugin-serum.dylib)
2026-03-11 19:31:04.048 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin FlexDMD loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/flexdmd/plugin-flexdmd.dylib)
2026-03-11 19:31:04.057 INFO  [12990483] [MsgPI::MsgPlugin::Load@510] Plugin VNI loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/vni/plugin-vni.dylib)
Visual Pinball v10.8.1 Beta (Rev. 9999 (unknown), macos BGFX 64bits)
2026-03-11 19:31:04.059 INFO  [12990483] [VPXPluginAPIImpl::PluginLog@239] WMP Plugin unloaded
```
Without symlink:
```
zsh❯ cd devel/vpinball

zsh❯ build/VPinballX_BGFX.app/Contents/MacOS/VPinballX_BGFX -v
2026-03-11 19:37:04.315 INFO  [13004604] [VPApp::InitInstance@297] Starting VPX - v10.8.1 Beta (Rev. 9999 (unknown), macos BGFX 64bits)
2026-03-11 19:37:04.316 INFO  [13004604] [VPApp::InitInstance@298] Settings file was loaded from /Users/sean/Library/Application Support/VPinballX/10.8/VPinballX.ini
2026-03-11 19:37:04.316 INFO  [13004604] [VPApp::InitInstance@299] Number of logical CPU cores: 12
2026-03-11 19:37:04.316 INFO  [13004604] [VPApp::InitInstance@300] Application path: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources
2026-03-11 19:37:04.316 INFO  [13004604] [VPApp::InitInstance@301] Preference path: /Users/sean/Library/Application Support/VPinballX/10.8
2026-03-11 19:37:04.319 INFO  [13004604] [WinMain@244] Plugin HelloWorld was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/helloworld/plugin-helloworld.dylib)
2026-03-11 19:37:04.319 INFO  [13004604] [WinMain@244] Plugin B2S was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/b2s/plugin-b2s.dylib)
2026-03-11 19:37:04.319 INFO  [13004604] [WinMain@244] Plugin DOF was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/dof/plugin-dof.dylib)
2026-03-11 19:37:04.321 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin PinMAME loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/pinmame/plugin-pinmame.dylib)
2026-03-11 19:37:04.321 INFO  [13004604] [WinMain@244] Plugin UpscaleDMD was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/upscaledmd/plugin-upscaledmd.dylib)
2026-03-11 19:37:04.321 INFO  [13004604] [WinMain@244] Plugin HelloScript was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/helloscript/plugin-helloscript.dylib)
2026-03-11 19:37:04.322 INFO  [13004604] [WinMain@244] Plugin RemoteControl was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/remote-control/plugin-remote-control.dylib)
2026-03-11 19:37:04.323 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin ScoreView loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/scoreview/plugin-scoreview.dylib)
2026-03-11 19:37:04.323 INFO  [13004604] [WinMain@244] Plugin AlphaDMD was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/alphadmd/plugin-alphadmd.dylib)
2026-03-11 19:37:04.325 INFO  [13004604] [VPXPluginAPIImpl::PluginLog@239] WMP Plugin loaded successfully
2026-03-11 19:37:04.325 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin WMP loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/wmp/plugin-wmp.dylib)
2026-03-11 19:37:04.325 INFO  [13004604] [WinMain@244] Plugin DMDUtil was found but is disabled (/Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/dmdutil/plugin-dmdutil.dylib)
2026-03-11 19:37:04.327 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin B2SLegacy loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/b2slegacy/plugin-b2slegacy.dylib)
2026-03-11 19:37:04.329 INFO  [13004604] [VPXPluginAPIImpl::PluginLog@239] AltSound Plugin loaded successfully
2026-03-11 19:37:04.329 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin AltSound loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/altsound/plugin-altsound.dylib)
2026-03-11 19:37:04.333 WARN  [13004604] [VPXPluginAPIImpl::PluginLog@240] PUP folder was not found (settings is '')
2026-03-11 19:37:04.333 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin PUP loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/pup/plugin-pup.dylib)
2026-03-11 19:37:04.334 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin Serum loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/serum/plugin-serum.dylib)
2026-03-11 19:37:04.337 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin FlexDMD loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/flexdmd/plugin-flexdmd.dylib)
2026-03-11 19:37:04.338 INFO  [13004604] [MsgPI::MsgPlugin::Load@510] Plugin VNI loaded (library: /Users/sean/devel/vpinball/build/VPinballX_BGFX.app/Contents/Resources/plugins/vni/plugin-vni.dylib)
Visual Pinball v10.8.1 Beta (Rev. 9999 (unknown), macos BGFX 64bits)
2026-03-11 19:37:04.341 INFO  [13004604] [VPXPluginAPIImpl::PluginLog@239] WMP Plugin unloaded
```