### PR TITLE
pup: handle FN 57 (overlay hide) as a known no-op

### DIFF
--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -447,6 +447,14 @@ void PUPPinDisplay::SendMSG(const string& szMsg)
                               pScreen->SetFadeStep(fs);
                         }
                         break;
+                     case 57:
+                        // "Overlay Hide" (OH) toggle for a screen that has text/label overlays.
+                        // PinUp Player 2.0+ only; older players ignore it.
+                        // { "mt":301, "SN": XX, "FN":57, "OH":0/1 } - OH 1 = hide overlay, 0 = show
+                        // We don't act on it yet, so sending it produces no visible change on screen.
+                        // TODO implement overlay hide/show toggling the screen's overlay (HUD) visibility
+                        LOGW(std::format("Overlay hide (OH) toggle not implemented, ignoring: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
+                        break;
                      default:
                         NOT_IMPLEMENTED(std::format("Unknown function not implemented: screen={{{}}}, fn={}, szMsg={}", pScreen->ToString(false), fn, szMsg));
                         break;


### PR DESCRIPTION
FN 57 is a PinUp Player 2.0+ "Overlay Hide" (OH) toggle. We don't act on it yet, so handle it explicitly with a warning instead of letting it fall through to the generic unknown-function error (which asserts in debug). Documents the message format and adds a TODO to implement it.