### PR TITLE
don't error when a value-returning member is used as a statement

### DIFF
--- a/src/core/DynamicScript.cpp
+++ b/src/core/DynamicScript.cpp
@@ -899,8 +899,6 @@ HRESULT DynamicTypeLibrary::Invoke(const ScriptClassDef * classDef, void* native
       return DISP_E_MEMBERNOTFOUND;
    }
    const ScriptClassMemberDef& memberDef = classDef->members[memberIndex];
-   if ((memberDef.type.id != TypeID::TYPEID_VOID) && (pVarResult == nullptr))
-      return E_POINTER;
 
    // Convert all incoming COM arguments to ScriptVariants
    ScriptVariant args[PSC_CALL_MAX_ARG_COUNT];
@@ -995,8 +993,13 @@ HRESULT DynamicTypeLibrary::Invoke(const ScriptClassDef * classDef, void* native
    // Convert then dispose the return value if any
    if (memberDef.type.id != TypeID::TYPEID_VOID)
    {
-      assert(V_VT(pVarResult) == VT_EMPTY);
-      ScriptToCOMVariant(memberDef.type, retValue, pVarResult);
+      // pVarResult is null when a non-void member is invoked as a statement (DISPATCH_METHOD), e.g. a
+      // property get used as a bare statement. That is valid: run the call but discard the result.
+      if (pVarResult != nullptr)
+      {
+         assert(V_VT(pVarResult) == VT_EMPTY);
+         ScriptToCOMVariant(memberDef.type, retValue, pVarResult);
+      }
       ReleaseScriptVariant(memberDef.type, retValue);
    }
 


### PR DESCRIPTION
A script can use a value-returning member - a property get, or a function -
as a bare statement, discarding the result (e.g. `Controller.Pause` on a line
by itself). In VBScript this is a valid no-op: the call runs and the result is
thrown away.

For a classic COM object this works fine. But objects provided by a plugin are
exposed through our own `DynamicDispatch` wrapper, which rejected this with an
error. That wrapper is used on all platforms (including Windows), so any
plugin-provided script object hit it. Because an unhandled error aborts the
rest of the running Sub, this could break table logic (the reported case
errored at startup with "Description unavailable").

This makes plugin-provided objects behave like a classic COM object for such
statements: run the call, discard the result, no error.

Reproduced with and verified on Medieval Castle (Original 2006), which errored
on startup and now loads cleanly.
https://vpuniverse.com/files/file/22310-medieval-castel-v10/