### PR TITLE
flexdmd: don't prepend base path to absolute asset paths

### DIFF
--- a/plugins/flexdmd/resources/AssetManager.cpp
+++ b/plugins/flexdmd/resources/AssetManager.cpp
@@ -134,7 +134,7 @@ AssetSrc* AssetManager::ResolveSrc(const string& src, AssetSrc* pBaseSrc)
    }
    else {
       pAssetSrc->SetSrcType(AssetSrcType_File);
-      if (!pBaseSrc)
+      if (!pBaseSrc && !std::filesystem::path(parts[0]).is_absolute())
          pAssetSrc->SetPath(m_szBasePath + parts[0]);
       else
          pAssetSrc->SetPath(parts[0]);


### PR DESCRIPTION
AssetManager::ResolveSrc unconditionally prefixed the base path (./) to file asset sources, so an absolute path from the script (e.g. FlexPath built from fso.GetAbsolutePathName) became .//home/... and failed to load. Skip the prefix when the source is already absolute, matching the original .NET FlexDMD Path.Combine behavior.

Fixes loading of https://vpuniverse.com/files/file/27952-the-grinchs-how-to-steal-christmas/ on standalone