### PR TITLE
flexdmd: fix use-after-free when Group.Get matches self

### DIFF
--- a/plugins/flexdmd/actors/Group.cpp
+++ b/plugins/flexdmd/actors/Group.cpp
@@ -66,7 +66,10 @@ void Group::Draw(Flex::SurfaceGraphics* pGraphics)
 Actor* Group::Get(const string& name, bool logMissing)
 {
    if (GetName() == name)
+   {
+      AddRef();
       return this;
+   }
 
    if (GetFlexDMD()->GetRuntimeVersion() <= 1008)
    {


### PR DESCRIPTION
Group::Get returns an owned (+1) reference on every path except the GetName()==name self-match, which returned 'this' without AddRef. Callers (HasChild, script dispatch wrappers) Release the result, so matching a group by its own name over-released it and freed a live on-stage actor, crashing on the next access.

This crashed https://vpuniverse.com/files/file/8524-timon-and-pumbaas-jungle-pinball/ on table startup