### PR TITLE
fix: ignore out of range BackglassMode values

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -7147,8 +7147,7 @@ STDMETHODIMP PinTable::get_BackglassMode(BackglassIndex *pVal)
 
 STDMETHODIMP PinTable::put_BackglassMode(BackglassIndex pVal)
 {
-   PLOGE << "BackglassMode is deprecated";
-   m_viewMode = (ViewSetupID)(pVal - DESKTOP);
+   PLOGE << "BackglassMode is deprecated and ignored, this call has no effect";
    return S_OK;
 }
 


### PR DESCRIPTION
put_BackglassMode computed m_viewMode = pVal - DESKTOP without validation. A script passing a raw 0/1 index (as Thunderbirds does) instead of the DESKTOP..FULL_SINGLE_SCREEN enum planted an out of range value into m_viewMode, causing out of bounds reads of m_BG_image / mViewSetups: intermittent crash or grey non-rendering background. Ignore values outside BG_DESKTOP..BG_FSS.

https://vpuniverse.com/files/file/25442-thunderbirds-are-go/

With this PR applied instead of a crash the table works and you get these logs:

```
2026-06-01 11:12:35.798 ERROR [2013793] [PinTable::put_BackglassMode@7150] BackglassMode is deprecated
2026-06-01 11:12:35.798 ERROR [2013793] [PinTable::put_BackglassMode@7156] Ignoring out of range BackglassMode value 0
```