### PR TITLE
Restore SDL video driver log

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -203,6 +203,9 @@ extern "C" int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, 
          // FIXME this is not correct as we may be running something else than the player (extract vbs, ...)
          exit(1);
       }
+      if (const char* const drv = SDL_GetCurrentVideoDriver()) {
+         PLOGI << "SDL video driver: " << drv;
+      }
 
       // Run the application
       if (cmdLine.m_command)


### PR DESCRIPTION
Logs the SDL3 video driver (e.g. "wayland", "x11", "windows") right after the SDL_INIT_VIDEO subsystem init in WinMain. Useful when diagnosing display-related issues - e.g. SDL3's heuristic of falling back to XWayland on Wayland sessions.

Originally added in ee2f55651, removed in 88baaccfc