### PR TITLE
Fix: X11 window placement on multi-monitor with GNOME/Mutter

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -213,8 +213,11 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
       if (m_fullscreen)
          wnd_flags |= SDL_WINDOW_FULLSCREEN;
 
-      #if !defined(_MSC_VER) // Win32 (we use _MSC_VER since standalone also defines WIN32 for non Win32 builds)
-      // On Windows, always on top is not always respected and if using SDL_WINDOW_UTILITY windows may end up being hidden with no way to select and move them
+      #if !defined(_MSC_VER) // Non-Windows platforms (Linux, macOS)
+      // On Linux/X11, window managers like GNOME/Mutter reposition borderless windows
+      // that match the screen size. Using override_redirect bypasses the WM entirely,
+      // ensuring all windows (including playfield) are placed at their requested position.
+      SDL_SetHint(SDL_HINT_X11_FORCE_OVERRIDE_REDIRECT, "1");
       if (m_windowId != VPXWindowId::VPXWINDOW_Playfield)
          wnd_flags |= SDL_WINDOW_UTILITY | SDL_WINDOW_ALWAYS_ON_TOP;
       #endif


### PR DESCRIPTION
On Linux/X11, GNOME/Mutter repositions borderless windows that match the screen size, ignoring the requested position. This causes the playfield window to appear on the wrong display in multi-monitor pincab setups.

Fix: set SDL_HINT_X11_FORCE_OVERRIDE_REDIRECT before window creation on non-Windows platforms. This uses X11 override_redirect to bypass the window manager, ensuring all windows are placed at their requested coordinates.

Tested on Ubuntu 24.04 / GNOME / X11 with 3 monitors (4K + 1440p + 1080p). Verified: playfield, backglass and DMD all correctly placed on their assigned displays.