### PR TITLE
pup: downgrade CustomPos trailing-parts log to warning

### DIFF
--- a/plugins/pup/PUPCustomPos.cpp
+++ b/plugins/pup/PUPCustomPos.cpp
@@ -5,7 +5,10 @@
 namespace PUP {
 
 /*
-   First number is always the screen. 1,22.5,45.3,55.1,54.7 [pupid # source screen,xpos,ypos,width,height] values in % of pupdisplay. 
+   First number is always the screen. 1,22.5,45.3,55.1,54.7 [pupid # source screen,xpos,ypos,width,height] values in % of pupdisplay.
+   Some packs add a 6th (and beyond) value (seen in PinUp Player). We don't know what it does and don't
+   implement it yet, but it is valid input, so the trailing parts are ignored rather than rejected.
+   TODO implement the trailing value(s)
 */
 
 std::unique_ptr<PUPCustomPos> PUPCustomPos::CreateFromCSV(const string& line)
@@ -18,7 +21,7 @@ std::unique_ptr<PUPCustomPos> PUPCustomPos::CreateFromCSV(const string& line)
       return nullptr;
    }
    if (parts.size() > 5){
-      LOGE(std::format("Ignoring trailing parts for CustomPos. Expected 5 parts, got {}: {}", parts.size(), line));
+      LOGW(std::format("Ignoring trailing parts for CustomPos (6th and beyond not yet implemented), handling 5 of {} parts: {}", parts.size(), line));
    }
 
    std::unique_ptr<PUPCustomPos> pCustomPos = std::make_unique<PUPCustomPos>();


### PR DESCRIPTION
The 6th value (and beyond) in CustomPos selects a mode flag (rotation, front, parenting, loop control) that is not yet implemented. Log it as a warning instead of an error and document the known modes.