### PR TITLE
OpenXR: use one view matrix per eye instead of a median one

### DIFF
--- a/src/math/ModelViewProj.h
+++ b/src/math/ModelViewProj.h
@@ -8,48 +8,58 @@ public:
    enum FlipMode { NONE, FLIPX, FLIPY };
    ModelViewProj(const unsigned int nEyes = 1) : m_nEyes(nEyes) {}
 
+   void SetModel(const Matrix3D& model) { SetWithDirty(model, m_matModel); }
+   void SetReflection(const Matrix3D& reflection) { SetWithDirty(reflection, m_matReflection); }
+   void SetView(const unsigned int index, const Matrix3D& view) { SetWithDirty(view, m_matView[index]); }
+   void SetProj(const unsigned int index, const Matrix3D& proj) { SetWithDirty(proj, m_matProj[index]); }
    void SetFlip(const FlipMode flip) { m_dirty = true; m_flip = flip; }
-   void SetModel(const Matrix3D& model) { MarkDirty(model, m_matModel); m_matModel = model; }
-   void SetView(const Matrix3D& view) { MarkDirty(view, m_matView); m_matView = view; }
-   void SetProj(const unsigned int index, const Matrix3D& proj) { MarkDirty(proj, m_matProj[index]); m_matProj[index] = proj; }
-   void SetReflection(const Matrix3D& reflection){ MarkDirty(reflection, m_matReflection); m_matReflection = reflection; }
+
    void Set(const ModelViewProj& mvp) {
       assert(m_nEyes == mvp.m_nEyes);
       m_flip = mvp.m_flip;
       m_matModel = mvp.m_matModel;
-      m_matView = mvp.m_matView;
       m_matReflection = mvp.m_matReflection;
       for (unsigned int i = 0; i < m_nEyes; i++)
-         m_matProj[i] = mvp.m_matProj[i];
-      m_dirty = mvp.m_dirty;
-      if (!mvp.m_dirty)
       {
-         m_matReflectedView = mvp.m_matReflectedView;
-         m_matModelView = mvp.m_matModelView;
-         m_matModelViewInverse = mvp.m_matModelViewInverse;
-         m_matModelViewInverseTranspose = mvp.m_matModelViewInverseTranspose;
+         m_matView[i] = mvp.m_matView[i];
+         m_matProj[i] = mvp.m_matProj[i];
+      }
+      m_dirty = mvp.m_dirty;
+      if (!m_dirty)
+      {
          for (unsigned int i = 0; i < m_nEyes; i++)
+         {
+            m_matReflectedView[i] = mvp.m_matReflectedView[i];
+            m_matModelView[i] = mvp.m_matModelView[i];
+            m_matModelViewInverse[i] = mvp.m_matModelViewInverse[i];
+            m_matModelViewInverseTranspose[i] = mvp.m_matModelViewInverseTranspose[i];
             m_matModelViewProj[i] = mvp.m_matModelViewProj[i];
-         m_viewVec = mvp.m_viewVec;
+            m_viewVec[i] = mvp.m_viewVec[i];
+         }
       }
    }
 
    const Matrix3D& GetModel() const { return m_matModel; }
-   const Matrix3D& GetView() const { Update(); return m_matReflectedView; }
+   const Matrix3D& GetView(const unsigned int eye) const { Update(); return m_matReflectedView[eye]; }
    const Matrix3D& GetProj(const unsigned int eye) const { return m_matProj[eye]; }
-   const Matrix3D& GetModelView() const { Update(); return m_matModelView; }
-   const Matrix3D& GetModelViewInverse() const { Update(); return m_matModelViewInverse; }
-   const Matrix3D& GetModelViewInverseTranspose() const { Update(); return m_matModelViewInverseTranspose; }
+   const Matrix3D& GetModelView(const unsigned int eye) const { Update(); return m_matModelView[eye]; }
+   const Matrix3D& GetModelViewInverse(const unsigned int eye) const { Update(); return m_matModelViewInverse[eye]; }
+   const Matrix3D& GetModelViewInverseTranspose(const unsigned int eye) const { Update(); return m_matModelViewInverseTranspose[eye]; }
    const Matrix3D& GetModelViewProj(const unsigned int eye) const { Update(); return m_matModelViewProj[eye]; }
-   const Vertex3Ds& GetViewVec() const { Update(); return m_viewVec; }
+   const Vertex3Ds& GetViewVec(const unsigned int eye) const { Update(); return m_viewVec[eye]; }
 
    const unsigned int m_nEyes;
 
 private:
-   void MarkDirty(const Matrix3D& newMat, const Matrix3D& oldMat)
+   void SetWithDirty(const Matrix3D& newMat, Matrix3D& localMat)
    {
-      if (!m_dirty)
-         m_dirty = memcmp(oldMat.m, newMat.m, 4 * 4 * sizeof(float)) != 0;
+      if (m_dirty)
+         localMat = newMat;
+      else if (memcmp(localMat.m, newMat.m, 4 * 4 * sizeof(float)) != 0)
+      {
+         m_dirty = true;
+         localMat = newMat;
+      }
    }
 
    void Update() const
@@ -57,53 +67,52 @@ private:
       if (m_dirty)
       {
          m_dirty = false;
-         m_matReflectedView = m_matReflection * m_matView;
-         m_matModelViewInverse = m_matModelView = m_matModel * m_matReflectedView;
-         m_matModelViewInverse.Invert();
-         m_matModelViewInverseTranspose = m_matModelViewInverse;
-         m_matModelViewInverseTranspose.Transpose();
+         for (unsigned int eye = 0; eye < m_nEyes; eye++)
+         {
+            m_matReflectedView[eye] = m_matReflection * m_matView[eye];
+            m_matModelView[eye] = m_matModel * m_matReflectedView[eye];
+            m_matModelViewInverse[eye] = Matrix3D::MatrixInverse(m_matModelView[eye]);
+            m_matModelViewInverseTranspose[eye] = m_matModelViewInverse[eye];
+            m_matModelViewInverseTranspose[eye].Transpose();
+            m_matModelViewProj[eye] = m_matModelView[eye] * m_matProj[eye];
+            const Matrix3D viewRot = Matrix3D::MatrixInverse(m_matReflectedView[eye]).GetRotationPart();
+            m_viewVec[eye] = viewRot * Vertex3Ds { 0.f, 0.f, 1.f };
+            m_viewVec[eye].NormalizeSafe();
+         }
+         // Flip is a clipspace flip, applied after projection
          switch (m_flip)
          {
-         case NONE:
-         {
-            for (unsigned int eye = 0; eye < m_nEyes; eye++)
-               m_matModelViewProj[eye] = m_matModelView * m_matProj[eye];
-            break;
-         }
+         case NONE: break;
          case FLIPX:
          {
             static constexpr Matrix3D flipx{-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
             for (unsigned int eye = 0; eye < m_nEyes; eye++)
-               m_matModelViewProj[eye] = m_matModelView * m_matProj[eye] * flipx;
+               m_matModelViewProj[eye] = m_matModelViewProj[eye] * flipx;
             break;
          }
          case FLIPY:
          {
             static constexpr Matrix3D flipy{1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
             for (unsigned int eye = 0; eye < m_nEyes; eye++)
-               m_matModelViewProj[eye] = m_matModelView * m_matProj[eye] * flipy;
+               m_matModelViewProj[eye] = m_matModelViewProj[eye] * flipy;
             break;
          }
+         default: assert(false); break;
          }
-         Matrix3D temp = m_matReflectedView;
-         temp.Invert();
-         const Matrix3D viewRot = temp.GetRotationPart();
-         m_viewVec = viewRot * Vertex3Ds{0, 0, 1};
-         m_viewVec.NormalizeSafe();
       }
    }
 
    Matrix3D m_matModel { Matrix3D::MatrixIdentity() };
-   Matrix3D m_matView { Matrix3D::MatrixIdentity() };
-   Matrix3D m_matProj[6];
    Matrix3D m_matReflection { Matrix3D::MatrixIdentity() };
+   Matrix3D m_matView[6];
+   Matrix3D m_matProj[6];
 
    mutable bool m_dirty = true;
    FlipMode m_flip = NONE;
-   mutable Matrix3D m_matReflectedView;
-   mutable Matrix3D m_matModelView;
-   mutable Matrix3D m_matModelViewInverse;
-   mutable Matrix3D m_matModelViewInverseTranspose;
+   mutable Matrix3D m_matReflectedView[6];
+   mutable Matrix3D m_matModelView[6];
+   mutable Matrix3D m_matModelViewInverse[6];
+   mutable Matrix3D m_matModelViewInverseTranspose[6];
    mutable Matrix3D m_matModelViewProj[6];
-   mutable Vertex3Ds m_viewVec;
+   mutable Vertex3Ds m_viewVec[6];
 };

--- a/src/math/matrix.h
+++ b/src/math/matrix.h
@@ -274,7 +274,7 @@ public:
    string ToString() const
    {
       std::stringstream ss;
-      ss << std::fixed << std::setw(8) << std::setprecision(2);
+      ss << std::fixed << std::setw(10) << std::setprecision(5);
       ss << "[ " << _11 << ' ' << _12 << ' ' << _13 << ' ' << _14 << '\n'
          << "  " << _21 << ' ' << _22 << ' ' << _23 << ' ' << _24 << '\n'
          << "  " << _31 << ' ' << _32 << ' ' << _33 << ' ' << _34 << '\n'

--- a/src/parts/primitive.cpp
+++ b/src/parts/primitive.cpp
@@ -10,6 +10,7 @@
 #include "miniz/miniz.h"
 #include "progmesh.h"
 #include "renderer/Renderer.h"
+#include "renderer/RenderCommand.h"
 #include "renderer/Shader.h"
 #include "renderer/trace.h"
 #include "ui/win/sur.h"
@@ -1097,10 +1098,12 @@ void Primitive::Render(const unsigned int renderMask)
       }
    }
 
+   // set transform
+   g_pplayer->m_renderer->UpdateBasicShaderMatrix(m_fullMatrix);
+
    if (isUIPass)
    {
       // FIXME use correct point for depth sorting
-      g_pplayer->m_renderer->UpdateBasicShaderMatrix(m_fullMatrix);
       if (renderMask & Renderer::UI_FILL)
          m_rd->DrawMesh(
             m_rd->m_basicShader, true, Vertex3Ds(), 10000.f, m_meshBuffer, RenderDevice::TRIANGLELIST, 0, m_groupdRendering ? m_numGroupIndices : (uint32_t)m_mesh.NumIndices());
@@ -1152,9 +1155,6 @@ void Primitive::Render(const unsigned int renderMask)
    {
       m_rd->m_basicShader->SetMaterial(mat, alpha != 100.f);
    }
-
-   // set transform
-   g_pplayer->m_renderer->UpdateBasicShaderMatrix(m_fullMatrix);
 
    // Check if this primitive is used as a lightmap and should be convoluted with the light shadows
    const bool lightmap = m_lightmap != nullptr && m_lightmap->m_d.m_shadows == ShadowMode::RAYTRACED_BALL_SHADOWS;
@@ -1221,8 +1221,8 @@ void Primitive::Render(const unsigned int renderMask)
             reflection_probe->ExtendAreaOfInterest(xMin, xMax, yMin, yMax);
             m_rd->AddRenderTargetDependency(reflections);
             Vertex3Ds plane_normal = reflection_probe->GetReflectionPlaneNormal();
-            const Matrix3D matWorldViewInverseTranspose = g_pplayer->m_renderer->GetMVP().GetModelViewInverseTranspose();
-            plane_normal = matWorldViewInverseTranspose.MultiplyVectorNoTranslate(plane_normal);
+            // In stereo, using a single view (from left eye) is ok enough as this is just to weight the probe
+            plane_normal = g_pplayer->m_renderer->GetMVP().GetModelViewInverseTranspose(0).MultiplyVectorNoTranslate(plane_normal);
             Vertex3Ds n(plane_normal.x, plane_normal.y, plane_normal.z);
             n.Normalize();
             m_rd->m_basicShader->SetVector(SHADER_mirrorNormal_factor, n.x, n.y, n.z, m_d.m_reflectionStrength);

--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -2600,10 +2600,10 @@ void RenderDevice::DrawMesh(Shader* shader, const bool isTranparentPass, const V
       // This happens during startup for offscreen rendering (somewhat hacky)
       depth = 0.f;
    else if (g_pplayer->m_renderer->GetShadeMode() != Renderer::ShadeMode::Default)
-      // Used by the new wireframe renderer: sort along view vector
+      // Used by the new wireframe renderer: sort along the left eye view vector
       //depth = isTranparentPass ? g_pplayer->m_renderer->GetMVP().GetModelView().MultiplyVectorNoPerspective(center).z : -g_pplayer->m_renderer->GetMVP().GetModelView().MultiplyVectorNoPerspective(center).z;
       // back to front
-      depth = g_pplayer->m_renderer->GetMVP().GetModelView().MultiplyVectorNoPerspective(center).z;
+      depth = g_pplayer->m_renderer->GetMVP().GetModelView(0).MultiplyVectorNoPerspective(center).z;
    else
       // Legacy sorting order (only along negative z axis, which is reversed for reflections).
       // This is completely wrong, but needed to preserve backward compatibility. We should sort along the view axis (especially for reflection probes)

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -1065,64 +1065,109 @@ void Renderer::SetupShaders()
 
 void Renderer::UpdateBasicShaderMatrix(const Matrix3D& objectTrafo)
 {
-   struct
-   {
-      Matrix3D matWorld;
-      Matrix3D matView;
-      Matrix3D matWorldView;
-      Matrix3D matWorldViewInverseTranspose;
-      Matrix3D matWorldViewProj[2];
-   } matrices;
-   GetMVP().SetModel(objectTrafo);
-   matrices.matWorld = GetMVP().GetModel();
-   matrices.matView = GetMVP().GetView();
-   matrices.matWorldView = GetMVP().GetModelView();
-   matrices.matWorldViewInverseTranspose = GetMVP().GetModelViewInverseTranspose();
-   const int nEyes = m_renderDevice->m_nEyes;
-   for (int eye = 0; eye < nEyes; eye++)
-      matrices.matWorldViewProj[eye] = GetMVP().GetModelViewProj(eye);
+   m_mvp.SetModel(objectTrafo);
 
 #if defined(ENABLE_DX9) || defined(ENABLE_BGFX)
-   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorld, &matrices.matWorld);
-   m_renderDevice->m_basicShader->SetMatrix(SHADER_matView, &matrices.matView);
-   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorldView, &matrices.matWorldView);
-   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorldViewInverseTranspose, &matrices.matWorldViewInverseTranspose);
-   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
-   m_renderDevice->m_flasherShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
-   m_renderDevice->m_lightShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
-   m_renderDevice->m_DMDShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
+   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorld, &m_mvp.GetModel());
+   m_renderDevice->m_basicShader->SetMatrix(SHADER_matView, &m_mvp.GetView(0), m_mvp.m_nEyes);
+   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorldView, &m_mvp.GetModelView(0), m_mvp.m_nEyes);
+   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorldViewInverseTranspose, &m_mvp.GetModelViewInverseTranspose(0), m_mvp.m_nEyes);
+   m_renderDevice->m_basicShader->SetMatrix(SHADER_matWorldViewProj, &m_mvp.GetModelViewProj(0), m_mvp.m_nEyes);
+   m_renderDevice->m_flasherShader->SetMatrix(SHADER_matWorldViewProj, &m_mvp.GetModelViewProj(0), m_mvp.m_nEyes);
+   m_renderDevice->m_lightShader->SetMatrix(SHADER_matWorldViewProj, &m_mvp.GetModelViewProj(0), m_mvp.m_nEyes);
+   m_renderDevice->m_DMDShader->SetMatrix(SHADER_matWorldViewProj, &m_mvp.GetModelViewProj(0), m_mvp.m_nEyes);
+
 #elif defined(ENABLE_OPENGL)
-   m_renderDevice->m_basicShader->SetUniformBlock(SHADER_basicMatrixBlock, &matrices.matWorld.m[0][0]);
-   m_renderDevice->m_flasherShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
-   m_renderDevice->m_lightShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
-   m_renderDevice->m_DMDShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
+   if (m_mvp.m_nEyes == 2)
+   {
+      struct
+      {
+         Matrix3D matWorld;
+         Matrix3D matView[2];
+         Matrix3D matWorldView[2];
+         Matrix3D matWorldViewInverseTranspose[2];
+         Matrix3D matWorldViewProj[2];
+      } matrices;
+      matrices.matWorld = m_mvp.GetModel();
+      for (unsigned int eye = 0; eye < m_mvp.m_nEyes; eye++)
+      {
+         matrices.matView[eye] = m_mvp.GetView(eye);
+         matrices.matWorldView[eye] = m_mvp.GetModelView(eye);
+         matrices.matWorldViewInverseTranspose[eye] = m_mvp.GetModelViewInverseTranspose(eye);
+         matrices.matWorldViewProj[eye] = m_mvp.GetModelViewProj(eye);
+      }
+      m_renderDevice->m_basicShader->SetUniformBlock(SHADER_basicMatrixBlock, &matrices.matWorld.m[0][0]);
+      m_renderDevice->m_flasherShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], m_mvp.m_nEyes);
+      m_renderDevice->m_lightShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], m_mvp.m_nEyes);
+      m_renderDevice->m_DMDShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], m_mvp.m_nEyes);
+   }
+   else
+   {
+      struct
+      {
+         Matrix3D matWorld;
+         Matrix3D matView;
+         Matrix3D matWorldView;
+         Matrix3D matWorldViewInverseTranspose;
+         Matrix3D matWorldViewProj;
+      } matrices;
+      matrices.matWorld = m_mvp.GetModel();
+      matrices.matView = m_mvp.GetView(0);
+      matrices.matWorldView = m_mvp.GetModelView(0);
+      matrices.matWorldViewInverseTranspose = m_mvp.GetModelViewInverseTranspose(0);
+      matrices.matWorldViewProj = m_mvp.GetModelViewProj(0);
+      m_renderDevice->m_basicShader->SetUniformBlock(SHADER_basicMatrixBlock, &matrices.matWorld.m[0][0]);
+      m_renderDevice->m_flasherShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj, m_mvp.m_nEyes);
+      m_renderDevice->m_lightShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj, m_mvp.m_nEyes);
+      m_renderDevice->m_DMDShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj, m_mvp.m_nEyes);
+   }
 #endif
 }
 
 void Renderer::UpdateBallShaderMatrix()
 {
-   struct
-   {
-      Matrix3D matView;
-      Matrix3D matWorldView;
-      Matrix3D matWorldViewInverse;
-      Matrix3D matWorldViewProj[2];
-   } matrices;
-   GetMVP().SetModel(Matrix3D::MatrixIdentity());
-   matrices.matView = GetMVP().GetView();
-   matrices.matWorldView = GetMVP().GetModelView();
-   matrices.matWorldViewInverse = GetMVP().GetModelViewInverse();
-   const int nEyes = m_renderDevice->m_nEyes;
-   for (int eye = 0; eye < nEyes; eye++)
-      matrices.matWorldViewProj[eye] = GetMVP().GetModelViewProj(eye);
+   m_mvp.SetModel(Matrix3D::MatrixIdentity());
 
 #if defined(ENABLE_DX9) || defined(ENABLE_BGFX)
-   m_renderDevice->m_ballShader->SetMatrix(SHADER_matWorldViewProj, &matrices.matWorldViewProj[0], nEyes);
-   m_renderDevice->m_ballShader->SetMatrix(SHADER_matWorldView, &matrices.matWorldView);
-   m_renderDevice->m_ballShader->SetMatrix(SHADER_matWorldViewInverse, &matrices.matWorldViewInverse);
-   m_renderDevice->m_ballShader->SetMatrix(SHADER_matView, &matrices.matView);
+   m_renderDevice->m_ballShader->SetMatrix(SHADER_matWorldViewProj, &m_mvp.GetModelViewProj(0), m_mvp.m_nEyes);
+   m_renderDevice->m_ballShader->SetMatrix(SHADER_matWorldView, &m_mvp.GetModelView(0), m_mvp.m_nEyes);
+   m_renderDevice->m_ballShader->SetMatrix(SHADER_matWorldViewInverse, &m_mvp.GetModelViewInverse(0), m_mvp.m_nEyes);
+   m_renderDevice->m_ballShader->SetMatrix(SHADER_matView, &m_mvp.GetView(0), m_mvp.m_nEyes);
+
 #elif defined(ENABLE_OPENGL)
-   m_renderDevice->m_ballShader->SetUniformBlock(SHADER_ballMatrixBlock, &matrices.matView.m[0][0]);
+   if (m_mvp.m_nEyes == 2)
+   {
+      struct
+      {
+         Matrix3D matView[2];
+         Matrix3D matWorldView[2];
+         Matrix3D matWorldViewInverse[2];
+         Matrix3D matWorldViewProj[2];
+      } matrices;
+      for (unsigned int eye = 0; eye < m_mvp.m_nEyes; eye++)
+      {
+         matrices.matView[eye] = m_mvp.GetView(eye);
+         matrices.matWorldView[eye] = m_mvp.GetModelView(eye);
+         matrices.matWorldViewInverse[eye] = m_mvp.GetModelViewInverse(eye);
+         matrices.matWorldViewProj[eye] = m_mvp.GetModelViewProj(eye);
+      }
+      m_renderDevice->m_ballShader->SetUniformBlock(SHADER_ballMatrixBlock, &matrices.matView[0].m[0][0]);
+   }
+   else
+   {
+      struct
+      {
+         Matrix3D matView;
+         Matrix3D matWorldView;
+         Matrix3D matWorldViewInverse;
+         Matrix3D matWorldViewProj;
+      } matrices;
+      matrices.matView = m_mvp.GetView(0);
+      matrices.matWorldView = m_mvp.GetModelView(0);
+      matrices.matWorldViewInverse = m_mvp.GetModelViewInverse(0);
+      matrices.matWorldViewProj = m_mvp.GetModelViewProj(0);
+      m_renderDevice->m_ballShader->SetUniformBlock(SHADER_ballMatrixBlock, &matrices.matView.m[0][0]);
+   }
 #endif
 }
 
@@ -1217,7 +1262,7 @@ void Renderer::SetupDisplayRenderer(const bool isBackdrop, Vertex3D_NoTex2* vert
       m_renderDevice->m_DMDShader->SetTexture(SHADER_displayGlass, glassTex);
    float parallaxU = 0.f, parallaxV = 0.f;
    if (!isBackdrop && (vertices != nullptr))
-   { // (fake) depth by applying some parallax mapping
+   { // (fake) depth by applying some parallax mapping (i stereo based on left eye view)
       const Vertex3Ds v0(vertices[0].x, vertices[0].y, vertices[0].z);
       const Vertex3Ds v1(vertices[1].x, vertices[1].y, vertices[1].z);
       const Vertex3Ds v2(vertices[3].x, vertices[3].y, vertices[3].z);
@@ -1231,7 +1276,7 @@ void Renderer::SetupDisplayRenderer(const bool isBackdrop, Vertex3D_NoTex2* vert
       const float r = 1.0f / (duv1.x * duv2.y - duv1.y * duv2.x);
       Vertex3Ds tangent = (dv1 * duv2.y - dv2 * duv1.y) * r;
       Vertex3Ds bitangent = (dv2 * duv1.x - dv1 * duv2.x) * r;
-      const Matrix3D& mv = GetMVP().GetModelView();
+      const Matrix3D& mv = GetMVP().GetModelView(0);
       tangent = mv.MultiplyVectorNoTranslate(tangent);
       bitangent = mv.MultiplyVectorNoTranslate(bitangent);
       Vertex3Ds eye = (v1 + v2) * 0.5f; // Assume a rectangle shape, use opposite corners to get its center
@@ -1515,9 +1560,7 @@ void Renderer::RenderItem(IEditable* const editable, bool isNoBackdrop)
    {
       #if defined(ENABLE_XR)
       if (m_stereo3D == STEREO_VR)
-      {
-         g_pplayer->m_vrDevice->UpdateVRPosition(spaceReference, GetMVP());
-      }
+         g_pplayer->m_vrDevice->UpdateVRPosition(spaceReference, m_mvp);
       else
       #endif
       {
@@ -1526,12 +1569,14 @@ void Renderer::RenderItem(IEditable* const editable, bool isNoBackdrop)
          case PartGroupData::SpaceReference::SR_CABINET:
          case PartGroupData::SpaceReference::SR_CABINET_FEET:
          case PartGroupData::SpaceReference::SR_ROOM:
-            m_mvp.SetView(g_pplayer->m_ptable->GetDefaultPlayfieldToCabMatrix() * m_playfieldView);
+            for (unsigned int eye = 0; eye < m_mvp.m_nEyes; eye++)
+               m_mvp.SetView(eye, g_pplayer->m_ptable->GetDefaultPlayfieldToCabMatrix() * m_playfieldView[eye]);
             break;
 
          case PartGroupData::SpaceReference::SR_PLAYFIELD:
          default:
-            m_mvp.SetView(m_playfieldView);
+            for (unsigned int eye = 0; eye < m_mvp.m_nEyes; eye++)
+               m_mvp.SetView(eye, m_playfieldView[eye]);
             break;
          }
       }
@@ -1541,7 +1586,8 @@ void Renderer::RenderItem(IEditable* const editable, bool isNoBackdrop)
          if (const auto nudge = g_pplayer->m_physics->GetTableDisplacement(); nudge.x != 0.f || nudge.y != 0.f)
          {
             const Matrix3D nudgeMat = Matrix3D::MatrixTranslate(2.5f * 100.f * m_visualNudgeStrength * nudge.x, 2.5f * 100.f * m_visualNudgeStrength * nudge.y, 0.f);
-            m_mvp.SetView(nudgeMat * m_mvp.GetView());
+            for (unsigned int eye = 0; eye < m_mvp.m_nEyes; eye++)
+               m_mvp.SetView(eye, nudgeMat * m_mvp.GetView(eye));
          }
       }
       m_mvpSpaceReference = spaceReference;
@@ -2287,8 +2333,12 @@ RenderTarget* Renderer::ApplyBallMotionBlur(RenderTarget* beforeTonemapRT, Rende
    return afterTonemapRT;
    #endif
 
-   // We do not support dynamic view point yet (i.e. MVP must be the same between the previosu render and this one)
+   // We do not support dynamic view point yet (i.e. MVP must be the same between the previous render and this one)
    if (m_disableStaticPrepass)
+      return afterTonemapRT;
+
+   // We do not support stereo mode yet
+   if (m_stereo3D != STEREO_OFF)
       return afterTonemapRT;
 
    if (m_motionBlurOff)
@@ -2334,7 +2384,7 @@ RenderTarget* Renderer::ApplyBallMotionBlur(RenderTarget* beforeTonemapRT, Rende
 
       // Discard stable balls or balls that have moved too much (which means the ball was likely created/moved)
       // We assume that velocity won't change before rendering (which is wrong) but extend it by a magic factor of 10
-      const Matrix3D view = GetMVP().GetView();
+      const Matrix3D view = GetMVP().GetView(0);
       const vec3 posl = pball->m_hitBall.m_d.m_pos + 0.5f * pball->m_hitBall.m_d.m_vel;
       const vec3 newPos = view.MultiplyVectorNoPerspective(posl);
       const vec3 delta = newPos - pball->m_lastRenderedPos;
@@ -2810,14 +2860,9 @@ void Renderer::RenderFrame()
    m_renderDevice->m_ballShader->SetTexture(SHADER_tex_ball_playfield, GetPreviousBackBufferTexture()->GetColorSampler());
 
    // Update camera point of view
-   #if defined(ENABLE_VR) || defined(ENABLE_XR)
-   if (m_stereo3D == STEREO_VR)
-   {
-      g_pplayer->m_vrDevice->UpdateVRPosition(m_mvpSpaceReference, GetMVP());
-   }
-   else 
-   #endif
-   m_playfieldView = m_mvp.GetView();
+   // FIXME this may lead to view drift if nudging and the mvp has not been initialized per frame
+   for (unsigned int eye = 0; eye < m_mvp.m_nEyes; eye++)
+      m_playfieldView[eye] = m_mvp.GetView(eye);
    m_mvpSpaceReference = PartGroupData::SpaceReference::SR_INHERIT; // Force update
 
    // If using static prerendering, apply nudging by shaking the screen (otherwise, apply table displacement)

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -291,7 +291,7 @@ private:
    PinTable* const m_table;
 
    ModelViewProj m_mvp; // Store the active Model / View / Projection
-   Matrix3D m_playfieldView; // Store the base playfield view matrix computed at beginning of frame render
+   Matrix3D m_playfieldView[2]; // Store the base playfield view matrix computed at beginning of frame render
    PartGroupData::SpaceReference m_mvpSpaceReference = PartGroupData::SpaceReference::SR_PLAYFIELD;
 
    bool m_isStaticPrepassDirty = true;

--- a/src/renderer/Shader.cpp
+++ b/src/renderer/Shader.cpp
@@ -329,30 +329,30 @@ string Shader::GetTechniqueName(ShaderTechniques technique)
    return shaderTechniqueNames[technique].name;
 }
 
-static unsigned int GetUniformStateSize(ShaderUniformType type)
+static unsigned int GetUniformStateSize(ShaderUniformType type, const int count)
 {
    switch (type)
    {
-   case SUT_Bool: return sizeof(bool);
-   case SUT_Int: return sizeof(int);
-   case SUT_Float: return sizeof(float);
-   case SUT_Float2: return 2 * sizeof(float);
-   case SUT_Float3: return 3 * sizeof(float);
-   case SUT_Float4: return 4 * sizeof(float);
-   case SUT_Float4v: return 4 * sizeof(float);
-   case SUT_Float3x4: return 16 * sizeof(float);
-   case SUT_Float4x3: return 16 * sizeof(float);
-   case SUT_Float4x4: return 16 * sizeof(float);
-   case SUT_DataBlock: return 1;
-   case SUT_Sampler: return sizeof(int);
+   case SUT_Bool: return count * sizeof(bool);
+   case SUT_Int: return count * sizeof(int);
+   case SUT_Float: return count * sizeof(float);
+   case SUT_Float2: return count * 2 * sizeof(float);
+   case SUT_Float3: return count * 3 * sizeof(float);
+   case SUT_Float4: return count * 4 * sizeof(float);
+   case SUT_Float4v: return count * 4 * sizeof(float);
+   case SUT_Float3x4: return count * 16 * sizeof(float);
+   case SUT_Float4x3: return count * 16 * sizeof(float);
+   case SUT_Float4x4: return count * 16 * sizeof(float);
+   case SUT_DataBlock: return count;
+   case SUT_Sampler: assert(count == 1); return sizeof(int);
    default: assert(false); return 0;
    }
 }
 
 #define SHADER_UNIFORM(type, name, count) \
-   { type, #name, count, count * GetUniformStateSize(type), 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
+   { type, #name, count, GetUniformStateSize(type, count), 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
 #define SHADER_SAMPLER(name, tex_unit, default_clampu, default_clampv, default_filter) \
-   { SUT_Sampler, #name, 1, GetUniformStateSize(SUT_Sampler), tex_unit, default_clampu, default_clampv, default_filter }
+   { SUT_Sampler, #name, 1, GetUniformStateSize(SUT_Sampler, 1), tex_unit, default_clampu, default_clampv, default_filter }
 ShaderUniform ShaderUniform::coreUniforms[SHADER_UNIFORM_COUNT] {
    // Shared uniforms
    SHADER_UNIFORM(SUT_Int, layer, 1),
@@ -360,13 +360,13 @@ ShaderUniform ShaderUniform::coreUniforms[SHADER_UNIFORM_COUNT] {
    SHADER_UNIFORM(SUT_Float4x4, matProj, 2), // +1 Matrix for stereo
    SHADER_UNIFORM(SUT_Float4x4, matProjInv, 2), // +1 Matrix for stereo
    SHADER_UNIFORM(SUT_Float4x4, matWorldViewProj, 2), // +1 Matrix for stereo
-   SHADER_UNIFORM(SUT_DataBlock, basicMatrixBlock, 6 * 16 * 4), // OpenGL only, +1 Matrix for stereo
-   SHADER_UNIFORM(SUT_DataBlock, ballMatrixBlock, 5 * 16 * 4), // OpenGL only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_DataBlock, basicMatrixBlock, (5 + 4) * 16 * 4), // OpenGL only, +4 Matrix for stereo
+   SHADER_UNIFORM(SUT_DataBlock, ballMatrixBlock, (4 + 4) * 16 * 4), // OpenGL only, +4 Matrix for stereo
    SHADER_UNIFORM(SUT_Float4x4, matWorld, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float4x3, matView, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float4x4, matWorldView, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float4x3, matWorldViewInverse, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float3x4, matWorldViewInverseTranspose, 1), // DX9 & BGFX only
+   SHADER_UNIFORM(SUT_Float4x3, matView, 2), // DX9 & BGFX only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_Float4x4, matWorldView, 2), // DX9 & BGFX only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_Float4x3, matWorldViewInverse, 2), // DX9 & BGFX only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_Float3x4, matWorldViewInverseTranspose, 2), // DX9 & BGFX only, +1 Matrix for stereo
    SHADER_UNIFORM(SUT_Float4, lightCenter_doShadow, 1), // Basic & Flasher (for ball shadows)
    SHADER_UNIFORM(SUT_Float4v, balls, 8), // Basic & Flasher (for ball shadows)
    SHADER_UNIFORM(SUT_Float4, staticColor_Alpha, 1), // Basic & Flasher
@@ -531,16 +531,20 @@ Shader::Shader(RenderDevice* renderDevice, const ShaderId id, const bool isStere
    #endif
 {
    const int nEyes = m_isStereo ? 2 : 1;
-   ShaderUniform::coreUniforms[SHADER_matProj].count = nEyes;
-   ShaderUniform::coreUniforms[SHADER_matProjInv].count = nEyes;
-   ShaderUniform::coreUniforms[SHADER_matWorldViewProj].count = nEyes;
-   ShaderUniform::coreUniforms[SHADER_basicMatrixBlock].count = (4 + nEyes) * 16 * 4;
-   ShaderUniform::coreUniforms[SHADER_ballMatrixBlock].count = (3 + nEyes) * 16 * 4;
-   ShaderUniform::coreUniforms[SHADER_matProj].stateSize = ShaderUniform::coreUniforms[SHADER_matProj].count * GetUniformStateSize(ShaderUniform::coreUniforms[SHADER_matProj].type);
-   ShaderUniform::coreUniforms[SHADER_matProjInv].stateSize = ShaderUniform::coreUniforms[SHADER_matProjInv].count * GetUniformStateSize(ShaderUniform::coreUniforms[SHADER_matProjInv].type);
-   ShaderUniform::coreUniforms[SHADER_matWorldViewProj].stateSize = ShaderUniform::coreUniforms[SHADER_matWorldViewProj].count * GetUniformStateSize(ShaderUniform::coreUniforms[SHADER_matWorldViewProj].type);
-   ShaderUniform::coreUniforms[SHADER_basicMatrixBlock].stateSize = ShaderUniform::coreUniforms[SHADER_basicMatrixBlock].count * GetUniformStateSize(ShaderUniform::coreUniforms[SHADER_basicMatrixBlock].type);
-   ShaderUniform::coreUniforms[SHADER_ballMatrixBlock].stateSize = ShaderUniform::coreUniforms[SHADER_ballMatrixBlock].count * GetUniformStateSize(ShaderUniform::coreUniforms[SHADER_ballMatrixBlock].type);
+   auto updateCount = [](ShaderUniforms uniform, int count)
+   {
+      ShaderUniform::coreUniforms[uniform].count = count;
+      ShaderUniform::coreUniforms[uniform].stateSize = GetUniformStateSize(ShaderUniform::coreUniforms[uniform].type, count);
+   };
+   updateCount(SHADER_matView, nEyes);
+   updateCount(SHADER_matWorldView, nEyes);
+   updateCount(SHADER_matWorldViewInverse, nEyes);
+   updateCount(SHADER_matWorldViewInverseTranspose, nEyes);
+   updateCount(SHADER_matProj, nEyes);
+   updateCount(SHADER_matProjInv, nEyes);
+   updateCount(SHADER_matWorldViewProj, nEyes);
+   updateCount(SHADER_basicMatrixBlock, (nEyes * 4 + 1) * 16 * 4);
+   updateCount(SHADER_ballMatrixBlock, (nEyes * 4) * 16 * 4);
 
    #if defined(ENABLE_BGFX)
       for (int i = 0; i < SHADER_TECHNIQUE_COUNT; i++)

--- a/src/renderer/Shader.h
+++ b/src/renderer/Shader.h
@@ -354,10 +354,10 @@ enum ShaderUniforms
    SHADER_UNIFORM(SUT_DataBlock, basicMatrixBlock, 6 * 16 * 4), // OpenGL only, +1 Matrix for stereo
    SHADER_UNIFORM(SUT_DataBlock, ballMatrixBlock, 5 * 16 * 4), // OpenGL only, +1 Matrix for stereo
    SHADER_UNIFORM(SUT_Float4x4, matWorld, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float4x3, matView, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float4x4, matWorldView, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float4x3, matWorldViewInverse, 1), // DX9 & BGFX only
-   SHADER_UNIFORM(SUT_Float3x4, matWorldViewInverseTranspose, 1), // DX9 & BGFX only
+   SHADER_UNIFORM(SUT_Float4x3, matView, 2), // DX9 & BGFX only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_Float4x4, matWorldView, 2), // DX9 & BGFX only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_Float4x3, matWorldViewInverse, 2), // DX9 & BGFX only, +1 Matrix for stereo
+   SHADER_UNIFORM(SUT_Float3x4, matWorldViewInverseTranspose, 2), // DX9 & BGFX only, +1 Matrix for stereo
    SHADER_UNIFORM(SUT_Float4, lightCenter_doShadow, 1), // Basic & Flasher (for ball shadows)
    SHADER_UNIFORM(SUT_Float4v, balls, 8), // Basic & Flasher (for ball shadows)
    SHADER_UNIFORM(SUT_Float4, staticColor_Alpha, 1), // Basic & Flasher
@@ -489,7 +489,7 @@ struct ShaderUniform
 public:
    ShaderUniformType type;
    string name;
-   unsigned int count;
+   uint16_t count;
    unsigned int stateSize;
    unsigned int tex_unit;
    SamplerAddressMode default_clampu;

--- a/src/renderer/VRDevice.cpp
+++ b/src/renderer/VRDevice.cpp
@@ -365,7 +365,7 @@ VRDevice::VRDevice(const Settings& settings)
          for (int i = 0; i < 2; i++)
          {
             const Matrix3D proj = Matrix3D::MatrixPerspectiveFovLH(90.f, 1.f, zNear, zFar);
-            m_pfMatProj[i] = coords * sceneScale * proj;
+            m_sceneProj[i] = coords * sceneScale * proj;
          }
       }
       else
@@ -393,7 +393,7 @@ VRDevice::VRDevice(const Settings& settings)
             for (int j = 0;j < 4;j++)
                matProjection.m[j][i] = left_eye_proj.m[i][j];
 
-         m_pfMatProj[0] = coords * sceneScale * matEye2Head * matProjection;
+         m_sceneProj[0] = coords * sceneScale * matEye2Head * matProjection;
 
          //Calculate right EyeProjection Matrix relative to HMD position
          matEye2Head = Matrix3D::MatrixIdentity();
@@ -408,7 +408,7 @@ VRDevice::VRDevice(const Settings& settings)
             for (int j = 0;j < 4;j++)
                matProjection.m[j][i] = right_eye_proj.m[i][j];
 
-         m_pfMatProj[1] = coords * sceneScale * matEye2Head * matProjection;
+         m_sceneProj[1] = coords * sceneScale * matEye2Head * matProjection;
       }
 
       if (vr::k_unMaxTrackedDeviceCount > 0) {
@@ -1163,13 +1163,6 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
          constexpr float zNear = 0.1f; // 10cm in front of player
          const float zFar = max(5.f, m_sceneSize * vpuToWorldScale); // This could be fairly optimized for better accuracy (as well as use an optimized depth buffer for rendering)
 
-         // Compute the eye median pose in VPU coordinates to be used as the view point for shading
-         XrPosef medianPoseInVPU;
-         XrVector3f_Lerp(&medianPoseInVPU.position, &views[0].pose.position, &views[1].pose.position, 0.5f);
-         XrQuaternionf_Lerp(&medianPoseInVPU.orientation, &views[0].pose.orientation, &views[1].pose.orientation, 0.5f);
-         XrVector3f_Scale(&medianPoseInVPU.position , & medianPoseInVPU.position, 1.f / vpuToWorldScale); // Convert position from meters to VPU
-         XrPosef_ToMatrix3D(&m_nextMedianView, &medianPoseInVPU);
-
          // Fixed value of 5 cm between playfield bottom and lockbar border
          // We could (should ?) make this a table data but this does not vary that much so this seems fine for the time being
          constexpr float lockbarToPlayfield = 5.f;
@@ -1219,8 +1212,16 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
          // Space positionning based on head pose (not continuous)
          if (m_headsetViewCentering)
          {
+            // Compute the eye median pose in VPU coordinates
+            Matrix3D medianView;
+            XrPosef medianPoseInVPU;
+            XrVector3f_Lerp(&medianPoseInVPU.position, &views[0].pose.position, &views[1].pose.position, 0.5f);
+            XrQuaternionf_Lerp(&medianPoseInVPU.orientation, &views[0].pose.orientation, &views[1].pose.orientation, 0.5f);
+            XrVector3f_Scale(&medianPoseInVPU.position, &medianPoseInVPU.position, 1.f / vpuToWorldScale); // Convert position from meters to VPU
+            XrPosef_ToMatrix3D(&medianView, &medianPoseInVPU);
+
             m_headsetViewCentering = false;
-            m_orientation = RADTOANG(atan2f(m_nextMedianView.m[0][2], m_nextMedianView.m[0][0]));
+            m_orientation = RADTOANG(atan2f(medianView.m[0][2], medianView.m[0][0]));
             m_tablePos.x = g_app->m_settings.GetPlayer_ScreenPlayerX() - VPUTOCM(medianPoseInVPU.position.x);
             m_tablePos.y = g_app->m_settings.GetPlayer_ScreenPlayerY() - VPUTOCM(medianPoseInVPU.position.z);
             m_tablePos.z = 0.f;
@@ -1246,6 +1247,8 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
             // Update fixed scaling, considering lockbar size to be the width of the playfield + 2"1/4
             const float tableWidth = VPUTOCM(table->m_right - table->m_left) + 2.25f * 2.54f;
             m_scale = clamp(m_lockbarWidth / tableWidth, 0.1f, 2.0f);
+            const Matrix3D sceneScale = Matrix3D::MatrixScale(m_scale);
+            const Matrix3D invSceneScale = Matrix3D::MatrixScale(1.f / m_scale);
 
             // Move table (in VPU coordinates), adjust coord from RH to LH system
             const Matrix3D coords = Matrix3D::MatrixScale(1.f, -1.f, 1.f);
@@ -1279,7 +1282,7 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
                 CMTOVPU(m_tablePos.y + lockbarToPlayfield),
                 CMTOVPU(m_tablePos.z + m_lockbarHeight - scaledGlassHeight)); 
             const Matrix3D playfieldPosInv = Matrix3D::MatrixInverse(playfieldPos);
-            m_pfWorld = coords * tableCoords * playfieldSlope * playfieldPos * viewOrientation;
+            m_pfWorld.m_toWorld = sceneScale * coords * tableCoords * playfieldSlope * playfieldPos * viewOrientation;
 
             const Matrix3D cabinetSlope = playfieldPosInv * Matrix3D::MatrixRotateX(ANGTORAD(liveSlope - baseSlope)) * playfieldPos;
             const Matrix3D pfToCab = viewOrientationInv // Revert view orientation
@@ -1291,7 +1294,7 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
                    CMTOVPU(m_tablePos.z + m_lockbarHeight - scaledGlassHeight) - groundToPlayfieldHeight)
                * cabinetSlope // Apply cabinet slope
                * viewOrientation; // Reapply view orientation
-            m_cabWorld = m_pfWorld * pfToCab;
+            m_cabWorld.m_toWorld = m_pfWorld.m_toWorld * pfToCab;
 
             // Feet are always touching the ground, scaled against the real world vs model defined playfield level
             // Note that since we are rotating the cabinet with its feet, the feet may slightly leave or enter the ground.
@@ -1305,7 +1308,7 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
                * Matrix3D::MatrixScale(1.f, 1.f, feetScale) // Scale feets in order to match feet bottom to real world floor
                * cabinetSlope // Apply cabinet slope
                * viewOrientation; // Reapply view orientation
-            m_feetWorld = m_pfWorld * pfToFeet;
+            m_feetWorld.m_toWorld = m_pfWorld.m_toWorld * pfToFeet;
 
             // Room does not apply the cabinet scaling nor any inclination, as it is the real world room
             const Matrix3D pfToRoom = viewOrientationInv // Revert view orientation
@@ -1319,32 +1322,33 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
                    CMTOVPU(m_tablePos.y + lockbarToPlayfield),
                    CMTOVPU(m_tablePos.z))
                * viewOrientation; // Reapply view orientation
-            m_roomWorld = m_pfWorld * pfToRoom;
+            m_roomWorld.m_toWorld = invSceneScale * m_pfWorld.m_toWorld * pfToRoom;
          }
 
          // As we only have one view matrix for shading, each eye view is integrated in the projection matrix, by reverting the 'shading' view matrix then
          // applying the eye view matrix, we also apply scale in the projection matrix as it would break shading otherwise (it needs an orthonormal view matrix)
 
-         m_pfMatView = m_pfWorld * m_nextMedianView;
-         m_cabMatView = m_cabWorld * m_nextMedianView;
-         m_feetMatView = m_feetWorld * m_nextMedianView;
-         m_roomMatView = m_roomWorld * m_nextMedianView;
-
-         const Matrix3D sceneScale = Matrix3D::MatrixScale(m_scale);
          const Matrix3D vpuScale = Matrix3D::MatrixScale(vpuToWorldScale);
-         const Matrix3D pfBaseView = Matrix3D::MatrixInverse(m_pfMatView) * sceneScale * m_pfWorld * vpuScale;
-         const Matrix3D cabBaseView = Matrix3D::MatrixInverse(m_cabMatView) * sceneScale * m_cabWorld * vpuScale;
-         const Matrix3D feetBaseView = Matrix3D::MatrixInverse(m_feetMatView) * sceneScale * m_feetWorld * vpuScale;
-         const Matrix3D roomBaseView = Matrix3D::MatrixInverse(m_roomMatView) * m_roomWorld * vpuScale;
-         for (uint32_t i = 0; i < viewCount; i++)
+         const Matrix3D invVpuScale = Matrix3D::MatrixScale(1.f / vpuToWorldScale);
+         const Matrix3D sceneScale = Matrix3D::MatrixScale(m_scale);
+         const Matrix3D invSceneScale = Matrix3D::MatrixScale(1.f / m_scale);
+
+         for (unsigned int eye = 0; eye < 2; eye++)
          {
-            XrPosef_ToMatrix3D(&m_nextView[i], &views[i].pose);
-            m_nextProj[i].SetPerspectiveFovRH(views[i].fov.angleLeft, views[i].fov.angleRight, views[i].fov.angleDown, views[i].fov.angleUp, zNear, zFar);
-            const Matrix3D viewProj = m_nextView[i] * m_nextProj[i];
-            m_pfMatProj[i] = pfBaseView * viewProj;
-            m_cabMatProj[i] = cabBaseView * viewProj;
-            m_feetMatProj[i] = feetBaseView * viewProj;
-            m_roomMatProj[i] = roomBaseView * viewProj;
+            Matrix3D view;
+            XrPosef_ToMatrix3D(&view, &views[eye].pose);
+            view = vpuScale * view * invVpuScale;
+            m_nextProj[eye].SetPerspectiveFovRH(views[eye].fov.angleLeft, views[eye].fov.angleRight, views[eye].fov.angleDown, views[eye].fov.angleUp, zNear, zFar);
+
+            // View is per eye, must be orthonormal (so every scale must be compensated)
+            const Matrix3D viewInvSceneScale = view * invSceneScale;
+            m_pfWorld.m_view[eye] = m_pfWorld.m_toWorld * viewInvSceneScale;
+            m_cabWorld.m_view[eye] = m_cabWorld.m_toWorld * viewInvSceneScale;
+            m_feetWorld.m_view[eye] = m_feetWorld.m_toWorld * viewInvSceneScale;
+            m_roomWorld.m_view[eye] = m_roomWorld.m_toWorld * view;
+
+            m_roomProj[eye] = vpuScale * m_nextProj[eye];
+            m_sceneProj[eye] = sceneScale * m_roomProj[eye];
          }
 
          // Swapchain is acquired, rendered to, and released together for all views as a texture array
@@ -1532,40 +1536,23 @@ void VRDevice::SubmitFrame(const std::shared_ptr<Sampler>& leftEye, const std::s
 
 void VRDevice::UpdateVRPosition(PartGroupData::SpaceReference spaceRef, ModelViewProj& mvp)
 {
+   using enum PartGroupData::SpaceReference;
+
    #ifdef ENABLE_XR
+      const Viewpoint* viewpoint = nullptr;
+      const Matrix3D* proj = nullptr;
       switch (spaceRef)
       {
-      case PartGroupData::SpaceReference::SR_PLAYFIELD:
-      {
-         mvp.SetView(m_pfMatView);
-         mvp.SetProj(0, m_pfMatProj[0]);
-         mvp.SetProj(1, m_pfMatProj[1]);
-         break;
+      case SR_PLAYFIELD: viewpoint = &m_pfWorld; proj = m_sceneProj; break;
+      case SR_CABINET: viewpoint = &m_cabWorld; proj = m_sceneProj; break;
+      case SR_CABINET_FEET: viewpoint = &m_feetWorld; proj = m_sceneProj; break;
+      case SR_ROOM: viewpoint = &m_roomWorld; proj = m_roomProj; break;
+      default: assert(false); return;
       }
-      
-      case PartGroupData::SpaceReference::SR_CABINET:
+      for (unsigned int eye = 0; eye < 2; eye++)
       {
-         mvp.SetView(m_cabMatView);
-         mvp.SetProj(0, m_cabMatProj[0]);
-         mvp.SetProj(1, m_cabMatProj[1]);
-         break;
-      }
-
-      case PartGroupData::SpaceReference::SR_CABINET_FEET:
-      {
-         mvp.SetView(m_feetMatView);
-         mvp.SetProj(0, m_feetMatProj[0]);
-         mvp.SetProj(1, m_feetMatProj[1]);
-         break;
-      }
-
-      case PartGroupData::SpaceReference::SR_ROOM:
-      {
-         mvp.SetView(m_roomMatView);
-         mvp.SetProj(0, m_roomMatProj[0]);
-         mvp.SetProj(1, m_roomMatProj[1]);
-         break;
-      }
+         mvp.SetView(eye, viewpoint->m_view[eye]);
+         mvp.SetProj(eye, proj[eye]);
       }
 
    #elif defined(ENABLE_VR)
@@ -1611,14 +1598,15 @@ void VRDevice::UpdateVRPosition(PartGroupData::SpaceReference spaceRef, ModelVie
          m_worldDirty = false;
          // Locate front left corner of the table in the room -x is to the right, -y is up and -z is back - all units in meters
          const float inv_transScale = 1.0f / (100.0f * m_scale);
-         m_pfWorld = Matrix3D::MatrixRotateX(ANGTORAD(-m_slope)) // Tilt playfield
+         m_pfWorld.m_toWorld = Matrix3D::MatrixRotateX(ANGTORAD(-m_slope)) // Tilt playfield
             * Matrix3D::MatrixRotateZ(ANGTORAD(180.f + m_orientation)) // Rotate table around VR height axis
             * Matrix3D::MatrixTranslate(-m_tablePos.x * inv_transScale, m_tablePos.y * inv_transScale, m_tablePos.z * inv_transScale);
       }
 
-      mvp.SetView(m_pfWorld * matView);
-      mvp.SetProj(0, m_pfMatProj[0]);
-      mvp.SetProj(1, m_pfMatProj[1]);
+      mvp.SetView(0, m_pfWorld.m_toWorld * matView);
+      mvp.SetView(1, m_pfWorld.m_toWorld * matView);
+      mvp.SetProj(0, m_sceneProj[0]);
+      mvp.SetProj(1, m_sceneProj[1]);
    #endif
 }
 

--- a/src/renderer/VRDevice.h
+++ b/src/renderer/VRDevice.h
@@ -161,18 +161,17 @@ private:
    float m_predictedDisplayTimestamp = 0.f;
 
    bool m_worldDirty = true;
-   Matrix3D m_pfWorld;
-   Matrix3D m_pfMatView;
-   Matrix3D m_pfMatProj[2];
-   Matrix3D m_cabWorld;
-   Matrix3D m_cabMatView;
-   Matrix3D m_cabMatProj[2];
-   Matrix3D m_feetWorld;
-   Matrix3D m_feetMatView;
-   Matrix3D m_feetMatProj[2];
-   Matrix3D m_roomWorld;
-   Matrix3D m_roomMatView;
-   Matrix3D m_roomMatProj[2];
+   struct Viewpoint
+   {
+      Matrix3D m_toWorld; // Matrix to transform from this viewpoint to world coordinates
+      Matrix3D m_view[2];
+   };
+   Viewpoint m_pfWorld;
+   Viewpoint m_cabWorld;
+   Viewpoint m_feetWorld;
+   Viewpoint m_roomWorld;
+   Matrix3D m_roomProj[2];
+   Matrix3D m_sceneProj[2];
 
 #ifdef ENABLE_VR
 public:
@@ -282,8 +281,6 @@ private:
    PFN_xrConvertTimeToTimespecTimeKHR m_xrConvertTimeToTimespecTimeKHR = nullptr;
    #endif
 
-   Matrix3D m_nextMedianView;
-   Matrix3D m_nextView[2];
    Matrix3D m_nextProj[2];
 
    bool m_debugUtilsExtensionSupported = false;

--- a/src/renderer/ViewSetup.cpp
+++ b/src/renderer/ViewSetup.cpp
@@ -555,7 +555,11 @@ void ViewSetup::ComputeMVP(const PinTable* const table, const float aspect, cons
    }
 
    // Define the view matrix. This matrix MUST be orthonormal (orthogonal axis with a unit length) or shading will be broken
-   mvp.SetView(lookat);
+   mvp.SetView(0, lookat);
+   // TODO this is wrong: each eye should have a different view for a lightly different shading
+   // VPX used to only support 1 view matrix so we have this hack. Clean it
+   if (mvp.m_nEyes > 1)
+      mvp.SetView(1, lookat);
 
    // Apply non uniform scene scaling after shading, in the projection matrix
    Matrix3D invLookAt(lookat);
@@ -583,7 +587,7 @@ void ViewSetup::ComputeMVP(const PinTable* const table, const float aspect, cons
       const float yOfs = ofs * sinf(rotation);
 
       // Compute the view orthonormal basis
-      const Matrix3D invView(mvp.GetView());
+      const Matrix3D invView(mvp.GetView(0)); // TODO apply eyeShift to view, not projection, as this is now supported by VPX
       const vec3 right = invView.GetOrthoNormalRight();
 
       // Left eye
@@ -607,12 +611,8 @@ void ViewSetup::ComputeMVP(const PinTable* const table, const float aspect, cons
    {
       // To be backward compatible while having a well behaving view matrix, we compute a view without the layback (which is meaningful with regards to what was used before).
       // We use it for rendering computation. It is reverted by the projection matrix which then apply the old transformation, including layback.
-      Matrix3D invView(mvp.GetView());
-      invView.Invert();
-      const Matrix3D tmp = invView * layback * mvp.GetView();
-      mvp.SetProj(0, tmp * mvp.GetProj(0));
-      if (stereo) // Real stereo is not really supported for legacy camera mode (it used to be only fake parallax stereo)
-         mvp.SetProj(1, tmp * mvp.GetProj(1));
+      for (unsigned int eye = 0; eye < mvp.m_nEyes; eye++)
+         mvp.SetProj(eye, Matrix3D::MatrixInverse(mvp.GetView(eye)) * layback * mvp.GetView(eye) * mvp.GetProj(eye));
    }
 
    if (!stereo && mvp.m_nEyes > 1)

--- a/src/shaders/bgfx/fs_ball.sc
+++ b/src/shaders/bgfx/fs_ball.sc
@@ -2,10 +2,10 @@
 
 $input v_worldPos, v_normal, v_texcoord0
 #ifdef STEREO
-	$input v_eye
+    $input v_eye
 #endif
 #ifdef CLIP
-	$input v_clipDistance
+    $input v_clipDistance
 #endif
 
 
@@ -13,18 +13,29 @@ $input v_worldPos, v_normal, v_texcoord0
 
 #define NUM_BALL_LIGHTS 8
 
-uniform mat4 matView;
-uniform mat4 matWorldView;
-uniform mat4 matWorldViewInverse;
 #ifdef STEREO
-	uniform mat4 matWorldViewProj[2];
-	uniform mat4 matProj[2];
-	// FIXME v_eye needs to be flat interpolated, but if declared as such in varying.def.sc, DX11 will fail (OpenGL/Vulkan are good)
-	#define mProj matProj[int(round(v_eye))]
+    uniform mat4 matView[2];
+    uniform mat4 matWorldView[2];
+    uniform mat4 matWorldViewInverse[2];
+    uniform mat4 matWorldViewProj[2];
+    uniform mat4 matProj[2];
+    // FIXME v_eye needs to be flat interpolated, but if declared as such in varying.def.sc, DX11 will fail (OpenGL/Vulkan are good)
+    #define mView             matView[int(round(v_eye))]
+    #define mWorldView        matWorldView[int(round(v_eye))]
+    #define mWorldViewInverse matWorldViewInverse[int(round(v_eye))]
+    #define mWorldViewProj    matWorldViewProj[int(round(v_eye))]
+    #define mProj             matProj[int(round(v_eye))]
 #else
-	uniform mat4 matWorldViewProj;
-	uniform mat4 matProj;
-	#define mProj matProj
+    uniform mat4 matView;
+    uniform mat4 matWorldView;
+    uniform mat4 matWorldViewInverse;
+    uniform mat4 matWorldViewProj;
+    uniform mat4 matProj;
+    #define mView             matView
+    #define mWorldView        matWorldView
+    #define mWorldViewInverse matWorldViewInverse
+    #define mWorldViewProj    matWorldViewProj
+    #define mProj             matProj
 #endif
 
 SAMPLER2D      (tex_ball_color, 0);     // base texture (used as a reflection map)
@@ -44,7 +55,11 @@ uniform vec4  invTableRes_reflection;
 uniform vec4  w_h_disableLighting; 
 #define disableLighting (w_h_disableLighting.z != 0.)
 
+#ifdef STEREO
+vec3 ballLightLoop(const vec3 pos, vec3 N, vec3 V, vec3 diffuse, vec3 glossy, const vec3 specular, const float edge, const bool is_metal, const float v_eye)
+#else
 vec3 ballLightLoop(const vec3 pos, vec3 N, vec3 V, vec3 diffuse, vec3 glossy, const vec3 specular, const float edge, const bool is_metal)
+#endif
 {
    // N and V must be already normalized by the caller
 
@@ -68,10 +83,14 @@ vec3 ballLightLoop(const vec3 pos, vec3 N, vec3 V, vec3 diffuse, vec3 glossy, co
 
    BRANCH if((!is_metal && (diffuseMax > 0.0)) || (glossyMax > 0.0))
       for(int i = 0; i < NUM_LIGHTS + NUM_BALL_LIGHTS; i++)  
-         color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal); // no clearcoat needed as only pointlights so far
+          #ifdef STEREO
+             color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal, v_eye); // no clearcoat needed as only pointlights so far
+          #else
+             color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal); // no clearcoat needed as only pointlights so far
+          #endif
 
    BRANCH if(!is_metal && (diffuseMax > 0.0))
-      color += DoEnvmapDiffuse(normalize(mul(matView, vec4(N, 0.0)).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N, 0.0), matViewInverseInverseTranspose)
+      color += DoEnvmapDiffuse(normalize(mul(mView, vec4(N, 0.0)).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N, 0.0), matViewInverseInverseTranspose)
 
    if(specularMax > 0.0)
       color += specular; //!! blend? //!! Fresnel with 1st layer?
@@ -100,8 +119,8 @@ void main()
     #ifdef EQUIRECTANGULAR
         // Equirectangular Map Reflections
         // trafo back to world for lookup into world space envmap
-        // matView is always an orthonormal matrix, so no need to normalize after transform
-        const vec3 rv = /*normalize*/(mul(vec4(-R,0.0), matView).xyz);
+        // mView is always an orthonormal matrix, so no need to normalize after transform
+        const vec3 rv = /*normalize*/(mul(vec4(-R,0.0), mView).xyz);
         const vec2 uv = ray_to_equirectangular_uv(rv);
         ballImageColor = texture2DLod(tex_ball_color, uv, lod).rgb;
     #else
@@ -138,13 +157,13 @@ void main()
 
     // No need to normalize here since the matWorldView matrix is normal (world is identity and view is always orthonormal)
     // No need to use a dedicated 'normal' matrix since the matWorldView is orthonormal (world is identity and view is always orthonormal)
-    //const vec3 playfield_normal = normalize(mul(vec4(0.,0.,1.,0.), matWorldViewInverse).xyz); //!! normalize necessary? // actually: mul(vec4(0.,0.,1.,0.), matWorldViewInverseTranspose), but optimized to save one matrix
-    const vec3 playfield_normal = mul(matWorldView, vec4(0.,0.,1.,0.)).xyz;
-    //const vec3 playfield_normal = matWorldView[2].xyz;
+    //const vec3 playfield_normal = normalize(mul(vec4(0.,0.,1.,0.), mWorldViewInverse).xyz); //!! normalize necessary? // actually: mul(vec4(0.,0.,1.,0.), mWorldViewInverseTranspose), but optimized to save one matrix
+    const vec3 playfield_normal = mul(mWorldView, vec4(0.,0.,1.,0.)).xyz;
+    //const vec3 playfield_normal = mWorldView[2].xyz;
     const float NdotR = dot(playfield_normal, R);
 
-    const vec3 playfield_p0 = mul(matWorldView, vec4(/*playfield_pos=*/0.,0.,0.,1.0)).xyz;
-    //const vec3 playfield_p0 = matWorldView[3].xyz;
+    const vec3 playfield_p0 = mul(mWorldView, vec4(/*playfield_pos=*/0.,0.,0.,1.0)).xyz;
+    //const vec3 playfield_p0 = mWorldView[3].xyz;
     const float t = dot(playfield_normal, v_worldPos.xyz - playfield_p0) / NdotR;
     const vec3 playfield_hit = v_worldPos.xyz - t * R;
 
@@ -165,7 +184,7 @@ void main()
     ); // a bit of supersampling, not strictly needed, but a bit better and not that costly
 
     // we don't clamp sampling outside the playfield (costly and no real visual impact)
-    // const vec2 uv = mul(matWorldViewInverse, vec4(playfield_hit, 1.0)).xy * invTableRes_reflection.xy;
+    // const vec2 uv = mul(mWorldViewInverse, vec4(playfield_hit, 1.0)).xy * invTableRes_reflection.xy;
     // && !(uv.x < 0.1 && uv.y < 0.1 && uv.x > 0.9 && uv.y > 0.9)
     BRANCH if (!(uvp.x < 0. || uvp.x > 1. || uvp.y < 0. || uvp.y > 1.) // outside of previous render => discard (we could use sampling techniques to optimize a bit)
             && !(t <= 0.)) // t < 0.0 may happen in some situation where ball intersects the playfield and the reflected point is inside the ball (like in kicker)
@@ -189,6 +208,10 @@ void main()
        specular *= vec3(1.,1.,1.)-decalColor; // see above
     #endif
 
-    gl_FragColor.rgb = ballLightLoop(v_worldPos.xyz, N, V, diffuse, glossy, specular, 1.0, false);
+    #ifdef STEREO
+       gl_FragColor.rgb = ballLightLoop(v_worldPos.xyz, N, V, diffuse, glossy, specular, 1.0, false, v_eye);
+    #else
+       gl_FragColor.rgb = ballLightLoop(v_worldPos.xyz, N, V, diffuse, glossy, specular, 1.0, false);
+    #endif
     gl_FragColor.a = cBase_Alpha.a;
 }

--- a/src/shaders/bgfx/fs_basic.sc
+++ b/src/shaders/bgfx/fs_basic.sc
@@ -2,10 +2,10 @@
 
 $input v_worldPos, v_tablePos, v_normal, v_texcoord0
 #ifdef STEREO
-	$input v_eye
+    $input v_eye
 #endif
 #ifdef CLIP
-	$input v_clipDistance
+    $input v_clipDistance
 #endif
 
 #include "common.sh"
@@ -24,17 +24,29 @@ SAMPLER2DSTEREO(tex_reflection, 5); // reflections
 SAMPLER2DSTEREO(tex_refraction, 6); // refractions
 SAMPLER2DSTEREO(tex_probe_depth, 7); // refractions depth probe
 
-uniform mat4 matWorldView;
-uniform mat4 matWorldViewInverseTranspose;
-uniform mat4 matWorld;
-uniform mat4 matView;
 #ifdef STEREO
-	uniform mat4 matProj[2];
-	// FIXME v_eye needs to be flat interpolated, but if declared as such in varying.def.sc, DX11 will fail (OpenGL/Vulkan are good)
-	#define mProj matProj[int(round(v_eye))]
+    uniform mat4 matView[2];
+    uniform mat4 matWorldView[2];
+    uniform mat4 matWorldViewInverseTranspose[2];
+    uniform mat4 matWorldViewProj[2];
+    uniform mat4 matProj[2];
+    // FIXME v_eye needs to be flat interpolated, but if declared as such in varying.def.sc, DX11 will fail (OpenGL/Vulkan are good)
+    #define mView                      matView[int(round(v_eye))]
+    #define mWorldView                 matWorldView[int(round(v_eye))]
+    #define mWorldViewInverseTranspose matWorldViewInverseTranspose[int(round(v_eye))]
+    #define mWorldViewProj             matWorldViewProj[int(round(v_eye))]
+    #define mProj                      matProj[int(round(v_eye))]
 #else
-	uniform mat4 matProj;
-	#define mProj matProj
+    uniform mat4 matView;
+    uniform mat4 matWorldView;
+    uniform mat4 matWorldViewInverseTranspose;
+    uniform mat4 matWorld;
+    uniform mat4 matProj;
+    #define mView                      matView
+    #define mWorldView                 matWorldView
+    #define mWorldViewInverseTranspose matWorldViewInverseTranspose
+    #define mWorldViewProj             matWorldViewProj
+    #define mProj                      matProj
 #endif
 
 uniform vec4 objectSpaceNormalMap; // float extended to vec4 for BGFX FIXME float uniforms are not supported: group or declare as vec4
@@ -94,7 +106,11 @@ mat3 TBN_trafo(const vec3 N, const vec3 V, const vec2 uv)
    return mat3(T, B, N * sqrt( max(dot(T,T), dot(B,B)) )); // inverse scale, as will be normalized anyhow later-on (to save some mul's)
 }
 
+#ifdef STEREO
+vec3 normal_map(const vec3 N, const vec3 V, const vec2 uv, const float v_eye)
+#else
 vec3 normal_map(const vec3 N, const vec3 V, const vec2 uv)
+#endif
 {
    vec3 tn;
    if (noMipMaps)
@@ -104,7 +120,7 @@ vec3 normal_map(const vec3 N, const vec3 V, const vec2 uv)
 
    BRANCH if (objectSpaceNormalMap.x != 0.0)
    { // Object space: this matches the object space, +X +Y +Z, export/baking in Blender with our trafo setup
-      return normalize(mul(matWorldViewInverseTranspose, vec4(tn.x, tn.y, -tn.z, 0.0)).xyz);
+      return normalize(mul(mWorldViewInverseTranspose, vec4(tn.x, tn.y, -tn.z, 0.0)).xyz);
    }
    else
    { // Tangent space
@@ -173,23 +189,23 @@ vec3 compute_refraction(const vec3 pos, const vec3 screenCoord, const vec3 N, co
 
 
 #ifdef REFL
-	#ifndef CLIP
-	EARLY_DEPTH_STENCIL
-	#endif
-	void main() {
-		// Reflection only pass variant of the basic material shading
-		#ifdef CLIP
-		if (v_clipDistance < 0.0)
-		   discard;
-		#endif
-		vec3 N = normalize(v_normal);
-		#ifdef STEREO
-		vec3 color = compute_reflection(gl_FragCoord.xy, N, v_eye);
-		#else
-		vec3 color = compute_reflection(gl_FragCoord.xy, N);
-		#endif
-		gl_FragColor = vec4(color.rgb * staticColor_Alpha.rgb, staticColor_Alpha.a);
-	}
+    #ifndef CLIP
+    EARLY_DEPTH_STENCIL
+    #endif
+    void main() {
+        // Reflection only pass variant of the basic material shading
+        #ifdef CLIP
+        if (v_clipDistance < 0.0)
+           discard;
+        #endif
+        vec3 N = normalize(v_normal);
+        #ifdef STEREO
+        vec3 color = compute_reflection(gl_FragCoord.xy, N, v_eye);
+        #else
+        vec3 color = compute_reflection(gl_FragCoord.xy, N);
+        #endif
+        gl_FragColor = vec4(color.rgb * staticColor_Alpha.rgb, staticColor_Alpha.a);
+    }
 
 #else
    #if !defined(AT) && !defined(CLIP)
@@ -231,12 +247,20 @@ vec3 compute_refraction(const vec3 pos, const vec3 screenCoord, const vec3 N, co
       vec3 N = normalize(v_normal);
       #ifdef TEX
          BRANCH if (doNormalMapping)
-             N = normal_map(N, -V, v_texcoord0);
+            #ifdef STEREO
+               N = normal_map(N, -V, v_texcoord0, v_eye);
+            #else
+               N = normal_map(N, -V, v_texcoord0);
+            #endif
       #endif
 
       //color = vec4((N+1.0)*0.5,1.0); return; // visualize normals
 
-      color = vec4(lightLoop(v_worldPos, N, V, diffuse, glossy, specular, edge, doMetal), pixel.a);
+      #ifdef STEREO
+         color = vec4(lightLoop(v_worldPos, N, V, diffuse, glossy, specular, edge, doMetal, v_eye), pixel.a);
+      #else
+         color = vec4(lightLoop(v_worldPos, N, V, diffuse, glossy, specular, edge, doMetal), pixel.a);
+      #endif
 
       BRANCH if (color.a < 1.0) // We may not opacify if we already are opaque
       {
@@ -257,9 +281,9 @@ vec3 compute_refraction(const vec3 pos, const vec3 screenCoord, const vec3 N, co
 
       BRANCH if (doReflections)
          #ifdef STEREO
-			color.rgb += compute_reflection(gl_FragCoord.xy, N, v_eye);
+            color.rgb += compute_reflection(gl_FragCoord.xy, N, v_eye);
          #else
-			color.rgb += compute_reflection(gl_FragCoord.xy, N);
+            color.rgb += compute_reflection(gl_FragCoord.xy, N);
          #endif
 
       BRANCH if (doRefractions)

--- a/src/shaders/bgfx/fs_classic_light.sc
+++ b/src/shaders/bgfx/fs_classic_light.sc
@@ -2,10 +2,10 @@
 
 $input v_worldPos, v_tablePos, v_normal, v_texcoord0
 #ifdef STEREO
-	$input v_eye
+    $input v_eye
 #endif
 #ifdef CLIP
-	$input v_clipDistance
+    $input v_clipDistance
 #endif
 
 #include "common.sh"
@@ -35,13 +35,20 @@ uniform vec4 lightColor2_falloff_power;
 uniform vec4 lightCenter_maxRange;
 uniform vec4 lightingOff; // single float, passed as vec4 (BGFX does not support float/int/bool uniforms)
 
-uniform mat4 matView;
+#ifdef STEREO
+    uniform mat4 matView[2];
+    // FIXME v_eye needs to be flat interpolated, but if declared as such in varying.def.sc, DX11 will fail (OpenGL/Vulkan are good)
+    #define mView                      matView[int(round(v_eye))]
+#else
+    uniform mat4 matView;
+    #define mView                      matView
+#endif
 
 #include "material.sh"
 #include "ball_shadows.sh"
 
 uniform vec4 u_basic_shade_mode;
-#define doMetal       	    (u_basic_shade_mode.x != 0.0)
+#define doMetal             (u_basic_shade_mode.x != 0.0)
 #define doNormalMapping     (u_basic_shade_mode.y != 0.0)
 #define doRefractions       (u_basic_shade_mode.z != 0.0)
 
@@ -73,7 +80,11 @@ EARLY_DEPTH_STENCIL void main()
         const vec3 specular = cClearcoat_EdgeAlpha.rgb*0.08;
         const float  edge   = doMetal ? 1.0 : Roughness_WrapL_Edge_Thickness.z;
 
-        color.rgb = lightLoop(v_worldPos, normalize(v_normal), normalize(/*camera=0,0,0,1*/-v_worldPos), diffuse, glossy, specular, edge, doMetal); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
+        #ifdef STEREO
+           color.rgb = lightLoop(v_worldPos, normalize(v_normal), normalize(/*camera=0,0,0,1*/-v_worldPos), diffuse, glossy, specular, edge, doMetal, v_eye); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
+        #else
+           color.rgb = lightLoop(v_worldPos, normalize(v_normal), normalize(/*camera=0,0,0,1*/-v_worldPos), diffuse, glossy, specular, edge, doMetal); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
+        #endif
         color.a = pixel.a;
     }
     color.a *= cBase_Alpha.a;

--- a/src/shaders/bgfx/material.sh
+++ b/src/shaders/bgfx/material.sh
@@ -62,11 +62,15 @@ vec3 FresnelSchlick(const vec3 spec, const float LdotH, const float edge)
 
 //
 
+#ifdef STEREO
+vec3 DoPointLight(const vec3 pos, const vec3 N, const vec3 V, const vec3 diffuse, const vec3 glossy, const float edge, const float glossyPower, const int i, const bool is_metal, const float v_eye) 
+#else
 vec3 DoPointLight(const vec3 pos, const vec3 N, const vec3 V, const vec3 diffuse, const vec3 glossy, const float edge, const float glossyPower, const int i, const bool is_metal) 
+#endif
 { 
    //!! do in vertex shader?! or completely before?!
-   //const vec3 lightDir = mul_w1(lightPos[i].xyz, matView) - pos;
-   const vec3 lightDir = ( mul(matView, vec4(lightPos[i].xyz, 1.0)) ).xyz - pos;
+   //const vec3 lightDir = mul_w1(lightPos[i].xyz, mView) - pos;
+   const vec3 lightDir = ( mul(mView, vec4(lightPos[i].xyz, 1.0)) ).xyz - pos;
    const vec3 L = normalize(lightDir);
    const float NdotL = dot(N, L);
    vec3 Out = vec3(0.0,0.0,0.0);
@@ -78,12 +82,12 @@ vec3 DoPointLight(const vec3 pos, const vec3 N, const vec3 V, const vec3 diffuse
    // add glossy component (modified ashikhmin/blinn bastard), not fully energy conserving, but good enough
    BRANCH if (NdotL > 0.0)
    {
-	 const vec3 H = normalize(L + V); // half vector
-	 const float NdotH = dot(N, H);
-	 const float LdotH = dot(L, H);
-	 const float VdotH = dot(V, H);
-	 if ((NdotH > 0.0) && (LdotH > 0.0) && (VdotH > 0.0))
-		Out += FresnelSchlick(glossy, LdotH, edge) * (((glossyPower + 1.0) / (8.0*VdotH)) * pow(NdotH, glossyPower));
+     const vec3 H = normalize(L + V); // half vector
+     const float NdotH = dot(N, H);
+     const float LdotH = dot(L, H);
+     const float VdotH = dot(V, H);
+     if ((NdotH > 0.0) && (LdotH > 0.0) && (VdotH > 0.0))
+        Out += FresnelSchlick(glossy, LdotH, edge) * (((glossyPower + 1.0) / (8.0*VdotH)) * pow(NdotH, glossyPower));
    }
 
    //float fAtten = saturate( 1.0 - dot(lightDir/cAmbient_LightRange.w, lightDir/cAmbient_LightRange.w) );
@@ -139,7 +143,11 @@ vec3 DoEnvmap2ndLayer(const vec3 color1stLayer, const vec3 pos, const vec3 N, co
 //   Glossy is performed with a very crude approximation of the BRDF and the roughness parameter (simple mip-mapping of the envmap).
 //   Specular just does a plain lookup in the envmap.
 // - Backside (normal pointing away) is lighted as well as front facing (needed since quite a lot of tables feature wrong normals, or for transparents with 2 pass rendering)
+#ifdef STEREO
+vec3 lightLoop(const vec3 pos, vec3 N, const vec3 V, vec3 diffuse, vec3 glossy, const vec3 specular, const float edge, const bool is_metal, const float v_eye) // input vectors (N,V) are normalized for BRDF evals
+#else
 vec3 lightLoop(const vec3 pos, vec3 N, const vec3 V, vec3 diffuse, vec3 glossy, const vec3 specular, const float edge, const bool is_metal) // input vectors (N,V) are normalized for BRDF evals
+#endif
 {
    vec3 color = vec3_splat(0.0);
 
@@ -172,25 +180,29 @@ vec3 lightLoop(const vec3 pos, vec3 N, const vec3 V, vec3 diffuse, vec3 glossy, 
       BRANCH if (fDisableLighting_top_below.x == 1.0)
          color += float(iLightPointNum) * diffuse; // Old bug kept for backward compatibility: when lighting is disabled, it results to applying it twice
       else for (int i = 0; i < NUM_LIGHTS; i++)
-         color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal); // no clearcoat needed as only pointlights so far
+         #ifdef STEREO
+            color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal, v_eye); // no clearcoat needed as only pointlights so far
+         #else
+            color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal); // no clearcoat needed as only pointlights so far
+         #endif
    }
 
    // Environment IBL
    BRANCH if (!is_metal && (diffuseMax > 0.0))
-      // trafo back to world for lookup into world space envmap // actually: mul(float4(N,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
-      // matView is always an orthonormal matrix, so no need to normalize after transform
-      color += DoEnvmapDiffuse(/*normalize*/(( mul(vec4(N,0.0), matView) ).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
+      // trafo back to world for lookup into world space envmap // actually: mul(float4(N,0.0), mViewInverseInverseTranspose), but optimized to save one matrix
+      // mView is always an orthonormal matrix, so no need to normalize after transform
+      color += DoEnvmapDiffuse(/*normalize*/(( mul(vec4(N,0.0), mView) ).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
    BRANCH if ((glossyMax > 0.0) || (specularMax > 0.0))
    {
-	   vec3 R = (2.0*NdotV)*N - V; // reflect(-V,N);
-	   // trafo back to world for lookup into world space envmap // actually: mul(float4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
-	   // matView is always an orthonormal matrix, so no need to normalize after transform
-	   R = /*normalize*/(( mul(vec4(R,0.0), matView) ).xyz); // trafo back to world for lookup into world space envmap // actually: mul(vec4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
-	   const vec2 Ruv = ray_to_equirectangular_uv(R);
-	   if (glossyMax > 0.0)
-		  color += DoEnvmapGlossy(N, V, Ruv, glossy, Roughness_WrapL_Edge_Thickness.x);
-	   if (specularMax > 0.0)
-		  color = DoEnvmap2ndLayer(color, pos, N, V, NdotV, Ruv, specular);
+       vec3 R = (2.0*NdotV)*N - V; // reflect(-V,N);
+       // trafo back to world for lookup into world space envmap // actually: mul(float4(R,0.0), mViewInverseInverseTranspose), but optimized to save one matrix
+       // mView is always an orthonormal matrix, so no need to normalize after transform
+       R = /*normalize*/(( mul(vec4(R,0.0), mView) ).xyz); // trafo back to world for lookup into world space envmap // actually: mul(vec4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
+       const vec2 Ruv = ray_to_equirectangular_uv(R);
+       if (glossyMax > 0.0)
+          color += DoEnvmapGlossy(N, V, Ruv, glossy, Roughness_WrapL_Edge_Thickness.x);
+       if (specularMax > 0.0)
+          color = DoEnvmap2ndLayer(color, pos, N, V, NdotV, Ruv, specular);
    }
 
    return /*Gamma(ToneMap(*/color/*))*/;

--- a/src/shaders/bgfx/vs_ball.sc
+++ b/src/shaders/bgfx/vs_ball.sc
@@ -3,49 +3,55 @@
 $input a_position, a_normal, a_texcoord0
 $output v_worldPos, v_normal, v_texcoord0
 #ifdef STEREO
-	$output v_eye
+    $output v_eye
 #endif
 #ifdef CLIP
-	$output v_clipDistance
+    $output v_clipDistance
 #endif
 
 #include "common.sh"
 
 uniform mat4 orientation;
-uniform mat4 matWorldView;
-uniform mat4 matWorldViewInverse;
 #ifdef STEREO
-	uniform vec4 layer;
-	uniform mat4 matWorldViewProj[2];
-	#define mvp matWorldViewProj[gl_InstanceID]
+    uniform vec4 layer;
+    uniform mat4 matWorldView[2];
+    uniform mat4 matWorldViewInverse[2];
+    uniform mat4 matWorldViewProj[2];
+    #define mWorldView        matWorldView[gl_InstanceID]
+    #define mWorldViewInverse matWorldViewInverse[gl_InstanceID]
+    #define mWorldViewProj    matWorldViewProj[gl_InstanceID]
 #else
-	uniform mat4 matWorldViewProj;
-	#define mvp matWorldViewProj
+    uniform mat4 matWorldView;
+    uniform mat4 matWorldViewInverse;
+    uniform mat4 matWorldViewProj;
+    #define mWorldView        matWorldView
+    #define mWorldViewInverse matWorldViewInverse
+    #define mWorldViewProj    matWorldViewProj
 #endif
 #ifdef CLIP
-	uniform vec4 clip_plane;
+    uniform vec4 clip_plane;
 #endif
 
 void main()
 {
-	// apply spinning and move the ball to it's actual position
-	vec4 pos = vec4(a_position, 1.0);
-	vec4 tpos = mul(orientation, pos);
-	pos.xyz = tpos.xyz;
-	#ifdef CLIP
-		v_clipDistance = dot(clip_plane, tpos);
-	#endif
+    // apply spinning and move the ball to it's actual position
+    vec4 pos = vec4(a_position, 1.0);
+    vec4 tpos = mul(orientation, pos);
+    pos.xyz = tpos.xyz;
+    #ifdef CLIP
+        v_clipDistance = dot(clip_plane, tpos);
+    #endif
 
-	// apply spinning to the normals too to get the sphere mapping effect
-	const vec3 nspin = mul(orientation, vec4(a_normal, 0.0)).xyz;
-	// Needs to use a 'normal' matrix, and to normalize since we allow non uniform stretching, therefore matWorldView is not orthonormal
-	v_normal = normalize(mul(vec4(nspin, 0.0), matWorldViewInverse).xyz); // actually: mul(vec4(nspin,0.), matWorldViewInverseTranspose), but optimized to save one matrix
+    // apply spinning to the normals too to get the sphere mapping effect
+    const vec3 nspin = mul(orientation, vec4(a_normal, 0.0)).xyz;
+    // Needs to use a 'normal' matrix, and to normalize since we allow non uniform stretching, therefore mWorldView is not orthonormal
+    v_normal = normalize(mul(vec4(nspin, 0.0), mWorldViewInverse).xyz); // actually: mul(vec4(nspin,0.), mWorldViewInverseTranspose), but optimized to save one matrix
 
-	v_texcoord0 = a_texcoord0;
-	v_worldPos = mul(matWorldView, pos).xyz;
-	#ifdef STEREO
-		gl_Layer = gl_InstanceID;
-		v_eye = layer.x + gl_InstanceID;
-	#endif
-	gl_Position = mul(mvp, pos);
+    v_texcoord0 = a_texcoord0;
+    v_worldPos = mul(mWorldView, pos).xyz;
+    #ifdef STEREO
+        gl_Layer = gl_InstanceID;
+        v_eye = layer.x + gl_InstanceID;
+    #endif
+    gl_Position = mul(mWorldViewProj, pos);
 }

--- a/src/shaders/bgfx/vs_ball_trail.sc
+++ b/src/shaders/bgfx/vs_ball_trail.sc
@@ -3,38 +3,36 @@
 $input a_position, a_normal, a_texcoord0
 $output v_worldPos
 #ifdef STEREO
-	$output v_eye
+    $output v_eye
 #endif
 #ifdef CLIP
-	$output v_clipDistance
+    $output v_clipDistance
 #endif
 
 #include "common.sh"
 
-uniform mat4 matWorldView;
-uniform mat4 matWorldViewInverse;
 #ifdef STEREO
-	uniform vec4 layer;
-	uniform mat4 matWorldViewProj[2];
-	#define mvp matWorldViewProj[gl_InstanceID]
+    uniform vec4 layer;
+    uniform mat4 matWorldViewProj[2];
+    #define mWorldViewProj matWorldViewProj[gl_InstanceID]
 #else
-	uniform mat4 matWorldViewProj;
-	#define mvp matWorldViewProj
+    uniform mat4 matWorldViewProj;
+    #define mWorldViewProj matWorldViewProj
 #endif
 #ifdef CLIP
-	uniform vec4 clip_plane;
+    uniform vec4 clip_plane;
 #endif
 
 void main()
 {
-	vec4 pos = vec4(a_position, 1.0);
-	v_worldPos = vec3(a_texcoord0.x, a_texcoord0.y, a_normal.x); // not exactly worlpos...
-	#ifdef CLIP
-		v_clipDistance = dot(clip_plane, pos);
-	#endif
-	#ifdef STEREO
-		gl_Layer = gl_InstanceID;
-		v_eye = layer.x + gl_InstanceID;
-	#endif
-	gl_Position = mul(mvp, pos);
+    vec4 pos = vec4(a_position, 1.0);
+    v_worldPos = vec3(a_texcoord0.x, a_texcoord0.y, a_normal.x); // not exactly worlpos...
+    #ifdef CLIP
+        v_clipDistance = dot(clip_plane, pos);
+    #endif
+    #ifdef STEREO
+        gl_Layer = gl_InstanceID;
+        v_eye = layer.x + gl_InstanceID;
+    #endif
+    gl_Position = mul(mWorldViewProj, pos);
 }

--- a/src/shaders/bgfx/vs_basic.sc
+++ b/src/shaders/bgfx/vs_basic.sc
@@ -3,53 +3,62 @@
 $input a_position, a_normal, a_texcoord0
 $output v_worldPos, v_tablePos, v_normal, v_texcoord0
 #ifdef STEREO
-	$output v_eye
+    $output v_eye
 #endif
 #ifdef CLIP
-	$output v_clipDistance
+    $output v_clipDistance
 #endif
 
 #include "common.sh"
 
 uniform mat4 matWorld;
-uniform mat4 matView;
-uniform mat4 matWorldView;
-uniform mat4 matWorldViewInverseTranspose;
 #ifdef STEREO
-	uniform vec4 layer;
-	uniform mat4 matWorldViewProj[2];
-	#define mvp matWorldViewProj[gl_InstanceID]
+    uniform vec4 layer;
+    uniform mat4 matView[2];
+    uniform mat4 matWorldView[2];
+    uniform mat4 matWorldViewInverseTranspose[2];
+    uniform mat4 matWorldViewProj[2];
+    #define mView                      matView[int(round(v_eye))]
+    #define mWorldView                 matWorldView[int(round(v_eye))]
+    #define mWorldViewInverseTranspose matWorldViewInverseTranspose[int(round(v_eye))]
+    #define mWorldViewProj             matWorldViewProj[int(round(v_eye))]
 #else
-	uniform mat4 matWorldViewProj;
-	#define mvp matWorldViewProj
+    uniform mat4 matView;
+    uniform mat4 matWorldView;
+    uniform mat4 matWorldViewInverseTranspose;
+    uniform mat4 matWorldViewProj;
+    #define mView                      matView
+    #define mWorldView                 matWorldView
+    #define mWorldViewInverseTranspose matWorldViewInverseTranspose
+    #define mWorldViewProj             matWorldViewProj
 #endif
 #ifdef CLIP
-	uniform vec4 clip_plane;
+    uniform vec4 clip_plane;
 #endif
 
 void main()
 {
-	vec4 pos = vec4(a_position, 1.0);
-	vec4 tpos = mul(matWorld, pos);
-	v_tablePos = tpos.xyz;
-	v_worldPos = mul(matWorldView, pos).xyz;
-	#ifdef CLIP
-		v_clipDistance = dot(clip_plane, tpos);
-	#endif
-	// Due to layback, we use non affine transform so we need to use inverse transpose of the world view matrix
-	v_normal = normalize(mul(matWorldViewInverseTranspose, vec4(a_normal, 0.0)).xyz);
-	//v_normal = normalize(mul(matWorldView, vec4(a_normal, 0.0)).xyz);
-	gl_Position = mul(mvp, pos);
-	#ifdef KICKER
-		gl_Position.z = mul(mvp, vec4(pos.x, pos.y, pos.z - 30.0, 1.0)).z;
-	#elif defined(CLASSIC_LIGHT)
-		gl_Position.z = max(gl_Position.z, 0.00006103515625); // clamp lights to near clip plane to avoid them being partially clipped // 0.00006103515625 due to 16bit half float
-	#endif
-	#ifdef TEX
-		v_texcoord0 = a_texcoord0;
-	#endif
-	#ifdef STEREO
-		gl_Layer = gl_InstanceID;
-		v_eye = layer.x + gl_InstanceID;
-	#endif
+    #ifdef STEREO
+        gl_Layer = gl_InstanceID;
+        v_eye = layer.x + gl_InstanceID;
+    #endif
+    vec4 pos = vec4(a_position, 1.0);
+    vec4 tpos = mul(matWorld, pos);
+    v_tablePos = tpos.xyz;
+    v_worldPos = mul(mWorldView, pos).xyz;
+    #ifdef CLIP
+        v_clipDistance = dot(clip_plane, tpos);
+    #endif
+    // Due to layback, we use non affine transform so we need to use inverse transpose of the world view matrix
+    v_normal = normalize(mul(mWorldViewInverseTranspose, vec4(a_normal, 0.0)).xyz);
+    //v_normal = normalize(mul(mWorldView, vec4(a_normal, 0.0)).xyz);
+    gl_Position = mul(mWorldViewProj, pos);
+    #ifdef KICKER
+        gl_Position.z = mul(mWorldViewProj, vec4(pos.x, pos.y, pos.z - 30.0, 1.0)).z;
+    #elif defined(CLASSIC_LIGHT)
+        gl_Position.z = max(gl_Position.z, 0.00006103515625); // clamp lights to near clip plane to avoid them being partially clipped // 0.00006103515625 due to 16bit half float
+    #endif
+    #ifdef TEX
+        v_texcoord0 = a_texcoord0;
+    #endif
 }

--- a/src/shaders/hlsl_glsl/BallShader.glfx
+++ b/src/shaders/hlsl_glsl/BallShader.glfx
@@ -11,9 +11,9 @@
 uniform mat4 orientation;
 
 layout(std140) uniform ballMatrixBlock {
-	mat4 matView;
-	mat4 matWorldView;
-	mat4 matWorldViewInverse;
+	mat4 matView[N_EYES];
+	mat4 matWorldView[N_EYES];
+	mat4 matWorldViewInverse[N_EYES];
 	mat4 matWorldViewProj[N_EYES];
 };
 
@@ -72,6 +72,8 @@ VS_OUT(vec4, worldPos_t0y);
 
 void main()
 {
+    VS_EYE;
+	
     // apply spinning and move the ball to it's actual position
     float4 pos = vec4(vPosition, 1.0);
     pos.xyz = (orientation * pos).xyz;
@@ -79,11 +81,10 @@ void main()
     // apply spinning to the normals too to get the sphere mapping effect
     const float3 nspin = (orientation * vec4(vNormal,0.0)).xyz;
     // Needs to use a 'normal' matrix, and to normalize since we allow non uniform stretching, therefore matWorldView is not orthonormal
-    const float3 normal = normalize((vec4(nspin, 0.0) * matWorldViewInverse).xyz); // actually: mul(vec4(nspin,0.), matWorldViewInverseTranspose), but optimized to save one matrix
+    const float3 normal = normalize((vec4(nspin, 0.0) * matWorldViewInverse[eye_vs]).xyz); // actually: mul(vec4(nspin,0.), matWorldViewInverseTranspose), but optimized to save one matrix
 
-    const float3 p = (matWorldView * pos).xyz;
+    const float3 p = (matWorldView[eye_vs] * pos).xyz;
 
-    VS_EYE;
     VS_POSITION(matWorldViewProj[eye_vs] * pos, pos);
     VS_VARYING(normal_t0x, float4(normal,tex0.x));
     VS_VARYING(worldPos_t0y, float4(p,tex0.y));
@@ -144,7 +145,7 @@ void main()
 
 ////FRAGMENT
 
-float3 ballLightLoop(const float3 pos, const float3 N, const float3 V, float3 diffuse, float3 glossy, const float3 specular, const float edge, const bool is_metal)
+float3 ballLightLoop(const float3 pos, const float3 N, const float3 V, float3 diffuse, float3 glossy, const float3 specular, const float edge, const bool is_metal, const float eye)
 {
    // N and V must be already normalized by the caller
    // N = normalize(N);
@@ -167,10 +168,10 @@ float3 ballLightLoop(const float3 pos, const float3 N, const float3 V, float3 di
 
    BRANCH if((!is_metal && (diffuseMax > 0.0)) || (glossyMax > 0.0))
       for(int i = 0; i < iLightPointBallsNum; i++)  
-         color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal); // no clearcoat needed as only pointlights so far
+         color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal, eye); // no clearcoat needed as only pointlights so far
 
    BRANCH if(!is_metal && (diffuseMax > 0.0))
-      color += DoEnvmapDiffuse(normalize((matView * vec4(N,0.0)).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N, 0.0), matViewInverseInverseTranspose)
+      color += DoEnvmapDiffuse(normalize((matView[int(eye)] * vec4(N,0.0)).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N, 0.0), matViewInverseInverseTranspose)
 
    if(specularMax > 0.0)
       color += specular; //!! blend? //!! Fresnel with 1st layer?
@@ -200,7 +201,7 @@ void main()
     { // Equirectangular Map Reflections
       // trafo back to world for lookup into world space envmap
       // matView is always an orthonormal matrix, so no need to normalize after transform
-      const float3 rv = /*normalize*/((float4(-R,0.0) * matView).xyz);
+      const float3 rv = /*normalize*/((float4(-R,0.0) * matView[int(eye)]).xyz);
       const float2 uv = ray_to_equirectangular_uv(rv);
       ballImageColor = textureLod(tex_ball_color, uv, lod).rgb;
     }
@@ -238,13 +239,13 @@ void main()
 
     // No need to normalize here since the matWorldView matrix is normal (world is identity and view is always orthonormal)
     // No need to use a dedicated 'normal' matrix since the matWorldView is orthonormal (world is identity and view is always orthonormal)
-    //const float3 playfield_normal = normalize((float4(0.,0.,1.,0.) * matWorldViewInverse).xyz); //!! normalize necessary? // actually: mul(float4(0.,0.,1.,0.), matWorldViewInverseTranspose), but optimized to save one matrix
-    //const float3 playfield_normal = (matWorldView * float4(0.,0.,1.,0.)).xyz;
-    const float3 playfield_normal = matWorldView[2].xyz;
+    //const float3 playfield_normal = normalize((float4(0.,0.,1.,0.) * matWorldViewInverse[int(eye)]).xyz); //!! normalize necessary? // actually: mul(float4(0.,0.,1.,0.), matWorldViewInverseTranspose[int(eye)]), but optimized to save one matrix
+    //const float3 playfield_normal = (matWorldView[int(eye)] * float4(0.,0.,1.,0.)).xyz;
+    const float3 playfield_normal = matWorldView[int(eye)][2].xyz;
     const float NdotR = dot(playfield_normal, R);
 
-    //const float3 playfield_p0 = mul_w1(float3(/*playfield_pos=*/0.,0.,0.), matWorldView);
-    const float3 playfield_p0 = matWorldView[3].xyz;
+    //const float3 playfield_p0 = mul_w1(float3(/*playfield_pos=*/0.,0.,0.), matWorldView[int(eye)]);
+    const float3 playfield_p0 = matWorldView[int(eye)][3].xyz;
     const float t = dot(playfield_normal, worldPos_t0y.xyz - playfield_p0) / NdotR;
     const float3 playfield_hit = worldPos_t0y.xyz - t * R;
 
@@ -260,7 +261,7 @@ void main()
     ); // a bit of supersampling, not strictly needed, but a bit better and not that costly
 
     // we don't clamp sampling outside the playfield (costly and no real visual impact)
-    // const float2 uv = (matWorldViewInverse * float4(playfield_hit, 1.0)).xy * invTableRes_reflection.xy;
+    // const float2 uv = (matWorldViewInverse[int(eye)] * float4(playfield_hit, 1.0)).xy * invTableRes_reflection.xy;
     // && !(uv.x < 0.1 && uv.y < 0.1 && uv.x > 0.9 && uv.y > 0.9)
     BRANCH if (!(uvp.x < 0. || uvp.x > 1. || uvp.y < 0. || uvp.y > 1.) // outside of previous render => discard (we could use sampling techniques to optimize a bit)
             && !(t <= 0.)) // t < 0.0 may happen in some situation where ball intersects the playfield and the reflected point is inside the ball (like in kicker)
@@ -282,7 +283,7 @@ void main()
     if(!%PARAM1%) // decalMode
        specular *= float3(1.,1.,1.)-decalColor; // see above
 
-    color.rgb = ballLightLoop(worldPos_t0y.xyz, N, V, diffuse, glossy, specular, 1.0, false);
+    color.rgb = ballLightLoop(worldPos_t0y.xyz, N, V, diffuse, glossy, specular, 1.0, false, eye);
     color.a = cBase_Alpha.a;
 }
 

--- a/src/shaders/hlsl_glsl/BasicShader.glfx
+++ b/src/shaders/hlsl_glsl/BasicShader.glfx
@@ -12,10 +12,10 @@
 
 layout(std140) uniform basicMatrixBlock {
 	mat4 matWorld;
-	mat4 matView;
-	mat4 matWorldView;
-	mat3x4 matWorldViewInverseTranspose;
-	vec4 unusedFillerFormatWorldViewInverseTranspose;
+	mat4 matView[N_EYES];
+	mat4 matWorldView[N_EYES];
+	mat3x4 matWorldViewInverseTranspose[N_EYES];
+	vec4 unusedFillerFormatWorldViewInverseTranspose[N_EYES];
 	mat4 matWorldViewProj[N_EYES];
 };
 
@@ -115,12 +115,12 @@ mat3 TBN_trafo(const float3 N, const float3 V, const float2 uv)
    return mat3(T, B, N * sqrt( max(dot(T,T), dot(B,B)) )); // inverse scale, as will be normalized anyhow later-on (to save some mul's)
 }
 
-float3 normal_map(const float3 N, const float3 V, const float2 uv)
+float3 normal_map(const float3 N, const float3 V, const float2 uv, const float eye)
 {
    const float3 tn = texture(tex_base_normalmap, uv).xyz * (255./127.) - (128./127.);
    BRANCH if (objectSpaceNormalMap)
    { // Object space: this matches the object space, +X +Y +Z, export/baking in Blender with our trafo setup
-      return normalize((matWorldViewInverseTranspose * float3(tn.x, tn.y, -tn.z)).xyz);
+      return normalize((matWorldViewInverseTranspose[int(eye)] * float3(tn.x, tn.y, -tn.z)).xyz);
    }
    else
    { // Tangent space
@@ -143,7 +143,7 @@ float3 compute_reflection(const float2 screenSpace, const float3 N, const float 
 float3 compute_refraction(const float3 pos, const float2 screenSpace, const float3 N, const float3 V, const float eye)
 {
    // Compute refracted visible position then project from world view position to probe UV
-   // const float4x4 matProj = mul(inverse4x4(matWorldView), matWorldViewProj[int(eye)]); // this has been moved to the matrix uniform stack for performance reasons
+   // const float4x4 matProj = mul(inverse4x4(matWorldView[int(eye)]), matWorldViewProj[int(eye)]); // this has been moved to the matrix uniform stack for performance reasons
    const float3 R = refract(V, N, 1.0 / 1.5); // n1 = 1.0 (air), n2 = 1.5 (plastic), eta = n1 / n2
    const float3 refracted_pos = pos + refractionThickness * R; // Shift ray by the thickness of the material
    const float4 proj = matProj[int(eye)] * float4(refracted_pos, 1.0);
@@ -202,9 +202,9 @@ void main()
    VS_VARYING(tablePos, table_pos);
    VS_VARYING(tex01, tc);
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
-   VS_VARYING(worldPos, (matWorldView * pos).xyz);
+   VS_VARYING(worldPos, (matWorldView[eye_vs] * pos).xyz);
    // Needs to use a 'normal' matrix, and to normalize since we allow non uniform stretching, therefore matWorldView is not orthonormal
-   VS_VARYING(normal, normalize((matWorldViewInverseTranspose*vNormal).xyz));
+   VS_VARYING(normal, normalize((matWorldViewInverseTranspose[eye_vs]*vNormal).xyz));
    VS_CLIP_DISTANCE(vec4(table_pos.xyz, 1.0));
 }
 
@@ -226,9 +226,9 @@ void main()
    VS_POSITION(matWorldViewProj[eye_vs] * pos, pos);
    VS_VARYING(tablePos, table_pos);
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
-   VS_VARYING(worldPos, (matWorldView * pos).xyz);
+   VS_VARYING(worldPos, (matWorldView[eye_vs] * pos).xyz);
    // Needs to use a 'normal' matrix, and to normalize since we allow non uniform stretching, therefore matWorldView is not orthonormal
-   VS_VARYING(normal, normalize((matWorldViewInverseTranspose*vNormal).xyz));
+   VS_VARYING(normal, normalize((matWorldViewInverseTranspose[eye_vs]*vNormal).xyz));
    VS_CLIP_DISTANCE(vec4(table_pos.xyz, 1.0));
 }
 
@@ -485,7 +485,7 @@ void main()
    const float3 V = normalize(/*camera=0,0,0,1*/-worldPos); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
    const float3 N = normalize(normal);
 
-   color = float4(lightLoop(worldPos, N, V, diffuse, glossy, specular, edge, is_metal), cBase_Alpha.a);
+   color = float4(lightLoop(worldPos, N, V, diffuse, glossy, specular, edge, is_metal, eye), cBase_Alpha.a);
 
    BRANCH if (color.a < 1.0) // We may not opacify if we already are opaque
    {
@@ -545,9 +545,9 @@ void main()
    const float3 V = normalize(/*camera=0,0,0,1*/-worldPos);
    float3 N = normalize(normal);
    BRANCH if (doNormalMapping)
-      N = normal_map(N, V, tex01);
+      N = normal_map(N, V, tex01, eye);
 
-   color = float4(lightLoop(worldPos, N, V, diffuse, glossy, specular, edge, is_metal), pixel.a);
+   color = float4(lightLoop(worldPos, N, V, diffuse, glossy, specular, edge, is_metal, eye), pixel.a);
 
    BRANCH if (color.a < 1.0) // We may not opacify if we already are opaque
    {
@@ -609,9 +609,9 @@ void main() {
    const float3 V = normalize(/*camera=0,0,0,1*/-worldPos);
    float3 N = normalize(normal);
    BRANCH if (doNormalMapping)
-      N = normal_map(N, V, tex01);
+      N = normal_map(N, V, tex01, eye);
 
-   color = float4(lightLoop(worldPos, N, V, diffuse, glossy, specular, edge, is_metal), pixel.a);
+   color = float4(lightLoop(worldPos, N, V, diffuse, glossy, specular, edge, is_metal, eye), pixel.a);
 
    BRANCH if (color.a < 1.0) // We may not opacify if we already are opaque
    {
@@ -767,9 +767,9 @@ void main()
    #endif
    VS_VARYING(tablePos, table_pos);
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
-   VS_VARYING(worldPos, (matWorldView * pos).xyz);
+   VS_VARYING(worldPos, (matWorldView[eye_vs] * pos).xyz);
    // Needs to use a 'normal' matrix, and to normalize since we allow non uniform stretching, therefore matWorldView is not orthonormal
-   VS_VARYING(normal, normalize((matWorldViewInverseTranspose*vNormal).xyz));
+   VS_VARYING(normal, normalize((matWorldViewInverseTranspose[eye_vs]*vNormal).xyz));
    VS_CLIP_DISTANCE(vec4(table_pos.xyz, 1.0));
 }
 

--- a/src/shaders/hlsl_glsl/ClassicLightShader.glfx
+++ b/src/shaders/hlsl_glsl/ClassicLightShader.glfx
@@ -46,10 +46,10 @@ void main()
    VS_VARYING(tablePos, table_pos);
    VS_VARYING(tex0, tc);
    // trafo all into worldview space (as most of the weird trafos happen in view, world is identity so far)
-   VS_VARYING(worldPos, (matWorldView * pos).xyz);
+   VS_VARYING(worldPos, (matWorldView[eye_vs] * pos).xyz);
    // No need to use a dedicated 'normal' matrix and normalize since the matWorldView is orthonormal (world is identity and view is always orthonormal) and we normalize in fragment shader
-   //VS_VARYING(normal, normalize((matWorldViewInverseTranspose * vNormal).xyz));
-   VS_VARYING(normal, (matWorldView * float4(vNormal, 0.0)).xyz);
+   //VS_VARYING(normal, normalize((matWorldViewInverseTranspose[eye_vs] * vNormal).xyz));
+   VS_VARYING(normal, (matWorldView[eye_vs] * float4(vNormal, 0.0)).xyz);
    VS_CLIP_DISTANCE(vec4(table_pos.xyz, 1.0));
 }
 
@@ -89,6 +89,7 @@ in vec2 tex0;
 in vec3 worldPos;
 in vec3 tablePos;
 in vec3 normal;
+flat in float eye;
 
 void main()
 {
@@ -107,7 +108,7 @@ void main()
         const float3 specular = cClearcoat_EdgeAlpha.xyz*0.08;
         const float  edge     = is_metal ? 1.0 : Roughness_WrapL_Edge_Thickness.z;
 
-        color.xyz = lightLoop(worldPos, normalize(normal), normalize(/*camera=0,0,0,1*/-worldPos), diffuse, glossy, specular, edge, is_metal); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
+        color.xyz = lightLoop(worldPos, normalize(normal), normalize(/*camera=0,0,0,1*/-worldPos), diffuse, glossy, specular, edge, is_metal, eye); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
         color.a = pixel.a;
     }
     color.a *= cBase_Alpha.a;
@@ -130,6 +131,7 @@ in vec2 tex0;
 in vec3 worldPos;
 in vec3 tablePos;
 in vec3 normal;
+flat in float eye;
 
 void main()
 {
@@ -154,7 +156,7 @@ void main()
         const float3 specular = cClearcoat_EdgeAlpha.xyz*0.08;
         const float  edge     = is_metal ? 1.0 : Roughness_WrapL_Edge_Thickness.z;
 
-        color.xyz = lightLoop(worldPos, normalize(normal), normalize(/*camera=0,0,0,1*/-worldPos), diffuse, glossy, specular, edge, is_metal); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
+        color.xyz = lightLoop(worldPos, normalize(normal), normalize(/*camera=0,0,0,1*/-worldPos), diffuse, glossy, specular, edge, is_metal, eye); //!! have a "real" view vector instead that mustn't assume that viewer is directly in front of monitor? (e.g. cab setup) -> viewer is always relative to playfield and/or user definable
     }
     color.a = cBase_Alpha.a;
 

--- a/src/shaders/hlsl_glsl/Material_GL.fxh
+++ b/src/shaders/hlsl_glsl/Material_GL.fxh
@@ -81,11 +81,11 @@ float3 FresnelSchlick(const float3 spec, const float LdotH, const float edge)
 
 //
 
-float3 DoPointLight(const float3 pos, const float3 N, const float3 V, const float3 diffuse, const float3 glossy, const float edge, const float glossyPower, const int i, const bool is_metal) 
+float3 DoPointLight(const float3 pos, const float3 N, const float3 V, const float3 diffuse, const float3 glossy, const float edge, const float glossyPower, const int i, const bool is_metal, const float eye) 
 { 
    //!! do in vertex shader?! or completely before?!
-   //const float3 lightDir = mul_w1(lightPos[i].xyz, matView) - pos;
-   const float3 lightDir = (matView * float4(lightPos[i].xyz, 1.0)).xyz - pos;
+   //const float3 lightDir = mul_w1(lightPos[i].xyz, matView[int(eye)]) - pos;
+   const float3 lightDir = (matView[int(eye)] * float4(lightPos[i].xyz, 1.0)).xyz - pos;
    const float3 L = normalize(lightDir);
    const float NdotL = dot(N, L);
    float3 Out = float3(0.0,0.0,0.0);
@@ -97,12 +97,12 @@ float3 DoPointLight(const float3 pos, const float3 N, const float3 V, const floa
    // add glossy component (modified ashikhmin/blinn bastard), not fully energy conserving, but good enough
    BRANCH if (NdotL > 0.0)
    {
-	 const float3 H = normalize(L + V); // half vector
-	 const float NdotH = dot(N, H);
-	 const float LdotH = dot(L, H);
-	 const float VdotH = dot(V, H);
-	 if ((NdotH > 0.0) && (LdotH > 0.0) && (VdotH > 0.0))
-		Out += FresnelSchlick(glossy, LdotH, edge) * (((glossyPower + 1.0) / (8.0*VdotH)) * pow(NdotH, glossyPower));
+     const float3 H = normalize(L + V); // half vector
+     const float NdotH = dot(N, H);
+     const float LdotH = dot(L, H);
+     const float VdotH = dot(V, H);
+     if ((NdotH > 0.0) && (LdotH > 0.0) && (VdotH > 0.0))
+        Out += FresnelSchlick(glossy, LdotH, edge) * (((glossyPower + 1.0) / (8.0*VdotH)) * pow(NdotH, glossyPower));
    }
 
    //float fAtten = saturate( 1.0 - dot(lightDir/cAmbient_LightRange.w, lightDir/cAmbient_LightRange.w) );
@@ -158,7 +158,7 @@ float3 DoEnvmap2ndLayer(const float3 color1stLayer, const float3 pos, const floa
 //   Glossy is performed with a very crude approximation of the BRDF and the roughness parameter (simple mip-mapping of the envmap).
 //   Specular just does a plain lookup in the envmap.
 // - Backside (normal pointing away) is lighted as well as front facing (needed since quite a lot of tables feature wrong normals, or for transparents with 2 pass rendering)
-float3 lightLoop(const float3 pos, float3 N, const float3 V, float3 diffuse, float3 glossy, const float3 specular, const float edge, const bool is_metal) // input vectors (N,V) are normalized for BRDF evals
+float3 lightLoop(const float3 pos, float3 N, const float3 V, float3 diffuse, float3 glossy, const float3 specular, const float edge, const bool is_metal, const float eye) // input vectors (N,V) are normalized for BRDF evals
 {
    float3 color = float3(0.0, 0.0, 0.0);
 
@@ -192,25 +192,25 @@ float3 lightLoop(const float3 pos, float3 N, const float3 V, float3 diffuse, flo
       BRANCH if (fDisableLighting_top_below.x == 1.0)
          color += float(iLightPointNum) * diffuse; // Old bug kept for backward compatibility: when lighting is disabled, it results to applying it twice
       else for (int i = 0; i < iLightPointNum; i++)
-         color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal); // no clearcoat needed as only pointlights so far
+         color += DoPointLight(pos, N, V, diffuse, glossy, edge, Roughness_WrapL_Edge_Thickness.x, i, is_metal, eye); // no clearcoat needed as only pointlights so far
    }
 
    // Environment IBL
    BRANCH if (!is_metal && (diffuseMax > 0.0))
       // trafo back to world for lookup into world space envmap // actually: mul(float4(N,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
       // matView is always an orthonormal matrix, so no need to normalize after transform
-      color += DoEnvmapDiffuse(/*normalize*/((float4(N,0.0) * matView).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
+      color += DoEnvmapDiffuse(/*normalize*/((float4(N,0.0) * matView[int(eye)]).xyz), diffuse); // trafo back to world for lookup into world space envmap // actually: mul(vec4(N,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
    BRANCH if ((glossyMax > 0.0) || (specularMax > 0.0))
    {
-	   float3 R = (2.0*NdotV)*N - V; // reflect(-V,N);
-	   // trafo back to world for lookup into world space envmap // actually: mul(float4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
-	   // matView is always an orthonormal matrix, so no need to normalize after transform
-	   R = /*normalize*/((float4(R,0.0) * matView).xyz); // trafo back to world for lookup into world space envmap // actually: mul(vec4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
-	   const float2 Ruv = ray_to_equirectangular_uv(R);
-	   if (glossyMax > 0.0)
-		  color += DoEnvmapGlossy(N, V, Ruv, glossy, Roughness_WrapL_Edge_Thickness.x);
-	   if (specularMax > 0.0)
-		  color = DoEnvmap2ndLayer(color, pos, N, V, NdotV, Ruv, specular);
+       float3 R = (2.0*NdotV)*N - V; // reflect(-V,N);
+       // trafo back to world for lookup into world space envmap // actually: mul(float4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
+       // matView is always an orthonormal matrix, so no need to normalize after transform
+       R = /*normalize*/((float4(R,0.0) * matView[int(eye)]).xyz); // trafo back to world for lookup into world space envmap // actually: mul(vec4(R,0.0), matViewInverseInverseTranspose), but optimized to save one matrix
+       const float2 Ruv = ray_to_equirectangular_uv(R);
+       if (glossyMax > 0.0)
+          color += DoEnvmapGlossy(N, V, Ruv, glossy, Roughness_WrapL_Edge_Thickness.x);
+       if (specularMax > 0.0)
+          color = DoEnvmap2ndLayer(color, pos, N, V, NdotV, Ruv, specular);
    }
 
    return /*Gamma(ToneMap(*/color/*))*/;

--- a/src/shaders/hlsl_glsl/UIShader.glfx
+++ b/src/shaders/hlsl_glsl/UIShader.glfx
@@ -14,7 +14,7 @@ out float2 tex0;
 out float4 color0;
 out float2 clipPos;
 
-uniform mat4 matWorldView;
+uniform mat4 matWorldView[N_EYES];
 
 uniform float4 staticColor_Alpha;
 #define stereoOfs staticColor_Alpha.x
@@ -38,7 +38,7 @@ uniform float4 clip_plane;
 void main()
 {
    clipPos = vPosition.xy;
-   gl_Position = matWorldView * vec4(vPosition.x, vPosition.y, 0.0, 1.0);
+   gl_Position = matWorldView[0] * vec4(vPosition.x, vPosition.y, 0.0, 1.0);
    color0 = sdrScale * float4(vNormal.rgb, vPosition.z);
    tex0 = tc;
    //tex0 = float2(tc.x, 1.0-tc.y);

--- a/src/ui/live/EditorUI.cpp
+++ b/src/ui/live/EditorUI.cpp
@@ -118,7 +118,7 @@ void EditorUI::Close()
 void EditorUI::ResetCameraFromPlayer()
 {
    // Try to setup editor camera to match the used one, but only mostly since the EditorUI does not have some view setup features like off-center, ...
-   m_camView = Matrix3D::MatrixScale(1.f, 1.f, -1.f) * m_renderer->GetMVP().GetView() * Matrix3D::MatrixScale(1.f, -1.f, 1.f);
+   m_camView = Matrix3D::MatrixScale(1.f, 1.f, -1.f) * m_renderer->GetMVP().GetView(0) * Matrix3D::MatrixScale(1.f, -1.f, 1.f);
 }
 
 void EditorUI::Render3D()
@@ -352,7 +352,7 @@ void EditorUI::RenderUI()
    if (m_camMode == ViewMode::PreviewCam)
    {
       m_renderer->InitLayout();
-      m_camView = RH2LH * m_renderer->GetMVP().GetView() * YAxis;
+      m_camView = RH2LH * m_renderer->GetMVP().GetView(0) * YAxis;
       m_camProj = YAxis * m_renderer->GetMVP().GetProj(0);
    }
    else
@@ -362,7 +362,8 @@ void EditorUI::RenderUI()
       // Right Hand to Left Hand (note that RH2LH = inverse(RH2LH), so RH2LH.RH2LH is identity, which property is used below)
       const Matrix3D view = RH2LH * m_camView * YAxis;
       const Matrix3D proj = YAxis * m_camProj;
-      m_renderer->GetMVP().SetView(view);
+      m_renderer->GetMVP().SetView(0, view);
+      m_renderer->GetMVP().SetView(1, view);
       m_renderer->GetMVP().SetProj(0, proj);
       m_renderer->GetMVP().SetProj(1, proj);
 

--- a/src/ui/live/LiveUI.cpp
+++ b/src/ui/live/LiveUI.cpp
@@ -432,8 +432,11 @@ void LiveUI::RenderUI()
    }
    const float right = (m_rotate == 1 || m_rotate == 3) ? io.DisplaySize.y : io.DisplaySize.x;
    const float bottom = (m_rotate == 1 || m_rotate == 3) ? io.DisplaySize.x : io.DisplaySize.y;
-   const Matrix3D matProj = matRotate * matTranslate * Matrix3D::MatrixOrthoOffCenterRH(0.f, right, bottom, 0.f, 0.f, 1.f);
-   m_rd->m_uiShader->SetMatrix(SHADER_matWorldView, &matProj);
+   Matrix3D matView[2];
+   matView[0] = matRotate * matTranslate * Matrix3D::MatrixOrthoOffCenterRH(0.f, right, bottom, 0.f, 0.f, 1.f);
+   if (m_rd->m_nEyes == 2)
+      matView[1] = matView[0];  
+   m_rd->m_uiShader->SetMatrix(SHADER_matWorldView, &matView[0], m_rd->m_nEyes);
    m_rd->m_uiShader->SetVector(SHADER_staticColor_Alpha,
       m_player->m_vrDevice ? ((float)m_player->m_vrDevice->GetEyeWidth() * 0.15f) : 0.f, // Stereo offset for VR (fake depth)
       0.f, // Unused


### PR DESCRIPTION
This fixes some slight artefact that could be seen or perceived when playing in VR