### PR TITLE
linux: restore fullscreen for BGFX

### DIFF
--- a/src/core/Settings.cpp
+++ b/src/core/Settings.cpp
@@ -153,6 +153,12 @@ void Settings::UpdateDefaults()
          reg.Register(GetWindow_FSWidth_Property(i)->WithDefault(conf.width));
          reg.Register(GetWindow_FSHeight_Property(i)->WithDefault(conf.height));
          #endif
+         #if defined(ENABLE_BGFX) && !defined(_MSC_VER)
+         // On Linux/macOS a screen-sized borderless window is not promoted to fullscreen by the
+         // compositor, so default the playfield to fullscreen(-desktop) for a usable fresh install.
+         if (i == VPXWindowId::VPXWINDOW_Playfield)
+            reg.Register(GetWindow_FullScreen_Property(i)->WithDefault(true));
+         #endif
          reg.Register(GetWindow_Width_Property(i)->WithDefault(i == 0 ? conf.width : (conf.width / 4)));
          reg.Register(GetWindow_Height_Property(i)->WithDefault(i == 0 ? conf.height : min(conf.width * 4 / 9, conf.height)));
          break;

--- a/src/core/Settings_properties.inl
+++ b/src/core/Settings_properties.inl
@@ -22,8 +22,11 @@ PropIntDyn(Player, PlayfieldWndX, "X Position"s, "Horizontal position of the win
 PropIntDyn(Player, PlayfieldWndY, "Y Position"s, "Vertical position of the window on the selected display"s, 0, 16384, 0);
 PropIntDyn(Player, PlayfieldWidth, "Width"s, "Width of the window"s, 0, 16384, 16384);
 PropIntDyn(Player, PlayfieldHeight, "Height"s, "Height of the window"s, 0, 16384, 16384);
-#ifndef ENABLE_BGFX
+// No fullscreen option on Windows+BGFX: a screen-sized borderless window already acts as fullscreen there.
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
 PropBoolDyn(Player, PlayfieldFullScreen, "Fullscreen"s, "Use fullscreen exclusive mode\nThis should be avoided unless you need to change the display resolution"s, false);
+#endif
+#ifndef ENABLE_BGFX
 PropIntDyn(Player, PlayfieldFSWidth, "Width"s, "Fullscreen display mode width"s, 0, 16384, 16384);
 PropIntDyn(Player, PlayfieldFSHeight, "Height"s, "Fullscreen display mode height"s, 0, 16384, 16384);
 PropFloatDyn(Player, PlayfieldRefreshRate, "Refresh Rate"s, "Fullscreen display mode refresh rate"s, 0.f, 1000.f, 0.f);
@@ -37,8 +40,10 @@ PropIntDyn(Backglass, BackglassWndX, "X Position"s, "Horizontal position of the 
 PropIntDyn(Backglass, BackglassWndY, "Y Position"s, "Vertical position of the window on the selected display"s, 0, 16384, 0);
 PropIntDyn(Backglass, BackglassWidth, "Width"s, "Width of the window"s, 0, 16384, 16384);
 PropIntDyn(Backglass, BackglassHeight, "Height"s, "Height of the window"s, 0, 16384, 16384);
-#ifndef ENABLE_BGFX
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
 PropBoolDyn(Backglass, BackglassFullScreen, "Fullscreen"s, "Use fullscreen exclusive mode\nThis should be avoided unless you need to change the display resolution"s, false);
+#endif
+#ifndef ENABLE_BGFX
 PropIntDyn(Backglass, BackglassFSWidth, "Width"s, "Fullscreen display mode width"s, 0, 16384, 16384);
 PropIntDyn(Backglass, BackglassFSHeight, "Height"s, "Fullscreen display mode height"s, 0, 16384, 16384);
 PropFloatDyn(Backglass, BackglassRefreshRate, "Fullscreen Refresh Rate"s, "Fullscreen display mode refresh rate"s, 0.f, 1000.f, 0.f);
@@ -52,8 +57,10 @@ PropIntDyn(ScoreView, ScoreViewWndX, "X Position"s, "Horizontal position of the 
 PropIntDyn(ScoreView, ScoreViewWndY, "Y Position"s, "Vertical position of the window on the selected display"s, 0, 16384, 0);
 PropIntDyn(ScoreView, ScoreViewWidth, "Width"s, "Width of the window"s, 0, 16384, 16384);
 PropIntDyn(ScoreView, ScoreViewHeight, "Height"s, "Height of the window"s, 0, 16384, 16384);
-#ifndef ENABLE_BGFX
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
 PropBoolDyn(ScoreView, ScoreViewFullScreen, "Fullscreen"s, "Use fullscreen exclusive mode\nThis should be avoided unless you need to change the display resolution"s, false);
+#endif
+#ifndef ENABLE_BGFX
 PropIntDyn(ScoreView, ScoreViewFSWidth, "Width"s, "Fullscreen display mode width"s, 0, 16384, 16384);
 PropIntDyn(ScoreView, ScoreViewFSHeight, "Height"s, "Fullscreen display mode height"s, 0, 16384, 16384);
 PropFloatDyn(ScoreView, ScoreViewRefreshRate, "Fullscreen Refresh Rate"s, "Fullscreen display mode refresh rate"s, 0.f, 1000.f, 0.f);
@@ -67,8 +74,10 @@ PropIntDyn(Topper, TopperWndX, "X Position"s, "Horizontal position of the Topper
 PropIntDyn(Topper, TopperWndY, "Y Position"s, "Vertical position of the Topper window on the selected display"s, 0, 16384, 0);
 PropIntDyn(Topper, TopperWidth, "Width"s, "Width of the Topper window"s, 0, 16384, 16384);
 PropIntDyn(Topper, TopperHeight, "Height"s, "Height of the Topper window"s, 0, 16384, 16384);
-#ifndef ENABLE_BGFX
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
 PropBoolDyn(Topper, TopperFullScreen, "Fullscreen"s, "Use fullscreen exclusive mode for the Topper window\nThis should be avoided unless you need to change the display resolution"s, false);
+#endif
+#ifndef ENABLE_BGFX
 PropIntDyn(Topper, TopperFSWidth, "Width"s, "Fullscreen display mode width for the Topper window"s, 0, 16384, 16384);
 PropIntDyn(Topper, TopperFSHeight, "Height"s, "Fullscreen display mode height for the Topper window"s, 0, 16384, 16384);
 PropFloatDyn(Topper, TopperRefreshRate, "Fullscreen Refresh Rate"s, "Fullscreen display mode refresh rate"s, 0.f, 1000.f, 0.f);
@@ -80,8 +89,10 @@ PropIntDyn(PlayerVR, PreviewWndX, "X Position"s, "Horizontal position of the win
 PropIntDyn(PlayerVR, PreviewWndY, "Y Position"s, "Vertical position of the window on the selected display"s, 0, 16384, 0);
 PropIntDyn(PlayerVR, PreviewWidth, "Width"s, "Width of the window"s, 0, 16384, 16384);
 PropIntDyn(PlayerVR, PreviewHeight, "Height"s, "Height of the window"s, 0, 16384, 16384);
-#ifndef ENABLE_BGFX
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
 PropBoolDyn(PlayerVR, PreviewFullScreen, "Fullscreen"s, "Use fullscreen exclusive mode\nThis should be avoided unless you need to change the display resolution."s, false);
+#endif
+#ifndef ENABLE_BGFX
 PropIntDyn(PlayerVR, PreviewFSWidth, "Width"s, "Fullscreen display mode width"s, 0, 16384, 16384);
 PropIntDyn(PlayerVR, PreviewFSHeight, "Height"s, "Fullscreen display mode height"s, 0, 16384, 16384);
 PropFloatDyn(PlayerVR, PreviewRefreshRate, "Fullscreen Refresh Rate"s, "Fullscreen display mode refresh rate"s, 0.f, 1000.f, 0.f);
@@ -96,9 +107,11 @@ PropArray(Window, WndY, int, Int, Int, m_propPlayer_PlayfieldWndY, m_propBackgla
 PropArray(Window, Width, int, Int, Int, m_propPlayer_PlayfieldWidth, m_propBackglass_BackglassWidth, m_propScoreView_ScoreViewWidth, m_propTopper_TopperWidth, m_propPlayerVR_PreviewWidth);
 PropArray(
    Window, Height, int, Int, Int, m_propPlayer_PlayfieldHeight, m_propBackglass_BackglassHeight, m_propScoreView_ScoreViewHeight, m_propTopper_TopperHeight, m_propPlayerVR_PreviewHeight);
-#ifndef ENABLE_BGFX
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
 PropArray(Window, FullScreen, bool, Bool, Int, m_propPlayer_PlayfieldFullScreen, m_propBackglass_BackglassFullScreen, m_propScoreView_ScoreViewFullScreen, m_propTopper_TopperFullScreen,
    m_propPlayerVR_PreviewFullScreen);
+#endif
+#ifndef ENABLE_BGFX
 PropArray(Window, FSWidth, int, Int, Int, m_propPlayer_PlayfieldFSWidth, m_propBackglass_BackglassFSWidth, m_propScoreView_ScoreViewFSWidth, m_propTopper_TopperFSWidth,
    m_propPlayerVR_PreviewFSWidth);
 PropArray(Window, FSHeight, int, Int, Int, m_propPlayer_PlayfieldFSHeight, m_propBackglass_BackglassFSHeight, m_propScoreView_ScoreViewFSHeight, m_propTopper_TopperFSHeight,

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -74,10 +74,17 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
    : m_windowId(windowId)
    , m_isVR(false)
 {
-#ifdef ENABLE_BGFX
+#if defined(ENABLE_BGFX) && defined(_MSC_VER)
+   // Windows+BGFX: a screen-sized borderless window already acts as fullscreen (Windows fullscreen
+   // optimization), so no explicit fullscreen flag is used and there is no Fullscreen setting.
    m_fullscreen = false;
 #else
+   // BGFX has no exclusive fullscreen (video mode change): for it m_fullscreen requests a
+   // fullscreen-desktop window. This is what makes a screen-sized playfield actually fill the
+   // display on Linux/macOS, where the compositor does not promote a borderless window the way
+   // Windows does. Other backends may still use exclusive fullscreen with a display mode (below).
    m_fullscreen = g_isMobile || settings.GetWindow_FullScreen(m_windowId);
+   #ifndef ENABLE_BGFX
    if (!g_isMobile && m_windowId == VPXWindowId::VPXWINDOW_Playfield)
    {
       // FIXME remove command line override => this is hacky and not needed anymore (use INI override instead)
@@ -86,6 +93,7 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
       else if (g_app->m_disEnableTrueFullscreen == 1)
          m_fullscreen = true;
    }
+   #endif
 #endif
 
    // Both fullscreen and windowed modes are anchored to a user selected display
@@ -161,7 +169,11 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
       m_height = m_fullscreen ? m_screenheight : settings.GetWindow_Height(m_windowId);
       m_refreshrate = selectedDisplay.refreshrate;
       m_bitdepth = selectedDisplay.depth;
+      #if !defined(ENABLE_BGFX) || defined(_MSC_VER)
+      // Exclusive fullscreen failed or was not requested: fall back to windowed. Non-Windows BGFX has
+      // no exclusive mode, so it keeps m_fullscreen here to request a fullscreen-desktop window.
       m_fullscreen = false;
+      #endif
 
       // Constrain window to screen
       if (m_width > m_screenwidth)
@@ -196,8 +208,8 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
    assert(m_height > 0 && m_height <= m_screenheight);
    assert(selectedDisplay.left <= wnd_x);
    assert(selectedDisplay.top <= wnd_y);
-   assert((wnd_x + m_width) <= (selectedDisplay.left + (m_fullscreen ? fullscreenDisplayMode->w : selectedDisplay.width))); // The fullscreen mode may have a different orientation than the display on mobile devices
-   assert((wnd_y + m_height) <= (selectedDisplay.top + (m_fullscreen ? fullscreenDisplayMode->h : selectedDisplay.height)));
+   assert((wnd_x + m_width) <= (selectedDisplay.left + ((m_fullscreen && fullscreenDisplayMode) ? fullscreenDisplayMode->w : selectedDisplay.width))); // The fullscreen mode may have a different orientation than the display on mobile devices
+   assert((wnd_y + m_height) <= (selectedDisplay.top + ((m_fullscreen && fullscreenDisplayMode) ? fullscreenDisplayMode->h : selectedDisplay.height)));
    if (m_refreshrate <= 0)
    {
       PLOGE << "Failed to get display refresh rate. VPX will use a 60Hz default which may be wrong and cause bad video synchronization.";

--- a/src/ui/live/ingameui/DisplaySettingsPage.cpp
+++ b/src/ui/live/ingameui/DisplaySettingsPage.cpp
@@ -290,7 +290,10 @@ void DisplaySettingsPage::BuildWindowPage()
       [this](Settings& settings) { settings.ResetWindow_Display(m_wndId); }, //
       [this](int v, Settings& settings, bool asTableOverride) { settings.SetWindow_Display(m_wndId, m_displays[v].displayName, asTableOverride); }));
 
-#ifndef ENABLE_BGFX
+   // Fullscreen toggle. On BGFX fullscreen means fullscreen-desktop (no exclusive video mode change),
+   // so there is no resolution selector below; other backends additionally show a video-mode picker
+   // when fullscreen is enabled. Not offered on Windows+BGFX (borderless screen-sized acts as fullscreen).
+#if !defined(ENABLE_BGFX) || !defined(_MSC_VER)
    // TODO this property is directly persisted. It does not follow the overall UI design: App/Table/Live state => Implement live state (will also enable table override)
    AddItem(std::make_unique<InGameUIItem>(
               Settings::m_propWindow_FullScreen[m_wndId], //
@@ -304,6 +307,10 @@ void DisplaySettingsPage::BuildWindowPage()
       .m_excludeFromDefault = true;
 
    const bool isFullScreen = m_player->m_ptable->m_settings.GetWindow_FullScreen(m_wndId);
+#else
+   const bool isFullScreen = false;
+#endif
+#ifndef ENABLE_BGFX
    if (isFullScreen)
    {
       int defaultMode = 0, selectedMode = 0, i = 0;
@@ -355,6 +362,7 @@ void DisplaySettingsPage::BuildWindowPage()
    }
    else
 #endif
+   if (!isFullScreen)
    {
       const int containerWidth = m_displays[wndDisplay].width;
       const int containerHeight = m_displays[wndDisplay].height;


### PR DESCRIPTION
On Linux BGFX the playfield stopped going fullscreen: a screen-sized borderless window is not promoted to fullscreen by the compositor the way Windows does, so it ended up placed under panels and clipped off-screen.

Bring back the Fullscreen setting and toggle as fullscreen-desktop (no video mode change), default it on for the playfield, and leave Windows+BGFX unchanged.

To be clear, I agree that `exclusive fullscreen` (mode changes) can be dropped. But there should still be a way to indicate to the compositor on linux that vpinball wants to take up the whole screen.

Somewhat related to #3366 but only focusing on fullscreen and not doing the heuristics

Example of what it looks like for a default config + score/backglass set up in-window  (mind the missing part at the bottom)

<img width="2194" height="1233" alt="image" src="https://github.com/user-attachments/assets/41af2fd4-2660-4c76-afd7-36b801636005" />

