### PR TITLE
audio: let parallel plugin sources play alongside the active source

### DIFF
--- a/plugins/pup/PUPPlugin.cpp
+++ b/plugins/pup/PUPPlugin.cpp
@@ -159,8 +159,24 @@ void DeleteTexture(VPXTexture texture)
 //
 
 static unsigned int onAudioUpdateId;
+static unsigned int onAudioSrcChangedId;
+static unsigned int getAudioSrcId;
 static vector<uint32_t> freeAudioStreamId;
 uint32_t nextAudioStreamId = 1;
+
+// PUP advertises itself as a parallel audio source (overrideId = 0) so the host
+// does not silence it when PinMAME or AltSound is the primary source.
+// PUP's per-video sub-streams allocate their own ids on top of this; this entry
+// is the umbrella registration that satisfies the CTLPI_AUDIO_GET_SRC_MSG contract.
+static AudioSrcId pupAudioSrcDef = {};
+
+static void OnGetAudioSrc(const unsigned int msgId, void* userData, void* msgData)
+{
+   GetAudioSrcMsg* msg = static_cast<GetAudioSrcMsg*>(msgData);
+   if (msg->count < msg->maxEntryCount)
+      memcpy(&msg->entries[msg->count], &pupAudioSrcDef, sizeof(AudioSrcId));
+   msg->count++;
+}
 
 CtlResId UpdateAudioStream(AudioUpdateMsg* msg)
 {
@@ -269,6 +285,17 @@ MSGPI_EXPORT void MSGPIAPI PUPPluginLoad(const uint32_t sessionId, const MsgPlug
    msgApi->SubscribeMsg(endpointId, onGameEndId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_EVT_ON_GAME_END), OnGameEnd, nullptr);
 
    onAudioUpdateId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_AUDIO_ON_UPDATE_MSG);
+   onAudioSrcChangedId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_AUDIO_ON_SRC_CHG_MSG);
+   getAudioSrcId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_AUDIO_GET_SRC_MSG);
+
+   pupAudioSrcDef.id.endpointId = endpointId;
+   pupAudioSrcDef.id.resId = nextAudioStreamId++;
+   pupAudioSrcDef.overrideId = { 0, 0 };
+   pupAudioSrcDef.type = CTLPI_AUDIO_SRC_BACKGLASS_STEREO;
+   pupAudioSrcDef.format = CTLPI_AUDIO_FORMAT_SAMPLE_FLOAT;
+   pupAudioSrcDef.sampleRate = 48000;
+   msgApi->SubscribeMsg(endpointId, getAudioSrcId, OnGetAudioSrc, nullptr);
+   msgApi->BroadcastMsg(endpointId, onAudioSrcChangedId, nullptr);
 
    const unsigned int getScriptApiId = msgApi->GetMsgID(SCRIPTPI_NAMESPACE, SCRIPTPI_MSG_GET_API);
    msgApi->BroadcastMsg(endpointId, getScriptApiId, &scriptApi);
@@ -299,6 +326,10 @@ MSGPI_EXPORT void MSGPIAPI PUPPluginUnload()
    scriptApi->SetCOMObjectOverride("PinUpPlayer.PinDisplay", nullptr);
    UnregisterPUP_PinDisplay([](ScriptClassDef* scd) { scriptApi->UnregisterScriptClass(scd); });
 
+   msgApi->UnsubscribeMsg(getAudioSrcId, OnGetAudioSrc, nullptr);
+   msgApi->BroadcastMsg(endpointId, onAudioSrcChangedId, nullptr);
+   msgApi->ReleaseMsgID(getAudioSrcId);
+   msgApi->ReleaseMsgID(onAudioSrcChangedId);
    msgApi->ReleaseMsgID(onAudioUpdateId);
 
    msgApi->UnsubscribeMsg(onControllerGameStartId, OnControllerGameStart, nullptr);

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2307,7 +2307,9 @@ void Player::OnAudioUpdated(const unsigned int msgId, void* userData, void* msgD
    if (me->m_activeAudioSourceId == 0)
       me->UpdateActiveAudioSource();
 
-   if (me->m_activeAudioSourceId != 0 && msg.id.id != me->m_activeAudioSourceId)
+   // Drop only sources that are explicitly overridden by another (e.g. PinMAME when AltSound is active).
+   // Non-overridden sources play in parallel — this lets supplemental plugins like PUP coexist with PinMAME.
+   if (me->m_overriddenAudioSourceIds.contains(msg.id.id))
       return;
 
    const auto &entry = me->m_audioStreams.find(msg.id.id);
@@ -2356,6 +2358,7 @@ void Player::UpdateActiveAudioSource()
    if (getSrcMsg.count == 0)
    {
       m_activeAudioSourceId = 0;
+      m_overriddenAudioSourceIds.clear();
       return;
    }
 
@@ -2388,19 +2391,28 @@ void Player::UpdateActiveAudioSource()
       }
    }
 
-   if (m_activeAudioSourceId != activeId)
+   m_activeAudioSourceId = activeId;
+
+   // Build the set of explicitly-overridden sources so OnAudioUpdated can silence them.
+   // Sources outside this set (the active one and any independent parallel sources like PUP) play together.
+   ankerl::unordered_dense::set<uint64_t> newOverridden;
+   for (const auto& src : sources)
+      if (src.overrideId.id != 0)
+         newOverridden.insert(src.overrideId.id);
+
+   for (const uint64_t id : newOverridden)
    {
-      if (m_activeAudioSourceId != 0)
+      if (!m_overriddenAudioSourceIds.contains(id))
       {
-         const auto &entry = m_audioStreams.find(m_activeAudioSourceId);
+         const auto &entry = m_audioStreams.find(id);
          if (entry != m_audioStreams.end() && m_audioPlayer->IsOpened(entry->second))
          {
             m_audioPlayer->CloseAudioStream(entry->second, false);
             m_audioStreams.erase(entry);
          }
       }
-      m_activeAudioSourceId = activeId;
    }
+   m_overriddenAudioSourceIds = std::move(newOverridden);
 }
 
 void Player::PauseMusic()

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -282,6 +282,7 @@ private:
    unsigned int m_onAudioSrcChangedMsgId;
    unsigned int m_getAudioSrcMsgId;
    uint64_t m_activeAudioSourceId = 0;
+   ankerl::unordered_dense::set<uint64_t> m_overriddenAudioSourceIds;
    ankerl::unordered_dense::map<uint64_t, VPX::AudioPlayer::AudioStreamID> m_audioStreams;
 #pragma endregion
 


### PR DESCRIPTION
## Summary

Fixes #3305 — the PUP plugin's audio was silently dropped whenever PinMAME (or AltSound) was the active audio source.

The host's audio routing assumed a single active source resolved through the override chain. Any `AudioUpdateMsg` whose id did not match `m_activeAudioSourceId` was dropped at `player.cpp:2310`. PUP, however, is supposed to play *in parallel* with the ROM audio (video soundtracks / music / SFX layered on top), not replace it — so its samples were silently discarded for any ROM-based table.

## Fix

Two coordinated changes:

- **Player** — replace the single-active filter with an explicit "overridden set". `UpdateActiveAudioSource()` now collects every `src.overrideId.id != 0` value into `m_overriddenAudioSourceIds`. `OnAudioUpdated` drops messages whose id is in that set. Sources outside the chain (PUP) and the chain tip (PinMAME, or AltSound when overriding it) coexist. Streams of newly-overridden sources are closed when the chain changes; streams that leave the set reopen lazily on the next audio update.

- **PUP plugin** — register itself as an audio source via `CTLPI_AUDIO_GET_SRC_MSG` with `overrideId = 0`, satisfying the API contract and making PUP visible to other plugins. The umbrella registration is metadata only; PUP's per-video sub-streams keep allocating their own ids.

No API/ABI change to `ControllerPlugin.h`. AltSound and PinMAME are unchanged — AltSound still overrides PinMAME (PinMAME ends up in the overridden set, silenced).

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| PinMAME only | plays | plays |
| PinMAME + AltSound (override) | AltSound plays, PinMAME silenced | unchanged |
| PinMAME + PUP | PUP silenced (bug) | both play in parallel |
| PinMAME + AltSound + PUP | only AltSound | AltSound + PUP, PinMAME silenced |
| PUP only (no-ROM table, e.g. JP's Deadpool) | plays | plays (no regression) |

## Test plan

- [x] Build passes on all CI targets (linux-x64, windows x86/x64, macos arm64/x64, mingw, RPI/RK3588)
- [x] Manual test on Linux 3-screen pincab (Demolition Man `dm_lx4`): PinMAME audio + PUP music screen 4 (`MusicOnly`) play simultaneously
- [x] Manual test on JP's Deadpool (PUP-only, no ROM): no regression
- [ ] Cross-check on Windows builds with AltSound+PinMAME+PUP combo