### PR TITLE
Add string and bool element type support to plugin script arrays

### DIFF
--- a/make/vpx-test.vcxproj
+++ b/make/vpx-test.vcxproj
@@ -36,6 +36,7 @@
     </ClCompile>
     <ClCompile Include="../../tests/vpx-test.cpp" />
     <ClCompile Include="../../tests/test-base-render.cpp" />
+    <ClCompile Include="../../tests/test-plugin-arrays.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="../../tests/vpx-test.h" />

--- a/plugins/helloscript/helloscript.cpp
+++ b/plugins/helloscript/helloscript.cpp
@@ -4,9 +4,10 @@
 #include "plugins/VPXPlugin.h"
 #include "plugins/ScriptablePlugin.h"
 #include <cstring>
+#include <cstdlib>
 
 namespace HelloScript {
-   
+
 static const MsgPluginAPI* msgApi = nullptr;
 static VPXPluginAPI* vpxApi = nullptr;
 static ScriptablePluginAPI* scriptApi = nullptr;
@@ -22,15 +23,88 @@ void put_Property2(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet) { p
 void AddRef(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet) { }
 void Release(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet) { }
 
-ScriptClassDef helloScriptClass { { "DummyClass" }, []() { return static_cast<void*>(new int[4]); }, 4,
+// Example: return a 1D string array with 3 elements
+void get_StringArray1D(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet)
+{
+   static const char* strings[] = { "hello", "world", "vpx" };
+   const unsigned int count = 3;
+   const size_t dataSize = count * sizeof(const char*);
+   ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 1 * sizeof(unsigned int) + dataSize));
+   array->Release = [](ScriptArray* me) { free(me); };
+   array->lengths[0] = count;
+   const char** pData = reinterpret_cast<const char**>(&array->lengths[1]);
+   for (unsigned int i = 0; i < count; i++)
+      pData[i] = strings[i];
+   pRet->vArray = array;
+}
+
+// Example: return a 2D string array (3 rows x 2 cols) — e.g. ID/value pairs
+void get_StringArray2D(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet)
+{
+   static const char* strings[] = { "l-1", "on", "l-2", "off", "coil1", "pulse" };
+   const unsigned int rows = 3, cols = 2;
+   const size_t dataSize = rows * cols * sizeof(const char*);
+   ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 2 * sizeof(unsigned int) + dataSize));
+   array->Release = [](ScriptArray* me) { free(me); };
+   array->lengths[0] = rows;
+   array->lengths[1] = cols;
+   const char** pData = reinterpret_cast<const char**>(&array->lengths[2]);
+   for (unsigned int i = 0; i < rows * cols; i++)
+      pData[i] = strings[i];
+   pRet->vArray = array;
+}
+
+// Example: return a 1D bool array with 4 elements
+void get_BoolArray1D(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet)
+{
+   const unsigned int count = 4;
+   const size_t dataSize = count * sizeof(char);
+   ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 1 * sizeof(unsigned int) + dataSize));
+   array->Release = [](ScriptArray* me) { free(me); };
+   array->lengths[0] = count;
+   char* pData = reinterpret_cast<char*>(&array->lengths[1]);
+   pData[0] = 1;
+   pData[1] = 0;
+   pData[2] = 1;
+   pData[3] = 1;
+   pRet->vArray = array;
+}
+
+// Example: return a 2D bool array (3 rows x 2 cols)
+void get_BoolArray2D(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet)
+{
+   const unsigned int rows = 3, cols = 2;
+   const size_t dataSize = rows * cols * sizeof(char);
+   ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 2 * sizeof(unsigned int) + dataSize));
+   array->Release = [](ScriptArray* me) { free(me); };
+   array->lengths[0] = rows;
+   array->lengths[1] = cols;
+   char* pData = reinterpret_cast<char*>(&array->lengths[2]);
+   pData[0] = 1; pData[1] = 0;
+   pData[2] = 0; pData[3] = 1;
+   pData[4] = 1; pData[5] = 1;
+   pRet->vArray = array;
+}
+
+// Array type definitions for string and bool arrays
+static ScriptArrayDef stringArray1DDef = { { "HelloStringArray1D" }, { "string" }, 1, { 0 } };
+static ScriptArrayDef stringArray2DDef = { { "HelloStringArray2D" }, { "string" }, 2, { 0, 0 } };
+static ScriptArrayDef boolArray1DDef = { { "HelloBoolArray1D" }, { "bool" }, 1, { 0 } };
+static ScriptArrayDef boolArray2DDef = { { "HelloBoolArray2D" }, { "bool" }, 2, { 0, 0 } };
+
+ScriptClassDef helloScriptClass { { "DummyClass" }, []() { return static_cast<void*>(new int[4]); }, 9,
    {
-      { { "AddRef" },    { "ulong" }, 0, {}, AddRef  },
-      { { "Release" },   { "ulong" }, 0, {}, Release },
-      { { "Property1" }, { "int" },   0, {}, get_Property1 },
-      { { "Property2" }, { "float" }, 0, {}, get_Property2 },
-      { { "Property2" }, { "void" }, 1, { { "float" } }, put_Property2 },
+      { { "AddRef" },        { "ulong" },               0, {}, AddRef  },
+      { { "Release" },       { "ulong" },               0, {}, Release },
+      { { "Property1" },     { "int" },                 0, {}, get_Property1 },
+      { { "Property2" },     { "float" },               0, {}, get_Property2 },
+      { { "Property2" },     { "void" },                1, { { "float" } }, put_Property2 },
+      { { "StringArray1D" }, { "HelloStringArray1D" },   0, {}, get_StringArray1D },
+      { { "StringArray2D" }, { "HelloStringArray2D" },   0, {}, get_StringArray2D },
+      { { "BoolArray1D" },   { "HelloBoolArray1D" },     0, {}, get_BoolArray1D },
+      { { "BoolArray2D" },   { "HelloBoolArray2D" },     0, {}, get_BoolArray2D },
    } };
-   
+
 }
 
 using namespace HelloScript;
@@ -43,6 +117,10 @@ MSGPI_EXPORT void MSGPIAPI HelloScriptPluginLoad(const uint32_t sessionId, const
    msgApi->BroadcastMsg(endpointId, getVpxApiMsgId, &vpxApi);
    getScriptApiMsgId = msgApi->GetMsgID(SCRIPTPI_NAMESPACE, SCRIPTPI_MSG_GET_API);
    msgApi->BroadcastMsg(endpointId, getScriptApiMsgId, &scriptApi);
+   scriptApi->RegisterScriptArrayType(&stringArray1DDef);
+   scriptApi->RegisterScriptArrayType(&stringArray2DDef);
+   scriptApi->RegisterScriptArrayType(&boolArray1DDef);
+   scriptApi->RegisterScriptArrayType(&boolArray2DDef);
    scriptApi->RegisterScriptClass(&helloScriptClass);
    scriptApi->SubmitTypeLibrary(endpointId);
 }
@@ -50,6 +128,10 @@ MSGPI_EXPORT void MSGPIAPI HelloScriptPluginLoad(const uint32_t sessionId, const
 MSGPI_EXPORT void MSGPIAPI HelloScriptPluginUnload()
 {
    scriptApi->UnregisterScriptClass(&helloScriptClass);
+   scriptApi->UnregisterScriptArrayType(&stringArray1DDef);
+   scriptApi->UnregisterScriptArrayType(&stringArray2DDef);
+   scriptApi->UnregisterScriptArrayType(&boolArray1DDef);
+   scriptApi->UnregisterScriptArrayType(&boolArray2DDef);
    msgApi->ReleaseMsgID(getVpxApiMsgId);
    msgApi->ReleaseMsgID(getScriptApiMsgId);
    vpxApi = nullptr;

--- a/plugins/helloscript/helloscript.cpp
+++ b/plugins/helloscript/helloscript.cpp
@@ -23,18 +23,25 @@ void put_Property2(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet) { p
 void AddRef(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet) { }
 void Release(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet) { }
 
-// Example: return a 1D string array with 3 elements
+// Example: return a 1D string array with 3 elements.
+// String elements are packed as ScriptString values, each carrying its own Release hook so the
+// host frees plugin-owned strings through the documented per-element lifecycle.
 void get_StringArray1D(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet)
 {
    static const char* strings[] = { "hello", "world", "vpx" };
    const unsigned int count = 3;
-   const size_t dataSize = count * sizeof(const char*);
+   const size_t dataSize = count * sizeof(ScriptString);
    ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 1 * sizeof(unsigned int) + dataSize));
    array->Release = [](ScriptArray* me) { free(me); };
    array->lengths[0] = count;
-   const char** pData = reinterpret_cast<const char**>(&array->lengths[1]);
+   ScriptString* pData = reinterpret_cast<ScriptString*>(&array->lengths[1]);
    for (unsigned int i = 0; i < count; i++)
-      pData[i] = strings[i];
+   {
+      const size_t n = strlen(strings[i]) + 1;
+      char* s = new char[n];
+      memcpy(s, strings[i], n);
+      pData[i] = { [](ScriptString* str) { delete[] str->string; }, s };
+   }
    pRet->vArray = array;
 }
 
@@ -43,14 +50,19 @@ void get_StringArray2D(void* me, int, ScriptVariant* pArgs, ScriptVariant* pRet)
 {
    static const char* strings[] = { "l-1", "on", "l-2", "off", "coil1", "pulse" };
    const unsigned int rows = 3, cols = 2;
-   const size_t dataSize = rows * cols * sizeof(const char*);
+   const size_t dataSize = rows * cols * sizeof(ScriptString);
    ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 2 * sizeof(unsigned int) + dataSize));
    array->Release = [](ScriptArray* me) { free(me); };
    array->lengths[0] = rows;
    array->lengths[1] = cols;
-   const char** pData = reinterpret_cast<const char**>(&array->lengths[2]);
+   ScriptString* pData = reinterpret_cast<ScriptString*>(&array->lengths[2]);
    for (unsigned int i = 0; i < rows * cols; i++)
-      pData[i] = strings[i];
+   {
+      const size_t n = strlen(strings[i]) + 1;
+      char* s = new char[n];
+      memcpy(s, strings[i], n);
+      pData[i] = { [](ScriptString* str) { delete[] str->string; }, s };
+   }
    pRet->vArray = array;
 }
 

--- a/src/core/DynamicScript.cpp
+++ b/src/core/DynamicScript.cpp
@@ -649,6 +649,30 @@ void DynamicTypeLibrary::ScriptToCOMVariant(const ScriptTypeNameDef& type, Scrip
          case TypeID::TYPEID_UINT16: COPY_ARRAY(uint16_t,     UI2); break;
          case TypeID::TYPEID_UINT32: COPY_ARRAY(uint32_t,     UI4); break;
          case TypeID::TYPEID_UINT64: COPY_ARRAY(uint64_t,     UI8); break;
+         case TypeID::TYPEID_STRING:
+         {
+            const char* const* pSrc = reinterpret_cast<const char* const*>(&sv.vArray->lengths[1]);
+            for (unsigned int i = 0; i < sv.vArray->lengths[0]; i++)
+            {
+               VariantInit(&pData[i]);
+               V_VT(&pData[i]) = VT_BSTR;
+               const int len = MultiByteToWideChar(CP_ACP, 0, pSrc[i], -1, nullptr, 0);
+               V_BSTR(&pData[i]) = SysAllocStringLen(nullptr, len - 1);
+               MultiByteToWideChar(CP_ACP, 0, pSrc[i], -1, V_BSTR(&pData[i]), len);
+            }
+            break;
+         }
+         case TypeID::TYPEID_BOOL:
+         {
+            const char* pSrc = reinterpret_cast<const char*>(&sv.vArray->lengths[1]);
+            for (unsigned int i = 0; i < sv.vArray->lengths[0]; i++)
+            {
+               VariantInit(&pData[i]);
+               V_VT(&pData[i]) = VT_BOOL;
+               V_BOOL(&pData[i]) = pSrc[i] ? VARIANT_TRUE : VARIANT_FALSE;
+            }
+            break;
+         }
          default: assert(false); // not yet implemented
          }
          #undef COPY_ARRAY
@@ -692,6 +716,39 @@ void DynamicTypeLibrary::ScriptToCOMVariant(const ScriptTypeNameDef& type, Scrip
          case TypeID::TYPEID_UINT16: COPY_ARRAY(uint16_t,     UI2); break;
          case TypeID::TYPEID_UINT32: COPY_ARRAY(uint32_t,     UI4); break;
          case TypeID::TYPEID_UINT64: COPY_ARRAY(uint64_t,     UI8); break;
+         case TypeID::TYPEID_STRING:
+         {
+            const char* const* pSrc = reinterpret_cast<const char* const*>(&sv.vArray->lengths[2]);
+            for (ix[0] = 0; ix[0] < static_cast<LONG>(sv.vArray->lengths[0]); ix[0]++)
+            {
+               for (ix[1] = 0; ix[1] < static_cast<LONG>(sv.vArray->lengths[1]); ix[1]++)
+               {
+                  VariantInit(&varValue);
+                  V_VT(&varValue) = VT_BSTR;
+                  const char* str = pSrc[ix[0] * sv.vArray->lengths[1] + ix[1]];
+                  const int len = MultiByteToWideChar(CP_ACP, 0, str, -1, nullptr, 0);
+                  V_BSTR(&varValue) = SysAllocStringLen(nullptr, len - 1);
+                  MultiByteToWideChar(CP_ACP, 0, str, -1, V_BSTR(&varValue), len);
+                  SafeArrayPutElement(psa, ix, &varValue);
+                  VariantClear(&varValue);
+               }
+            }
+            break;
+         }
+         case TypeID::TYPEID_BOOL:
+         {
+            V_VT(&varValue) = VT_BOOL;
+            const char* pSrc = reinterpret_cast<const char*>(&sv.vArray->lengths[2]);
+            for (ix[0] = 0; ix[0] < static_cast<LONG>(sv.vArray->lengths[0]); ix[0]++)
+            {
+               for (ix[1] = 0; ix[1] < static_cast<LONG>(sv.vArray->lengths[1]); ix[1]++)
+               {
+                  V_BOOL(&varValue) = pSrc[ix[0] * sv.vArray->lengths[1] + ix[1]] ? VARIANT_TRUE : VARIANT_FALSE;
+                  SafeArrayPutElement(psa, ix, &varValue);
+               }
+            }
+            break;
+         }
          default: assert(false); // not yet implemented
          }
          #undef COPY_ARRAY

--- a/src/core/DynamicScript.cpp
+++ b/src/core/DynamicScript.cpp
@@ -651,14 +651,14 @@ void DynamicTypeLibrary::ScriptToCOMVariant(const ScriptTypeNameDef& type, Scrip
          case TypeID::TYPEID_UINT64: COPY_ARRAY(uint64_t,     UI8); break;
          case TypeID::TYPEID_STRING:
          {
-            const char* const* pSrc = reinterpret_cast<const char* const*>(&sv.vArray->lengths[1]);
+            const ScriptString* const pSrc = reinterpret_cast<const ScriptString*>(&sv.vArray->lengths[1]);
             for (unsigned int i = 0; i < sv.vArray->lengths[0]; i++)
             {
                VariantInit(&pData[i]);
                V_VT(&pData[i]) = VT_BSTR;
-               const int len = MultiByteToWideChar(CP_ACP, 0, pSrc[i], -1, nullptr, 0);
+               const int len = MultiByteToWideChar(CP_ACP, 0, pSrc[i].string, -1, nullptr, 0);
                V_BSTR(&pData[i]) = SysAllocStringLen(nullptr, len - 1);
-               MultiByteToWideChar(CP_ACP, 0, pSrc[i], -1, V_BSTR(&pData[i]), len);
+               MultiByteToWideChar(CP_ACP, 0, pSrc[i].string, -1, V_BSTR(&pData[i]), len);
             }
             break;
          }
@@ -718,14 +718,14 @@ void DynamicTypeLibrary::ScriptToCOMVariant(const ScriptTypeNameDef& type, Scrip
          case TypeID::TYPEID_UINT64: COPY_ARRAY(uint64_t,     UI8); break;
          case TypeID::TYPEID_STRING:
          {
-            const char* const* pSrc = reinterpret_cast<const char* const*>(&sv.vArray->lengths[2]);
+            const ScriptString* const pSrc = reinterpret_cast<const ScriptString*>(&sv.vArray->lengths[2]);
             for (ix[0] = 0; ix[0] < static_cast<LONG>(sv.vArray->lengths[0]); ix[0]++)
             {
                for (ix[1] = 0; ix[1] < static_cast<LONG>(sv.vArray->lengths[1]); ix[1]++)
                {
                   VariantInit(&varValue);
                   V_VT(&varValue) = VT_BSTR;
-                  const char* str = pSrc[ix[0] * sv.vArray->lengths[1] + ix[1]];
+                  const char* str = pSrc[ix[0] * sv.vArray->lengths[1] + ix[1]].string;
                   const int len = MultiByteToWideChar(CP_ACP, 0, str, -1, nullptr, 0);
                   V_BSTR(&varValue) = SysAllocStringLen(nullptr, len - 1);
                   MultiByteToWideChar(CP_ACP, 0, str, -1, V_BSTR(&varValue), len);
@@ -784,7 +784,20 @@ void DynamicTypeLibrary::ReleaseScriptVariant(const ScriptTypeNameDef& type, Scr
          PSC_RELEASE(typeDef.classDef->classDef, sv.vObject);
       break;
 
-   case TypeDef::TD_ARRAY: sv.vArray->Release(sv.vArray); break;
+   case TypeDef::TD_ARRAY:
+      // String elements carry a per-element lifecycle (ScriptString::Release), mirroring the
+      // scalar string convention. Release each element before freeing the array block itself.
+      if (typeDef.arrayDef->type.id == TypeID::TYPEID_STRING)
+      {
+         unsigned int count = sv.vArray->lengths[0];
+         for (unsigned int d = 1; d < typeDef.arrayDef->nDimensions; d++)
+            count *= sv.vArray->lengths[d];
+         ScriptString* pData = reinterpret_cast<ScriptString*>(&sv.vArray->lengths[typeDef.arrayDef->nDimensions]);
+         for (unsigned int i = 0; i < count; i++)
+            pData[i].Release(&pData[i]);
+      }
+      sv.vArray->Release(sv.vArray);
+      break;
 
    default: assert(false);
    }

--- a/tests/test-plugin-arrays.cpp
+++ b/tests/test-plugin-arrays.cpp
@@ -1,0 +1,209 @@
+// license:GPLv3+
+
+#include "core/stdafx.h"
+#include "vpx-test.h"
+#include "doctest.h"
+
+#include "core/DynamicScript.h"
+
+#include <cstdlib>
+#include <cstring>
+
+// Helper to build a 2D string ScriptArray from a flat array of C strings.
+// Layout: [Release][lengths[0]=rows][lengths[1]=cols][const char* ptrs...]
+static ScriptArray* MakeStringArray2D(unsigned int rows, unsigned int cols, const char* const* strings)
+{
+   const size_t dataSize = rows * cols * sizeof(const char*);
+   ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 2 * sizeof(unsigned int) + dataSize));
+   array->Release = [](ScriptArray* me) { free(me); };
+   array->lengths[0] = rows;
+   array->lengths[1] = cols;
+   const char** pData = reinterpret_cast<const char**>(&array->lengths[2]);
+   for (unsigned int i = 0; i < rows * cols; i++)
+      pData[i] = strings[i];
+   return array;
+}
+
+// Helper to build a 2D bool ScriptArray from a flat array of chars.
+// Layout: [Release][lengths[0]=rows][lengths[1]=cols][char values...]
+static ScriptArray* MakeBoolArray2D(unsigned int rows, unsigned int cols, const char* values)
+{
+   const size_t dataSize = rows * cols * sizeof(char);
+   ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 2 * sizeof(unsigned int) + dataSize));
+   array->Release = [](ScriptArray* me) { free(me); };
+   array->lengths[0] = rows;
+   array->lengths[1] = cols;
+   char* pData = reinterpret_cast<char*>(&array->lengths[2]);
+   memcpy(pData, values, dataSize);
+   return array;
+}
+
+// Handlers for the test plugin class
+namespace TestPluginArrays {
+
+static void TestAddRef(void*, int, ScriptVariant*, ScriptVariant*) { }
+static void TestRelease(void*, int, ScriptVariant*, ScriptVariant*) { }
+
+static void get_StringArray2D(void*, int, ScriptVariant*, ScriptVariant* pRet)
+{
+   static const char* strings[] = { "l-1", "on", "coil1", "pulse", "gi1", "off" };
+   pRet->vArray = MakeStringArray2D(3, 2, strings);
+}
+
+static void get_BoolArray2D(void*, int, ScriptVariant*, ScriptVariant* pRet)
+{
+   static const char values[] = { 1, 0, 0, 1, 1, 1 };
+   pRet->vArray = MakeBoolArray2D(3, 2, values);
+}
+
+// Array type definitions
+static ScriptArrayDef stringArray2DDef = { { "TestStringArray2D" }, { "string" }, 2, { 0, 0 } };
+static ScriptArrayDef boolArray2DDef = { { "TestBoolArray2D" }, { "bool" }, 2, { 0, 0 } };
+
+// Class definition — flexible array member requires static storage
+static ScriptClassDef testClass = { { "TestArrayClass" }, []() { return static_cast<void*>(new int(0)); }, 4,
+   {
+      { { "AddRef" },        { "ulong" },              0, {}, TestAddRef },
+      { { "Release" },       { "ulong" },              0, {}, TestRelease },
+      { { "StringArray2D" }, { "TestStringArray2D" },   0, {}, get_StringArray2D },
+      { { "BoolArray2D" },   { "TestBoolArray2D" },     0, {}, get_BoolArray2D },
+   } };
+
+} // namespace TestPluginArrays
+
+
+// Helper: invoke a property getter by name on a DynamicDispatch and return the VARIANT result.
+static VARIANT InvokePropertyGet(DynamicDispatch* disp, const wchar_t* name)
+{
+   DISPID dispId = -1;
+   LPOLESTR names[] = { const_cast<LPOLESTR>(name) };
+   HRESULT hr = disp->GetIDsOfNames(IID_NULL, names, 1, 0, &dispId);
+   assert(hr == S_OK);
+   (void)hr;
+
+   VARIANT result;
+   VariantInit(&result);
+   DISPPARAMS params = { nullptr, nullptr, 0, 0 };
+   UINT argErr = 0;
+   disp->Invoke(dispId, IID_NULL, 0, DISPATCH_PROPERTYGET, &params, &result, nullptr, &argErr);
+   return result;
+}
+
+// Helper: extract a VARIANT element from a 2D SAFEARRAY
+static VARIANT SafeArrayGet2D(SAFEARRAY* psa, LONG row, LONG col)
+{
+   VARIANT val;
+   VariantInit(&val);
+   LONG ix[2] = { row, col };
+   SafeArrayGetElement(psa, ix, &val);
+   return val;
+}
+
+
+TEST_CASE("Plugin 2D string and bool array marshalling")
+{
+   using namespace TestPluginArrays;
+
+   // Set up a type library with string/bool 2D array types and a class
+   DynamicTypeLibrary typeLib;
+   typeLib.RegisterScriptArray(&stringArray2DDef);
+   typeLib.RegisterScriptArray(&boolArray2DDef);
+   typeLib.RegisterScriptClass(&testClass);
+   typeLib.ResolveAllClasses();
+
+   // Create a DynamicDispatch wrapping a dummy object
+   void* obj = testClass.CreateObject();
+   DynamicDispatch* disp = new DynamicDispatch(&typeLib, &testClass, obj);
+
+   SUBCASE("2D string array")
+   {
+      VARIANT result = InvokePropertyGet(disp, L"StringArray2D");
+      CHECK(V_VT(&result) == (VT_ARRAY | VT_VARIANT));
+
+      SAFEARRAY* psa = V_ARRAY(&result);
+      REQUIRE(psa != nullptr);
+      CHECK(SafeArrayGetDim(psa) == 2);
+
+      // Check dimensions: 3 rows x 2 cols
+      LONG lBound0, uBound0, lBound1, uBound1;
+      SafeArrayGetLBound(psa, 1, &lBound0);
+      SafeArrayGetUBound(psa, 1, &uBound0);
+      SafeArrayGetLBound(psa, 2, &lBound1);
+      SafeArrayGetUBound(psa, 2, &uBound1);
+      CHECK(lBound0 == 0);
+      CHECK(uBound0 == 2);
+      CHECK(lBound1 == 0);
+      CHECK(uBound1 == 1);
+
+      // Check element values — each should be VT_BSTR
+      auto checkStr = [&](LONG row, LONG col, const char* expected)
+      {
+         VARIANT val = SafeArrayGet2D(psa, row, col);
+         CHECK(V_VT(&val) == VT_BSTR);
+         if (V_VT(&val) == VT_BSTR)
+         {
+            string actual = MakeString(V_BSTR(&val));
+            CHECK(actual == expected);
+         }
+         VariantClear(&val);
+      };
+
+      checkStr(0, 0, "l-1");
+      checkStr(0, 1, "on");
+      checkStr(1, 0, "coil1");
+      checkStr(1, 1, "pulse");
+      checkStr(2, 0, "gi1");
+      checkStr(2, 1, "off");
+
+      VariantClear(&result);
+   }
+
+   SUBCASE("2D bool array")
+   {
+      VARIANT result = InvokePropertyGet(disp, L"BoolArray2D");
+      CHECK(V_VT(&result) == (VT_ARRAY | VT_VARIANT));
+
+      SAFEARRAY* psa = V_ARRAY(&result);
+      REQUIRE(psa != nullptr);
+      CHECK(SafeArrayGetDim(psa) == 2);
+
+      // Check dimensions: 3 rows x 2 cols
+      LONG lBound0, uBound0, lBound1, uBound1;
+      SafeArrayGetLBound(psa, 1, &lBound0);
+      SafeArrayGetUBound(psa, 1, &uBound0);
+      SafeArrayGetLBound(psa, 2, &lBound1);
+      SafeArrayGetUBound(psa, 2, &uBound1);
+      CHECK(lBound0 == 0);
+      CHECK(uBound0 == 2);
+      CHECK(lBound1 == 0);
+      CHECK(uBound1 == 1);
+
+      // Check element values — each should be VT_BOOL
+      auto checkBool = [&](LONG row, LONG col, bool expected)
+      {
+         VARIANT val = SafeArrayGet2D(psa, row, col);
+         CHECK(V_VT(&val) == VT_BOOL);
+         if (V_VT(&val) == VT_BOOL)
+            CHECK(V_BOOL(&val) == (expected ? VARIANT_TRUE : VARIANT_FALSE));
+         VariantClear(&val);
+      };
+
+      checkBool(0, 0, true);
+      checkBool(0, 1, false);
+      checkBool(1, 0, false);
+      checkBool(1, 1, true);
+      checkBool(2, 0, true);
+      checkBool(2, 1, true);
+
+      VariantClear(&result);
+   }
+
+   disp->Release();
+   // Free the object allocated by CreateObject (matches new int(0))
+   delete static_cast<int*>(obj);
+
+   // Clean up type registrations
+   typeLib.UnregisterScriptClass(&testClass);
+   typeLib.UnregisterScriptArray(&stringArray2DDef);
+   typeLib.UnregisterScriptArray(&boolArray2DDef);
+}

--- a/tests/test-plugin-arrays.cpp
+++ b/tests/test-plugin-arrays.cpp
@@ -9,18 +9,29 @@
 #include <cstdlib>
 #include <cstring>
 
+// Counts how many string elements have had their ScriptString::Release called, so the
+// test can verify the host walks the array and releases each element (not just the block).
+static int g_stringElemReleaseCount = 0;
+
 // Helper to build a 2D string ScriptArray from a flat array of C strings.
-// Layout: [Release][lengths[0]=rows][lengths[1]=cols][const char* ptrs...]
+// Layout: [Release][lengths[0]=rows][lengths[1]=cols][ScriptString values...]
+// Each element is a ScriptString carrying its own Release hook (heap-allocated copy),
+// matching the scalar string convention so the lifecycle is owned per element.
 static ScriptArray* MakeStringArray2D(unsigned int rows, unsigned int cols, const char* const* strings)
 {
-   const size_t dataSize = rows * cols * sizeof(const char*);
+   const size_t dataSize = rows * cols * sizeof(ScriptString);
    ScriptArray* array = static_cast<ScriptArray*>(malloc(sizeof(ScriptArray) + 2 * sizeof(unsigned int) + dataSize));
    array->Release = [](ScriptArray* me) { free(me); };
    array->lengths[0] = rows;
    array->lengths[1] = cols;
-   const char** pData = reinterpret_cast<const char**>(&array->lengths[2]);
+   ScriptString* pData = reinterpret_cast<ScriptString*>(&array->lengths[2]);
    for (unsigned int i = 0; i < rows * cols; i++)
-      pData[i] = strings[i];
+   {
+      const size_t n = strlen(strings[i]) + 1;
+      char* s = new char[n];
+      memcpy(s, strings[i], n);
+      pData[i] = { [](ScriptString* str) { delete[] str->string; ++g_stringElemReleaseCount; }, s };
+   }
    return array;
 }
 
@@ -117,6 +128,7 @@ TEST_CASE("Plugin 2D string and bool array marshalling")
 
    SUBCASE("2D string array")
    {
+      g_stringElemReleaseCount = 0;
       VARIANT result = InvokePropertyGet(disp, L"StringArray2D");
       CHECK(V_VT(&result) == (VT_ARRAY | VT_VARIANT));
 
@@ -156,6 +168,11 @@ TEST_CASE("Plugin 2D string and bool array marshalling")
       checkStr(2, 1, "off");
 
       VariantClear(&result);
+
+      // The marshaller copies each element to a BSTR owned by the SAFEARRAY, then the host
+      // releases the source ScriptArray. Each element's ScriptString::Release must run so
+      // plugin-owned strings are freed through the documented per-element lifecycle.
+      CHECK(g_stringElemReleaseCount == 6);
    }
 
    SUBCASE("2D bool array")


### PR DESCRIPTION
## Summary
- Adds `TYPEID_STRING` and `TYPEID_BOOL` support to the array marshaller in `DynamicScript.cpp` (both 1D and 2D code paths), replacing `assert(false)` stubs with working conversions
- Strings are packed as `const char*` pointers in the `ScriptArray` data area and converted to `VT_BSTR` via `MultiByteToWideChar`/`SysAllocStringLen`; bools are packed as `char[]` and mapped to `VT_BOOL`
- Extends the `helloscript` plugin with 1D/2D string and bool array examples so plugin authors have a reference
- Adds a doctest case exercising the 2D marshalling through the full `DynamicTypeLibrary::Invoke` pipeline

## Why
Plugins that use string-identified hardware (e.g. MPF's `"l-1"`, `"coil1"`) need to return data as 2D SAFEARRAYs where column 0 is a string ID and column 1 is a state value. Without string array support, plugin authors targeting macOS/Linux can't match the data formats that existing VBScript tables expect from the Windows COM bridge, splitting the ecosystem.

PinMAME's plugin uses int32 element types because PinMAME's hardware is numbered (lamp 1, coil 5). MPF uses string identifiers, which is why this limitation is hit.

## What changed

**`src/core/DynamicScript.cpp`** — Added `TYPEID_STRING` and `TYPEID_BOOL` cases to `ScriptToCOMVariant` for both 1D and 2D arrays. The string conversion matches the existing scalar string pattern (line ~595). For 2D strings, `VariantClear` is called after `SafeArrayPutElement` to free the local BSTR copy.

**`plugins/helloscript/helloscript.cpp`** — Added 4 example getter functions (`StringArray1D`, `StringArray2D`, `BoolArray1D`, `BoolArray2D`) demonstrating the packing convention for both element types.

**`tests/test-plugin-arrays.cpp`** — New doctest case that creates a standalone `DynamicTypeLibrary`, registers array types and a test class, invokes property getters via `DynamicDispatch`, and verifies SAFEARRAY dimensions and element values (38 assertions).

**`make/vpx-test.vcxproj`** — Added the new test file to the VS test project.

## Memory ownership convention
- Plugin packs `const char*` pointers into the `ScriptArray` data area pointing to plugin-owned strings
- Marshaller copies each string to a BSTR via `SysAllocStringLen`; the SAFEARRAY owns those BSTRs
- After marshalling, `ReleaseScriptVariant` calls `sv.vArray->Release(sv.vArray)` — no cross-boundary ownership transfer

## Test plan
- [x] New doctest case passes on Windows (38/38 assertions, verified via CI)
- [x] All 20 desktop build targets pass (Windows DX9/GL/BGFX, macOS, Linux)
- [x] Mobile builds pass (iOS, Android, Quest)
- [x] SBC builds pass (RPI, RK3588)
- [ ] Existing render test suite (manual — requires GPU)