### PR TITLE
wmp: fix audio underrun caused by sleep_for drift accumulation

### DIFF
--- a/plugins/wmp/WMPAudioPlayer.cpp
+++ b/plugins/wmp/WMPAudioPlayer.cpp
@@ -16,12 +16,12 @@ struct AudioCallbackData {
 
 static uint32_t nextAudioResId = 1;
 
-WMPAudioPlayer::WMPAudioPlayer(MsgPluginAPI* msgApi, uint32_t endpointId, unsigned int onAudioUpdateId) 
+WMPAudioPlayer::WMPAudioPlayer(MsgPluginAPI* msgApi, uint32_t endpointId, unsigned int onAudioUpdateId)
    : m_msgApi(msgApi)
    , m_endpointId(endpointId)
    , m_onAudioUpdateId(onAudioUpdateId)
    , m_isLoaded(false)
-   , m_isPlaying(false) 
+   , m_isPlaying(false)
    , m_isPaused(false)
    , m_volume(0.5f)
    , m_shouldStopStreaming(false)
@@ -188,7 +188,12 @@ void WMPAudioPlayer::StartStreaming()
    m_thread = std::thread([this]() {
       constexpr size_t bufferSizeFrames = BUFFER_SIZE_FRAMES;
       float* audioBuffer = new float[bufferSizeFrames * m_channels];
-   
+
+      // Anchor all sleep targets to an absolute clock so that OS timer
+      // overshoot on one iteration is corrected by a shorter sleep on the
+      // next, rather than accumulating indefinitely.
+      auto nextSendTime = std::chrono::steady_clock::now();
+
       while (!m_shouldStopStreaming && m_isPlaying && !m_isPaused) {
          ma_uint64 framesRead = 0;
          const ma_result result = wmp_ma_decoder_read_pcm_frames(&m_decoder, audioBuffer, bufferSizeFrames, &framesRead);
@@ -206,8 +211,12 @@ void WMPAudioPlayer::StartStreaming()
 
          SendAudioChunk(audioBuffer, (size_t)framesRead);
 
-         double bufferDurationMs = (double)framesRead / (double)m_sampleRate * 1000.0;
-         std::this_thread::sleep_for(std::chrono::microseconds((int)(bufferDurationMs * 800.)));
+         // Advance the absolute target by 80% of this chunk's duration.
+         // If we already overslept, sleep_until returns immediately and the
+         // next chunk is sent without delay, self-correcting the drift.
+         const double chunkDurationUs = (double)framesRead / (double)m_sampleRate * 1e6;
+         nextSendTime += std::chrono::microseconds((long long)(chunkDurationUs * 0.8));
+         std::this_thread::sleep_until(nextSendTime);
       }
 
       if (!m_shouldStopStreaming) {


### PR DESCRIPTION
Fixes #3440 

Replace sleep_for with sleep_until against a steady_clock anchor in WMPAudioPlayer::StartStreaming(). The anchor advances by 80% of each chunk's duration; if the OS oversleeps on one iteration the next sleep_until fires proportionally sooner, self-correcting drift rather than allowing it to accumulate.

On Windows the default timer resolution is 15.6ms, so sleep_for(18.6ms) could regularly overshoot to 31.2ms (two timer ticks), eventually starving the audio consumer.

Before and after audio captures:

https://github.com/user-attachments/assets/8d0ddf3f-e9c7-4cf5-845a-e1a940e24cbf

https://github.com/user-attachments/assets/f823f38f-07a3-41a0-b0c1-fafb0781f071
