### PR TITLE
Fix build: add missing standard library includes

### DIFF
--- a/plugins/pup/PUPLabel.h
+++ b/plugins/pup/PUPLabel.h
@@ -4,6 +4,7 @@
 
 #include "common.h"
 
+#include <climits>
 #include <future>
 
 #include <SDL3_ttf/SDL_ttf.h>

--- a/third-party/include/imgui/imconfig.h
+++ b/third-party/include/imgui/imconfig.h
@@ -120,6 +120,7 @@
 // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
 // Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
 // Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
+#include <cstdint>
 #define ImDrawIdx uint32_t
 
 //---- Override ImDrawCallback signature (will need to modify renderer backends accordingly)


### PR DESCRIPTION
- imconfig.h: include <cstdint> for uint32_t (used by ImDrawIdx)
- PUPLabel.h: include <climits> for INT_MIN/INT_MAX

Newer libstdc++ no longer transitively pulls in these headers.