### PR TITLE
plugins: misc pup updates

### DIFF
--- a/plugins/flexdmd/actors/LibAv.h
+++ b/plugins/flexdmd/actors/LibAv.h
@@ -81,6 +81,7 @@ public:
    typedef int(CDECL* fn_av_image_get_buffer_size)(enum AVPixelFormat pix_fmt, int width, int height, int align);
    typedef void*(CDECL* fn_av_malloc)(size_t size) av_alloc_size(1);
    typedef int(CDECL* fn_av_samples_get_buffer_size)(int* linesize, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align);
+   typedef void(CDECL* fn_av_log_set_level)(int level);
 
    typedef void(CDECL* fn_swr_free)(struct SwrContext** s);
    typedef int(CDECL* fn_swr_alloc_set_opts2)(struct SwrContext** ps, const AVChannelLayout* out_ch_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, const AVChannelLayout* in_ch_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate, int log_offset, void* log_ctx);
@@ -122,6 +123,7 @@ public:
    fn_av_image_get_buffer_size _av_image_get_buffer_size = nullptr;
    fn_av_malloc _av_malloc = nullptr;
    fn_av_samples_get_buffer_size _av_samples_get_buffer_size = nullptr;
+   fn_av_log_set_level _av_log_set_level = nullptr;
 
    fn_swr_alloc_set_opts2 _swr_alloc_set_opts2 = nullptr;
    fn_swr_convert _swr_convert = nullptr;
@@ -210,6 +212,7 @@ private:
          _av_image_get_buffer_size = reinterpret_cast<fn_av_image_get_buffer_size>(GetProcAddress(hinstLib, "av_image_get_buffer_size"));
          _av_malloc = reinterpret_cast<fn_av_malloc>(GetProcAddress(hinstLib, "av_malloc"));
          _av_samples_get_buffer_size = reinterpret_cast<fn_av_samples_get_buffer_size>(GetProcAddress(hinstLib, "av_samples_get_buffer_size"));
+         _av_log_set_level = reinterpret_cast<fn_av_log_set_level>(GetProcAddress(hinstLib, "av_log_set_level"));
          isLoaded &= _av_get_bytes_per_sample && _av_fast_malloc && _av_frame_alloc && _av_frame_copy_props && _av_frame_free && _av_free && _av_image_fill_arrays && _av_image_get_buffer_size && _av_malloc && _av_samples_get_buffer_size;
       }
 
@@ -263,6 +266,7 @@ private:
       _av_image_get_buffer_size = &av_image_get_buffer_size;
       _av_malloc = &av_malloc;
       _av_samples_get_buffer_size = &av_samples_get_buffer_size;
+      _av_log_set_level = &av_log_set_level;
 
       _swr_alloc_set_opts2 = &swr_alloc_set_opts2;
       _swr_convert = &swr_convert;
@@ -274,6 +278,9 @@ private:
       _sws_getCachedContext = &sws_getCachedContext;
       _sws_scale = &sws_scale;
    #endif
+
+      if (_av_log_set_level)
+         _av_log_set_level(AV_LOG_ERROR);
    }
 
 };

--- a/plugins/pup/LibAv.h
+++ b/plugins/pup/LibAv.h
@@ -81,6 +81,7 @@ public:
    typedef int(CDECL* fn_av_image_get_buffer_size)(enum AVPixelFormat pix_fmt, int width, int height, int align);
    typedef void*(CDECL* fn_av_malloc)(size_t size) av_alloc_size(1);
    typedef int(CDECL* fn_av_samples_get_buffer_size)(int* linesize, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align);
+   typedef void(CDECL* fn_av_log_set_level)(int level);
 
    typedef void(CDECL* fn_swr_free)(struct SwrContext** s);
    typedef int(CDECL* fn_swr_alloc_set_opts2)(struct SwrContext** ps, const AVChannelLayout* out_ch_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, const AVChannelLayout* in_ch_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate, int log_offset, void* log_ctx);
@@ -122,6 +123,7 @@ public:
    fn_av_image_get_buffer_size _av_image_get_buffer_size = nullptr;
    fn_av_malloc _av_malloc = nullptr;
    fn_av_samples_get_buffer_size _av_samples_get_buffer_size = nullptr;
+   fn_av_log_set_level _av_log_set_level = nullptr;
 
    fn_swr_alloc_set_opts2 _swr_alloc_set_opts2 = nullptr;
    fn_swr_convert _swr_convert = nullptr;
@@ -210,6 +212,7 @@ private:
          _av_image_get_buffer_size = reinterpret_cast<fn_av_image_get_buffer_size>(GetProcAddress(hinstLib, "av_image_get_buffer_size"));
          _av_malloc = reinterpret_cast<fn_av_malloc>(GetProcAddress(hinstLib, "av_malloc"));
          _av_samples_get_buffer_size = reinterpret_cast<fn_av_samples_get_buffer_size>(GetProcAddress(hinstLib, "av_samples_get_buffer_size"));
+         _av_log_set_level = reinterpret_cast<fn_av_log_set_level>(GetProcAddress(hinstLib, "av_log_set_level"));
          isLoaded &= _av_get_bytes_per_sample && _av_fast_malloc && _av_frame_alloc && _av_frame_copy_props && _av_frame_free && _av_free && _av_image_fill_arrays && _av_image_get_buffer_size && _av_malloc && _av_samples_get_buffer_size;
       }
 
@@ -263,6 +266,7 @@ private:
       _av_image_get_buffer_size = &av_image_get_buffer_size;
       _av_malloc = &av_malloc;
       _av_samples_get_buffer_size = &av_samples_get_buffer_size;
+      _av_log_set_level = &av_log_set_level;
 
       _swr_alloc_set_opts2 = &swr_alloc_set_opts2;
       _swr_convert = &swr_convert;
@@ -274,6 +278,9 @@ private:
       _sws_getCachedContext = &sws_getCachedContext;
       _sws_scale = &sws_scale;
    #endif
+
+      if (_av_log_set_level)
+         _av_log_set_level(AV_LOG_ERROR);
    }
 
 };

--- a/plugins/pup/PUPImage.cpp
+++ b/plugins/pup/PUPImage.cpp
@@ -17,6 +17,16 @@ PUPImage::~PUPImage()
       DeleteTexture(m_pTexture);
 }
 
+void PUPImage::Clear()
+{
+   m_file.clear();
+   if (m_pTexture) {
+      DeleteTexture(m_pTexture);
+      m_pTexture = nullptr;
+   }
+   m_pSurface.reset();
+}
+
 void PUPImage::Load(const std::filesystem::path& szFile)
 {
    m_file = szFile;
@@ -31,7 +41,7 @@ void PUPImage::Load(const std::filesystem::path& szFile)
       m_pSurface = std::unique_ptr<SDL_Surface, void (*)(SDL_Surface*)>(SDL_ConvertSurface(m_pSurface.get(), SDL_PIXELFORMAT_RGBA32), SDL_DestroySurface);
 }
 
-void PUPImage::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect)
+void PUPImage::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, float alpha)
 {
    // Update texture
    if (m_pTexture == nullptr && m_pSurface) {
@@ -40,10 +50,10 @@ void PUPImage::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect)
    }
 
    // Render image
-   if (m_pTexture)
+   if (m_pTexture && alpha > 0.f)
    {
       VPXTextureInfo* texInfo = GetTextureInfo(m_pTexture);
-      ctx->DrawImage(ctx, m_pTexture, 1.f, 1.f, 1.f, 1.f,
+      ctx->DrawImage(ctx, m_pTexture, 1.f, 1.f, 1.f, alpha,
          0.f, 0.f, static_cast<float>(texInfo->width), static_cast<float>(texInfo->height),
          0.f, 0.f, 0.f, 
          static_cast<float>(rect.x), static_cast<float>(rect.y), static_cast<float>(rect.w), static_cast<float>(rect.h));

--- a/plugins/pup/PUPImage.h
+++ b/plugins/pup/PUPImage.h
@@ -15,7 +15,8 @@ public:
    const std::filesystem::path& GetFile() const { return m_file; }
 
    void Load(const std::filesystem::path& szFile);
-   void Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect);
+   void Clear();
+   void Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, float alpha = 1.f);
 
 private:
    std::filesystem::path m_file;

--- a/plugins/pup/PUPLabel.cpp
+++ b/plugins/pup/PUPLabel.cpp
@@ -591,7 +591,7 @@ void PUPLabel::SetSpecial(const string& szSpecial)
    }
 }
 
-void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int pagenum)
+void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int pagenum, float screenAlpha)
 {
    std::lock_guard lock(m_mutex);
 
@@ -708,7 +708,9 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    {
       if (m_animation->Update(rect, dest))
       {
-         if (m_animation->IsFade())
+         if (m_animation->IsScreenFade() && m_pScreen)
+            m_pScreen->m_screenAlpha = m_animation->m_alpha;
+         else if (m_animation->IsFade())
             m_alpha = m_animation->m_alpha;
          if (m_animation->IsZoom())
             m_zoom = m_animation->m_zoom;
@@ -722,6 +724,9 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       }
       else
       {
+         if (m_animation->IsScreenFade() && m_pScreen)
+            m_pScreen->m_screenAlpha = m_animation->m_alpha;
+
          dest.x += m_animation->m_xOffset;
          dest.y += m_animation->m_yOffset;
          visible = m_animation->m_visible;
@@ -729,7 +734,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       }
    }
 
-   float alpha = m_animation ? m_animation->m_alpha : m_alpha;
+   float alpha = (m_animation ? m_animation->m_alpha : m_alpha) * screenAlpha;
 
    float zoom = m_animation ? m_animation->m_zoom : m_zoom;
    if (zoom != 100.0f)
@@ -1076,6 +1081,7 @@ PUPLabel::Animation::Animation(PUPLabel* label, unsigned int lengthMs, int foreg
    , m_alphaStart(alphaStart)
    , m_alphaEnd(alphaEnd)
    , m_pulseSpeed(pulseSpeed)
+   , m_screenFade(screenFade)
 {
    m_alpha = static_cast<float>(m_alphaStart) / 255.0f;
 }

--- a/plugins/pup/PUPLabel.cpp
+++ b/plugins/pup/PUPLabel.cpp
@@ -186,7 +186,7 @@ void PUPLabel::SetCaption(const string& szCaption)
          m_szPath.clear();
 
          const string szExt = extension_from_path(szText);
-         if (szExt == "gif" || szExt == "png" || szExt == "apng" || szExt == "bmp" || szExt == "jpg")
+         if (szExt == "gif" || szExt == "png" || szExt == "apng" || szExt == "bmp" || szExt == "jpg" || szExt == "jpeg")
          {
             std::filesystem::path fs_path(normalize_path_separators(szText));
             string playlistFolder = fs_path.parent_path().string();
@@ -258,9 +258,9 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          switch (json["at"s].as<int>(0))
          {
          case 1:
-            // See pDMDLabelFlash — fq is the toggle interval in milliseconds
-            if (json["len"s].exists() && json["fc"s].exists() && json["fq"s].exists() && json["fq"s].as<int>() > 0)
-               m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(), json["fc"s].as<int>(), json["fq"s].as<int>());
+            // See pDMDLabelFlash — fq is the toggle interval in milliseconds, fc is optional
+            if (json["len"s].exists() && json["fq"s].exists() && json["fq"s].as<int>() > 0)
+               m_animation = std::make_unique<Animation>(this, json["len"s].as<int>(), json["fc"s].as<int>(m_color), json["fq"s].as<int>());
             else
             {
                LOGE("Invalid label animation specified: {" + szSpecial + '}');
@@ -270,12 +270,12 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          case 2:
             // See pDMDLabelMoveHorz / pDMDLabelMoveVert / pDMDLabelMoveTO
             // See pDMDLabelMoveHorzFade / pDMDLabelMoveVertFade — af = alpha fade start time (ms before end)
-            if (json["len"s].exists() && json["fc"s].exists())
+            if (json["len"s].exists())
             {
                int len = json["len"s].as<int>();
                int mlen = json["mlen"s].as<int>(0);
                if (mlen == 0) mlen = len;
-               m_animation = std::make_unique<Animation>(this, len, json["fc"s].as<int>(),
+               m_animation = std::make_unique<Animation>(this, len, json["fc"s].as<int>(m_color),
                   json["xps"s].as<int>(0), json["xpe"s].as<int>(0), json["yps"s].as<int>(0), json["ype"s].as<int>(0),
                   mlen, json["tt"s].as<int>(0), json["mColor"s].as<int>(m_color));
                m_animation->m_alphaFade = json["af"s].as<int>(0);
@@ -522,7 +522,64 @@ void PUPLabel::SetSpecial(const string& szSpecial)
          {
             // See pDMDPNGAnimate — speed is frame timer, 100 is ~30fps
             m_anigif = value.as<int>();
+            m_animating = m_anigif > 0;
             m_dirty = true;
+         }
+         else if (key == "animate")
+         {
+            // See pDMDPNGAnimate / pDMDPNGAnimateOnce — animation interval in ms, 0 stops
+            int interval = value.as<int>();
+            if (interval < 1)
+            {
+               m_animating = false;
+            }
+            else
+            {
+               m_visible = true;
+               m_anigif = interval;
+               m_animating = true;
+               m_dirty = true;
+            }
+         }
+         else if (key == "anistart")
+         {
+            int interval = value.as<int>();
+            m_anigif = interval;
+            m_animating = interval > 0;
+            m_dirty = true;
+         }
+         else if (key == "gifloop")
+         {
+            // See pDMDPNGAnimateEx — 1=loop forever (default), 0=play once
+            m_gifLoop = (value.as<int>() == 1);
+         }
+         else if (key == "gifstart")
+         {
+            // See pDMDPNGAnimateEx / pDMDPNGShowFrame — start frame index, -1 resets to full range
+            m_gifStart = value.as<int>();
+            if (m_gifStart < 0)
+            {
+               m_gifStart = 0;
+               m_gifEnd = -1;
+            }
+            m_animationFrame = -1;
+            m_animationStart = SDL_GetTicks();
+         }
+         else if (key == "gifend")
+         {
+            // See pDMDPNGAnimateEx / pDMDPNGShowFrame — end frame index, start==end shows single frame
+            m_gifEnd = value.as<int>();
+            if (m_gifStart == m_gifEnd && m_gifEnd >= 0)
+               m_dirty = true;
+         }
+         else if (key == "aniendhide")
+         {
+            // See pDMDPNGAnimateOnce — 1=hide label when animation completes
+            m_hideOnAnimEnd = (value.as<int>() == 1);
+         }
+         else if (key == "anidispose")
+         {
+            // See pDMDPNGAnimateOnceAndDispose — marks for cleanup after play
          }
          else if (key == "width")
          {
@@ -615,10 +672,12 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    {
       m_dirty = false;
       if (!m_szPath.empty())
+      {
          m_pendingTextureUpdate = std::async(std::launch::async, [this]() {
             std::lock_guard lock(m_mutex);
             return UpdateImageTexture(m_type, m_szPath);
          });
+      }
       else if (m_pFont)
          m_pendingTextureUpdate = std::async(std::launch::async, [this, rect, fontColor]() {
             std::lock_guard lock(m_mutex);
@@ -631,7 +690,42 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
 
    if (m_renderState.m_pAnimation)
    {
-      int expectedFrame = static_cast<int>(static_cast<float>(SDL_GetTicks() - m_animationStart) * (float)(60. / 1000.)) % m_renderState.m_pAnimation->count;
+      const int frameCount = m_renderState.m_pAnimation->count;
+      const int startFrame = (m_gifStart >= 0 && m_gifStart < frameCount) ? m_gifStart : 0;
+      const int endFrame = (m_gifEnd >= 0 && m_gifEnd < frameCount) ? m_gifEnd : frameCount - 1;
+
+      int expectedFrame = startFrame;
+      if (startFrame != endFrame)
+      {
+         int elapsed = static_cast<int>(SDL_GetTicks() - m_animationStart);
+         float speed = m_anigif > 0 ? m_anigif / 100.f : 1.f;
+         elapsed = static_cast<int>(elapsed * speed);
+         const int startOffset = startFrame > 0 ? m_renderState.m_accumulatedDelays[startFrame - 1] : 0;
+         const int rangeDuration = m_renderState.m_accumulatedDelays[endFrame] - startOffset;
+         if (rangeDuration > 0)
+         {
+            if (m_gifLoop)
+            {
+               elapsed = elapsed % rangeDuration;
+            }
+            else if (elapsed >= rangeDuration)
+            {
+               elapsed = rangeDuration - 1;
+               if (m_animating)
+               {
+                  m_animating = false;
+                  if (m_hideOnAnimEnd)
+                     m_visible = false;
+               }
+            }
+         }
+         const auto& delays = m_renderState.m_accumulatedDelays;
+         expectedFrame = static_cast<int>(std::upper_bound(delays.begin() + startFrame, delays.begin() + endFrame + 1, startOffset + elapsed) - delays.begin());
+         if (expectedFrame > endFrame)
+            expectedFrame = endFrame;
+         if (expectedFrame < startFrame)
+            expectedFrame = startFrame;
+      }
       if (expectedFrame != m_animationFrame)
       {
          m_animationFrame = expectedFrame;
@@ -724,6 +818,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       }
       else
       {
+         // See pDMDScreenFadeOut / pDMDScreenFadeIn — at=7 fades the entire screen
          if (m_animation->IsScreenFade() && m_pScreen)
             m_pScreen->m_screenAlpha = m_animation->m_alpha;
 
@@ -791,8 +886,16 @@ PUPLabel::RenderState PUPLabel::UpdateImageTexture(PUP_LABEL_TYPE type, const st
    }
    else if (type == PUP_LABEL_TYPE_GIF)
    {
-      rs.m_pAnimation = IMG_LoadAnimation(szPath.string().c_str());
+      rs.m_pAnimation = std::shared_ptr<IMG_Animation>(IMG_LoadAnimation(szPath.string().c_str()), IMG_FreeAnimation);
       if (rs.m_pAnimation) {
+         rs.m_accumulatedDelays.resize(rs.m_pAnimation->count);
+         int accum = 0;
+         for (int i = 0; i < rs.m_pAnimation->count; i++)
+         {
+            accum += rs.m_pAnimation->delays[i];
+            rs.m_accumulatedDelays[i] = accum;
+         }
+         rs.m_totalDuration = accum;
          SDL_Surface* image = rs.m_pAnimation->frames[0];
          if (image) {
             if (image->format == SDL_PIXELFORMAT_RGBA32)
@@ -1154,8 +1257,23 @@ bool PUPLabel::Animation::Update(const SDL_Rect& screenRect, const SDL_FRect& la
 
    if (m_motionLen)
    {
-      // TODO implement tweening
       float pos = saturate(static_cast<float>(elapsed) / static_cast<float>(m_motionLen));
+      switch (m_motionTween)
+      {
+      default:
+      // Robert Penner easing functions (see https://easings.net)
+      case 0: break;
+      case 1: pos = pos * pos; break;
+      case 2: pos = pos * (2.f - pos); break;
+      case 3: pos = pos < 0.5f ? 2.f * pos * pos : -1.f + (4.f - 2.f * pos) * pos; break;
+      case 4: pos = pos * pos * pos; break;
+      case 5: { float t = pos - 1.f; pos = t * t * t + 1.f; } break;
+      case 6: pos = pos < 0.5f ? 4.f * pos * pos * pos : (pos - 1.f) * (2.f * pos - 2.f) * (2.f * pos - 2.f) + 1.f; break;
+      case 7: pos = pos * pos * pos * pos; break;
+      case 8: { float t = pos - 1.f; pos = -(t * t * t * t) + 1.f; } break;
+      case 9: pos = pos < 0.5f ? 8.f * pos * pos * pos * pos : -8.f * (pos - 1.f) * (pos - 1.f) * (pos - 1.f) * (pos - 1.f) + 1.f; break;
+      case 10: pos = pos * pos * pos * pos * pos; break;
+      }
       const float xBase = labelRect.x;
       const float xLeft = static_cast<float>(screenRect.x) - labelRect.w;
       const float xRight = static_cast<float>(screenRect.x) + static_cast<float>(screenRect.w);
@@ -1166,10 +1284,15 @@ bool PUPLabel::Animation::Update(const SDL_Rect& screenRect, const SDL_FRect& la
       // other values = percentage position (see pDMDLabelMoveTO)
       const float screenW = static_cast<float>(screenRect.w);
       const float screenH = static_cast<float>(screenRect.h);
+      // TODO: position interpretation when only end is specified (no start) is uncertain.
+      // GOTG bumper pops use ype:150 with no yps — video shows upward movement.
+      // Current: treat as pixel offset upward from current position when start is absent.
       const float xs = m_xps == 0 ? xBase : m_xps == 1 ? xRight : m_xps == -1 ? xLeft : static_cast<float>(screenRect.x) + screenW * (float)m_xps / 100.f;
-      const float xe = m_xpe == 0 ? xBase : m_xpe == 1 ? xRight : m_xpe == -1 ? xLeft : static_cast<float>(screenRect.x) + screenW * (float)m_xpe / 100.f;
+      const float xe = m_xpe == 0 ? xBase : m_xpe == 1 ? xRight : m_xpe == -1 ? xLeft
+         : (m_xps == 0 ? xBase - static_cast<float>(m_xpe) : static_cast<float>(screenRect.x) + screenW * (float)m_xpe / 100.f);
       const float ys = m_yps == 0 ? yBase : m_yps == 1 ? yBottom : m_yps == -1 ? yTop : static_cast<float>(screenRect.y) + screenH * (float)m_yps / 100.f;
-      const float ye = m_ype == 0 ? yBase : m_ype == 1 ? yBottom : m_ype == -1 ? yTop : static_cast<float>(screenRect.y) + screenH * (float)m_ype / 100.f;
+      const float ye = m_ype == 0 ? yBase : m_ype == 1 ? yBottom : m_ype == -1 ? yTop
+         : (m_yps == 0 ? yBase - static_cast<float>(m_ype) : static_cast<float>(screenRect.y) + screenH * (float)m_ype / 100.f);
       m_color = pos < 1.0f ? m_motionColor : m_foregroundColor;
       m_xOffset = lerp(xs, xe, pos) - xBase;
       m_yOffset = lerp(ys, ye, pos) - yBase;

--- a/plugins/pup/PUPLabel.h
+++ b/plugins/pup/PUPLabel.h
@@ -45,7 +45,7 @@ public:
    bool GetOnShowVisible() const { return m_onShowVisible; }
    void SetVisible(bool visible);
    void SetSpecial(const string& szSpecial);
-   void Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int pagenum);
+   void Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int pagenum, float screenAlpha = 1.f);
    const string& GetName() const { return m_szName; }
    bool IsAnimating() const { return m_animation != nullptr; }
    void SetScreen(PUPScreen* pScreen) { m_pScreen = pScreen; }
@@ -160,6 +160,7 @@ private:
 
       bool Update(const SDL_Rect& screenRect, const SDL_FRect& labelRect);
       bool IsFade() const { return m_alphaStart != m_alphaEnd; }
+      bool IsScreenFade() const { return m_screenFade; }
       bool IsZoom() const { return m_zoomStart != m_zoomEnd; }
       bool IsWiggle() const { return m_wiggleStart != m_wiggleEnd; }
 
@@ -193,6 +194,7 @@ private:
       int m_alphaStart = 255;
       int m_alphaEnd = 255;
       int m_pulseSpeed = 0;
+      bool m_screenFade = false;
 
       float m_zoomStart = 100.f;
       float m_zoomEnd = 100.f;

--- a/plugins/pup/PUPLabel.h
+++ b/plugins/pup/PUPLabel.h
@@ -84,6 +84,11 @@ private:
    float m_autoFitHeight = 0;
    PUPScreen* m_pScreen = nullptr;
    int m_anigif = 0;
+   bool m_gifLoop = true;
+   int m_gifStart = -1;
+   int m_gifEnd = -1;
+   bool m_hideOnAnimEnd = false;
+   bool m_animating = false;
 
    PUP_LABEL_TYPE m_type = PUP_LABEL_TYPE_TEXT;
    std::filesystem::path m_szPath;
@@ -102,8 +107,6 @@ private:
       {
          if (m_pTexture)
             DeleteTexture(m_pTexture);
-         if (m_pAnimation)
-            IMG_FreeAnimation(m_pAnimation);
       }
 
       RenderState(RenderState&& other) noexcept
@@ -112,10 +115,11 @@ private:
          , m_prerenderedColor(other.m_prerenderedColor)
          , m_width(other.m_width)
          , m_height(other.m_height)
-         , m_pAnimation(other.m_pAnimation)
+         , m_pAnimation(std::move(other.m_pAnimation))
+         , m_accumulatedDelays(std::move(other.m_accumulatedDelays))
+         , m_totalDuration(other.m_totalDuration)
       {
          other.m_pTexture = nullptr;
-         other.m_pAnimation = nullptr;
       }
 
       RenderState& operator=(RenderState&& other) noexcept
@@ -124,18 +128,17 @@ private:
          {
             if (m_pTexture)
                DeleteTexture(m_pTexture);
-            if (m_pAnimation)
-               IMG_FreeAnimation(m_pAnimation);
 
             m_prerenderedHeight = other.m_prerenderedHeight;
             m_prerenderedColor = other.m_prerenderedColor;
             m_pTexture = other.m_pTexture;
-            m_pAnimation = other.m_pAnimation;
+            m_pAnimation = std::move(other.m_pAnimation);
+            m_accumulatedDelays = std::move(other.m_accumulatedDelays);
+            m_totalDuration = other.m_totalDuration;
             m_width = other.m_width;
             m_height = other.m_height;
 
             other.m_pTexture = nullptr;
-            other.m_pAnimation = nullptr;
          }
          return *this;
       }
@@ -144,8 +147,10 @@ private:
       int m_prerenderedHeight = 0; // Height used to evaluate text rendering
       int m_prerenderedColor = 0; // Color used for prerendering the text
       float m_width = 0; // Width of rendered text (unused for images)
-      float m_height = 0; // height of rendered text (unused for images)
-      IMG_Animation* m_pAnimation = nullptr;
+      float m_height = 0; // Height of rendered text (unused for images)
+      std::shared_ptr<IMG_Animation> m_pAnimation;
+      vector<int> m_accumulatedDelays;
+      int m_totalDuration = 0;
    };
    RenderState UpdateImageTexture(PUP_LABEL_TYPE type, const std::filesystem::path& szPath);
    RenderState UpdateLabelTexture(int outHeight, TTF_Font* pFont, const string& szCaption, float size, int color, int shadowstate, int shadowcolor, SDL_FPoint offset);

--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -513,6 +513,45 @@ int PUPManager::ProcessDmdFrame(const DisplaySrcId& src, const uint8_t* frame)
    return -1;
 }
 
+void PUPManager::DuckAllExcept(int masterScreenNum, float duckLevel)
+{
+   m_duckMasterScreen = masterScreenNum;
+   m_preDuckVolumes.clear();
+   for (const auto& [key, screen] : m_screenMap)
+   {
+      if (key != masterScreenNum)
+      {
+         m_preDuckVolumes[key] = screen->GetVolume();
+         screen->SetVolume(duckLevel);
+      }
+   }
+   auto masterScreen = GetScreen(masterScreenNum);
+   if (masterScreen)
+   {
+      masterScreen->SetOnMainEndCallback([this]() {
+         Unduck();
+      });
+   }
+}
+
+void PUPManager::Unduck()
+{
+   for (const auto& [key, volume] : m_preDuckVolumes)
+   {
+      auto screen = GetScreen(key);
+      if (screen)
+         screen->SetVolume(volume);
+   }
+   m_preDuckVolumes.clear();
+   if (m_duckMasterScreen >= 0)
+   {
+      auto masterScreen = GetScreen(m_duckMasterScreen);
+      if (masterScreen)
+         masterScreen->SetOnMainEndCallback(nullptr);
+   }
+   m_duckMasterScreen = -1;
+}
+
 void PUPManager::QueueDOFEvent(char c, int id, int value)
 {
    //LOGD(std::format("DOF Event {}{:03} = {}", c, id, value));

--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -245,6 +245,15 @@ void PUPManager::LoadFonts()
    {
       LOGI("No FONTS folder found"s);
    }
+
+   if (m_vpxApi)
+   {
+      VPXInfo vpxInfo;
+      m_vpxApi->GetVpxInfo(&vpxInfo);
+      std::filesystem::path fallbackPath = std::filesystem::path(vpxInfo.path) / "assets" / "LiberationSans-Regular.ttf";
+      if (TTF_Font* pFont = TTF_OpenFont(fallbackPath.string().c_str(), 8))
+         AddFont(pFont, "LiberationSans-Regular.ttf");
+   }
 }
 
 void PUPManager::LoadPlaylists()
@@ -530,6 +539,16 @@ void PUPManager::QueueDOFEvent(char c, int id, int value)
                // Dispatch trigger action on main thread
                m_msgApi->RunOnMainThread(m_endpointId, 0.0, [](void* userData) { static_cast<PUPTrigger*>(userData)->Trigger()(); }, trigger);
             }
+            // Reset trigger condition values so the trigger can fire again
+            // when the same B2SData event is sent repeatedly (e.g., D9=1 each ball)
+            for (auto& trigger : triggers[0]->GetTriggers())
+            {
+               if (trigger.m_type == c && trigger.m_number == id)
+               {
+                  trigger.m_value = 0;
+                  break;
+               }
+            }
          }
       }
    }
@@ -609,56 +628,27 @@ int PUPManager::Render(VPXRenderContext2D* const renderCtx, void* context)
       if (parent)
          screens.push_back(screen);
    }
-   #define LOG_RENDER 0
-   #if LOG_RENDER
-   std::stringstream renderLog;
-   renderLog << "Back [";
-   auto log = [&renderLog](std::shared_ptr<PUPScreen> screen, int pass)
+   // Render order — two layers per screen, popups on top:
+   //   Non-popup screens:
+   //     1. Video layer (passes 0-1): PuPFrames background + video/static image
+   //     2. Overlay layer (passes 2-3): PuPOverlays image + labels
+   //   Popup screens (ForcePop/ForcePopBack) render entirely on top:
+   //     3. All passes (0-3)
+
+   auto renderScreens = [&renderCtx, &screens](bool popup, int startPass, int endPass)
    {
-      if (pass == 0 && screen->HasUnderlay())
-         renderLog << screen->GetScreenNum() << "u ";
-      else if (pass == 1 && (!screen->IsPop() || screen->IsMainPlaying()))
-         renderLog << screen->GetScreenNum() << ' ';
-      else if (pass == 2 && screen->HasOverlay())
-         renderLog << screen->GetScreenNum() << "o ";
+      for (int pass = startPass; pass <= endPass; pass++)
+         std::ranges::for_each(screens,
+            [&renderCtx, pass, popup](const auto& screen)
+            {
+               if (screen->IsPop() == popup && screen->GetMode() != PUPScreen::Mode::Off)
+                  screen->Render(renderCtx, pass);
+            });
    };
-   #else
-   auto log = [](std::shared_ptr<PUPScreen> screen, int pass) { };
-   #endif
-   for (int pass = 0; pass < 3; pass++)
-      std::ranges::for_each(screens,
-         [&renderCtx, pass, &log](const auto& screen)
-         {
-            const bool isBack = screen->IsBackgroundPlaying() || screen->GetMode() == PUPScreen::Mode::ForceBack || screen->GetMode() == PUPScreen::Mode::ForcePopBack;
-            if (isBack)
-            {
-               log(screen, pass);
-               screen->Render(renderCtx, pass);
-            }
-         });
-   #if LOG_RENDER
-   renderLog << "] Front [";
-   #endif
-   for (int pass = 0; pass < 3; pass++)
-      std::ranges::for_each(screens,
-         [&renderCtx, pass, &log](const auto& screen)
-         {
-            const bool isBack = screen->IsBackgroundPlaying() || screen->GetMode() == PUPScreen::Mode::ForceBack || screen->GetMode() == PUPScreen::Mode::ForcePopBack;
-            if (!isBack && screen->GetMode() != PUPScreen::Mode::Off)
-            {
-               log(screen, pass);
-               screen->Render(renderCtx, pass);
-            }
-         });
-   #if LOG_RENDER
-   renderLog << ']';
-   LOGD("Render: " + renderLog.str());
-   #endif
-   std::ranges::for_each(screens,
-      [&renderCtx](const auto& screen)
-      {
-         screen->Render(renderCtx, 3);
-      });
+
+   renderScreens(false, 0, 1);
+   renderScreens(false, 2, 3);
+   renderScreens(true, 0, 3);
 
    // Set Game time after rendering to avoid updating while rendering if the decode thread are waiting for it
    if (me->m_vpxApi)

--- a/plugins/pup/PUPManager.h
+++ b/plugins/pup/PUPManager.h
@@ -87,6 +87,9 @@ public:
 
    void QueueDOFEvent(char c, int id, int value);
 
+   void DuckAllExcept(int masterScreenNum, float duckLevel);
+   void Unduck();
+
 private:
    void UnloadFonts();
    void LoadFonts();
@@ -124,6 +127,8 @@ private:
    std::mutex m_eventMutex;
    std::unique_ptr<DOFEventStream> m_dofEventStream;
 
+   int m_duckMasterScreen = -1;
+   ankerl::unordered_dense::map<int, float> m_preDuckVolumes;
 };
 
 }

--- a/plugins/pup/PUPManager.h
+++ b/plugins/pup/PUPManager.h
@@ -123,6 +123,7 @@ private:
 
    std::mutex m_eventMutex;
    std::unique_ptr<DOFEventStream> m_dofEventStream;
+
 };
 
 }

--- a/plugins/pup/PUPMediaManager.cpp
+++ b/plugins/pup/PUPMediaManager.cpp
@@ -7,34 +7,27 @@
 
 namespace PUP {
 
-static string GetPlayerName(PUPScreen* pScreen, bool isMain)
-{
-   return "PUP.#" + std::to_string(pScreen->GetScreenNum()) + (isMain ? ".Main" : ".Back");
-}
-
 PUPMediaManager::PUPMediaManager(PUPScreen* pScreen)
-   : m_pBackgroundPlayer(std::make_unique<PUPMediaManagerPlayer>(GetPlayerName(pScreen, false)))
-   , m_pMainPlayer(std::make_unique<PUPMediaManagerPlayer>(GetPlayerName(pScreen, true)))
+   : m_player("PUP.#" + std::to_string(pScreen->GetScreenNum()))
    , m_pScreen(pScreen)
    , m_bounds()
 {
-   m_pBackgroundPlayer->player.SetOnEndCallback([this](PUPMediaPlayer* player) { OnPlayerEnd(player); });
-   m_pMainPlayer->player.SetOnEndCallback([this](PUPMediaPlayer* player) { OnPlayerEnd(player); });
+   m_player.SetOnEndCallback([this](PUPMediaPlayer* player) { OnPlayerEnd(player); });
 }
 
 PUPMediaManager::~PUPMediaManager()
 {
+   m_shuttingDown = true;
 }
 
 void PUPMediaManager::SetGameTime(double gameTime)
 {
-   m_pBackgroundPlayer->player.SetGameTime(gameTime);
-   m_pMainPlayer->player.SetGameTime(gameTime);
+   m_player.SetGameTime(gameTime);
 }
 
 void PUPMediaManager::Play(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlayFile, float volume, int priority, bool skipSamePriority, int length, bool background)
 {
-   if (!background && skipSamePriority && IsMainPlaying() && priority <= m_pMainPlayer->priority)
+   if (!background && skipSamePriority && IsMainPlaying() && priority <= m_mainPriority)
    {
       LOGE(std::format("Skipping same priority, screen={{{}}}, playlist={}, playFile={{{}}}, priority={}", m_pScreen->ToString(false), pPlaylist->ToString(), szPlayFile.string(), priority));
       return;
@@ -46,77 +39,161 @@ void PUPMediaManager::Play(PUPPlaylist* pPlaylist, const std::filesystem::path& 
       return;
    }
 
-   LOGD(std::format("> Play screen={{{}}}, playlist={{{}}}, playFile={}, path={}, volume={:.1f}, priority={}, length={}, background={}", m_pScreen->ToString(false), pPlaylist->ToString(), szPlayFile.string(), szPath.string(), volume, priority, length, background));
+   // Single player per screen — background config stores what to play when main ends.
    if (background)
    {
-      m_pBackgroundPlayer->player.Play(szPath, volume);
-      m_pBackgroundPlayer->player.SetLoop(true);
-      m_pBackgroundPlayer->szPath = szPath;
-      m_pBackgroundPlayer->volume = volume;
+      LOGD(std::format("BG CONFIG: screen={}, file={}", m_pScreen->GetScreenNum(), szPath.filename().string()));
+      m_bg.szPath = szPath;
+      m_bg.volume = volume;
+      m_bg.active = true;
+      if (!m_playingMain)
+         PlayBackground();
    }
    else
    {
-      m_pBackgroundPlayer->player.Pause(true);
-      m_pMainPlayer->player.Play(szPath, volume);
-      m_pMainPlayer->player.SetLength(length);
-      m_pMainPlayer->szPath = szPath;
-      m_pMainPlayer->volume = volume;
-      m_pMainPlayer->priority = priority;
+      if (szPath == m_mainPath && m_player.IsPlaying() && m_playingMain)
+      {
+         LOGD(std::format("MAIN SKIP (same file): screen={}, file={}", m_pScreen->GetScreenNum(), szPath.filename().string()));
+         m_player.SetVolume(volume);
+      }
+      else if (szPath == m_bg.szPath && m_bg.active && m_player.IsPlaying() && !m_playingMain)
+      {
+         LOGD(std::format("MAIN SKIP (bg has file): screen={}, file={}", m_pScreen->GetScreenNum(), szPath.filename().string()));
+      }
+      else if (m_playingMain && priority < m_mainPriority)
+      {
+         // Lower priority than current — queue it
+         LOGD(std::format("QUEUED: screen={}, pri={}, file={}", m_pScreen->GetScreenNum(), priority, szPath.filename().string()));
+         m_playQueue.push_back({ szPath, volume, priority, length, 0 });
+      }
+      else
+      {
+         PlayImmediate(szPath, volume, priority, length);
+      }
    }
+}
+
+void PUPMediaManager::PlayImmediate(const std::filesystem::path& szPath, float volume, int priority, int length)
+{
+   LOGD(std::format("MAIN PLAY: screen={}, vol={:.0f}, pri={}, len={}, file={}", m_pScreen->GetScreenNum(), volume, priority, length, szPath.filename().string()));
+   m_playingMain = true;
+   m_player.Play(szPath, volume);
+   m_player.SetLength(length);
+   m_mainPath = szPath;
+   m_mainVolume = volume;
+   m_mainPriority = priority;
+   m_playQueue.clear();
+}
+
+// When main video ends, background config is loaded into the same player with loop enabled.
+void PUPMediaManager::PlayBackground()
+{
+   if (m_bg.active && !m_bg.szPath.empty())
+   {
+      LOGD(std::format("BG PLAY: screen={}, file={}", m_pScreen->GetScreenNum(), m_bg.szPath.filename().string()));
+      m_player.Play(m_bg.szPath, m_bg.volume);
+      m_player.SetLoop(true);
+      m_playingMain = false;
+      m_mainPath.clear();
+   }
+}
+
+void PUPMediaManager::PlayNextFromQueue()
+{
+   uint64_t now = SDL_GetTicks();
+   while (!m_playQueue.empty())
+   {
+      auto item = m_playQueue.front();
+      m_playQueue.pop_front();
+      if (item.expiry > 0 && now > item.expiry)
+         continue;
+      PlayImmediate(item.szPath, item.volume, item.priority, item.length);
+      return;
+   }
+   PlayBackground();
 }
 
 void PUPMediaManager::Pause()
 {
-   m_pMainPlayer->player.Pause(true);
+   m_player.Pause(true);
 }
 
 void PUPMediaManager::Resume()
 {
-   m_pMainPlayer->player.Pause(false);
+   m_player.Pause(false);
 }
 
+// See pDMDBackLoopStart — mode=1 saves current file as background config and loops it.
+// mode=0 clears only if set via SetBackGround (not trigger SetBG). Popup screens are excluded.
 void PUPMediaManager::SetAsBackGround(bool isBackground)
 {
    if (isBackground) {
-      LOGD("Replacing background player, screen={" + m_pScreen->ToString(false) + '}');
-      std::swap(m_pMainPlayer, m_pBackgroundPlayer);
-      m_pBackgroundPlayer->player.SetLoop(true);
-      m_pMainPlayer->player.Stop();
+      if (m_pScreen->IsPop())
+         return;
+      if (m_playingMain && !m_mainPath.empty())
+      {
+         m_bg.szPath = m_mainPath;
+         m_bg.volume = m_mainVolume;
+         m_bg.active = true;
+         m_bg.setViaSetBackGround = true;
+         m_player.SetLoop(true);
+         m_playingMain = false;
+         m_mainPath.clear();
+      }
    }
    else {
-      LOGD("Making background player the main player (no looping), screen={" + m_pScreen->ToString(false) + '}');
-      std::swap(m_pMainPlayer, m_pBackgroundPlayer);
-      m_pMainPlayer->player.SetLoop(false);
-      m_pBackgroundPlayer->player.Stop();
+      if (m_bg.setViaSetBackGround)
+      {
+         m_bg.szPath.clear();
+         m_bg.active = false;
+         m_bg.setViaSetBackGround = false;
+         if (!m_playingMain)
+         {
+            m_player.Stop();
+         }
+      }
    }
-   m_pBackgroundPlayer->player.SetName(GetPlayerName(m_pScreen, false));
-   m_pMainPlayer->player.SetName(GetPlayerName(m_pScreen, true));
 }
 
 void PUPMediaManager::SetLoop(bool isLoop)
 {
-   m_pMainPlayer->player.SetLoop(isLoop);
+   m_player.SetLoop(isLoop);
 }
 
 void PUPMediaManager::SetMaxLength(int length)
 {
-   m_pMainPlayer->player.SetLength(length);
+   m_player.SetLength(length);
 }
 
 void PUPMediaManager::SetVolume(float volume)
 {
-   m_pBackgroundPlayer->player.SetVolume(volume);
-   m_pMainPlayer->player.SetVolume(volume);
+   m_player.SetVolume(volume);
 }
 
+// See pDMDStopBackLoop — stops main, starts background if configured
 void PUPMediaManager::Stop()
 {
-   m_pMainPlayer->player.Stop();
+   LOGD(std::format("STOP: screen={}, wasMain={}, bgActive={}", m_pScreen->GetScreenNum(), m_playingMain, m_bg.active));
+   m_playingMain = false;
+   m_mainPath.clear();
+   m_playQueue.clear();
+   if (m_bg.active && !m_bg.szPath.empty())
+      PlayBackground();
+   else
+      m_player.Stop();
+}
+
+void PUPMediaManager::StopBackground()
+{
+   m_bg.szPath.clear();
+   m_bg.active = false;
+   if (!m_playingMain)
+      m_player.Stop();
 }
 
 void PUPMediaManager::Stop(int priority)
 {
-   if (priority > m_pMainPlayer->priority) {
+   if (priority > m_mainPriority) {
       LOGD(std::format("Priority > main player priority: screen={{{}}}, priority={}", m_pScreen->ToString(false), priority));
       Stop();
    }
@@ -128,7 +205,7 @@ void PUPMediaManager::Stop(int priority)
 void PUPMediaManager::Stop(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlayFile)
 {
    std::filesystem::path szPath = pPlaylist->GetPlayFilePath(szPlayFile);
-   if (!szPath.empty() && szPath == m_pMainPlayer->szPath) {
+   if (!szPath.empty() && szPath == m_mainPath) {
       LOGD(std::format("Main player stopping playback: screen={{{}}}, path={}", m_pScreen->ToString(false), szPath.string()));
       Stop();
    }
@@ -140,8 +217,7 @@ void PUPMediaManager::Stop(PUPPlaylist* pPlaylist, const std::filesystem::path& 
 void PUPMediaManager::SetBounds(const SDL_Rect& rect)
 {
    m_bounds = rect;
-   m_pBackgroundPlayer->player.SetBounds(rect);
-   m_pMainPlayer->player.SetBounds(rect);
+   m_player.SetBounds(rect);
 }
 
 void PUPMediaManager::SetMask(const std::filesystem::path& path)
@@ -156,31 +232,43 @@ void PUPMediaManager::SetMask(const std::filesystem::path& path)
       SDL_LockSurface(m_mask.get());
       uint32_t* __restrict rgba = static_cast<uint32_t*>(m_mask->pixels);
       const uint32_t maskValue = rgba[0];
-      for (int i = 0; i < m_mask->h; i++, rgba += (m_mask->pitch - m_mask->w * sizeof(uint32_t)))
+      const int rowPadding = (m_mask->pitch / static_cast<int>(sizeof(uint32_t))) - m_mask->w;
+      for (int i = 0; i < m_mask->h; i++, rgba += rowPadding)
          for (int j = 0; j < m_mask->w; j++, rgba++)
             *rgba = (*rgba == maskValue) ? 0x00000000u : 0xFFFFFFFFu;
       SDL_UnlockSurface(m_mask.get());
    }
-   m_pBackgroundPlayer->player.SetMask(m_mask);
-   m_pMainPlayer->player.SetMask(m_mask);
+   m_player.SetMask(m_mask);
 }
 
+// When main video ends, check queue then fall back to background.
 void PUPMediaManager::OnPlayerEnd(PUPMediaPlayer* player)
 {
-   if (player == &m_pMainPlayer->player)
-      m_pBackgroundPlayer->player.Pause(false);
+   if (m_shuttingDown)
+      return;
+   bool wasMain = m_playingMain;
+   LOGD(std::format("ON END: screen={}, wasMain={}, mainFile={}, bgActive={}", m_pScreen->GetScreenNum(), wasMain, m_mainPath.filename().string(), m_bg.active));
+   if (m_playingMain)
+   {
+      m_playingMain = false;
+      m_mainPath.clear();
+   }
+   if (wasMain)
+   {
+      if (m_onMainEndCallback)
+         m_onMainEndCallback();
+      PlayNextFromQueue();
+   }
 }
 
-bool PUPMediaManager::IsMainPlaying() const { return m_pMainPlayer->player.IsPlaying(); }
+bool PUPMediaManager::IsMainPlaying() { return m_player.IsPlaying(); }
 
-bool PUPMediaManager::IsBackgroundPlaying() const { return m_pBackgroundPlayer->player.IsPlaying(); }
+bool PUPMediaManager::IsBackgroundPlaying() { return m_bg.active && !m_bg.szPath.empty() && !m_playingMain && m_player.IsPlaying(); }
 
 void PUPMediaManager::Render(VPXRenderContext2D* const ctx)
 {
-   if (m_pMainPlayer->player.IsPlaying())
-      m_pMainPlayer->player.Render(ctx, m_bounds);
-   else if (m_pBackgroundPlayer->player.IsPlaying())
-      m_pBackgroundPlayer->player.Render(ctx, m_bounds);
+   if (m_player.IsPlaying())
+      m_player.Render(ctx, m_bounds);
 }
 
 }

--- a/plugins/pup/PUPMediaManager.cpp
+++ b/plugins/pup/PUPMediaManager.cpp
@@ -265,10 +265,10 @@ bool PUPMediaManager::IsMainPlaying() { return m_player.IsPlaying(); }
 
 bool PUPMediaManager::IsBackgroundPlaying() { return m_bg.active && !m_bg.szPath.empty() && !m_playingMain && m_player.IsPlaying(); }
 
-void PUPMediaManager::Render(VPXRenderContext2D* const ctx)
+void PUPMediaManager::Render(VPXRenderContext2D* const ctx, float alpha)
 {
    if (m_player.IsPlaying())
-      m_player.Render(ctx, m_bounds);
+      m_player.Render(ctx, m_bounds, alpha);
 }
 
 }

--- a/plugins/pup/PUPMediaManager.h
+++ b/plugins/pup/PUPMediaManager.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "PUPMediaPlayer.h"
+#include <deque>
 
 namespace PUP {
 
@@ -24,40 +25,58 @@ public:
    void SetMaxLength(int length);
    void SetVolume(float volume);
    void Stop();
+   void StopBackground();
    void Stop(int priority);
    void Stop(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlayFile);
    void Render(VPXRenderContext2D* const ctx);
-   bool IsMainPlaying() const;
-   bool IsBackgroundPlaying() const;
+   bool IsMainPlaying();
+   bool IsBackgroundPlaying();
 
    void SetBounds(const SDL_Rect& rect);
    void SetMask(const std::filesystem::path& path);
 
+   void SetOnMainEndCallback(std::function<void()> callback) { m_onMainEndCallback = std::move(callback); }
+
 private:
    void OnPlayerEnd(PUPMediaPlayer* player);
+   void PlayBackground();
+   void PlayNextFromQueue();
+   void PlayImmediate(const std::filesystem::path& szPath, float volume, int priority, int length);
 
-   class PUPMediaManagerPlayer final
+   PUPMediaPlayer m_player; // Single player per screen, switches between main and background content
+
+   // Background config — stores what to play when main ends, not a running player
+   struct BackgroundConfig
    {
-   public:
-      explicit PUPMediaManagerPlayer(const string& name)
-         : player(name)
-      {
-      }
-      ~PUPMediaManagerPlayer() = default;
-
-      PUPMediaPlayer player;
       std::filesystem::path szPath;
       float volume = 1.0f;
-      int priority = 0;
+      bool active = false;
+      bool setViaSetBackGround = false;
    };
+   BackgroundConfig m_bg;
+
+   // Play queue — pending items played in order when current ends
+   struct PlayItem
+   {
+      std::filesystem::path szPath;
+      float volume;
+      int priority;
+      int length;
+      uint64_t expiry; // SDL_GetTicks() deadline, 0 = no expiry
+   };
+   std::deque<PlayItem> m_playQueue;
+
+   std::filesystem::path m_mainPath;
+   float m_mainVolume = 1.0f;
+   int m_mainPriority = 0;
+   bool m_playingMain = false;
+   bool m_shuttingDown = false;
+
+   std::function<void()> m_onMainEndCallback;
 
    std::shared_ptr<SDL_Surface> m_mask = nullptr;
 
-   std::unique_ptr<PUPMediaManagerPlayer> m_pBackgroundPlayer;
-   std::unique_ptr<PUPMediaManagerPlayer> m_pMainPlayer;
-
    PUPScreen* const m_pScreen;
-
    SDL_Rect m_bounds;
 };
 

--- a/plugins/pup/PUPMediaManager.h
+++ b/plugins/pup/PUPMediaManager.h
@@ -28,7 +28,7 @@ public:
    void StopBackground();
    void Stop(int priority);
    void Stop(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlayFile);
-   void Render(VPXRenderContext2D* const ctx);
+   void Render(VPXRenderContext2D* const ctx, float alpha = 1.f);
    bool IsMainPlaying();
    bool IsBackgroundPlaying();
 

--- a/plugins/pup/PUPMediaPlayer.cpp
+++ b/plugins/pup/PUPMediaPlayer.cpp
@@ -309,7 +309,7 @@ void PUPMediaPlayer::SetLength(int length)
    });
 }
 
-void PUPMediaPlayer::Render(VPXRenderContext2D* const ctx, const SDL_Rect& destRect)
+void PUPMediaPlayer::Render(VPXRenderContext2D* const ctx, const SDL_Rect& destRect, float alpha)
 {
    if (!m_running)
       return;
@@ -345,7 +345,7 @@ void PUPMediaPlayer::Render(VPXRenderContext2D* const ctx, const SDL_Rect& destR
    }
 
    const VPXTextureInfo* texInfo = GetTextureInfo(selectedFrame.texture);
-   ctx->DrawImage(ctx, selectedFrame.texture, 1.f, 1.f, 1.f, 1.f, 0.f, 0.f, static_cast<float>(texInfo->width), static_cast<float>(texInfo->height), 0.f, 0.f, 0.f,
+   ctx->DrawImage(ctx, selectedFrame.texture, 1.f, 1.f, 1.f, alpha, 0.f, 0.f, static_cast<float>(texInfo->width), static_cast<float>(texInfo->height), 0.f, 0.f, 0.f,
       static_cast<float>(destRect.x), static_cast<float>(destRect.y), static_cast<float>(destRect.w), static_cast<float>(destRect.h));
 
    selectedFrame.age = 0;

--- a/plugins/pup/PUPMediaPlayer.cpp
+++ b/plugins/pup/PUPMediaPlayer.cpp
@@ -37,8 +37,7 @@ PUPMediaPlayer::~PUPMediaPlayer()
 
 bool PUPMediaPlayer::IsPlaying()
 {
-   std::lock_guard lock(m_mutex);
-   return m_running || (m_pendingPlay > m_pendingStop);
+   return m_running.load(std::memory_order_relaxed) || (m_pendingPlay.load(std::memory_order_relaxed) > m_pendingStop.load(std::memory_order_relaxed));
 }
 
 void PUPMediaPlayer::SetName(const string& name)
@@ -86,23 +85,13 @@ void PUPMediaPlayer::Play(const std::filesystem::path& filename, float volume)
    {
       LOGD("> Playing filename=" + filename.string());
 
-      //Should we do the callback when we are switching from a video to another ?
-      //std::function<void(PUPMediaPlayer*)> onEndCallback = m_onEndCallback;
-      //m_onEndCallback = [](PUPMediaPlayer*) { };
+      auto savedCallback = m_onEndCallback;
+      m_onEndCallback = [](PUPMediaPlayer*) { };
       StopBlocking();
-      //m_onEndCallback = onEndCallback;
+      m_onEndCallback = savedCallback;
 
-      std::lock_guard lock(m_mutex);
-
-      m_filename = filename;
-      m_volume = volume;
-      m_loop = false;
-      m_paused = false;
-      m_syncOnGameTime = m_gameTime >= 0.0;
-      m_startTimestamp = m_syncOnGameTime ? m_gameTime : (static_cast<double>(SDL_GetTicks()) / 1000.0);
-
-      // Open file
-      if (m_libAv._avformat_open_input(&m_pFormatContext, filename.string().c_str(), nullptr, nullptr) != 0)
+      AVFormatContext* pFormatContext = nullptr;
+      if (m_libAv._avformat_open_input(&pFormatContext, filename.string().c_str(), nullptr, nullptr) != 0)
       {
          LOGE("Unable to open: filename=" + filename.string());
          m_pendingPlay--;
@@ -110,68 +99,64 @@ void PUPMediaPlayer::Play(const std::filesystem::path& filename, float volume)
       }
 
       // Retrieve stream information (some formats do not have these available in the header, so this is needed to read a few frames and get the info)
-      m_libAv._avformat_find_stream_info(m_pFormatContext, nullptr);
+      m_libAv._avformat_find_stream_info(pFormatContext, nullptr);
 
-      // Find video stream
-      for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
+      int videoStream = -1;
+      int audioStream = -1;
+      AVCodecContext* pVideoContext = nullptr;
+      AVCodecContext* pAudioContext = nullptr;
+
+      for (unsigned int i = 0; i < pFormatContext->nb_streams; i++)
       {
-         if (m_pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && !(m_pFormatContext->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC))
+         if (pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && !(pFormatContext->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC))
          {
-            m_videoStream = i;
+            videoStream = i;
             break;
          }
       }
 
-      // Open video stream
-      if (m_videoStream >= 0)
+      if (videoStream >= 0)
       {
-         AVStream* pStream = m_pFormatContext->streams[m_videoStream];
-         AVCodecParameters* pCodecParameters = pStream->codecpar;
-         m_pVideoContext = OpenStream(m_pFormatContext, m_videoStream);
-         if (m_pVideoContext)
+         AVCodecParameters* pCodecParameters = pFormatContext->streams[videoStream]->codecpar;
+         pVideoContext = OpenStream(pFormatContext, videoStream);
+         if (pVideoContext)
          {
-            LOGD(std::format("Video stream: {} {}x{}", m_libAv._avcodec_get_name(m_pVideoContext->codec_id), pCodecParameters->width, pCodecParameters->height));
+            LOGD(std::format("Video stream: {} {}x{} file={}", m_libAv._avcodec_get_name(pVideoContext->codec_id), pCodecParameters->width, pCodecParameters->height, filename.string()));
          }
          else
          {
             LOGE("Unable to open video stream: filename=" + filename.string());
          }
       }
-      else
-      {
-         m_videoStream = -1;
-      }
 
-      // Find audio stream
-      if (m_videoStream >= 0)
+      if (videoStream >= 0)
       {
-         m_audioStream = m_libAv._av_find_best_stream(m_pFormatContext, AVMEDIA_TYPE_AUDIO, -1, m_videoStream, NULL, 0);
-         if (m_audioStream == AVERROR_DECODER_NOT_FOUND)
+         audioStream = m_libAv._av_find_best_stream(pFormatContext, AVMEDIA_TYPE_AUDIO, -1, videoStream, NULL, 0);
+         if (audioStream == AVERROR_DECODER_NOT_FOUND)
          {
             LOGE("No audio stream found: filename=" + filename.string());
+            audioStream = -1;
          }
       }
       else
       {
-         for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
+         for (unsigned int i = 0; i < pFormatContext->nb_streams; i++)
          {
-            if (m_pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+            if (pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
             {
-               m_audioStream = i;
+               audioStream = i;
                break;
             }
          }
       }
 
-      // Open audio stream
-      if (m_audioStream >= 0)
+      if (audioStream >= 0)
       {
-         AVStream* pStream = m_pFormatContext->streams[m_audioStream];
-         AVCodecParameters* pCodecParameters = pStream->codecpar;
-         m_pAudioContext = OpenStream(m_pFormatContext, m_audioStream);
-         if (m_pAudioContext)
+         AVCodecParameters* pCodecParameters = pFormatContext->streams[audioStream]->codecpar;
+         pAudioContext = OpenStream(pFormatContext, audioStream);
+         if (pAudioContext)
          {
-            LOGD(std::format("Audio stream: {} {} channels, {} Hz", m_libAv._avcodec_get_name(m_pAudioContext->codec_id), pCodecParameters->ch_layout.nb_channels, pCodecParameters->sample_rate));
+            LOGD(std::format("Audio stream: {} {} channels, {} Hz", m_libAv._avcodec_get_name(pAudioContext->codec_id), pCodecParameters->ch_layout.nb_channels, pCodecParameters->sample_rate));
          }
          else
          {
@@ -179,16 +164,30 @@ void PUPMediaPlayer::Play(const std::filesystem::path& filename, float volume)
          }
       }
 
-      if (!m_pVideoContext && !m_pAudioContext)
+      if (!pVideoContext && !pAudioContext)
       {
          LOGE("No video or audio stream found: filename=" + filename.string());
-         StopBlocking();
+         m_libAv._avformat_close_input(&pFormatContext);
          m_pendingPlay--;
          return;
       }
 
-      m_running = true;
-      m_thread = std::thread(&PUPMediaPlayer::Run, this);
+      {
+         std::lock_guard lock(m_mutex);
+         m_filename = filename;
+         m_volume = volume;
+         m_loop = false;
+         m_paused = false;
+         m_syncOnGameTime = m_gameTime >= 0.0;
+         m_startTimestamp = m_syncOnGameTime ? m_gameTime : (static_cast<double>(SDL_GetTicks()) / 1000.0);
+         m_pFormatContext = pFormatContext;
+         m_videoStream = videoStream;
+         m_pVideoContext = pVideoContext;
+         m_audioStream = audioStream;
+         m_pAudioContext = pAudioContext;
+         m_running = true;
+         m_thread = std::thread(&PUPMediaPlayer::Run, this);
+      }
       m_pendingPlay--;
    });
 }
@@ -222,11 +221,6 @@ void PUPMediaPlayer::Stop()
 
 void PUPMediaPlayer::StopBlocking()
 {
-   if (IsPlaying())
-   {
-      LOGD("Stop: " + m_filename.string());
-   }
-
    // Stop decoder thread and flush queue
    std::unique_lock lock(m_mutex);
    m_running = false;
@@ -408,14 +402,13 @@ void PUPMediaPlayer::Run()
       const int rfRet = m_libAv._av_read_frame(m_pFormatContext, pPacket);
       if (rfRet == AVERROR_EOF)
       {
-         // End of stream, loop or stop
          if (!loop)
             break;
          if (m_pVideoContext)
          {
             if (m_libAv._av_seek_frame(m_pFormatContext, m_videoStream, 0, 0) < 0)
             {
-               LOGE("Unable to seek video stream. Aborting loop"s);
+               LOGE("Unable to seek video stream. Aborting loop: " + m_filename.filename().string());
                break;
             }
             m_libAv._avcodec_flush_buffers(m_pVideoContext);
@@ -424,18 +417,22 @@ void PUPMediaPlayer::Run()
          {
             if (m_libAv._av_seek_frame(m_pFormatContext, m_audioStream, 0, 0) < 0)
             {
-               LOGE("Unable to seek audio stream. Aborting loop"s);
+               LOGE("Unable to seek audio stream: " + m_filename.filename().string());
             }
             m_libAv._avcodec_flush_buffers(m_pAudioContext);
          }
          m_playIndex++;
-         m_startTimestamp = m_syncOnGameTime ? m_gameTime : SDL_GetTicks();
+         m_startTimestamp = m_syncOnGameTime ? m_gameTime : (static_cast<double>(SDL_GetTicks()) / 1000.0);
+         {
+            std::lock_guard lock(m_mutex);
+            for (auto& frame : m_frames)
+               frame.valid = false;
+         }
          continue;
       }
       else if (rfRet < 0)
       {
-         // Error reading file, stop playing
-         LOGE("Error while reading video frame"s);
+         LOGE(std::format("Error reading frame: name={}, file={}, ret={}", m_name, m_filename.filename().string(), rfRet));
          break;
       }
 
@@ -484,13 +481,12 @@ void PUPMediaPlayer::Run()
 
    {
       std::lock_guard lock(m_mutex);
+      LOGD(std::format("Player stopped: name={}, file={}", m_name, m_filename.filename().string()));
       m_running = false;
       StopAudioStream(m_audioResId);
       m_audioResId.id = 0;
       m_onEndCallback(this);
    }
-
-   LOGD("Play done " + m_filename.string());
 }
 
 void PUPMediaPlayer::HandleVideoFrame(AVFrame* frame)

--- a/plugins/pup/PUPMediaPlayer.cpp
+++ b/plugins/pup/PUPMediaPlayer.cpp
@@ -85,6 +85,8 @@ void PUPMediaPlayer::Play(const std::filesystem::path& filename, float volume)
    {
       LOGD("> Playing filename=" + filename.string());
 
+      // Suppress end callback during play-to-play transition — the previous video
+      // is being replaced, not ending naturally.
       auto savedCallback = m_onEndCallback;
       m_onEndCallback = [](PUPMediaPlayer*) { };
       StopBlocking();

--- a/plugins/pup/PUPMediaPlayer.h
+++ b/plugins/pup/PUPMediaPlayer.h
@@ -24,7 +24,7 @@ public:
    void SetVolume(float volume);
    void SetLoop(bool loop);
    void SetLength(int length);
-   void Render(VPXRenderContext2D* const ctx, const SDL_Rect& destRect);
+   void Render(VPXRenderContext2D* const ctx, const SDL_Rect& destRect, float alpha = 1.f);
 
    void SetName(const string& name);
    void SetOnEndCallback(const std::function<void(PUPMediaPlayer*)>& onEndCallback) { std::lock_guard lock(m_mutex); m_onEndCallback = onEndCallback; }

--- a/plugins/pup/PUPMediaPlayer.h
+++ b/plugins/pup/PUPMediaPlayer.h
@@ -41,8 +41,8 @@ private:
    string m_name;
    SDL_Rect m_bounds;
 
-   int m_pendingPlay = 0;
-   int m_pendingStop = 0;
+   std::atomic<int> m_pendingPlay = 0;
+   std::atomic<int> m_pendingStop = 0;
 
    std::function<void(PUPMediaPlayer*)> m_onEndCallback = [](PUPMediaPlayer*) { };
 
@@ -91,7 +91,7 @@ private:
 
    std::mutex m_mutex;
    std::thread m_thread;
-   bool m_running = false;
+   std::atomic<bool> m_running = false;
 
    const LibAV::LibAV& m_libAv;
 

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -332,9 +332,16 @@ void PUPPinDisplay::SendMSG(const string& szMsg)
                         NOT_IMPLEMENTED("Set OS window z ordering is not implemented. szMsg=" + szMsg);
                         break;
                      case 22:
-                        // set screen transparency { "mt":301, "SN": 16, "FN":22, "AM":1, "AV":255 } AV: Alpha Value (0-255), AM: Alpha mode enabled 0/1?
-                        NOT_IMPLEMENTED(std::format("Set screen transparency not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
+                     {
+                        // set screen transparency { "mt":301, "SN": 16, "FN":22, "AM":1, "AV":255 }
+                        // AV: Alpha Value (0-255), AM: Alpha mode enabled (1) or disabled (0)
+                        int am = json["AM"s].as<int>(0);
+                        if (am)
+                           pScreen->m_screenAlpha = static_cast<float>(json["AV"s].as<int>(255)) / 255.f;
+                        else
+                           pScreen->m_screenAlpha = 1.f;
                         break;
+                     }
                      case 30:
                         // {'mt':301, 'SN': XX, 'FN':30, 'PM':1 } set (play ?) jukebox mode: jukebox mode will auto advance to next media in playlist and you can use next/prior sub to manuall advance
                         NOT_IMPLEMENTED(std::format("Jukebox mode not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -56,8 +56,16 @@ void PUPPinDisplay::playlistadd(int screenNum, const string& folder, int sort, i
 
 void PUPPinDisplay::playlistplay(int screenNum, const string& playlist)
 {
+   // Play next file from playlist (shuffled or in order) with default volume and no priority
    std::shared_ptr<PUPScreen> pScreen = m_pupManager.GetScreen(screenNum, true);
-   NOT_IMPLEMENTED(std::format("Not implemented: screenNum={}, playlist={}", screenNum, playlist));
+   if (pScreen)
+   {
+      PUPPlaylist* pPlaylist = pScreen->GetPlaylist(playlist);
+      if (pPlaylist)
+         pScreen->Play(pPlaylist, ""s, pPlaylist->GetVolume(), 0, false, 0, false);
+      else
+         LOGE(std::format("Playlist not found: screenNum={}, playlist={}", screenNum, playlist));
+   }
 }
 
 void PUPPinDisplay::playlistplayex(int screenNum, const string& playlist, const string& playfilename, int volume, int priority)
@@ -184,7 +192,8 @@ void PUPPinDisplay::SetLoop(int screenNum, int LoopState)
 
 void PUPPinDisplay::SetBackGround(int screenNum, int mode)
 {
-   // if you set Mode=1, it will set current playing file as background (loop it always).  Mode=0 to cancel background.  Note if user has 'POP-UP' mode this will be disabled automagically (you don't need to worry about it).
+   // if you set Mode=1, it will set current playing file as background (loop it always).  Mode=0 to cancel background.
+   LOGD(std::format("SetBackGround called: screenNum={}, mode={}", screenNum, mode));
    std::shared_ptr<PUPScreen> pScreen = m_pupManager.GetScreen(screenNum, true);
    if (pScreen)
       pScreen->SetAsBackGround(mode);
@@ -455,10 +464,8 @@ void PUPPinDisplay::LabelNew(int screenNum, const string& LabelName, const strin
    if (!pScreen)
       return;
 
-   if (!pScreen->IsLabelInit()) {
-      LOGE("LabelInit has not been called: screenNum=" + std::to_string(screenNum));
-      return;
-   }
+   if (!pScreen->IsLabelInit())
+      pScreen->SetLabelInit();
 
    pScreen->AddLabel(new PUPLabel(&m_pupManager, LabelName, FontName, static_cast<float>(Size), Color,
       static_cast<float>(Angle) / 10.0f, (PUP_LABEL_XALIGN)xAlign, (PUP_LABEL_YALIGN)yAlign,
@@ -636,35 +643,53 @@ void PUPPinDisplay::playevent(int screenNum, const string& playlist, const strin
    std::shared_ptr<PUPScreen> pScreen = m_pupManager.GetScreen(screenNum, true);
    if (!pScreen)
       return;
-   // TODO handle seconds and Special
-   pScreen->Play(playlist, playfilename, static_cast<float>(volume), priority);
 
-   //  'playtype for triggers
-   //  'ptNormal=0;
-   //  'ptLoop=1;
-   //  'ptSplashReset=2;
-   //  'ptSplashResume=3;
-   //  'ptStopScreen=4;
-   //  'ptStopFile=5;
-   //  'ptSetBG=6;
-   //  'ptPlaySSF=7;
-   //  'ptSkipSameP=8;
-   //  'ptCustomFunc=9;
-   //  'ptForcePlay=10;
-   //  'ptQueueSameP=11;
-   //  'ptQueueAlways=12;
+   // playtype: 0=Normal, 1=Loop, 2=SplashReset, 3=SplashResume, 4=StopScreen,
+   //           5=StopFile, 6=SetBG, 7=PlaySSF, 8=SkipSameP, 9=CustomFunc,
+   //           10=ForcePlay, 11=QueueSameP, 12=QueueAlways
    switch (playtype) {
-   case 0:
-      // Normal
+   case 0: // Normal
+      pScreen->Play(playlist, playfilename, static_cast<float>(volume), priority);
+      if (Seconds > 0)
+         pScreen->SetLength(Seconds);
       break;
    case 1: // Loop
+      pScreen->Play(playlist, playfilename, static_cast<float>(volume), priority);
       pScreen->SetLoop(1);
       break;
-   case 6: // SetBG
-      pScreen->SetAsBackGround(1);
+   case 2: // SplashReset
+   case 3: // SplashResume
+      pScreen->Play(playlist, playfilename, static_cast<float>(volume), priority);
+      if (Seconds > 0)
+         pScreen->SetLength(Seconds);
       break;
+   case 4: // StopScreen
+      pScreen->Stop(priority);
+      break;
+   case 5: // StopFile
+   {
+      PUPPlaylist* pPlaylist = pScreen->GetPlaylist(playlist);
+      if (pPlaylist)
+         pScreen->Stop(pPlaylist, playfilename);
+      break;
+   }
+   case 6: // SetBG
+   {
+      PUPPlaylist* pPlaylist = pScreen->GetPlaylist(playlist);
+      if (pPlaylist)
+         pScreen->Play(pPlaylist, playfilename, static_cast<float>(volume), priority, false, Seconds, true);
+      break;
+   }
+   case 8: // SkipSamePriority
+   {
+      PUPPlaylist* pPlaylist = pScreen->GetPlaylist(playlist);
+      if (pPlaylist)
+         pScreen->Play(pPlaylist, playfilename, static_cast<float>(volume), priority, true, Seconds, false);
+      break;
+   }
    default:
       NOT_IMPLEMENTED("Not implemented: playevent playtype=" + std::to_string(playtype));
+      break;
    }
 }
 

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -286,9 +286,15 @@ void PUPPinDisplay::SendMSG(const string& szMsg)
                if (pScreen) {
                   int fn = json["FN"s].as<int>();
                   switch (fn) {
+                     case 2:
+                        // See pDisableLoopRefresh — form state flags (FF/FO), controls Windows form redraw
+                        // { "mt":301, "SN": XX, "FN": 2, "FF":0/1, "FO":0/1 }
+                        NOT_IMPLEMENTED(std::format("Loop refresh flags not implemented: screen={{{}}}, FF={}, FO={}", pScreen->ToString(false), json["FF"s].as<int>(0), json["FO"s].as<int>(0)));
+                        break;
                      case 3:
-                        // hide/show overlay text - { "mt":301, "SN": XX, "FN":3, "OT": 0 } - OT 0/1 overlay text on off bool
-                        NOT_IMPLEMENTED("Show/Hide screen not implemented. szMsg=" + szMsg);
+                        // See pDMDSetHUD — show/hide overlay window (overlay image + labels)
+                        // { "mt":301, "SN": XX, "FN":3, "OT": 0 } - OT 0/1
+                        pScreen->m_hudVisible = (json["OT"s].as<int>(0) != 0);
                         break;
                      case 4:
                         // set StayOnTop { "mt":301, "SN": XX, "FN":4, "FS":1/0 }
@@ -379,8 +385,9 @@ void PUPPinDisplay::SendMSG(const string& szMsg)
                         NOT_IMPLEMENTED(std::format("Slow PC mode is not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
                         break;
                      case 46:
-                        // pad all text { "mt":301, "SN": XX, "FN":46, "PA":1 } - PA 0/1 = padd text bool
-                        NOT_IMPLEMENTED(std::format("Pad all text is not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
+                        // See pDMDAlwaysPAD — pad all text with space before/after for shadow clipping
+                        // { "mt":301, "SN": XX, "FN":46, "PA":1 } - PA 0/1 = pad text bool
+                        NOT_IMPLEMENTED(std::format("Pad text not implemented: screen={{{}}}, PA={}", pScreen->ToString(false), json["PA"s].as<int>(0)));
                         break;
                      case 50:
                         // pSetAspectRatio(PuPID, arWidth, arHeight) "{ ""mt"":301, ""SN"": "&PuPID& ", ""FN"": 50, ""WIDTH"": "&arWidth&", ""HEIGHT"": "&arHeight&" }"   
@@ -480,6 +487,10 @@ void PUPPinDisplay::LabelSet(int screenNum, const string& LabelName, const strin
    if (!pScreen)
       return;
 
+   // See pDMDSetHUD — pBackground visibility controls the HUD layer
+   if (StrCompareNoCase(LabelName, "pBackground"s))
+      pScreen->m_hudVisible = Visible;
+
    PUPLabel* pLabel = pScreen->GetLabel(LabelName);
    if (!pLabel) {
       if (m_warnedLabels[screenNum].find(LabelName) == m_warnedLabels[screenNum].end())
@@ -524,7 +535,15 @@ void PUPPinDisplay::LabelInit(int screenNum)
 {
    std::shared_ptr<PUPScreen> pScreen = m_pupManager.GetScreen(screenNum, true);
    if (pScreen)
+   {
       pScreen->SetLabelInit();
+      // See pDMDSetHUD — pBackground label created automatically during LabelInit
+      if (!pScreen->GetLabel("pBackground"))
+      {
+         pScreen->AddLabel(new PUPLabel(&m_pupManager, "pBackground"s, "Liberation Sans"s, 50.f, 0xFF, 0.f,
+            PUP_LABEL_XALIGN_CENTER, PUP_LABEL_YALIGN_CENTER, 0.f, 0.f, -1, true));
+      }
+   }
 }
 
 const string& PUPPinDisplay::GetGetGame() const

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -383,12 +383,13 @@ void PUPPinDisplay::SendMSG(const string& szMsg)
                         NOT_IMPLEMENTED(std::format("Safe loop mode not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
                         break;
                      case 42:
-                        // will temporary volume duck all pups (not masterid) till masterid currently playing video ends.  will auto-return all pups to normal.
-                        // VolLevel is number,  0 to mute 99 for 99%
-                        // ALL may be omitted, not sure how it affects
-                        // "{ ""mt"":301, ""SN"": "& MasterPuPID& ", ""FN"": 42, ""DV"": "&VolLevel&" , ""ALL"":1 }"                 
-                        NOT_IMPLEMENTED(std::format("Temporary volume ducking is not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
+                     {
+                        // See PUPDMD AudioDuckPuP — temporarily duck all screens except master
+                        // "{ ""mt"":301, ""SN"": "& MasterPuPID& ", ""FN"": 42, ""DV"": "&VolLevel&" , ""ALL"":1 }"
+                        float duckLevel = static_cast<float>(json["DV"s].as<int>(50)) / 100.0f;
+                        m_pupManager.DuckAllExcept(sn, duckLevel);
                         break;
+                     }
                      case 45:
                         // slow pc mode { "mt":301, "SN":XX, "FN":45, "SP":1 } - SP 0/1 = slow pc mode bool
                         NOT_IMPLEMENTED(std::format("Slow PC mode is not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));

--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -51,6 +51,8 @@ PUPScreen::~PUPScreen()
 {
    if (m_pageTimer)
       SDL_RemoveTimer(m_pageTimer);
+   if (m_imageTimer)
+      SDL_RemoveTimer(m_imageTimer);
 
    for (auto& [key, pPlaylist] : m_playlistMap)
       delete pPlaylist;
@@ -273,6 +275,16 @@ uint32_t PUPScreen::PageTimerElapsed(void* param, SDL_TimerID timerID, uint32_t 
    return interval;
 }
 
+uint32_t PUPScreen::ImageTimerElapsed(void* param, SDL_TimerID timerID, uint32_t interval)
+{
+   PUPScreen* me = static_cast<PUPScreen*>(param);
+   std::lock_guard lock(me->m_screenMutex);
+   SDL_RemoveTimer(me->m_imageTimer);
+   me->m_imageTimer = 0;
+   me->m_staticImage.Clear();
+   return interval;
+}
+
 void PUPScreen::SetBounds(int x, int y, int w, int h)
 {
    assert(std::this_thread::get_id() == m_apiThread);
@@ -313,6 +325,26 @@ void PUPScreen::Play(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlay
    switch (pPlaylist->GetFunction())
    {
    case PUPPlaylist::Function::Default:
+   {
+      // PNGs/JPGs bypass FFmpeg — loaded as static image on the video layer.
+      // Persists until replaced by a new image or video play.
+      const string ext = extension_from_path(szPlayFile.string());
+      if (ext == "png" || ext == "jpg" || ext == "jpeg" || ext == "bmp")
+      {
+         if (background)
+         {
+            m_background.Load(pPlaylist->GetPlayFilePath(szPlayFile));
+            m_pMediaPlayerManager->StopBackground();
+         }
+         else
+         {
+            Stop();
+            m_staticImage.Load(pPlaylist->GetPlayFilePath(szPlayFile));
+            if (length > 0)
+               m_imageTimer = SDL_AddTimer(length * 1000, ImageTimerElapsed, this);
+         }
+         break;
+      }
       switch (m_mode)
       {
       case Mode::Off:
@@ -323,8 +355,7 @@ void PUPScreen::Play(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlay
          break;
 
       case Mode::ForcePopBack:
-         m_pManager->SendScreenToFront(this);
-         //m_pManager->SendScreenToBack(this);
+         m_pManager->SendScreenToBack(this);
          break;
 
       case Mode::ForceOn:
@@ -340,11 +371,12 @@ void PUPScreen::Play(PUPPlaylist* pPlaylist, const std::filesystem::path& szPlay
          break;
 
       case Mode::Show:
-         // What should we do here ?
          break;
       }
+      m_staticImage.Clear();
       m_pMediaPlayerManager->Play(pPlaylist, szPlayFile, m_mainVolume * (m_pParent ? (volume / 100.0f) * m_pParent->GetVolume() : volume), priority, skipSamePriority, length, background);
       break;
+   }
 
    case PUPPlaylist::Function::Frames:
       m_background.Load(pPlaylist->GetPlayFilePath(szPlayFile));
@@ -375,6 +407,9 @@ void PUPScreen::Stop()
 {
    assert(std::this_thread::get_id() == m_apiThread);
    m_pMediaPlayerManager->Stop();
+   if (m_imageTimer)
+      SDL_RemoveTimer(m_imageTimer);
+   m_imageTimer = 0;
 }
 
 void PUPScreen::Stop(int priority)
@@ -411,6 +446,12 @@ void PUPScreen::SetLength(int length)
 {
    assert(std::this_thread::get_id() == m_apiThread);
    m_pMediaPlayerManager->SetMaxLength(length);
+   if (length > 0 && !m_staticImage.GetFile().empty())
+   {
+      if (m_imageTimer)
+         SDL_RemoveTimer(m_imageTimer);
+      m_imageTimer = SDL_AddTimer(length * 1000, ImageTimerElapsed, this);
+   }
 }
 
 void PUPScreen::SetAsBackGround(int mode)
@@ -444,7 +485,11 @@ void PUPScreen::Render(VPXRenderContext2D* const ctx, int pass) {
    {
    case 0: m_background.Render(ctx, m_rect, m_screenAlpha); break;
 
-   case 1: m_pMediaPlayerManager->Render(ctx, m_screenAlpha); break;
+   case 1:
+      m_pMediaPlayerManager->Render(ctx, m_screenAlpha);
+      if (!m_pMediaPlayerManager->IsMainPlaying() && !m_pMediaPlayerManager->IsBackgroundPlaying())
+         m_staticImage.Render(ctx, m_rect, m_screenAlpha);
+      break;
 
    case 2: m_overlay.Render(ctx, m_rect, m_screenAlpha); break;
 

--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -165,6 +165,11 @@ void PUPScreen::SetVolume(float volume)
    m_pMediaPlayerManager->SetVolume(m_mainVolume * m_volume);
 }
 
+void PUPScreen::SetOnMainEndCallback(const std::function<void()>& callback)
+{
+   m_pMediaPlayerManager->SetOnMainEndCallback(callback);
+}
+
 void PUPScreen::SetVolumeCurrent(float volume)
 {
    assert(std::this_thread::get_id() == m_apiThread);
@@ -277,7 +282,6 @@ void PUPScreen::SetPage(int pagenum, int seconds)
 
 uint32_t PUPScreen::PageTimerElapsed(void* param, SDL_TimerID timerID, uint32_t interval)
 {
-   // Note: this callback is called on SDL thread (so not API thread) so we need to sync against concurrent changes
    PUPScreen* me = static_cast<PUPScreen*>(param);
    std::lock_guard lock(me->m_screenMutex);
    SDL_RemoveTimer(me->m_pageTimer);

--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -140,6 +140,17 @@ void PUPScreen::LoadTriggers()
    }
 }
 
+void PUPScreen::SetMode(Mode mode)
+{
+   if (mode == m_mode)
+      return;
+   bool wasVisible = (m_mode != Mode::Off && m_mode != Mode::MusicOnly);
+   m_mode = mode;
+   bool isVisible = (m_mode != Mode::Off && m_mode != Mode::MusicOnly);
+   if (wasVisible && !isVisible)
+      m_pMediaPlayerManager->Stop();
+}
+
 void PUPScreen::SetMainVolume(float volume)
 {
    assert(std::this_thread::get_id() == m_apiThread);
@@ -491,7 +502,10 @@ void PUPScreen::Render(VPXRenderContext2D* const ctx, int pass) {
          m_staticImage.Render(ctx, m_rect, m_screenAlpha);
       break;
 
-   case 2: m_overlay.Render(ctx, m_rect, m_screenAlpha); break;
+   case 2:
+      if (m_hudVisible)
+         m_overlay.Render(ctx, m_rect, m_screenAlpha);
+      break;
 
    case 3:
       for (PUPLabel* pLabel : m_labels)

--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -442,15 +442,15 @@ void PUPScreen::Render(VPXRenderContext2D* const ctx, int pass) {
 
    switch (pass)
    {
-   case 0: m_background.Render(ctx, m_rect); break;
+   case 0: m_background.Render(ctx, m_rect, m_screenAlpha); break;
 
-   case 1: m_pMediaPlayerManager->Render(ctx); break;
+   case 1: m_pMediaPlayerManager->Render(ctx, m_screenAlpha); break;
 
-   case 2: m_overlay.Render(ctx, m_rect); break;
+   case 2: m_overlay.Render(ctx, m_rect, m_screenAlpha); break;
 
    case 3:
       for (PUPLabel* pLabel : m_labels)
-         pLabel->Render(ctx, m_rect, m_pagenum);
+         pLabel->Render(ctx, m_rect, m_pagenum, m_screenAlpha);
       break;
    }
 }

--- a/plugins/pup/PUPScreen.h
+++ b/plugins/pup/PUPScreen.h
@@ -45,6 +45,7 @@ public:
 
    Mode GetMode() const { return m_mode; }
    void SetMode(Mode mode);
+
    bool IsPop() const { return m_mode == PUPScreen::Mode::ForcePopBack || m_mode == PUPScreen::Mode::ForcePop; }
 
    bool IsTransparent() const { return m_transparent; }
@@ -56,6 +57,7 @@ public:
    void SetMainVolume(float volume); // Set user defined global volume (allow to mute)
    void SetVolume(float volume); // Set default, and apply it to played media
    void SetVolumeCurrent(float volume); // Only modifiy volume of currently playing medias
+   void SetOnMainEndCallback(const std::function<void()>& callback);
 
    const std::unique_ptr<PUPCustomPos>& GetCustomPos() const { return m_pCustomPos; }
    void SetCustomPos(const string& szCustomPos);

--- a/plugins/pup/PUPScreen.h
+++ b/plugins/pup/PUPScreen.h
@@ -49,6 +49,8 @@ public:
 
    bool IsTransparent() const { return m_transparent; }
 
+   float m_screenAlpha = 1.0f;
+
    float GetVolume() const { return m_volume; }
    void SetMainVolume(float volume); // Set user defined global volume (allow to mute)
    void SetVolume(float volume); // Set default, and apply it to played media

--- a/plugins/pup/PUPScreen.h
+++ b/plugins/pup/PUPScreen.h
@@ -124,12 +124,15 @@ private:
    ankerl::unordered_dense::map<string, PUPPlaylist*> m_playlistMap;
    ankerl::unordered_dense::map<string, vector<PUPTrigger*>> m_triggerMap;
    PUPImage m_background;
+   PUPImage m_staticImage;
    PUPImage m_overlay;
    std::unique_ptr<PUPMediaManager> m_pMediaPlayerManager;
    bool m_labelInit = false;
    int m_pagenum = 0;
    int m_defaultPagenum = 0;
    SDL_TimerID m_pageTimer = 0;
+   SDL_TimerID m_imageTimer = 0;
+   static uint32_t ImageTimerElapsed(void* param, SDL_TimerID timerID, uint32_t interval);
    PUPScreen* m_pParent = nullptr;
    vector<std::shared_ptr<PUPScreen>> m_children;
    const std::thread::id m_apiThread;

--- a/plugins/pup/PUPScreen.h
+++ b/plugins/pup/PUPScreen.h
@@ -124,9 +124,9 @@ private:
    ankerl::unordered_dense::map<string, PUPLabel*> m_labelMap;
    ankerl::unordered_dense::map<string, PUPPlaylist*> m_playlistMap;
    ankerl::unordered_dense::map<string, vector<PUPTrigger*>> m_triggerMap;
-   PUPImage m_background;
-   PUPImage m_staticImage;
-   PUPImage m_overlay;
+   PUPImage m_background;    // PuPFrames playlist — underlay behind video
+   PUPImage m_staticImage;   // Static PNG/JPG from Default function — renders on video layer, bypasses FFmpeg
+   PUPImage m_overlay;       // PuPOverlays/PuPAlphas playlist — overlay rendered above video
    std::unique_ptr<PUPMediaManager> m_pMediaPlayerManager;
    bool m_labelInit = false;
    int m_pagenum = 0;

--- a/plugins/pup/PUPScreen.h
+++ b/plugins/pup/PUPScreen.h
@@ -44,12 +44,13 @@ public:
    string ToString(bool full = true) const;
 
    Mode GetMode() const { return m_mode; }
-   void SetMode(Mode mode) { m_mode = mode; }
+   void SetMode(Mode mode);
    bool IsPop() const { return m_mode == PUPScreen::Mode::ForcePopBack || m_mode == PUPScreen::Mode::ForcePop; }
 
    bool IsTransparent() const { return m_transparent; }
 
    float m_screenAlpha = 1.0f;
+   bool m_hudVisible = true;
 
    float GetVolume() const { return m_volume; }
    void SetMainVolume(float volume); // Set user defined global volume (allow to mute)

--- a/plugins/pup/PUPTrigger.cpp
+++ b/plugins/pup/PUPTrigger.cpp
@@ -105,6 +105,22 @@ PUPTrigger::PUPTrigger(bool active, const string& szDescript, const string& szTr
       m_action = [&]() { m_pScreen->Play(m_pPlaylist, m_szPlayFile, m_volume, m_priority, false, m_length, true); };
       break;
 
+   case PUPTrigger::Action::SplashReset:
+      m_action = [&]()
+      {
+         // Play splash video, background will restart from beginning when splash ends
+         m_pScreen->Play(m_pPlaylist, m_szPlayFile, m_volume, m_priority, false, m_length, false);
+      };
+      break;
+
+   case PUPTrigger::Action::SplashReturn:
+      m_action = [&]()
+      {
+         // Play splash video, background will resume from where it left off when splash ends
+         m_pScreen->Play(m_pPlaylist, m_szPlayFile, m_volume, m_priority, false, m_length, false);
+      };
+      break;
+
    case PUPTrigger::Action::SkipSamePriority:
       m_action = [&]() { m_pScreen->Play(m_pPlaylist, m_szPlayFile, m_volume, m_priority, true, m_length, false); };
       break;


### PR DESCRIPTION
The following PR has several updates to the PuP plugin after countless runs of DieHard, B66, TF, Futurama, TNA, GOTG, and MB.

I used Claude extensively to:
- Add debug logs to the plugin
- Add debug logs to VBS scripts
- Examine 1000+ VBS files from [vpxtable_scripts](https://github.com/sverrewl/vpxtable_scripts)
- Analyze any docs I could find on PuP

I also watched several YouTube videos to try to get matching behavior.

Even after all that, there are still some issues that need more work:
- B66 sometimes loses its border image
- GOTG seems to have lots of audio in the background
- DieHard ball text border is wrong
- TF gets stuck with the Select Player in the lower middle, or it will just be black
- MB flickers on Linux

---

Below is a summary of the changes *(summary generated by AI)*:

## Media Manager Rewrite

Replaced dual player system with a single `PUPMediaPlayer` per screen that switches between main and background content.

- **BackgroundConfig** stores path/volume/active state without running a player — when main ends, loads into same player with loop enabled
- **Play queue** (`std::deque<PlayItem>`) for lower-priority items, checked for expiry on dequeue
- **Same-file skip** avoids flicker when same file requested (volume update only)
- **Play-to-play transition** suppresses OnEndCallback during StopBlocking to prevent background briefly starting between videos
- **Lock-free `IsPlaying()`** — atomic `m_running`, `m_pendingPlay`, `m_pendingStop` eliminate mutex contention from render thread
- **FFmpeg init outside mutex** — file open, stream probe, and codec init done with local variables before brief lock to swap into members (previously held across all FFmpeg I/O, blocking render for 50-500ms)

## Alpha/Transparency and Screen Fade

Threads `float alpha` through the entire render pipeline via `m_screenAlpha` on PUPScreen.

- All 4 render passes apply `m_screenAlpha`
- **Screen fade animation (at=7)** modifies `m_pScreen->m_screenAlpha` instead of label alpha — see `pDMDScreenFadeOut`/`pDMDScreenFadeIn`. Used by [Scarface](https://github.com/sverrewl/vpxtable_scripts)
- **SendMSG FN=22** — AM=1 enables alpha mode, AV sets value (0-255). Used by [GOTG](https://github.com/sverrewl/vpxtable_scripts)

## Static Image Support

PNG/JPG files bypass FFmpeg and load via SDL_Image directly. FFmpeg requires opening a format context, probing streams, initializing a codec, and decoding a frame for what is essentially a single pixel buffer. SDL_Image loads to an SDL_Surface in one call, avoiding tying up the video player.

- Extension detection for `.png`, `.jpg`, `.jpeg`, `.bmp` in Default function playlists
- `m_staticImage` renders in pass 1 only when no video playing
- SDL timer auto-clears static image after `length` seconds
- Cleared when video playback starts

## GIF Animation and Tween/Easing

**GIF properties** (SetSpecial mt=2, from `_PUPDMD_WIP_beta18.txt`):

| Property | Description | Used by |
|----------|-------------|---------|
| `gifloop` | 1=loop forever (default), 0=play once | [Darkest Dungeon](https://github.com/sverrewl/vpxtable_scripts) |
| `gifstart`/`gifend` | Frame range, -1 resets, same=single frame | [Darkest Dungeon](https://github.com/sverrewl/vpxtable_scripts) |
| `animate` | Interval in ms, 0 stops | — |
| `aniendhide` | Hide label when animation completes | [Darkest Dungeon](https://github.com/sverrewl/vpxtable_scripts) |
| `anidispose` | Mark for cleanup after playback | — |
| `anigif` | Speed (100=normal, 50=half, 200=double) | [B66](https://github.com/sverrewl/vpxtable_scripts), [Blood Machines](https://github.com/sverrewl/vpxtable_scripts), [CyberRace](https://github.com/sverrewl/vpxtable_scripts) |

**Frame timing:** Precomputed accumulated delay array for O(log n) frame lookup.

**Tween/easing** (`tt` parameter): Robert Penner easing curves (see [easings.net](https://easings.net)), values 0-10. Linear, quad, cubic, quart, quint in/out/in-out. Scripts use `tt:0`, `tt:3`, `tt:5` in practice. Used by [B66](https://github.com/sverrewl/vpxtable_scripts), [GOTG](https://github.com/sverrewl/vpxtable_scripts), [Led Zeppelin](https://github.com/sverrewl/vpxtable_scripts), [Goonies](https://github.com/sverrewl/vpxtable_scripts), [Stranger Things](https://github.com/sverrewl/vpxtable_scripts), [Scarface](https://github.com/sverrewl/vpxtable_scripts).

**Animation `fc` default:** Flash and Motion animations now default to label color when `fc` not specified.

## HUD Visibility and pBackground Label

- `m_hudVisible` gates pass 2 (overlay image) — see `pDMDSetHUD`. Used by [Scarface](https://github.com/sverrewl/vpxtable_scripts)
- **SendMSG FN=3** sets `m_hudVisible` via OT parameter. Used by [B66](https://github.com/sverrewl/vpxtable_scripts), [pizzatime](https://github.com/sverrewl/vpxtable_scripts), [Scarface](https://github.com/sverrewl/vpxtable_scripts)
- `pBackground` label auto-created during LabelInit, its visibility controls HUD layer
- `SetMode()` stops playback when transitioning to hidden state
- LabelNew auto-calls SetLabelInit if not yet called
- **FN=2** (`pDisableLoopRefresh`) and **FN=46** (`pDMDAlwaysPAD`) — logged but not acted on (Windows-specific behavior)

## Playevent Playtypes, Trigger Reset, and Misc Fixes

**Playtypes:**

| Type | Name | Behavior |
|------|------|----------|
| 0 | Normal | Play once, optional length |
| 1 | Loop | Play with looping |
| 2 | SplashReset | Play, background restarts from beginning |
| 3 | SplashResume | Play, background resumes position |
| 4 | StopScreen | Stop by priority |
| 5 | StopFile | Stop specific file |
| 6 | SetBG | Configure as background loop |
| 8 | SkipSamePriority | Skip if same/lower priority playing |

Used by [Darkest Dungeon](https://github.com/sverrewl/vpxtable_scripts), [Stranger Things](https://github.com/sverrewl/vpxtable_scripts)

**Other fixes:**
- Trigger condition values reset after firing so same B2S event can re-trigger
- Render order rewrite: non-popup passes 0-1, then 2-3, then popup 0-3 (prevents cross-screen layering issues)
- LiberationSans fallback font for missing fonts
- `playlistplay` implemented
- ForcePopBack now correctly sends to back

## Audio Ducking

From `_PUPDMD_WIP_beta18.txt` (`AudioDuckPuP`). Used by [B66](https://github.com/sverrewl/vpxtable_scripts).

- **SendMSG FN=42** — DV is volume percentage (0=mute, 99=99%)
- Saves all non-master screen volumes, sets to DV percent, auto-restores when master video ends

## FFmpeg Log Suppression

`av_log_set_level(AV_LOG_ERROR)` in both PUP and FlexDMD LibAv.h. Suppresses "Detected creation time before 1970" warnings.

---

## Architecture

### Render Pipeline

Each screen renders 4 passes multiplied by `m_screenAlpha`:

| Pass | Content | Source |
|------|---------|--------|
| 0 | Background underlay | PuPFrames playlist |
| 1 | Video or static image | FFmpeg player or SDL_Image |
| 2 | Overlay (gated by `m_hudVisible`) | PuPOverlays/PuPAlphas playlist |
| 3 | Labels (filtered by page) | Text, image, GIF |

**Screen render order:**
1. Non-popup screens passes 0-1 (all video layers first)
2. Non-popup screens passes 2-3 (overlays on top of all video)
3. Popup screens passes 0-3 (entirely on top, only when playing)

### Video Playback

One `PUPMediaPlayer` per screen, no separate background player.

**Play request:** same file playing → volume update only; background has file → skip; lower priority → queue; otherwise → play immediately.

**Video ends:** check queue for non-expired items → play background with loop → stop.

**Background** is a config struct (path + volume), not a running player.

### Key PuP API Functions

| Function | Implementation |
|----------|---------------|
| `pDMDPNGAnimate` | `animate` in SetSpecial mt=2 |
| `pDMDPNGAnimateEx` | `gifstart`, `gifend`, `gifloop` |
| `pDMDPNGShowFrame` | `gifstart`=`gifend` |
| `pDMDPNGAnimateOnce` | `gifloop:0`, `aniendhide:1` |
| `pDMDScreenFadeOut/In` | Animation at=7 |
| `pDMDBackLoopStart` | `SetBackGround(1)` |
| `pDMDStopBackLoop` | `SetBackGround(0)` |
| `pDMDSetHUD` | `pBackground` visibility |
| `AudioDuckPuP` | SendMSG FN=42 |
