### PR TITLE
plugins: several PUP fixes, implement more missing animations

### DIFF
--- a/plugins/pup/PUPLabel.cpp
+++ b/plugins/pup/PUPLabel.cpp
@@ -3,6 +3,8 @@
 /*
  * This code was derived from notes at:
  *
+ * https://www.nailbuster.com/wikipinup/doku.php?id=pup_dmd
+ * https://nailbuster.com/pupupdatesv14/PUPDMDFramework_Starter_v1_1.zip
  * https://nailbuster.com/pup/PUPDMD_Reference_v13.zip
  */
 
@@ -22,6 +24,113 @@
 #define LOG_PUPLABEL 0
 
 namespace PUP {
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795
+#endif
+
+// FIXME rotation is done via CPU (90/270 degress render blank via GPU?)
+static SDL_Surface* RotateSurface(SDL_Surface* src, float angleDeg)
+{
+   if (!src || angleDeg == 0.f)
+      return nullptr;
+
+   const float rad = -angleDeg * (float)(M_PI / 180.0);
+   const float c = cosf(rad);
+   const float s = sinf(rad);
+   const float absC = fabsf(c);
+   const float absS = fabsf(s);
+
+   const int srcW = src->w;
+   const int srcH = src->h;
+   const int dstW = (int)ceilf(srcW * absC + srcH * absS);
+   const int dstH = (int)ceilf(srcW * absS + srcH * absC);
+
+   SDL_Surface* dst = SDL_CreateSurface(dstW, dstH, SDL_PIXELFORMAT_RGBA32);
+   if (!dst)
+      return nullptr;
+
+   SDL_LockSurface(src);
+   SDL_LockSurface(dst);
+
+   const uint32_t* srcPixels = (const uint32_t*)src->pixels;
+   uint32_t* dstPixels = (uint32_t*)dst->pixels;
+   const int srcPitch = src->pitch / 4;
+   const int dstPitch = dst->pitch / 4;
+
+   const float srcCx = srcW * 0.5f;
+   const float srcCy = srcH * 0.5f;
+   const float dstCx = dstW * 0.5f;
+   const float dstCy = dstH * 0.5f;
+
+   for (int dy = 0; dy < dstH; dy++)
+   {
+      for (int dx = 0; dx < dstW; dx++)
+      {
+         const float rx = (dx - dstCx) * c + (dy - dstCy) * s + srcCx;
+         const float ry = -(dx - dstCx) * s + (dy - dstCy) * c + srcCy;
+         const int sx = (int)rx;
+         const int sy = (int)ry;
+         if (sx >= 0 && sx < srcW && sy >= 0 && sy < srcH)
+            dstPixels[dy * dstPitch + dx] = srcPixels[sy * srcPitch + sx];
+         else
+            dstPixels[dy * dstPitch + dx] = 0;
+      }
+   }
+
+   SDL_UnlockSurface(dst);
+   SDL_UnlockSurface(src);
+   return dst;
+}
+
+// See pDMDLabelSetFilter — apply pixel filter to an RGBA32 surface
+// fmode: 1=invertRGB, 2=invert(+alpha), 3=grayscale, 4=invertalpha, 5=clear
+static void ApplyFilter(SDL_Surface* surf, int filterMode)
+{
+   if (!surf || filterMode <= 0 || filterMode > 5)
+      return;
+
+   SDL_LockSurface(surf);
+   uint32_t* pixels = (uint32_t*)surf->pixels;
+   const int pitch = surf->pitch / 4;
+   const int w = surf->w;
+   const int h = surf->h;
+
+   for (int y = 0; y < h; y++)
+   {
+      for (int x = 0; x < w; x++)
+      {
+         uint32_t& px = pixels[y * pitch + x];
+         const uint8_t r = px & 0xFF;
+         const uint8_t g = (px >> 8) & 0xFF;
+         const uint8_t b = (px >> 16) & 0xFF;
+         const uint8_t a = (px >> 24) & 0xFF;
+
+         switch (filterMode)
+         {
+         case 1: // invertRGB
+            px = (a << 24) | ((255 - b) << 16) | ((255 - g) << 8) | (255 - r);
+            break;
+         case 2: // invert (RGB + alpha)
+            px = ((255 - a) << 24) | ((255 - b) << 16) | ((255 - g) << 8) | (255 - r);
+            break;
+         case 3: // grayscale
+         {
+            const uint8_t gray = static_cast<uint8_t>(0.299f * r + 0.587f * g + 0.114f * b);
+            px = (a << 24) | (gray << 16) | (gray << 8) | gray;
+            break;
+         }
+         case 4: // invertalpha
+            px = ((255 - a) << 24) | (b << 16) | (g << 8) | r;
+            break;
+         case 5: // clear
+            px = 0;
+            break;
+         }
+      }
+   }
+   SDL_UnlockSurface(surf);
+}
 
 #ifndef GetRValue
 #define GetRValue(rgba32) static_cast<uint8_t>(rgba32)
@@ -149,8 +258,9 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          switch (json["at"s].as<int>(0))
          {
          case 1:
+            // See pDMDLabelFlash — fq is the toggle interval in milliseconds
             if (json["len"s].exists() && json["fc"s].exists() && json["fq"s].exists() && json["fq"s].as<int>() > 0)
-               m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(), json["fc"s].as<int>(), 1000 / json["fq"s].as<int>());
+               m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(), json["fc"s].as<int>(), json["fq"s].as<int>());
             else
             {
                LOGE("Invalid label animation specified: {" + szSpecial + '}');
@@ -158,14 +268,95 @@ void PUPLabel::SetSpecial(const string& szSpecial)
             break;
             
          case 2:
+            // See pDMDLabelMoveHorz / pDMDLabelMoveVert / pDMDLabelMoveTO
+            // See pDMDLabelMoveHorzFade / pDMDLabelMoveVertFade — af = alpha fade start time (ms before end)
             if (json["len"s].exists() && json["fc"s].exists())
-               m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(), json["fc"s].as<int>(), 
+            {
+               int len = json["len"s].as<int>();
+               int mlen = json["mlen"s].as<int>(0);
+               if (mlen == 0) mlen = len;
+               m_animation = std::make_unique<Animation>(this, len, json["fc"s].as<int>(),
                   json["xps"s].as<int>(0), json["xpe"s].as<int>(0), json["yps"s].as<int>(0), json["ype"s].as<int>(0),
-                  json["mlen"s].as<int>(0), json["tt"s].as<int>(0), json["mColor"s].as<int>(0));
+                  mlen, json["tt"s].as<int>(0), json["mColor"s].as<int>(m_color));
+               m_animation->m_alphaFade = json["af"s].as<int>(0);
+            }
             else
             {
                LOGE("Invalid label animation specified: {" + szSpecial + '}');
             }
+            break;
+
+         case 3:
+         {
+            // See pDMDZoomBig — zoom from hstart% to hend% over len ms
+            float hstart = static_cast<float>(json["hstart"s].as<double>(100));  // default 100% (normal size)
+            float hend = static_cast<float>(json["hend"s].as<double>(200));    // default 200% (double size)
+            m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(1000), json["fc"s].as<int>(m_color), hstart, hend, 0);  // 1000ms fallback
+            break;
+         }
+
+         case 4:
+         {
+            // See pDMDLabelPulseText / pDMDLabelPulseImage — bounce zoom between hstart% and hend%
+            // See pDMDLabelPulseNumber — numstart/numend count up during animation.
+            // pspeed=0 means use a default bounce speed derived from the zoom range.
+            float hstart = static_cast<float>(json["hstart"s].as<double>(80));   // default 80% from pDMDLabelPulseText
+            float hend = static_cast<float>(json["hend"s].as<double>(120));      // default 120% from pDMDLabelPulseText
+            int pspeed = json["pspeed"s].as<int>(0);
+            if (pspeed == 0)
+               pspeed = std::max(1, static_cast<int>(hend - hstart));
+            m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(3000), json["fc"s].as<int>(m_color), hstart, hend, pspeed);  // 3000ms fallback if len missing
+            m_animation->m_numStart = json["numstart"s].as<int>(INT_MIN);   // INT_MIN = no number counting
+            m_animation->m_numEnd = json["numend"s].as<int>(INT_MIN);
+            m_animation->m_numFormat = json["numformat"s].as<int>(0);       // 0=plain, 1=thousands separators
+            break;
+         }
+
+         case 5:
+         {
+            // See pDMDLabelFadeOut / pDMDLabelFadeIn — alpha ease from astart to aend over len ms
+            int astart = json["astart"s].as<int>(255);   // default 255 (fully visible) from pDMDLabelFadeOut
+            int aend = json["aend"s].as<int>(0);          // default 0 (invisible) from pDMDLabelFadeOut
+            m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(1000), json["fc"s].as<int>(m_color), astart, aend, 0, false);  // 1000ms fallback
+            break;
+         }
+
+         case 6:
+         {
+            // See pDMDLabelFadePulse — alpha oscillates between astart and aend
+            int astart = json["astart"s].as<int>(70);    // default 70 (dim) from pDMDLabelFadePulse
+            int aend = json["aend"s].as<int>(255);        // default 255 (full) from pDMDLabelFadePulse
+            int pspeed = json["pspeed"s].as<int>(40);     // default 40 (alpha units per tick) from pDMDLabelFadePulse
+            m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(3000), json["fc"s].as<int>(m_color), astart, aend, pspeed, false);  // 3000ms fallback
+            break;
+         }
+
+         case 7:
+         {
+            // See pDMDScreenFadeOut / pDMDScreenFadeIn — same as at=5 but for parent screen
+            int astart = json["astart"s].as<int>(255);   // default 255 from pDMDScreenFadeOut
+            int aend = json["aend"s].as<int>(0);          // default 0 from pDMDScreenFadeOut
+            m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(1000), json["fc"s].as<int>(m_color), astart, aend, 0, true);  // 1000ms fallback
+            break;
+         }
+
+         case 8:
+         {
+            // See pDMDLabelWiggleText / pDMDLabelWiggleImage — rotation bounces between rstart and rend
+            // Uses GPU rotation since wiggle angles are small (never hits 90°/270°).
+            float rstart = static_cast<float>(json["rstart"s].as<double>(-45)) / 10.0f;  // default -4.5 deg from pDMDLabelWiggleText
+            float rend = static_cast<float>(json["rend"s].as<double>(45)) / 10.0f;       // default +4.5 deg from pDMDLabelWiggleText
+            int rspeed = json["rspeed"s].as<int>(5);   // default 5 from pDMDLabelWiggleText, 0 = use range as speed
+            if (rspeed == 0)
+               rspeed = std::max(1, static_cast<int>(fabsf(rend - rstart)));
+            m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(3000), json["fc"s].as<int>(m_color), rstart, rend, rspeed, 0);  // 3000ms fallback
+            break;
+         }
+
+         case 10:
+            // See pDMDLabelClone / pDMDLabelCloneDelay — delayed show.
+            // True cloning (creating a duplicate label) is not yet implemented.
+            NOT_IMPLEMENTED("at=10 clone not implemented"s);
             break;
 
          default:
@@ -186,28 +377,30 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          }
          else if (key == "zback")
          {
+            // See pDMDLabelSendToBack
             if (value.as<int>() == 1)
                m_pScreen->SendLabelToBack(this);
          }
          else if (key == "ztop")
          {
+            // See pDMDLabelSendToFront
             if (value.as<int>() == 1)
                m_pScreen->SendLabelToFront(this);
          }
          else if (key == "size")
          {
+            // See pDMDLabelSetSizeText — height as percent of display height
             m_size = static_cast<float>(json["size"s].as<double>());
             m_dirty = true;
          }
          else if (key == "xpos")
          {
+            // See pDMDLabelSetPos — position as percent of display width/height
             m_xPos = static_cast<float>(value.as<double>());
-            m_dirty = true;
          }
          else if (key == "ypos")
          {
             m_yPos = static_cast<float>(value.as<double>());
-            m_dirty = true;
          }
          else if (key == "fname")
          {
@@ -224,75 +417,83 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          }
          else if (key == "color")
          {
+            // See pDMDLabelSetColor
             m_color = value.as<int>();
             m_dirty = true;
          }
          else if (key == "xalign")
          {
+            // See PDMDLabelSetAlign — 0=left 1=center 2=right, 0=top 1=center 2=bottom
+            // Dirty because TTF_SetFontWrapAlignment uses xAlign for multi-line text justification
             m_xAlign = (PUP_LABEL_XALIGN)value.as<int>();
             m_dirty = true;
          }
          else if (key == "yalign")
          {
             m_yAlign = (PUP_LABEL_YALIGN)value.as<int>();
-            m_dirty = true;
          }
          else if (key == "pagenum")
          {
             m_pagenum = value.as<int>();
-            m_dirty = true;
          }
          else if (key == "stopani")
          {
-            // stop any pup animations on label/image (zoom/flash/pulse).  this is not about animated gifs
+            // See pDMDLabelStopAnis — stop any pup animations on label/image (zoom/flash/pulse), not animated gifs
             m_animation = nullptr;
+            m_alpha = 1.0f;
+            m_zoom = 100.0f;
+            m_gradState = 0;
+            m_filterMode = 0;
+            m_autoFitWidth = 0;
+            m_autoFitHeight = 0;
             m_dirty = true;
          }
          else if (key == "rotate")
          {
-            // in tenths.  so 900 is 90 degrees. rotate support for images too.  note images must be aligned center to rotate properly(default)
+            // See pDMDLabelSetRotate — in tenths, so 900 is 90 degrees. rotate support for images too.
+            // note images must be aligned center to rotate properly(default)
             m_angle = static_cast<float>(value.as<double>() / 10.0);
             m_dirty = true;
          }
          else if (key == "zoom")
          {
-            // 120 for 120% of current height, 80% etc...
-            NOT_IMPLEMENTED("zoom not implemented"s);
-            m_dirty = true;
+            // See pDMDLabelSetZoom — 120 for 120% of current height, 80% etc...
+            m_zoom = static_cast<float>(value.as<double>());
          }
          else if (key == "alpha")
          {
-            // '0-255  255=full, 0=blank
-            NOT_IMPLEMENTED("alpha not implemented"s);
-            m_dirty = true;
+            // See pDMDLabelSetAlpha — 0-255  255=full, 0=blank
+            m_alpha = clamp(value.as<int>(), 0, 255) / 255.0f;
          }
          else if (key == "gradstate")
          {
-            // color=gradcolor, gradstate = 0 (gradstate is percent)
-            NOT_IMPLEMENTED("gradstate/gradcolor not implemented"s);
+            // See pDMDLabelSetColorGradient — gradstate controls gradient blend (0=off, 1+=on)
+            m_gradState = value.as<int>();
             m_dirty = true;
          }
          else if (key == "gradcolor")
          {
-            // color=gradcolor, gradstate = 0 (gradstate is percent)
-            NOT_IMPLEMENTED("gradstate/gradcolor not implemented"s);
+            // See pDMDLabelSetColorGradientPercent — end color of the vertical gradient
+            m_gradColor = value.as<int>();
             m_dirty = true;
          }
          else if (key == "grayscale")
          {
-            // only on image objects.  will show as grayscale.  1=gray filter on 0=off normal mode
-            NOT_IMPLEMENTED("filter not implemented"s);
+            // See pDMDLabelSetGrayScale — shortcut for filter mode 3 on images. 1=on, 0=off
+            m_filterMode = (value.as<int>() == 1) ? 3 : 0;
             m_dirty = true;
          }
          else if (key == "filter")
          {
-            // fmode 1-5 (invertRGB, invert,grayscale,invertalpha,clear),blur)
-            NOT_IMPLEMENTED("filter not implemented"s);
+            // See pDMDLabelSetFilter — fmode 1=invertRGB, 2=invert, 3=grayscale, 4=invertalpha, 5=clear/blur
+            m_filterMode = value.as<int>();
             m_dirty = true;
          }
          else if (key == "shadowstate")
          {
-            m_shadowState = value.as<int>();
+            // See pDMDLabelSetShadow / pDMDLabelSetBorder / pDMDLabelSetOutShadow
+            // shadowstate is a simple on/off: 0 disables shadow, non-zero enables drop shadow (type 1)
+            m_shadowType = (value.as<int>() != 0) ? 1 : 0;
             m_dirty = true;
          }
          else if (key == "shadowcolor")
@@ -302,12 +503,13 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          }
          else if (key == "shadowtype")
          {
-            // ST = 1 (Shadow), ST = 2 (Border)
-            NOT_IMPLEMENTED("shadowtype not implemented"s);
+            // shadowtype sets the rendering mode directly: 0=none, 1=drop shadow, 2=border
+            m_shadowType = value.as<int>();
             m_dirty = true;
          }
          else if (key == "xoffset")
          {
+            // See pDMDLabelSetShadow / pDMDLabelSetBorder — shadow displacement as % of font height
             m_xoffset = static_cast<float>(value.as<double>());
             m_dirty = true;
          }
@@ -318,11 +520,13 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          }
          else if (key == "anigif")
          {
+            // See pDMDPNGAnimate — speed is frame timer, 100 is ~30fps
             m_anigif = value.as<int>();
             m_dirty = true;
          }
          else if (key == "width")
          {
+            // See pDMDLabelSetSizeImage — width/height as percent of display dimensions
             m_imageWidth = static_cast<float>(value.as<double>());
             m_dirty = true;
          }
@@ -333,22 +537,39 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          }
          else if (key == "autow")
          {
-            NOT_IMPLEMENTED("autow not implemented"s);
+            // See pDMDLabelSetAutoSize — auto-shrink font to fit within specified dimensions
+            m_autoFitWidth = static_cast<float>(value.as<double>());
             m_dirty = true;
          }
          else if (key == "autoh")
          {
-            NOT_IMPLEMENTED("autoh not implemented"s);
+            m_autoFitHeight = static_cast<float>(value.as<double>());
             m_dirty = true;
          }
          else if (key == "outline")
          {
+            // See pDMDLabelSetBorder / pDMDLabelSetOutShadow — outline=1 upgrades shadow to border mode (type 2)
             m_outline = value.as<int>();
+            if (m_outline == 1)
+               m_shadowType = 2;
             m_dirty = true;
          }
          else if (key == "bold")
          {
             m_bold = (value.as<int>() == 1);
+            m_dirty = true;
+         }
+         else if (key == "italic")
+         {
+            m_italic = (value.as<int>() == 1);
+            m_dirty = true;
+         }
+         else if (key == "v2")
+         {
+            // See pupCreateLabel / pupCreateLabelImage
+            // v2 enables absolute positioning: xpos/ypos=0 means literally 0%,
+            // disabling the default behavior where 0 maps to center/right/bottom edge
+            m_useAbsolutePos = true;
             m_dirty = true;
          }
          else
@@ -357,6 +578,11 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          }
       }
    }
+      break;
+
+   case 0:
+      // mt=0 or missing mt
+      // Batman66 sends mt=0 which spams the log
       break;
 
    default:
@@ -369,7 +595,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
 {
    std::lock_guard lock(m_mutex);
 
-   if (!m_visible || pagenum != m_pagenum || m_szCaption.empty() || (m_animation && !m_animation->m_visible))
+   if ((!m_visible && !m_animation) || pagenum != m_pagenum || m_szCaption.empty())
       return;
    
    int fontColor = m_animation ? m_animation->m_color : m_color;
@@ -396,7 +622,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       else if (m_pFont)
          m_pendingTextureUpdate = std::async(std::launch::async, [this, rect, fontColor]() {
             std::lock_guard lock(m_mutex);
-            return UpdateLabelTexture(rect.h, m_pFont, m_szCaption, m_size, fontColor, m_shadowState, m_shadowColor, { m_xoffset, m_yoffset} );
+            return UpdateLabelTexture(rect.h, m_pFont, m_szCaption, m_size, fontColor, m_shadowType, m_shadowColor, { m_xoffset, m_yoffset} );
          });
    }
 
@@ -438,8 +664,13 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    SDL_FRect dest = { static_cast<float>(rect.x), static_cast<float>(rect.y), width, height };
 
    float xposPercent = m_xPos / 100.0f;
-   if (m_xPos == 0.f && m_xAlign == PUP_LABEL_XALIGN_CENTER)
-      xposPercent = 0.5f;
+   if (m_xPos == 0.f && !m_useAbsolutePos)
+   {
+      if (m_xAlign == PUP_LABEL_XALIGN_CENTER)
+         xposPercent = 0.5f;
+      else if (m_xAlign == PUP_LABEL_XALIGN_RIGHT)
+         xposPercent = 1.0f;
+   }
 
    dest.x += static_cast<float>(rect.w) * xposPercent;
 
@@ -449,15 +680,27 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       dest.x -= width;
 
    float yposPercent = m_yPos / 100.0f;
-   if (m_yPos == 0.f && m_yAlign == PUP_LABEL_YALIGN_CENTER)
-      yposPercent = 0.5f;
+   if (m_yPos == 0.f && !m_useAbsolutePos)
+   {
+      if (m_yAlign == PUP_LABEL_YALIGN_CENTER)
+         yposPercent = 0.5f;
+      else if (m_yAlign == PUP_LABEL_YALIGN_BOTTOM)
+         yposPercent = 1.0f;
+   }
 
    dest.y += static_cast<float>(rect.h) * yposPercent;
 
    if (m_yAlign == PUP_LABEL_YALIGN_CENTER)
       dest.y -= (height / 2.f);
    else if (m_yAlign == PUP_LABEL_YALIGN_BOTTOM)
-      dest.y = static_cast<float>(rect.y + rect.h) - height - (static_cast<float>(rect.h) * yposPercent);
+      dest.y -= height;
+
+   if (m_shadowType == 2)
+   {
+      const float fontHeight = (m_size / 100.0f) * static_cast<float>(rect.h);
+      dest.x += static_cast<float>(static_cast<int>(fontHeight * (m_xoffset / 100.0f))) * -2.f;
+      dest.y += static_cast<float>(static_cast<int>(fontHeight * (m_yoffset / 100.0f))) * -2.f;
+   }
 
    bool visible = true;
    int color = 0xFFFFFFFF;
@@ -465,7 +708,17 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    {
       if (m_animation->Update(rect, dest))
       {
+         if (m_animation->IsFade())
+            m_alpha = m_animation->m_alpha;
+         if (m_animation->IsZoom())
+            m_zoom = m_animation->m_zoom;
+         if (m_animation->m_alphaFade > 0)
+            m_alpha = 0.f;
+         // Persist final motion position so label stays where the animation left it
+         m_xPos += (m_animation->m_xOffset / static_cast<float>(rect.w)) * 100.f;
+         m_yPos += (m_animation->m_yOffset / static_cast<float>(rect.h)) * 100.f;
          m_animation = nullptr;
+         return;
       }
       else
       {
@@ -476,13 +729,32 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       }
    }
 
-   if (visible)
+   float alpha = m_animation ? m_animation->m_alpha : m_alpha;
+
+   float zoom = m_animation ? m_animation->m_zoom : m_zoom;
+   if (zoom != 100.0f)
    {
-      // FIXME implement color (as the naimation may animate it)
-      // FIXME implement rotation center (used to be SDL_FPoint center = { height / 2.0f, 0 };)
+      const float scale = zoom / 100.0f;
+      const float cx = dest.x + dest.w * 0.5f;
+      const float cy = dest.y + dest.h * 0.5f;
+      dest.w *= scale;
+      dest.h *= scale;
+      dest.x = cx - dest.w * 0.5f;
+      dest.y = cy - dest.h * 0.5f;
+   }
+
+   if (visible && alpha > 0.f)
+   {
+      // FIXME implement color (as the animation may animate it)
+      // FIXME rotation is done via CPU (90/270 degress render blank via GPU?)
+      // Wiggle animation uses GPU rotation since the angles are small
       const VPXTextureInfo* texInfo = GetTextureInfo(m_renderState.m_pTexture);
-      ctx->DrawImage(ctx, m_renderState.m_pTexture, 1.f, 1.f, 1.f, 1.f, 0.f, 0.f, static_cast<float>(texInfo->width), static_cast<float>(texInfo->height), 0.f, 0.f, -m_angle, dest.x, dest.y,
-         dest.w, dest.h);
+      const float drawAngle = (m_animation && m_animation->IsWiggle()) ? m_animation->m_wiggle : 0.f;
+      const float pivotX = (drawAngle != 0.f) ? static_cast<float>(texInfo->width) * 0.5f : 0.f;
+      const float pivotY = (drawAngle != 0.f) ? static_cast<float>(texInfo->height) * 0.5f : 0.f;
+      ClipDrawImage(ctx, m_renderState.m_pTexture, 1.f, 1.f, 1.f, alpha,
+         0.f, 0.f, static_cast<float>(texInfo->width), static_cast<float>(texInfo->height),
+         pivotX, pivotY, drawAngle, dest, rect);
    }
 }
 
@@ -502,6 +774,8 @@ PUPLabel::RenderState PUPLabel::UpdateImageTexture(PUP_LABEL_TYPE type, const st
          image = newImage;
       }
       if (image) {
+         if (m_filterMode > 0)
+            ApplyFilter(image, m_filterMode);
          rs.m_pTexture = CreateTexture(image);
          SDL_DestroySurface(image);
       }
@@ -548,15 +822,25 @@ PUPLabel::RenderState PUPLabel::UpdateLabelTexture(int outHeight, TTF_Font* pFon
    TTF_FontStyleFlags style = TTF_STYLE_NORMAL;
    // FIXME TTF_STYLE_BOLD gives bad results (test with Blood Machines, during Bonus sequence)
    // style |= m_bold ? TTF_STYLE_BOLD : 0;
+   if (m_italic) style |= TTF_STYLE_ITALIC;
    TTF_SetFontSize(pFont, fontHeight);
    // FIXME TTF_SetFontOutline does not gives clean outlines
    // TTF_SetFontOutline(pFont, m_outline);
    TTF_SetFontOutline(pFont, 0);
    TTF_SetFontStyle(pFont, style);
    TTF_SetFontHinting(pFont, TTF_HINTING_NORMAL);
+   TTF_SetFontWrapAlignment(pFont,
+      m_xAlign == PUP_LABEL_XALIGN_CENTER ? TTF_HORIZONTAL_ALIGN_CENTER :
+      m_xAlign == PUP_LABEL_XALIGN_RIGHT  ? TTF_HORIZONTAL_ALIGN_RIGHT :
+                                             TTF_HORIZONTAL_ALIGN_LEFT);
 
    string text = szCaption;
-   std::replace_if(text.begin(), text.end(), [pFont](char c) { return !TTF_FontHasGlyph(pFont, c); }, ' ');
+   std::replace_if(text.begin(), text.end(), [pFont](char c) { return c != '\n' && !TTF_FontHasGlyph(pFont, c); }, ' ');
+
+   // See pDMDLabelSetAutoSize — shrink font until text fits within autow/autoh dimensions
+   const float maxW = (m_autoFitWidth > 0) ? (m_autoFitWidth / 100.0f) * static_cast<float>(outHeight) * (16.0f / 9.0f) : 0;
+   const float maxH = (m_autoFitHeight > 0) ? (m_autoFitHeight / 100.0f) * static_cast<float>(outHeight) : 0;
+   float adjustedHeight = fontHeight;
 
    SDL_Color textColor = { GetRValue(m_color), GetGValue(m_color), GetBValue(m_color), 255 };
    SDL_Surface* pTextSurface = TTF_RenderText_Blended_Wrapped(pFont, text.c_str(), text.length(), textColor, 0);
@@ -566,18 +850,113 @@ PUPLabel::RenderState PUPLabel::UpdateLabelTexture(int outHeight, TTF_Font* pFon
       return rs;
    }
 
+   while (pTextSurface && (maxW > 0 || maxH > 0))
+   {
+      bool fits = true;
+      if (maxW > 0 && pTextSurface->w > maxW) fits = false;
+      if (maxH > 0 && pTextSurface->h > maxH) fits = false;
+      if (fits || adjustedHeight < 4.f) break;
+      adjustedHeight -= 2.f;
+      TTF_SetFontSize(pFont, adjustedHeight);
+      SDL_DestroySurface(pTextSurface);
+      pTextSurface = TTF_RenderText_Blended_Wrapped(pFont, text.c_str(), text.length(), textColor, 0);
+   }
+
    const int xoffset = static_cast<int>(fontHeight * (offset.x / 100.0f));
    const int yoffset = static_cast<int>(fontHeight * (offset.y / 100.0f));
-   SDL_Surface* pMergedSurface = SDL_CreateSurface(pTextSurface->w + abs(xoffset), pTextSurface->h + abs(yoffset), SDL_PIXELFORMAT_RGBA32);
+   const int absxoff = abs(xoffset);
+   const int absyoff = abs(yoffset);
+
+   if (shadowstate == 2 && (absxoff != 0 || absyoff != 0))
+   {
+      // See pDMDLabelSetBorder — border/outline mode: render shadow text at offsets around
+      // all edges to form a border, then render foreground text centered on top
+      SDL_Surface* pMergedSurface = SDL_CreateSurface(pTextSurface->w + absxoff * 2, pTextSurface->h + absyoff * 2, SDL_PIXELFORMAT_RGBA32);
+      if (!pMergedSurface)
+      {
+         LOGE("Unable to render text: label=" + m_szName + ", error=" + SDL_GetError());
+         SDL_DestroySurface(pTextSurface);
+         return rs;
+      }
+
+      const SDL_Color shadowColor = { GetRValue(shadowcolor), GetGValue(shadowcolor), GetBValue(shadowcolor), 255 };
+      SDL_Surface* pShadowSurface = TTF_RenderText_Blended_Wrapped(pFont, text.c_str(), text.length(), shadowColor, 0);
+      if (pShadowSurface)
+      {
+         const int offsets[][2] = {
+            {0, 0}, {absxoff, 0}, {absxoff * 2, 0},
+            {0, absyoff}, {absxoff * 2, absyoff},
+            {0, absyoff * 2}, {absxoff, absyoff * 2}, {absxoff * 2, absyoff * 2}
+         };
+         for (const auto& off : offsets)
+         {
+            SDL_Rect r = { off[0], off[1], pShadowSurface->w, pShadowSurface->h };
+            SDL_BlitSurface(pShadowSurface, nullptr, pMergedSurface, &r);
+         }
+         SDL_DestroySurface(pShadowSurface);
+      }
+
+      SDL_Rect textRect = { absxoff, absyoff, pTextSurface->w, pTextSurface->h };
+      SDL_BlitSurface(pTextSurface, nullptr, pMergedSurface, &textRect);
+      SDL_DestroySurface(pTextSurface);
+
+      if (m_gradState > 0)
+      {
+         SDL_LockSurface(pMergedSurface);
+         uint32_t* pixels = (uint32_t*)pMergedSurface->pixels;
+         const int pitch = pMergedSurface->pitch / 4;
+         const int h = pMergedSurface->h;
+         for (int y = 0; y < h; y++)
+         {
+            const float t = (float)y / (float)(h > 1 ? h - 1 : 1);
+            const uint8_t gr = GetRValue(m_color) + static_cast<uint8_t>(t * (GetRValue(m_gradColor) - GetRValue(m_color)));
+            const uint8_t gg = GetGValue(m_color) + static_cast<uint8_t>(t * (GetGValue(m_gradColor) - GetGValue(m_color)));
+            const uint8_t gb = GetBValue(m_color) + static_cast<uint8_t>(t * (GetBValue(m_gradColor) - GetBValue(m_color)));
+            for (int x = 0; x < pMergedSurface->w; x++)
+            {
+               uint32_t& px = pixels[y * pitch + x];
+               const uint8_t a = (px >> 24) & 0xFF;
+               if (a > 0)
+                  px = (a << 24) | (gb << 16) | (gg << 8) | gr;
+            }
+         }
+         SDL_UnlockSurface(pMergedSurface);
+      }
+
+      if (m_filterMode > 0)
+         ApplyFilter(pMergedSurface, m_filterMode);
+
+      if (m_angle != 0.f)
+      {
+         SDL_Surface* pRotated = RotateSurface(pMergedSurface, m_angle);
+         if (pRotated)
+         {
+            SDL_DestroySurface(pMergedSurface);
+            pMergedSurface = pRotated;
+         }
+      }
+
+      rs.m_pTexture = CreateTexture(pMergedSurface);
+      if (rs.m_pTexture)
+      {
+         rs.m_width = static_cast<float>(pMergedSurface->w);
+         rs.m_height = static_cast<float>(pMergedSurface->h);
+      }
+      SDL_DestroySurface(pMergedSurface);
+      return rs;
+   }
+
+   SDL_Surface* pMergedSurface = SDL_CreateSurface(pTextSurface->w + absxoff, pTextSurface->h + absyoff, SDL_PIXELFORMAT_RGBA32);
    if (!pMergedSurface)
    {
       LOGE("Unable to render text: label=" + m_szName + ", error=" + SDL_GetError());
+      SDL_DestroySurface(pTextSurface);
       return rs;
    }
-   //SDL_FillSurfaceRect(pMergedSurface, NULL, SDL_MapRGBA(SDL_GetPixelFormatDetails(pMergedSurface->format), nullptr, 255, 255, 0, 255));
 
    if (shadowstate && (xoffset != 0 || yoffset != 0))
-   { // Shadow rendering
+   {
+      // See pDMDLabelSetShadow — drop shadow: render shadow text at offset, foreground at origin
       const SDL_Color shadowColor = { GetRValue(shadowcolor), GetGValue(shadowcolor), GetBValue(shadowcolor), 255 };
       SDL_Surface* pShadowSurface = TTF_RenderText_Blended_Wrapped(pFont, text.c_str(), text.length(), shadowColor, 0);
       if (pShadowSurface)
@@ -597,10 +976,47 @@ PUPLabel::RenderState PUPLabel::UpdateLabelTexture(int outHeight, TTF_Font* pFon
       }
    }
    else
-   { // BGRA to RGBA conversion
+   {
       SDL_BlitSurface(pTextSurface, nullptr, pMergedSurface, nullptr);
    }
    SDL_DestroySurface(pTextSurface);
+
+   // See pDMDLabelSetColorGradient — apply vertical gradient from color to gradcolor
+   if (m_gradState > 0)
+   {
+      SDL_LockSurface(pMergedSurface);
+      uint32_t* pixels = (uint32_t*)pMergedSurface->pixels;
+      const int pitch = pMergedSurface->pitch / 4;
+      const int h = pMergedSurface->h;
+      for (int y = 0; y < h; y++)
+      {
+         const float t = (float)y / (float)(h > 1 ? h - 1 : 1);
+         const uint8_t gr = GetRValue(m_color) + static_cast<uint8_t>(t * (GetRValue(m_gradColor) - GetRValue(m_color)));
+         const uint8_t gg = GetGValue(m_color) + static_cast<uint8_t>(t * (GetGValue(m_gradColor) - GetGValue(m_color)));
+         const uint8_t gb = GetBValue(m_color) + static_cast<uint8_t>(t * (GetBValue(m_gradColor) - GetBValue(m_color)));
+         for (int x = 0; x < pMergedSurface->w; x++)
+         {
+            uint32_t& px = pixels[y * pitch + x];
+            const uint8_t a = (px >> 24) & 0xFF;
+            if (a > 0)
+               px = (a << 24) | (gb << 16) | (gg << 8) | gr;
+         }
+      }
+      SDL_UnlockSurface(pMergedSurface);
+   }
+
+   if (m_filterMode > 0)
+      ApplyFilter(pMergedSurface, m_filterMode);
+
+   if (m_angle != 0.f)
+   {
+      SDL_Surface* pRotated = RotateSurface(pMergedSurface, m_angle);
+      if (pRotated)
+      {
+         SDL_DestroySurface(pMergedSurface);
+         pMergedSurface = pRotated;
+      }
+   }
 
    rs.m_pTexture = CreateTexture(pMergedSurface);
    if (rs.m_pTexture)
@@ -650,7 +1066,47 @@ PUPLabel::Animation::Animation(PUPLabel* label, unsigned int lengthMs, int foreg
    , m_motionColor(motionColor)
 {
 }
-   
+
+PUPLabel::Animation::Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, int alphaStart, int alphaEnd, int pulseSpeed, bool screenFade)
+   : m_label(label)
+   , m_color(label->m_color)
+   , m_lengthMs(lengthMs)
+   , m_foregroundColor(foregroundColor)
+   , m_startTimestamp(SDL_GetTicks())
+   , m_alphaStart(alphaStart)
+   , m_alphaEnd(alphaEnd)
+   , m_pulseSpeed(pulseSpeed)
+{
+   m_alpha = static_cast<float>(m_alphaStart) / 255.0f;
+}
+
+PUPLabel::Animation::Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, float zoomStart, float zoomEnd, int zoomPulseSpeed)
+   : m_label(label)
+   , m_color(label->m_color)
+   , m_lengthMs(lengthMs)
+   , m_foregroundColor(foregroundColor)
+   , m_startTimestamp(SDL_GetTicks())
+   , m_zoomStart(zoomStart)
+   , m_zoomEnd(zoomEnd)
+   , m_zoomPulseSpeed(zoomPulseSpeed)
+{
+   m_zoom = m_zoomStart;
+}
+
+PUPLabel::Animation::Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, float wiggleStart, float wiggleEnd, int wiggleSpeed, int dummy)
+   : m_label(label)
+   , m_color(label->m_color)
+   , m_lengthMs(lengthMs)
+   , m_foregroundColor(foregroundColor)
+   , m_startTimestamp(SDL_GetTicks())
+   , m_wiggleStart(wiggleStart)
+   , m_wiggleEnd(wiggleEnd)
+   , m_wiggleSpeed(wiggleSpeed)
+{
+   (void)dummy;
+   m_wiggle = m_wiggleStart;
+}
+
 bool PUPLabel::Animation::Update(const SDL_Rect& screenRect, const SDL_FRect& labelRect)
 {
    uint64_t elapsed = SDL_GetTicks() - m_startTimestamp;
@@ -660,14 +1116,34 @@ bool PUPLabel::Animation::Update(const SDL_Rect& screenRect, const SDL_FRect& la
       m_color = m_label->m_color;
       m_xOffset = 0.f;
       m_yOffset = 0.f;
-      m_visible = true;
+      m_alpha = static_cast<float>(m_alphaEnd) / 255.0f;
+      m_zoom = m_zoomEnd;
+      if (m_numStart != INT_MIN)
+      {
+         string numStr = std::to_string(m_numEnd);
+         if (m_numFormat == 1)
+         {
+            int insertPos = static_cast<int>(numStr.length()) - 3;
+            while (insertPos > 0) { numStr.insert(insertPos, ","); insertPos -= 3; }
+         }
+         PUPLabel* label = const_cast<PUPLabel*>(m_label);
+         label->m_szCaption = numStr;
+         label->m_dirty = true;
+      }
       return true;
    }
 
    if (m_flashingPeriod)
    {
-      m_visible = ((elapsed / m_flashingPeriod) & 1) != 0;
+      // See pDMDLabelFlash — toggle visibility every fq milliseconds
+      m_visible = ((elapsed / m_flashingPeriod) & 1) == 0;
       m_color = m_foregroundColor;
+   }
+
+   if (m_delayShow > 0)
+   {
+      // See pDMDLabelClone — hide until delay elapsed, then show
+      m_visible = (static_cast<int>(elapsed) >= m_delayShow);
    }
 
    if (m_motionLen)
@@ -680,13 +1156,105 @@ bool PUPLabel::Animation::Update(const SDL_Rect& screenRect, const SDL_FRect& la
       const float yBase = labelRect.y;
       const float yTop = static_cast<float>(screenRect.y) - labelRect.h;
       const float yBottom = static_cast<float>(screenRect.y) + static_cast<float>(screenRect.h);
-      const float xs = m_xps == 0 ? xBase : m_xps == 1 ? xRight : xLeft;
-      const float xe = m_xpe == 0 ? xBase : m_xpe == 1 ? xRight : xLeft;
-      const float ys = m_yps == 0 ? yBase : m_yps == 1 ? yBottom : yTop;
-      const float ye = m_ype == 0 ? yBase : m_ype == 1 ? yBottom : yTop;
+      // -1 = off-screen left/top, 0 = current position, 1 = off-screen right/bottom,
+      // other values = percentage position (see pDMDLabelMoveTO)
+      const float screenW = static_cast<float>(screenRect.w);
+      const float screenH = static_cast<float>(screenRect.h);
+      const float xs = m_xps == 0 ? xBase : m_xps == 1 ? xRight : m_xps == -1 ? xLeft : static_cast<float>(screenRect.x) + screenW * m_xps / 100.f;
+      const float xe = m_xpe == 0 ? xBase : m_xpe == 1 ? xRight : m_xpe == -1 ? xLeft : static_cast<float>(screenRect.x) + screenW * m_xpe / 100.f;
+      const float ys = m_yps == 0 ? yBase : m_yps == 1 ? yBottom : m_yps == -1 ? yTop : static_cast<float>(screenRect.y) + screenH * m_yps / 100.f;
+      const float ye = m_ype == 0 ? yBase : m_ype == 1 ? yBottom : m_ype == -1 ? yTop : static_cast<float>(screenRect.y) + screenH * m_ype / 100.f;
       m_color = pos < 1.0f ? m_motionColor : m_foregroundColor;
-      m_xOffset = lerp(pos, xs, xe) - xBase;
-      m_yOffset = lerp(pos, ys, ye) - yBase;
+      m_xOffset = lerp(xs, xe, pos) - xBase;
+      m_yOffset = lerp(ys, ye, pos) - yBase;
+
+      if (m_alphaFade > 0)
+      {
+         const int fadeStart = static_cast<int>(m_lengthMs) - m_alphaFade;
+         if (static_cast<int>(elapsed) > fadeStart)
+            m_alpha = 1.0f - clamp(static_cast<float>(elapsed - fadeStart) / static_cast<float>(m_alphaFade), 0.f, 1.f);
+      }
+   }
+
+   if (m_alphaStart != m_alphaEnd)
+   {
+      const float as = static_cast<float>(m_alphaStart) / 255.0f;
+      const float ae = static_cast<float>(m_alphaEnd) / 255.0f;
+      if (m_pulseSpeed > 0)
+      {
+         // See pDMDLabelFadePulse — bounce alpha between astart and aend
+         // Approximate one full cycle takes range/speed*2 ticks * 33ms
+         const float range = static_cast<float>(m_alphaEnd - m_alphaStart);
+         const float periodMs = (range / static_cast<float>(m_pulseSpeed)) * 2.0f * 33.0f;
+         const float cyclePos = fmodf(static_cast<float>(elapsed), periodMs) / periodMs;
+         const float t = cyclePos < 0.5f ? cyclePos * 2.0f : 2.0f - cyclePos * 2.0f;
+         m_alpha = as + t * (ae - as);
+      }
+      else
+      {
+         // See pDMDLabelFadeOut / pDMDLabelFadeIn / pDMDScreenFadeOut / pDMDScreenFadeIn
+         float pos = clamp(static_cast<float>(elapsed) / static_cast<float>(m_lengthMs), 0.f, 1.f);
+         m_alpha = as + pos * (ae - as);
+      }
+      m_color = m_foregroundColor;
+   }
+
+   if (m_zoomStart != m_zoomEnd)
+   {
+      if (m_zoomPulseSpeed != 0)
+      {
+         // See pDMDLabelPulseText / pDMDLabelPulseImage — bounce zoom between hstart and hend
+         // Approximate one full cycle (start->end->start) every 500ms
+         const float periodMs = 500.0f;
+         const float cyclePos = fmodf(static_cast<float>(elapsed), periodMs) / periodMs;
+         const float t = cyclePos < 0.5f ? cyclePos * 2.0f : 2.0f - cyclePos * 2.0f;
+         m_zoom = m_zoomStart + t * (m_zoomEnd - m_zoomStart);
+      }
+      else
+      {
+         // See pDMDZoomBig — zoom from hstart to hend over len ms
+         float pos = clamp(static_cast<float>(elapsed) / static_cast<float>(m_lengthMs), 0.f, 1.f);
+         m_zoom = m_zoomStart + pos * (m_zoomEnd - m_zoomStart);
+      }
+      m_color = m_foregroundColor;
+   }
+
+   if (m_wiggleStart != m_wiggleEnd)
+   {
+      // See pDMDLabelWiggleText / pDMDLabelWiggleImage — bounce rotation between rstart and rend.
+      const float periodMs = 300.0f;
+      const float cyclePos = fmodf(static_cast<float>(elapsed), periodMs) / periodMs;
+      const float t = cyclePos < 0.5f ? cyclePos * 2.0f : 2.0f - cyclePos * 2.0f;
+      m_wiggle = m_wiggleStart + t * (m_wiggleEnd - m_wiggleStart);
+      m_color = m_foregroundColor;
+   }
+
+   // See pDMDLabelPulseNumber — interpolate number and update label caption
+   if (m_numStart != INT_MIN)
+   {
+      float pos = clamp(static_cast<float>(elapsed) / static_cast<float>(m_lengthMs), 0.f, 1.f);
+      int num = (pos >= 1.f) ? m_numEnd : m_numStart + static_cast<int>(pos * static_cast<float>(m_numEnd - m_numStart));
+      string numStr;
+      if (m_numFormat == 1)
+      {
+         numStr = std::to_string(num);
+         int insertPos = static_cast<int>(numStr.length()) - 3;
+         while (insertPos > 0)
+         {
+            numStr.insert(insertPos, ",");
+            insertPos -= 3;
+         }
+      }
+      else
+         numStr = std::to_string(num);
+
+      if (numStr != m_numText)
+      {
+         m_numText = numStr;
+         PUPLabel* label = const_cast<PUPLabel*>(m_label);
+         label->m_szCaption = numStr;
+         label->m_dirty = true;
+      }
    }
 
    return false;

--- a/plugins/pup/PUPLabel.h
+++ b/plugins/pup/PUPLabel.h
@@ -47,6 +47,7 @@ public:
    void SetSpecial(const string& szSpecial);
    void Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int pagenum);
    const string& GetName() const { return m_szName; }
+   bool IsAnimating() const { return m_animation != nullptr; }
    void SetScreen(PUPScreen* pScreen) { m_pScreen = pScreen; }
    string ToString() const;
 
@@ -67,11 +68,20 @@ private:
    string m_szCaption;
    int m_pagenum;
    int m_shadowColor = 0;
-   int m_shadowState = 0;
+   int m_shadowType = 0;
    float m_xoffset = 0;
    float m_yoffset = 0;
    int m_outline = 0;
    bool m_bold = false;
+   bool m_italic = false;
+   float m_alpha = 1.0f;
+   bool m_useAbsolutePos = false;
+   float m_zoom = 100.0f;
+   int m_gradColor = 0;
+   int m_gradState = 0;
+   int m_filterMode = 0;
+   float m_autoFitWidth = 0;
+   float m_autoFitHeight = 0;
    PUPScreen* m_pScreen = nullptr;
    int m_anigif = 0;
 
@@ -144,12 +154,21 @@ private:
    public:
       Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, int flashingPeriod);
       Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, int xps, int xpe, int yps, int ype, int motionLen, int motionTween, int motionColor);
+      Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, int alphaStart, int alphaEnd, int pulseSpeed, bool screenFade);
+      Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, float zoomStart, float zoomEnd, int zoomPulseSpeed);
+      Animation(PUPLabel* label, unsigned int lengthMs, int foregroundColor, float wiggleStart, float wiggleEnd, int wiggleSpeed, int dummy);
 
       bool Update(const SDL_Rect& screenRect, const SDL_FRect& labelRect);
+      bool IsFade() const { return m_alphaStart != m_alphaEnd; }
+      bool IsZoom() const { return m_zoomStart != m_zoomEnd; }
+      bool IsWiggle() const { return m_wiggleStart != m_wiggleEnd; }
 
       bool m_visible = true;
       float m_xOffset = 0.f;
       float m_yOffset = 0.f;
+      float m_alpha = 1.f;
+      float m_zoom = 100.f;
+      float m_wiggle = 0.f;
       int m_color;
 
    private:
@@ -167,6 +186,28 @@ private:
       int m_motionLen = 0;
       int m_motionTween = 0;
       int m_motionColor = 0;
+   public:
+      int m_alphaFade = 0;
+   private:
+
+      int m_alphaStart = 255;
+      int m_alphaEnd = 255;
+      int m_pulseSpeed = 0;
+
+      float m_zoomStart = 100.f;
+      float m_zoomEnd = 100.f;
+      int m_zoomPulseSpeed = 0;
+
+      float m_wiggleStart = 0.f;
+      float m_wiggleEnd = 0.f;
+      int m_wiggleSpeed = 0;
+
+   public:
+      int m_delayShow = 0;
+      int m_numStart = INT_MIN;
+      int m_numEnd = INT_MAX;
+      int m_numFormat = 0;
+      string m_numText;
    };
 
    bool m_dirty = true;

--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -133,7 +133,17 @@ void PUPManager::SetGameDir(const string& szRomName)
 
 void PUPManager::LoadConfig(const string& szRomName)
 {
+   // Tables commonly call B2SInit multiple times
+   // Skip reload for the same ROM to avoid destroying screens and their labels
+   if (!m_szPath.empty() && lowerCase(szRomName) == lowerCase(m_szRomName))
+   {
+      LOGI("Same ROM, skipping re-init"s);
+      return;
+   }
+
    Unload();
+
+   m_szRomName = szRomName;
 
    SetGameDir(szRomName);
 
@@ -194,6 +204,7 @@ void PUPManager::Unload()
    m_playlists.clear();
 
    m_szPath.clear();
+   m_szRomName.clear();
 }
 
 void PUPManager::UnloadFonts()

--- a/plugins/pup/PUPManager.h
+++ b/plugins/pup/PUPManager.h
@@ -99,6 +99,7 @@ private:
    float m_mainVolume = 1.f;
    std::filesystem::path m_szRootPath;
    std::filesystem::path m_szPath;
+   string m_szRomName;
    vector<std::shared_ptr<PUPScreen>> m_screenOrder;
    ankerl::unordered_dense::map<int, std::shared_ptr<PUPScreen>> m_screenMap;
    vector<TTF_Font*> m_fonts;

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -446,8 +446,8 @@ void PUPPinDisplay::LabelNew(int screenNum, const string& LabelName, const strin
       return;
    }
 
-   pScreen->AddLabel(new PUPLabel(&m_pupManager, LabelName, FontName, static_cast<float>(Size), Color, 
-      static_cast<float>(Angle), (PUP_LABEL_XALIGN)xAlign, (PUP_LABEL_YALIGN)yAlign, 
+   pScreen->AddLabel(new PUPLabel(&m_pupManager, LabelName, FontName, static_cast<float>(Size), Color,
+      static_cast<float>(Angle) / 10.0f, (PUP_LABEL_XALIGN)xAlign, (PUP_LABEL_YALIGN)yAlign,
       static_cast<float>(xMargin), static_cast<float>(yMargin), PageNum, Visible));
 
    return;
@@ -484,7 +484,10 @@ void PUPPinDisplay::LabelSet(int screenNum, const string& LabelName, const strin
    }
 
    pLabel->SetCaption(Caption);
-   pLabel->SetVisible(Visible);
+   // Animations override visibility in the renderer — a label with an active
+   // animation renders regardless of m_visible
+   if (!pLabel->IsAnimating())
+      pLabel->SetVisible(Visible);
    pLabel->SetSpecial(Special);
 }
 

--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -449,10 +449,8 @@ void PUPScreen::Render(VPXRenderContext2D* const ctx, int pass) {
    case 2: m_overlay.Render(ctx, m_rect); break;
 
    case 3:
-      // FIXME port SDL_SetRenderClipRect(m_pRenderer, &m_rect);
       for (PUPLabel* pLabel : m_labels)
          pLabel->Render(ctx, m_rect, m_pagenum);
-      // FIXME port SDL_SetRenderClipRect(m_pRenderer, NULL);
       break;
    }
 }

--- a/plugins/pup/common.cpp
+++ b/plugins/pup/common.cpp
@@ -245,6 +245,44 @@ bool StrCompareNoCase(const string& strA, const string& strB)
          [](char a, char b) { return cLower(a) == cLower(b); });
 }
 
+// We render all screens to a shared surface, so clip manually by adjusting texture source and destination rects
+#define PUP_CLIP_LABELS 1
+
+void ClipDrawImage(VPXRenderContext2D* ctx, VPXTexture texture,
+   float tintR, float tintG, float tintB, float alpha,
+   float texX, float texY, float texW, float texH,
+   float pivotX, float pivotY, float rotation,
+   const SDL_FRect& dest, const SDL_Rect& clipRect)
+{
+#if PUP_CLIP_LABELS
+   // TNA uses angle=1 (0.1) which prevents clipping. If rotation is near zero, clip anyway
+   if (fabsf(rotation) < 0.5f)
+   {
+      const float cl = fmaxf(dest.x, static_cast<float>(clipRect.x));
+      const float ct = fmaxf(dest.y, static_cast<float>(clipRect.y));
+      const float cr = fminf(dest.x + dest.w, static_cast<float>(clipRect.x + clipRect.w));
+      const float cb = fminf(dest.y + dest.h, static_cast<float>(clipRect.y + clipRect.h));
+      if (cl >= cr || ct >= cb)
+         return;
+
+      const float lf = (cl - dest.x) / dest.w;
+      const float tf = (ct - dest.y) / dest.h;
+      const float rf = (dest.x + dest.w - cr) / dest.w;
+      const float bf = (dest.y + dest.h - cb) / dest.h;
+
+      ctx->DrawImage(ctx, texture, tintR, tintG, tintB, alpha,
+         texX + lf * texW, texY + bf * texH, texW * (1.f - lf - rf), texH * (1.f - tf - bf),
+         pivotX, pivotY, rotation,
+         cl, ct, cr - cl, cb - ct);
+      return;
+   }
+#endif
+   ctx->DrawImage(ctx, texture, tintR, tintG, tintB, alpha,
+      texX, texY, texW, texH,
+      pivotX, pivotY, rotation,
+      dest.x, dest.y, dest.w, dest.h);
+}
+
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN

--- a/plugins/pup/common.h
+++ b/plugins/pup/common.h
@@ -108,4 +108,10 @@ string lowerCase(string input);
 std::filesystem::path lowerCase(std::filesystem::path input);
 void SetThreadName(const string &name);
 
+void ClipDrawImage(VPXRenderContext2D* ctx, VPXTexture texture,
+   float tintR, float tintG, float tintB, float alpha,
+   float texX, float texY, float texW, float texH,
+   float pivotX, float pivotY, float rotation,
+   const SDL_FRect& dest, const SDL_Rect& clipRect);
+
 }

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -2983,7 +2983,7 @@ void Renderer::DrawImage(VPXRenderContext2D* ctx, VPXTexture texture, const floa
    rdl->SetRenderState(RenderState::DESTBLEND, RenderState::INVSRC_ALPHA);
    rdl->SetRenderState(RenderState::BLENDOP, RenderState::BLENDOP_ADD);
    rdl->SetRenderState(RenderState::ALPHABLENDENABLE, (alpha != 1.f || !tex->IsOpaque()) ? RenderState::RS_TRUE : RenderState::RS_FALSE);
-   rdl->m_basicShader->SetVector(SHADER_cBase_Alpha, tintR, tintG, tintB, alpha);
+   rdl->m_basicShader->SetVector(SHADER_staticColor_Alpha, tintR, tintG, tintB, alpha);
    // We force to linear (no sRGB decoding) when rendering in sRGB colorspace, this assumes that the texture is in sRGB colorspace to get correct gamma (other situations would need dedicated shaders to handle them efficiently)
    assert(tex->m_format == BaseTexture::SRGB || tex->m_format == BaseTexture::SRGBA || tex->m_format == BaseTexture::SRGB565);
    // Disable filtering and mipmap generation if they are not needed
@@ -3014,6 +3014,8 @@ void Renderer::DrawImage(VPXRenderContext2D* ctx, VPXTexture texture, const floa
    }
    rdl->m_basicShader->SetTechnique(SHADER_TECHNIQUE_unshaded_with_texture);
    rdl->DrawTexturedQuad(rdl->m_basicShader, vertices, true, g_pplayer->m_renderer->m_ancillaryRenderSetup.depthbias);
+   if (alpha != 1.f || tintR != 1.f || tintG != 1.f || tintB != 1.f)
+      rdl->m_basicShader->SetVector(SHADER_staticColor_Alpha, 1.f, 1.f, 1.f, 1.f);
 }
 
 void Renderer::DrawMatrixDisplay(VPXRenderContext2D* ctx, VPXDisplayRenderStyle style, VPXTexture glassTex, const float glassTintR, const float glassTintG, const float glassTintB,


### PR DESCRIPTION
  - Fixed BOTTOM/RIGHT alignment positioning
  - Fixed xPos=0/yPos=0 defaults for CENTER/RIGHT/BOTTOM alignments
  - Added v2 flag support
  - Added label clipping
  - Fixed multiple B2SInit locking up backglass
  - Fixed LabelNew angle parameter (divide by 10)
  - Fixed DrawImage shader uniform (`SHADER_staticColor_Alpha` instead of `SHADER_cBase_Alpha`)
  - Fixed multi-line text and alignment
  - Fixed motion animation lerp 
  - Fixed flash animation
  - Added alpha transparency support
  - Added italic support
  - Added shadow type 2 (border/outline) rendering and position adjustment
  - Added label rotation using CPU (FIXME 90 and 270 on GPU make label disappear)
  - Added gradient fill
  - Added filter effects (invertRGB, invert, grayscale, invertAlpha, clear)
  - Added auto-fit text
  - Added fade animations
  - Added zoom animations
  - Added wiggle animation
  - Added motion alpha fade
  - Added pulse number counting
  - Added PUPDMD framework doc references throughout