### PR TITLE
core.vbs: guard mFastTimer access in EnableUpdate

### DIFF
--- a/scripts/core.vbs
+++ b/scripts/core.vbs
@@ -204,7 +204,7 @@ Class cvpmTimer
 		On Error Resume Next
 		If aFast Then
 			If aEnabled Then mFastUpdates.Add aClass, 0 : Else mFastUpdates.Remove aClass
-			mFastTimer.TimerEnabled = mFastUpdates.Count > 0
+			If IsObject(mFastTimer) Then mFastTimer.TimerEnabled = mFastUpdates.Count > 0
 		Else
 			If aEnabled Then mSlowUpdates.Add aClass, 0 : Else mSlowUpdates.Remove aClass
 		End If


### PR DESCRIPTION
`cvpmTimer.EnableUpdate` accesses `mFastTimer.TimerEnabled` unconditionally, but `mFastTimer` is only set when `InitTimer` is called with a `PulseTimer` element. Classes that register their `NeedUpdate` before `PulseTimer_Init` runs hit "Object required" (800a01a8), silently swallowed by the On Error Resume Next. Guard with `IsObject` so the error doesn't occur in the first place.