### PR TITLE
Fix normalize_path_separators destroying UNC path prefix

### DIFF
--- a/plugins/flexdmd/common.cpp
+++ b/plugins/flexdmd/common.cpp
@@ -90,7 +90,8 @@ string normalize_path_separators(const string& szPath)
       std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
    #endif
 
-   auto end = std::unique(szResult.begin(), szResult.end(),
+   const bool isUNC = szResult.size() >= 2 && szResult[0] == PATH_SEPARATOR_CHAR && szResult[1] == PATH_SEPARATOR_CHAR;
+   auto end = std::unique(isUNC ? szResult.begin() + 2 : szResult.begin(), szResult.end(),
       [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
    szResult.erase(end, szResult.end());
 

--- a/plugins/pup/common.cpp
+++ b/plugins/pup/common.cpp
@@ -162,7 +162,8 @@ string normalize_path_separators(const string& szPath)
       std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
    #endif
 
-   auto end = std::unique(szResult.begin(), szResult.end(),
+   const bool isUNC = szResult.size() >= 2 && szResult[0] == PATH_SEPARATOR_CHAR && szResult[1] == PATH_SEPARATOR_CHAR;
+   auto end = std::unique(isUNC ? szResult.begin() + 2 : szResult.begin(), szResult.end(),
       [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
    szResult.erase(end, szResult.end());
 

--- a/plugins/serum/common.cpp
+++ b/plugins/serum/common.cpp
@@ -9,7 +9,7 @@
 #endif
 
 namespace Serum {
-   
+
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -64,7 +64,8 @@ string normalize_path_separators(const string& szPath)
       std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
    #endif
 
-   auto end = std::unique(szResult.begin(), szResult.end(),
+   const bool isUNC = szResult.size() >= 2 && szResult[0] == PATH_SEPARATOR_CHAR && szResult[1] == PATH_SEPARATOR_CHAR;
+   auto end = std::unique(isUNC ? szResult.begin() + 2 : szResult.begin(), szResult.end(),
       [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
    szResult.erase(end, szResult.end());
 

--- a/plugins/vni/common.cpp
+++ b/plugins/vni/common.cpp
@@ -64,7 +64,8 @@ string normalize_path_separators(const string& szPath)
       std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
    #endif
 
-   auto end = std::unique(szResult.begin(), szResult.end(),
+   const bool isUNC = szResult.size() >= 2 && szResult[0] == PATH_SEPARATOR_CHAR && szResult[1] == PATH_SEPARATOR_CHAR;
+   auto end = std::unique(isUNC ? szResult.begin() + 2 : szResult.begin(), szResult.end(),
       [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
    szResult.erase(end, szResult.end());
 

--- a/plugins/wmp/common.cpp
+++ b/plugins/wmp/common.cpp
@@ -31,7 +31,8 @@ string normalize_path_separators(const string& szPath)
       std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
    #endif
 
-   auto end = std::unique(szResult.begin(), szResult.end(),
+   const bool isUNC = szResult.size() >= 2 && szResult[0] == PATH_SEPARATOR_CHAR && szResult[1] == PATH_SEPARATOR_CHAR;
+   auto end = std::unique(isUNC ? szResult.begin() + 2 : szResult.begin(), szResult.end(),
       [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
    szResult.erase(end, szResult.end());
 

--- a/src/core/def.cpp
+++ b/src/core/def.cpp
@@ -599,7 +599,8 @@ string normalize_path_separators(const string& szPath)
       std::ranges::replace(szResult.begin(), szResult.end(), '/', PATH_SEPARATOR_CHAR);
    #endif
 
-   auto end = std::unique(szResult.begin(), szResult.end(),
+   const bool isUNC = szResult.size() >= 2 && szResult[0] == PATH_SEPARATOR_CHAR && szResult[1] == PATH_SEPARATOR_CHAR;
+   auto end = std::unique(isUNC ? szResult.begin() + 2 : szResult.begin(), szResult.end(),
       [](char a, char b) { return a == b && a == PATH_SEPARATOR_CHAR; });
    szResult.erase(end, szResult.end());
 


### PR DESCRIPTION
Fixes #3454

std::unique with the PATH_SEPARATOR_CHAR predicate was collapsing the intentional leading \\\\ of UNC paths (\\\\server\\share\\...) to a single \\, making the path invalid and silently breaking file resolution on network shares and mapped drives that resolve to UNC via weakly_canonical().

Logs before and after fix:
* [vpinball-windows-bloodmachines-err.log](https://github.com/user-attachments/files/28448697/vpinball-windows-bloodmachines-err.log) (wmp; silent)
* [vpinball-windows-bloodmachines-fix.log](https://github.com/user-attachments/files/28448701/vpinball-windows-bloodmachines-fix.log)
* [vpinball-windows-strangerthings-err.log](https://github.com/user-attachments/files/28448705/vpinball-windows-strangerthings-err.log) (flexdmd)
* [vpinball-windows-strangerthings-fix.log](https://github.com/user-attachments/files/28448707/vpinball-windows-strangerthings-fix.log)
