### PR TITLE
pup: fix intermittent segfault and data race

### DIFF
--- a/plugins/pup/PUPMediaPlayer.cpp
+++ b/plugins/pup/PUPMediaPlayer.cpp
@@ -527,14 +527,14 @@ void PUPMediaPlayer::HandleVideoFrame(AVFrame* frame)
 
    // Take ownership of the frame
    FrameInfo& selectedFrame = m_frames[selectedFrameSlot];
+   int targetWidth, targetHeight;
    {
       std::lock_guard lock(m_mutex);
       selectedFrame.valid = false;
+      // Read m_bounds under the lock to avoid a data race with SetBounds()
+      targetWidth = m_bounds.w > 0 ? m_bounds.w : m_pVideoContext->width;
+      targetHeight = m_bounds.h > 0 ? m_bounds.h : m_pVideoContext->height;
    }
-
-   // Lazily create/recreate video frame conversion context and frame queue, adjusted to the render size
-   const int targetWidth = m_bounds.w > 0 ? m_bounds.w : m_pVideoContext->width;
-   const int targetHeight = m_bounds.h > 0 ? m_bounds.h : m_pVideoContext->height;
    constexpr AVPixelFormat targetFormat = AV_PIX_FMT_RGBA;
    if ((selectedFrame.frame != nullptr) && ((selectedFrame.frame->width != targetWidth) || (selectedFrame.frame->height != targetHeight)))
    {

--- a/plugins/pup/PUPMediaPlayer.h
+++ b/plugins/pup/PUPMediaPlayer.h
@@ -39,7 +39,7 @@ private:
    void HandleVideoFrame(AVFrame* pFrame);
 
    string m_name;
-   SDL_Rect m_bounds;
+   SDL_Rect m_bounds = {};
 
    std::atomic<int> m_pendingPlay = 0;
    std::atomic<int> m_pendingStop = 0;


### PR DESCRIPTION
Fixes #3438 

Two bugs in PUPMediaPlayer::HandleVideoFrame:

1. SDL_Rect m_bounds had no initializer. Before SetBounds() is called, m_bounds.w/h contain heap garbage. A positive garbage value passes the
   > 0 guard and is used as texture dimensions; UpdateTexture fails to
   allocate the multi-gigabyte buffer and returns null, av_image_fill_arrays puts null into frame->data[0], and sws_scale writes to address 0. Fix: SDL_Rect m_bounds = {} in the header.

2. SetBounds() writes m_bounds on the command queue thread under m_mutex, but HandleVideoFrame read m_bounds on the decoder thread without the lock — a data race that could produce torn width/height values. Fix: capture targetWidth/targetHeight inside the existing m_mutex lock already taken to invalidate the selected frame slot.

Logs before and after fix:
* [vpinball-windows-mingw-blood-machines-err.log](https://github.com/user-attachments/files/28369952/vpinball-windows-mingw-blood-machines-err.log)
* [vpinball-windows-mingw-blood-machines-fix.log](https://github.com/user-attachments/files/28369957/vpinball-windows-mingw-blood-machines-fix.log)
