### PR TITLE
core: don't crash when script passes Nothing as an object arg

### DIFF
--- a/src/core/DynamicScript.cpp
+++ b/src/core/DynamicScript.cpp
@@ -421,6 +421,11 @@ bool DynamicTypeLibrary::COMToScriptVariant(const VARIANT* cv, const ScriptTypeN
       if ((V_VT(cv) == VT_DISPATCH) || (V_VT(cv) == (VT_BYREF | VT_DISPATCH)))
       {
          DynamicDispatch* dispatch = static_cast<DynamicDispatch*>((V_VT(cv) & VT_BYREF) ? *V_DISPATCHREF(cv) : V_DISPATCH(cv));
+         if (dispatch == nullptr)
+         {
+            PLOGE << "Null object (Nothing) passed where an object of class " << typeDef.classDef->classDef->name.name << " was expected";
+            return false;
+         }
          sv.vObject = dispatch->m_nativeObject;
          if (sv.vObject != nullptr)
             PSC_ADD_REF(typeDef.classDef->classDef, sv.vObject);
@@ -428,6 +433,11 @@ bool DynamicTypeLibrary::COMToScriptVariant(const VARIANT* cv, const ScriptTypeN
       else if ((V_VT(cv) == VT_UNKNOWN) || (V_VT(cv) == (VT_BYREF | VT_UNKNOWN)))
       {
          DynamicDispatch* dispatch = static_cast<DynamicDispatch*>((V_VT(cv) & VT_BYREF) ? *V_UNKNOWNREF(cv) : V_UNKNOWN(cv));
+         if (dispatch == nullptr)
+         {
+            PLOGE << "Null object (Nothing) passed where an object of class " << typeDef.classDef->classDef->name.name << " was expected";
+            return false;
+         }
          sv.vObject = dispatch->m_nativeObject;
          if (sv.vObject != nullptr)
             PSC_ADD_REF(typeDef.classDef->classDef, sv.vObject);


### PR DESCRIPTION
COMToScriptVariant dereferenced the dispatch pointer of a VT_DISPATCH/ VT_UNKNOWN variant without a null check, so passing Nothing where a plugin object was expected segfaulted instead of being treated as a null object. A script error should not crash vpinball.

```
  ERROR [COMToScriptVariant@426] Null object (Nothing) passed where an object of class FlexDMD_Actor was expected
  ERROR [Invoke@911]              Failed to convert a parameter in call to FlexDMD_Group.AddActor
```

https://vpuniverse.com/files/file/27952-the-grinchs-how-to-steal-christmas/