### PR TITLE
fix: don't crash loading an auto-aspect image decal

### DIFF
--- a/src/parts/decal.cpp
+++ b/src/parts/decal.cpp
@@ -325,7 +325,8 @@ void Decal::EnsureSize()
 
       if (m_d.m_decaltype == DecalImage)
       {
-         Texture * const pin = m_ptable->GetImage(m_d.m_szImage);
+         // m_ptable is not set yet during the early Load/Init/CopyForPlay calls; RenderSetup recomputes once it is
+         Texture * const pin = m_ptable ? m_ptable->GetImage(m_d.m_szImage) : nullptr;
          m_realwidth = m_realheight;
          if (pin)
             m_realwidth *= (float)((double)pin->m_width / (double)pin->m_height);
@@ -360,8 +361,9 @@ void Decal::RenderSetup(Renderer *renderer)
    assert(m_renderer == nullptr);
    m_renderer = renderer;
 
+   EnsureSize();
    UpdateBounds();
-   
+
 #ifndef __STANDALONE__
    if (m_d.m_decaltype == DecalText)
    {


### PR DESCRIPTION
`Decal::Load` calls `EnsureSize`, but for an image decal with auto aspect sizing that dereferences `m_ptable` to look up the image. `m_ptable` is only set later in `AddPart` (and the image is not loaded yet at that point), so loading such a decal crashed.

Guard the image lookup against a missing table, and (re)compute the size in `RenderSetup` once the decal is added and its images are available.

https://www.vpforums.org/index.php?app=downloads&showfile=13406