### PR TITLE
core.vbs: guard vpmTimer update-list removal against missing key

### DIFF
--- a/scripts/core.vbs
+++ b/scripts/core.vbs
@@ -201,12 +201,19 @@ Class cvpmTimer
 	End Sub
 
 	Sub EnableUpdate(aClass, aFast, aEnabled)
-		On Error Resume Next
 		If aFast Then
-			If aEnabled Then mFastUpdates.Add aClass, 0 : Else mFastUpdates.Remove aClass
+			If aEnabled Then
+				mFastUpdates.Add aClass, 0
+			ElseIf mFastUpdates.Exists(aClass) Then
+				mFastUpdates.Remove aClass
+			End If
 			If IsObject(mFastTimer) Then mFastTimer.TimerEnabled = mFastUpdates.Count > 0
 		Else
-			If aEnabled Then mSlowUpdates.Add aClass, 0 : Else mSlowUpdates.Remove aClass
+			If aEnabled Then
+				mSlowUpdates.Add aClass, 0
+			ElseIf mSlowUpdates.Exists(aClass) Then
+				mSlowUpdates.Remove aClass
+			End If
 		End If
 	End Sub
 


### PR DESCRIPTION
EnableUpdate removed aClass from the fast/slow update dictionary even when it was never registered. Removing a non-existent key raises a Scripting.Dictionary error, previously hidden by On Error Resume Next but logged by the standalone VBScript engine.

Guard the removal with Exists so the error never occurs, and drop the now-unnecessary On Error Resume Next.

It's just cleaner than OERN which tends to also pick up unexpected errors