### PR TITLE
dmdutil: fix crash when closing a table

### DIFF
--- a/plugins/dmdutil/DMDUtilPlugin.cpp
+++ b/plugins/dmdutil/DMDUtilPlugin.cpp
@@ -111,6 +111,11 @@ static void UpdateThread()
 
       std::lock_guard<std::mutex> lock(sourceMutex);
 
+      // The loop condition above is read without the lock, so the source may have been reset (e.g. removed
+      // during teardown, clearing GetRenderFrame) before we get here. Re-validate under the lock.
+      if (selectedDmdId.GetRenderFrame == nullptr)
+         continue;
+
       const DisplayFrame frame = selectedDmdId.GetRenderFrame(selectedDmdId.id);
       if (lastFrameID == frame.frameId)
          continue;

--- a/plugins/dmdutil/DMDUtilPlugin.cpp
+++ b/plugins/dmdutil/DMDUtilPlugin.cpp
@@ -1,6 +1,7 @@
 // license:GPLv3+
 
 #include <cstdlib>
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <charconv>
@@ -33,7 +34,7 @@ static unsigned int getDmdSrcMsgId;
 static std::mutex sourceMutex;
 static std::thread updateThread;
 static DisplaySrcId selectedDmdId = {};
-static bool isRunning = false;
+static std::atomic<bool> isRunning = false;
 
 static DMDUtil::DMD* pDmd = nullptr;
 
@@ -104,16 +105,16 @@ void DMDUTILCALLBACK OnDMDUtilLog(DMDUtil_LogLevel logLevel, const char* format,
 static void UpdateThread()
 {
    int lastFrameID = 0;
-   while (isRunning && pDmd && selectedDmdId.id.id != 0)
+   while (isRunning)
    {
       // Fixed update at 60 FPS
       std::this_thread::sleep_for(std::chrono::microseconds(16666));
 
       std::lock_guard<std::mutex> lock(sourceMutex);
 
-      // The loop condition above is read without the lock, so the source may have been reset (e.g. removed
-      // during teardown, clearing GetRenderFrame) before we get here. Re-validate under the lock.
-      if (selectedDmdId.GetRenderFrame == nullptr)
+      // Read the shared source/display state under the lock: it can be reset (e.g. the source removed
+      // during teardown, clearing GetRenderFrame) concurrently with this thread. Skip until it is valid.
+      if (pDmd == nullptr || selectedDmdId.id.id == 0 || selectedDmdId.GetRenderFrame == nullptr)
          continue;
 
       const DisplayFrame frame = selectedDmdId.GetRenderFrame(selectedDmdId.id);


### PR DESCRIPTION
Closing a table could crash the player: during teardown the active DMD source is
cleared while the background DMD update thread is still running, so it called into
an already-cleared render callback.

- Validate the source before using it.
- Harden the update thread: atomic running flag, source read only under the lock.

Reproduced and fixed with Timon and Pumbaa's Jungle Pinball (crashed on ESC exit, now exits cleanly).

https://vpuniverse.com/files/file/8524-timon-and-pumbaas-jungle-pinball/