### PR TITLE
misc: don't warn for unconfigured PUP folder and display at startup

### DIFF
--- a/plugins/pup/PUPPlugin.cpp
+++ b/plugins/pup/PUPPlugin.cpp
@@ -287,7 +287,11 @@ MSGPI_EXPORT void MSGPIAPI PUPPluginLoad(const uint32_t sessionId, const MsgPlug
    std::filesystem::path rootPath = find_case_insensitive_directory_path(pupFolder / "pupvideos"sv);
    if (rootPath.empty())
    {
-      LOGW("PUP folder was not found (settings is '" + pupFolder.string() + "')");
+      if (pupFolder.empty())
+         // No global folder configured: the per-table 'pupvideos' folder (next to each table) is the primary source.
+         LOGI("No global PUP folder configured; per-table 'pupvideos' used when present");
+      else
+         LOGW("PUP folder was not found (settings is '" + pupFolder.string() + "')");
    }
    pupManager = std::make_unique<PUPManager>(msgApi, endpointId, rootPath);
 }

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -89,11 +89,18 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
 #endif
 
    // Both fullscreen and windowed modes are anchored to a user selected display
-   const DisplayConfig selectedDisplay = GetDisplayConfig(settings.GetWindow_Display((int)m_windowId));
-   if (selectedDisplay.displayName != settings.GetWindow_Display((int)m_windowId))
+   const string configuredDisplay = settings.GetWindow_Display((int)m_windowId);
+   const DisplayConfig selectedDisplay = GetDisplayConfig(configuredDisplay);
+   if (selectedDisplay.displayName != configuredDisplay)
    {
-      PLOGW << "The selected display \"" << settings.GetWindow_Display((int)m_windowId)
-            << "\" is not available. Using display \"" << selectedDisplay.displayName << "\" instead.";
+      if (configuredDisplay.empty())
+      {
+         PLOGI << "No display configured. Using display \"" << selectedDisplay.displayName << "\".";
+      }
+      else
+      {
+         PLOGW << "The selected display \"" << configuredDisplay << "\" is not available. Using display \"" << selectedDisplay.displayName << "\" instead.";
+      }
    }
    int wnd_x = selectedDisplay.left;
    int wnd_y = selectedDisplay.top;


### PR DESCRIPTION
Both logged a WARN on every startup for the normal default (unset) case:

- PUP: an empty global PUP folder is normal. The per-table 'pupvideos' folder next to the table is the primary source and is always checked first; the global folder is only a fallback. Log info for the unset case, and keep the warning for a configured-but-missing folder.
- Display: an empty display setting is normal. Log info naming the display actually used, and keep the warning only when a configured display is unavailable.