### PR TITLE
flexdmd: fix plugin path resolution on Windows/MinGW

### DIFF
--- a/plugins/flexdmd/common.cpp
+++ b/plugins/flexdmd/common.cpp
@@ -206,7 +206,9 @@ string GetPluginPath()
     if (pathBuf.empty())
         return string();
 
-    const size_t lastSep = pathBuf.find_last_of(PATH_SEPARATOR_CHAR);
+    // Accept both separators: POSIX paths use '/', Win32 APIs (GetModuleFileNameA) always
+    // return '\' regardless of compiler, and PATH_SEPARATOR_CHAR is '/' on MinGW.
+    const size_t lastSep = pathBuf.find_last_of("\\/");
     if (lastSep == string::npos)
         return string();
 


### PR DESCRIPTION
Fixes #3436 

GetModuleFileNameA (Win32 API) always returns backslash-separated paths regardless of the compiler or runtime. PATH_SEPARATOR_CHAR is defined as '/' on MinGW builds, so find_last_of(PATH_SEPARATOR_CHAR) failed to find the directory separator, causing GetPluginPath() to return an empty string and the FlexDMD plugin to fail to locate its assets.

Fix by searching for both separators with find_last_of("\\\\/"), which correctly handles both Win32 backslash paths and POSIX forward-slash paths without conditioning on the build environment.

Logs before and after fix:
* [vpinball-windows-mingw-blood-machines-err.log](https://github.com/user-attachments/files/28369120/vpinball-windows-mingw-blood-machines-err.log)
* [vpinball-windows-mingw-blood-machines-fix.log](https://github.com/user-attachments/files/28369121/vpinball-windows-mingw-blood-machines-fix.log)
