### PR TITLE
report a meaningful error for a value-returning member used as a statement

### DIFF
--- a/src/core/DynamicScript.cpp
+++ b/src/core/DynamicScript.cpp
@@ -900,7 +900,12 @@ HRESULT DynamicTypeLibrary::Invoke(const ScriptClassDef * classDef, void* native
    }
    const ScriptClassMemberDef& memberDef = classDef->members[memberIndex];
    if ((memberDef.type.id != TypeID::TYPEID_VOID) && (pVarResult == nullptr))
-      return E_POINTER;
+      // A value-returning member invoked with no result buffer was used as a statement (e.g. a bare
+      // property get). Report it as native COM does (-> VBScript error 438).
+      // TODO a value-returning function used as a bare statement should run and discard its result (as
+      // native does), but a property getter and a function are indistinguishable here (identical member
+      // shape), so such a call fails with 438 too. Telling them apart needs a flag in ScriptClassMemberDef.
+      return DISP_E_MEMBERNOTFOUND;
 
    // Convert all incoming COM arguments to ScriptVariants
    ScriptVariant args[PSC_CALL_MAX_ARG_COUNT];


### PR DESCRIPTION
Using a value-returning member (a property get, or a function) as a bare
statement on a plugin-provided object returned `E_POINTER`, which VBScript
can't map. Now returns `DISP_E_MEMBERNOTFOUND`, matching the error native
Windows gives.

Before:
```
Runtime error on line 411, col 32: Description unavailable
```

After:
```
Runtime error on line 411, col 32: Object doesn't support this property or method
```

Still an error, just reported properly. A TODO notes that a
value-returning *function* used this way should run instead, but it can't be
told apart from a property getter here.

https://vpuniverse.com/files/file/22310-medieval-castel-v10/
Shows this issue here, `Controller.Pause` should be assigned
```vbscript
Sub table1_unPaused
    If Isobject(Controller)Then Controller.Pause
End Sub
```