### PR TITLE
fix: only start ball-control drag on a real in-play ball

### DIFF
--- a/src/ui/live/BallControl.cpp
+++ b/src/ui/live/BallControl.cpp
@@ -35,6 +35,15 @@ void BallControl::SetMode(Mode mode)
    m_mode = mode;
 }
 
+bool BallControl::IsDraggedBallSelectable() const
+{
+   // A ball is only a valid drag target while it is in active play: visible and not held in a kicker
+   // (trough/saucer/lock). Checked at use time rather than registration because a ball's state changes
+   // (e.g. trough balls are briefly unlocked while being shuffled along the trough). Matches the physics
+   // engine, which skips locked balls in HitBall::UpdateVelocities.
+   return m_draggedBall != nullptr && m_draggedBall->m_d.m_visible && !m_draggedBall->m_hitBall.m_d.m_lockedInKicker;
+}
+
 void BallControl::Update(const int width, const int height)
 {
    using enum Mode;
@@ -54,7 +63,7 @@ void BallControl::Update(const int width, const int height)
       break;
 
    case DragBall:
-      if (ImGui::IsMouseDown(ImGuiMouseButton_Left) && !leftFlipperPressed)
+      if (IsDraggedBallSelectable() && ImGui::IsMouseDown(ImGuiMouseButton_Left) && !leftFlipperPressed)
          HandleDragBall(width, height);
       break;
       

--- a/src/ui/live/BallControl.cpp
+++ b/src/ui/live/BallControl.cpp
@@ -35,7 +35,7 @@ void BallControl::SetMode(Mode mode)
    m_mode = mode;
 }
 
-bool BallControl::IsDraggedBallSelectable() const
+bool BallControl::IsSelectedBallDraggable() const
 {
    // A ball is only a valid drag target while it is in active play: visible and not held in a kicker
    // (trough/saucer/lock). Checked at use time rather than registration because a ball's state changes
@@ -63,7 +63,7 @@ void BallControl::Update(const int width, const int height)
       break;
 
    case DragBall:
-      if (IsDraggedBallSelectable() && ImGui::IsMouseDown(ImGuiMouseButton_Left) && !leftFlipperPressed)
+      if (IsSelectedBallDraggable() && ImGui::IsMouseDown(ImGuiMouseButton_Left) && !leftFlipperPressed)
          HandleDragBall(width, height);
       break;
       

--- a/src/ui/live/BallControl.h
+++ b/src/ui/live/BallControl.h
@@ -42,6 +42,7 @@ private:
    void HandleDragBall(const int width, const int height);
    void HandleDestroyBall(const int width, const int height) const;
    void HandleThrowBalls(const int width, const int height);
+   bool IsDraggedBallSelectable() const;
 
    LiveUI& m_liveUI;
    Mode m_mode = Mode::Disabled;

--- a/src/ui/live/BallControl.h
+++ b/src/ui/live/BallControl.h
@@ -42,7 +42,7 @@ private:
    void HandleDragBall(const int width, const int height);
    void HandleDestroyBall(const int width, const int height) const;
    void HandleThrowBalls(const int width, const int height);
-   bool IsDraggedBallSelectable() const;
+   bool IsSelectedBallDraggable() const;
 
    LiveUI& m_liveUI;
    Mode m_mode = Mode::Disabled;


### PR DESCRIPTION
Ball control registers the most recently plunger/kicker-touched ball as the drag target without checking it can actually be dragged, so it could latch onto a ball that isn't in play:
- an invisible helper ball (e.g. Rollercoaster Tycoon's hidden SpinnerBall),
- a ball held in a kicker such as the trough/saucer/lock (which the physics engine already refuses to move, HitBall::UpdateVelocities).

Only start a drag when the target is visible and not held in a kicker, re-checked each frame since the registered ball's state changes. This also stops a click with no valid target from getting stuck "dragging" nothing, which blocked further selection until a flipper press.

_I have another pr coming that visually shows what ball is selected which improves things even more. But that needs more discussion._