### PR TITLE
feat: log script file paths when read or loaded

### DIFF
--- a/src/core/ScriptGlobalTable.cpp
+++ b/src/core/ScriptGlobalTable.cpp
@@ -354,7 +354,10 @@ STDMETHODIMP ScriptGlobalTable::GetTextFile(BSTR FileName, BSTR *pContents)
          buffer << scriptFile.rdbuf();
          string content = buffer.str();
          if (szFileName.ends_with(".vbs"))
+         {
+            PLOGI << "Reading script: " << file.string();
             content = g_pplayer->m_pluginAPI.ApplyScriptCOMObjectOverrides(content);
+         }
          *pContents = MakeWideBSTR(content);
          return S_OK;
       }

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -2208,6 +2208,7 @@ void PinTable::LoadScriptOverride(const std::filesystem::path& scriptPath)
       PLOGE << "Failed to open script file";
       return;
    }
+   PLOGI << "Loading script: " << scriptPath.string();
    
    std::streamsize size = file.tellg();
    file.seekg(0, std::ios::beg);


### PR DESCRIPTION
Make it clear which script files (and from which resolved path) a table actually pulls in:

- `GetTextFile` logs `"Reading script: <path>"` for every .vbs it reads (the ExecuteGlobal GetTextFile include chain: controller/core/sega/...). It says "reading" because the caller is not guaranteed to execute it.
- `LoadScriptOverride` logs `"Loading script: <path>"` for an external <table>.vbs sidecar that overrides the embedded table script.

The `fso.OpenTextFile` editor-fallback path lives in the VBScript runtime, not our source, so it is not covered.