### PR TITLE
core.vbs: guard mFastTimer access in cvpmTimer.EnableUpdate

### DIFF
--- a/scripts/core.vbs
+++ b/scripts/core.vbs
@@ -204,7 +204,7 @@ Class cvpmTimer
 		On Error Resume Next
 		If aFast Then
 			If aEnabled Then mFastUpdates.Add aClass, 0 : Else mFastUpdates.Remove aClass
-			mFastTimer.TimerEnabled = mFastUpdates.Count > 0
+			If IsObject(mFastTimer) Then mFastTimer.TimerEnabled = mFastUpdates.Count > 0
 		Else
 			If aEnabled Then mSlowUpdates.Add aClass, 0 : Else mSlowUpdates.Remove aClass
 		End If


### PR DESCRIPTION
`cvpmTurntable.Class_Initialize` calls `AdjustTargets`, which sets `NeedUpdate` (line 1450) and therefore calls `cvpmTimer.EnableUpdate` with `aFast=True` — before `InitTurntable` has had a chance to call `InitTimer` and assign `mFastTimer`. This raises      
  "Object required" (`800a01a8`) on every `cvpmTurntable` construction, silently swallowed by the `On Error Resume Next` at line 204.                                                                                                                                
                                                                                                                                                                                                                                                                     
  Guard with `IsObject(mFastTimer)` so the error doesn't occur in the first place.                                                                                                                                                                                   
   
  ### Call chain                                                                                                                                                                                                                                                     
                                                                  
  Set spinner = New cvpmTurntable                                                                                                                                                                                                                                    
    → Class_Initialize (line 1413)
      → AdjustTargets (line 1416)                                                                                                                                                                                                                                    
        → NeedUpdate = mBalls.Count Or SpinUp Or SpinDown (line 1450)                                                                                                                                                                                                
          → EnableUpdate Me, True, True (line 1338/1419)
            → mFastTimer.TimerEnabled = ...  ← 💥 mFastTimer not set yet                                                                                                                                                                                             
                                                                                                                                                                                                                                                                     
  `mFastTimer` is only assigned later when `InitTurntable` calls `vpmTimer.InitTimer aTrigger, True` (line 1343).        