### PR TITLE
Fix VBScript TypeName() returning Object on Windows MinGW

### DIFF
--- a/src/core/ScriptGlobalTable.h
+++ b/src/core/ScriptGlobalTable.h
@@ -12,7 +12,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
 #endif
    // Headers to support communication between the game and the script.
    STDMETHOD(EndModal)();

--- a/src/core/ScriptInterpreter.h
+++ b/src/core/ScriptInterpreter.h
@@ -108,7 +108,7 @@ private:
 
    /**
     * Will be nullptr on systems that don't support debugging.
-    * 
+    *
     * For example, wine 6.9 says ...
     * > no class object {78a51822-51f4-11d0-8f20-00805f2cd064} could be created for context 0x17
     * ... if I try to create CLSID_ProcessDebugManager
@@ -129,7 +129,7 @@ private:
    public:
       STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId);
       STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr);
-      STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+      STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
 #endif
       BEGIN_COM_MAP(DebuggerModule)
       COM_INTERFACE_ENTRY(IVPDebug)

--- a/src/parts/Collection.h
+++ b/src/parts/Collection.h
@@ -16,7 +16,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Collection();

--- a/src/parts/PartGroup.h
+++ b/src/parts/PartGroup.h
@@ -53,7 +53,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    PartGroup() { }

--- a/src/parts/ball.h
+++ b/src/parts/ball.h
@@ -119,7 +119,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Ball();

--- a/src/parts/bumper.h
+++ b/src/parts/bumper.h
@@ -54,7 +54,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Bumper() { m_d.m_ringDropOffset = 0.0f; }

--- a/src/parts/decal.h
+++ b/src/parts/decal.h
@@ -47,7 +47,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Decal() { m_wzName = L"Decal"sv; }

--- a/src/parts/dispreel.h
+++ b/src/parts/dispreel.h
@@ -52,7 +52,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    DispReel() { m_desktopBackdrop = true; } // DispReel is always located on backdrop
@@ -132,7 +132,7 @@ public:
        m_d.m_v2.y = m_d.m_v1.y + getBoxHeight();
    }
    float   GetSpacing() const { return m_d.m_reelspacing; }
-   void    SetSpacing(const float newSpace) 
+   void    SetSpacing(const float newSpace)
    {
        m_d.m_reelspacing = max(0.0f, newSpace);
        m_d.m_v2.x = m_d.m_v1.x + getBoxWidth();

--- a/src/parts/dragpoint.h
+++ b/src/parts/dragpoint.h
@@ -20,7 +20,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
 #endif
    DragPoint() { }
 

--- a/src/parts/flasher.h
+++ b/src/parts/flasher.h
@@ -81,7 +81,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Flasher() { m_menuid = IDR_SURFACEMENU; }

--- a/src/parts/flipper.h
+++ b/src/parts/flipper.h
@@ -6,7 +6,7 @@
 #include "physics/hitable.h"
 #include "physics/hitflipper.h"
 #include "renderer/Renderable.h"
-#include "ui/win/resource.h"  
+#include "ui/win/resource.h"
 #include "utils/eventproxy.h"
 
 
@@ -17,7 +17,7 @@ class FlipperData final : public BaseProperty
 public:
    float m_BaseRadius;
    float m_EndRadius;
-   float m_FlipperRadiusMin; // the flipper length reduction at maximum difficulty 
+   float m_FlipperRadiusMin; // the flipper length reduction at maximum difficulty
    float m_FlipperRadiusMax;
    float m_FlipperRadius;
    float m_StartAngle;
@@ -78,7 +78,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Flipper() { }

--- a/src/parts/gate.h
+++ b/src/parts/gate.h
@@ -47,7 +47,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Gate() { }

--- a/src/parts/hittarget.h
+++ b/src/parts/hittarget.h
@@ -64,7 +64,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
 

--- a/src/parts/kicker.h
+++ b/src/parts/kicker.h
@@ -50,7 +50,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Kicker() { }
@@ -65,8 +65,8 @@ public:
       COM_INTERFACE_ENTRY(IProvideClassInfo)
       COM_INTERFACE_ENTRY(IProvideClassInfo2)
    END_COM_MAP()
-   //DECLARE_NOT_AGGREGATABLE(Kicker) 
-   // Remove the comment from the line above if you don't want your object to 
+   //DECLARE_NOT_AGGREGATABLE(Kicker)
+   // Remove the comment from the line above if you don't want your object to
    // support aggregation.
 
    BEGIN_CONNECTION_POINT_MAP(Kicker)

--- a/src/parts/light.h
+++ b/src/parts/light.h
@@ -88,7 +88,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Light() : m_lightcenter(this) { m_menuid = IDR_SURFACEMENU; m_d.m_depthBias = 0.0f; m_d.m_shape = ShapeCustom; m_d.m_visible = true; }

--- a/src/parts/lightseq.h
+++ b/src/parts/lightseq.h
@@ -84,7 +84,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    LightSeq() { }

--- a/src/parts/pintable.h
+++ b/src/parts/pintable.h
@@ -72,7 +72,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    STDMETHOD(get_BallFrontDecal)(/*[out, retval]*/ BSTR *pVal);

--- a/src/parts/plunger.h
+++ b/src/parts/plunger.h
@@ -121,7 +121,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    BEGIN_COM_MAP(Plunger)

--- a/src/parts/primitive.h
+++ b/src/parts/primitive.h
@@ -90,7 +90,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
 

--- a/src/parts/ramp.h
+++ b/src/parts/ramp.h
@@ -57,7 +57,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Ramp()

--- a/src/parts/rubber.h
+++ b/src/parts/rubber.h
@@ -50,7 +50,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Rubber()

--- a/src/parts/spinner.h
+++ b/src/parts/spinner.h
@@ -48,7 +48,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Spinner() { }

--- a/src/parts/surface.h
+++ b/src/parts/surface.h
@@ -18,7 +18,7 @@ class MeshBuffer;
 class SurfaceData final : public BaseProperty
 {
 public:
-   float m_slingshot_threshold;	// speed at which ball needs to trigger slingshot 
+   float m_slingshot_threshold;	// speed at which ball needs to trigger slingshot
    string m_szSideImage;
    string m_szTopMaterial;
    string m_szSideMaterial;
@@ -59,7 +59,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
 

--- a/src/parts/textbox.h
+++ b/src/parts/textbox.h
@@ -49,7 +49,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Textbox() { m_desktopBackdrop = true; } // Textbox is always located on backdrop
@@ -63,8 +63,8 @@ public:
       COM_INTERFACE_ENTRY(IProvideClassInfo2)
       //COM_INTERFACE_ENTRY(ISupportErrorInfo)
    END_COM_MAP()
-   //DECLARE_NOT_AGGREGATABLE(Textbox) 
-   // Remove the comment from the line above if you don't want your object to 
+   //DECLARE_NOT_AGGREGATABLE(Textbox)
+   // Remove the comment from the line above if you don't want your object to
    // support aggregation.
 
    BEGIN_CONNECTION_POINT_MAP(Textbox)

--- a/src/parts/timer.h
+++ b/src/parts/timer.h
@@ -38,7 +38,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Timer() { }

--- a/src/parts/trigger.h
+++ b/src/parts/trigger.h
@@ -50,7 +50,7 @@ public:
 #ifdef __STANDALONE__
    STDMETHOD(GetIDsOfNames)(REFIID /*riid*/, LPOLESTR* rgszNames, UINT cNames, LCID lcid,DISPID* rgDispId);
    STDMETHOD(Invoke)(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
-   STDMETHOD(GetDocumentation)(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
+   STDMETHOD(GetDocumentation)(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile);
    HRESULT FireDispID(const DISPID dispid, DISPPARAMS * const pdispparams) final;
 #endif
    Trigger() { m_menuid = IDR_SURFACEMENU; }
@@ -65,8 +65,8 @@ public:
       COM_INTERFACE_ENTRY(IProvideClassInfo)
       COM_INTERFACE_ENTRY(IProvideClassInfo2)
    END_COM_MAP()
-   //DECLARE_NOT_AGGREGATABLE(Trigger) 
-   // Remove the comment from the line above if you don't want your object to 
+   //DECLARE_NOT_AGGREGATABLE(Trigger)
+   // Remove the comment from the line above if you don't want your object to
    // support aggregation.
 
    BEGIN_CONNECTION_POINT_MAP(Trigger)

--- a/standalone/idl/parser/src/main/java/org/vpinball/IDLParserToCpp.java
+++ b/standalone/idl/parser/src/main/java/org/vpinball/IDLParserToCpp.java
@@ -335,7 +335,7 @@ public class IDLParserToCpp {
 		buffer.append("\n");
 		buffer.append("};\n");
 		buffer.append("\n");
-		
+
 		buffer.append("size_t min = 1, max = ARRAYSIZE(namesIdsList) - 1, i;\n");
 		buffer.append("int r;\n");
 		buffer.append("while(min <= max) {\n");
@@ -400,7 +400,7 @@ public class IDLParserToCpp {
 		for (String key : dispatchMap.keySet()) {
 			Dispatch dispatch = dispatchMap.get(key);
 
-			buffer.append("case " + dispatch.getId() + ": {\n"); 
+			buffer.append("case " + dispatch.getId() + ": {\n");
 
 			int index = 0;
 
@@ -421,8 +421,8 @@ public class IDLParserToCpp {
 				buffer.append("}\n");
 			}
 
-			buffer.append("break;\n"); 
-			buffer.append("}\n"); 
+			buffer.append("break;\n");
+			buffer.append("}\n");
 		}
 
 		if (enumMap != null) {
@@ -457,7 +457,7 @@ public class IDLParserToCpp {
 		buffer.append("\n");
 
 		if (!excludeDocumentation) {
-			buffer.append("STDMETHODIMP " + idlInterface.getClassName() + "::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {\n");
+			buffer.append("STDMETHODIMP " + idlInterface.getClassName() + "::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {\n");
 			buffer.append("if (index == MEMBERID_NIL) {\n");
 			buffer.append("*pBstrName = SysAllocString(L\"" + idlInterface.getDocumentationName() + "\");\n");
 			buffer.append("return S_OK;\n");
@@ -549,7 +549,7 @@ public class IDLParserToCpp {
 		buffer.append("\n");
 		buffer.append("};\n");
 		buffer.append("\n");
-		
+
 		buffer.append("static WCHAR wzName[MAXSTRING];\n");
 		buffer.append("size_t min = 1, max = ARRAYSIZE(idsNamesList) - 1, i;\n");
 		buffer.append("int r;\n");
@@ -765,22 +765,22 @@ public class IDLParserToCpp {
 				else if ("LONG_PTR".equals(param.getType())) {
 					header.append(generateHeaderVariant(index, param, "VT_UI4", method));
 					buffer.append("(LONG_PTR)V_UI4(&var" + index + ")");
-				}   
+				}
 				else if ("UserDefaultOnOff".equals(param.getType())
 						|| "FXAASettings".equals(param.getType())
 						|| "PhysicsSet".equals(param.getType())
 						|| "BackglassIndex".equals(param.getType())
 						|| "ImageAlignment".equals(param.getType())
-						|| "PlungerType".equals(param.getType()) 
-						|| "TextAlignment".equals(param.getType()) 
+						|| "PlungerType".equals(param.getType())
+						|| "TextAlignment".equals(param.getType())
 						|| "TriggerShape".equals(param.getType())
-						|| "LightState".equals(param.getType()) 
-						|| "KickerType".equals(param.getType()) 
-						|| "DecalType".equals(param.getType()) 
-						|| "SizingType".equals(param.getType()) 
-						|| "TargetType".equals(param.getType()) 
-						|| "GateType".equals(param.getType()) 
-						|| "RampType".equals(param.getType()) 
+						|| "LightState".equals(param.getType())
+						|| "KickerType".equals(param.getType())
+						|| "DecalType".equals(param.getType())
+						|| "SizingType".equals(param.getType())
+						|| "TargetType".equals(param.getType())
+						|| "GateType".equals(param.getType())
+						|| "RampType".equals(param.getType())
 						|| "RampImageAlignment".equals(param.getType())
 						|| "SequencerState".equals(param.getType())
 						|| "RenderMode".equals(param.getType())
@@ -915,7 +915,7 @@ public class IDLParserToCpp {
 		index = 0;
 
 		for (Param param : method.getParamList()) {
-			if (param.getParamType() != ParamType.OUT && 
+			if (param.getParamType() != ParamType.OUT &&
 					param.getParamType() != ParamType.OUT_RETVAL) {
 				buffer.append("VariantClear(&var" + index + ");\n");
 			}

--- a/standalone/vpinball_standalone_i_proxy.cpp
+++ b/standalone/vpinball_standalone_i_proxy.cpp
@@ -123,7 +123,7 @@ STDMETHODIMP Collection::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid,
 	return hres;
 }
 
-STDMETHODIMP Collection::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Collection::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Collection");
 		return S_OK;
@@ -2183,7 +2183,7 @@ STDMETHODIMP PinTable::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, W
 	return hres;
 }
 
-STDMETHODIMP PinTable::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP PinTable::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Table");
 		return S_OK;
@@ -5026,7 +5026,7 @@ STDMETHODIMP ScriptGlobalTable::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCI
 	return hres;
 }
 
-STDMETHODIMP ScriptGlobalTable::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP ScriptGlobalTable::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"TableGlobal");
 		return S_OK;
@@ -5156,7 +5156,7 @@ STDMETHODIMP ScriptInterpreter::DebuggerModule::Invoke(DISPID dispIdMember, REFI
 	return hres;
 }
 
-STDMETHODIMP ScriptInterpreter::DebuggerModule::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP ScriptInterpreter::DebuggerModule::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"VPDebug");
 		return S_OK;
@@ -6028,7 +6028,7 @@ STDMETHODIMP Surface::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Surface::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Surface::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Wall");
 		return S_OK;
@@ -6282,7 +6282,7 @@ STDMETHODIMP DragPoint::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, 
 	return hres;
 }
 
-STDMETHODIMP DragPoint::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP DragPoint::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"ControlPoint");
 		return S_OK;
@@ -7129,7 +7129,7 @@ STDMETHODIMP Flipper::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Flipper::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Flipper::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Flipper");
 		return S_OK;
@@ -7331,7 +7331,7 @@ STDMETHODIMP Timer::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD
 	return hres;
 }
 
-STDMETHODIMP Timer::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Timer::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Timer");
 		return S_OK;
@@ -8223,7 +8223,7 @@ STDMETHODIMP Plunger::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Plunger::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Plunger::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Plunger");
 		return S_OK;
@@ -8714,7 +8714,7 @@ STDMETHODIMP Textbox::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Textbox::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Textbox::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Textbox");
 		return S_OK;
@@ -9456,7 +9456,7 @@ STDMETHODIMP Bumper::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WOR
 	return hres;
 }
 
-STDMETHODIMP Bumper::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Bumper::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Bumper");
 		return S_OK;
@@ -9971,7 +9971,7 @@ STDMETHODIMP Trigger::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Trigger::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Trigger::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Trigger");
 		return S_OK;
@@ -10852,7 +10852,7 @@ STDMETHODIMP Light::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD
 	return hres;
 }
 
-STDMETHODIMP Light::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Light::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Light");
 		return S_OK;
@@ -11514,7 +11514,7 @@ STDMETHODIMP Kicker::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WOR
 	return hres;
 }
 
-STDMETHODIMP Kicker::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Kicker::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Kicker");
 		return S_OK;
@@ -11940,7 +11940,7 @@ STDMETHODIMP Decal::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD
 	return hres;
 }
 
-STDMETHODIMP Decal::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Decal::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Decal");
 		return S_OK;
@@ -13458,7 +13458,7 @@ STDMETHODIMP Primitive::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, 
 	return hres;
 }
 
-STDMETHODIMP Primitive::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Primitive::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Primitive");
 		return S_OK;
@@ -14313,7 +14313,7 @@ STDMETHODIMP HitTarget::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, 
 	return hres;
 }
 
-STDMETHODIMP HitTarget::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP HitTarget::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"HitTarget");
 		return S_OK;
@@ -14991,7 +14991,7 @@ STDMETHODIMP Gate::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD 
 	return hres;
 }
 
-STDMETHODIMP Gate::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Gate::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Gate");
 		return S_OK;
@@ -15532,7 +15532,7 @@ STDMETHODIMP Spinner::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Spinner::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Spinner::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Spinner");
 		return S_OK;
@@ -16327,7 +16327,7 @@ STDMETHODIMP Ramp::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD 
 	return hres;
 }
 
-STDMETHODIMP Ramp::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Ramp::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Ramp");
 		return S_OK;
@@ -17045,7 +17045,7 @@ STDMETHODIMP Flasher::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WO
 	return hres;
 }
 
-STDMETHODIMP Flasher::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Flasher::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Flasher");
 		return S_OK;
@@ -17644,7 +17644,7 @@ STDMETHODIMP Rubber::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WOR
 	return hres;
 }
 
-STDMETHODIMP Rubber::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Rubber::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"Rubber");
 		return S_OK;
@@ -18297,7 +18297,7 @@ STDMETHODIMP Ball::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, WORD 
 	return hres;
 }
 
-STDMETHODIMP Ball::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP Ball::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"IBall");
 		return S_OK;
@@ -19024,7 +19024,7 @@ STDMETHODIMP DispReel::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, W
 	return hres;
 }
 
-STDMETHODIMP DispReel::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP DispReel::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"DispReel");
 		return S_OK;
@@ -19222,7 +19222,7 @@ STDMETHODIMP PartGroup::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, 
 	return hres;
 }
 
-STDMETHODIMP PartGroup::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP PartGroup::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"PartGroup");
 		return S_OK;
@@ -19548,7 +19548,7 @@ STDMETHODIMP LightSeq::Invoke(DISPID dispIdMember, REFIID /*riid*/, LCID lcid, W
 	return hres;
 }
 
-STDMETHODIMP LightSeq::GetDocumentation(INT index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
+STDMETHODIMP LightSeq::GetDocumentation(MEMBERID index, BSTR *pBstrName, BSTR *pBstrDocString, DWORD *pdwHelpContext, BSTR *pBstrHelpFile) {
 	if (index == MEMBERID_NIL) {
 		*pBstrName = SysAllocString(L"LightSeq");
 		return S_OK;


### PR DESCRIPTION
Fixes #3413 

On Windows MinGW, LONG (used by MEMBERID) and INT are distinct types (long vs int), so GetDocumentation(INT index, ...) did not override ITypeInfo::GetDocumentation(MEMBERID memid, ...) and the vtable slot remained pointing at IDispatchImpl's E_NOTIMPL stub. This caused TypeName() to fall through to return Object for all VPX host objects, triggering VBScript error 17 in core.vbs TypeName() guards (e.g. WHO Dunnit).

Change all 26 GetDocumentation declarations (headers) and definitions (standalone/vpinball_standalone_i_proxy.cpp) from INT index to MEMBERID index so the override correctly binds on all platforms including MinGW.

Also fix the IDL code generator (IDLParserToCpp.java) so regenerating the proxy does not reintroduce the bug.

File logs before and after change:
* [vpinball-windows-mingw-acdc-err.log](https://github.com/user-attachments/files/28445404/vpinball-windows-mingw-acdc-err.log)
* [vpinball-windows-mingw-acdc-fix.log](https://github.com/user-attachments/files/28445407/vpinball-windows-mingw-acdc-fix.log)
