### PR TITLE
pup: render ForcePop screens and keep labels on same-page show

### DIFF
--- a/plugins/pup/PUPScreen.cpp
+++ b/plugins/pup/PUPScreen.cpp
@@ -274,10 +274,18 @@ void PUPScreen::SendLabelToFront(PUPLabel* pLabel)
 void PUPScreen::SetPage(int pagenum, int seconds)
 {
    assert(std::this_thread::get_id() == m_apiThread);
+
+   // Reapply each label's on-show default ONLY when the page actually changes. A same-page
+   // hold (e.g. KOTH ball-save LabelShowPage(5,1,3)) must leave script-toggled labels alone -
+   // that was the disappearing-bonus-labels bug.
+   const bool pageChanged = (pagenum != m_pagenum);
    m_pagenum = pagenum;
 
-   for (const auto& label : m_labels)
-      label->SetVisible(label->GetOnShowVisible());
+   if (pageChanged)
+   {
+      for (const auto& label : m_labels)
+         label->SetVisible(label->GetOnShowVisible());
+   }
 
    if (seconds == 0)
    {
@@ -495,10 +503,10 @@ void PUPScreen::Render(VPXRenderContext2D* const ctx, int pass) {
 
    UpdateTimers();
 
-   // Pop screen window are dynamically created/destroyed when playing starts/ends
-   if (IsPop() && !IsMainPlaying())
-      return;
-
+   // ForcePop / ForcePopBack only affect z-order (topmost), handled by the render-order tiers
+   // in PUPManager::Render. The screen still renders its background, overlay, labels and static
+   // image when no main video is playing, so packs that drive a screen purely via background
+   // videos, overlays, or labels stay visible.
    if (m_mode == Mode::Off || m_mode == Mode::MusicOnly)
       return;
 


### PR DESCRIPTION
Discord upset over DD and KOTH not working. 

`ForcePop` screens were only rendered while a queued "main" video was playing, which hid script driven PuP packs.

Tested with the following:

```
"DarkestDungeon_3.06.vpx"
"Indiana Jones (Stern 2008)-Hanibal-2.6.vpx"
"The Matrix (Original) 0.99.0-new-vpx-editor.vpx"
"KOTH-Original-v1.03.vpx"
"Batman66_1.1.0.vpx"
"Cuphead Pro PuP Perdition Edition (D. Goblett & Co 2020).vpx"
"Die Hard Trilogy (VPW 2023) v0.98.vpx"
"Flintstones Cartoon VR Edition (Williams 1994).vpx"
"Futurama (Original 2024) v1.1.vpx"
"GOTG_2.1.1.vpx"
"Monster Bash (Williams 1998) VPWmod v1.0.vpx"
"Stranger Things (Original 2020) LW v3.06.vpx"
"Transformers Pro (Stern 2011) v.2.0.2 with VR Room.vpx"
"Total Nuclear Annihilation (Spooky 2017) VPW v2.3.vpx"
```