### PR TITLE
Handle Function/Getter called without using return var

### DIFF
--- a/src/core/DynamicScript.cpp
+++ b/src/core/DynamicScript.cpp
@@ -899,8 +899,6 @@ HRESULT DynamicTypeLibrary::Invoke(const ScriptClassDef * classDef, void* native
       return DISP_E_MEMBERNOTFOUND;
    }
    const ScriptClassMemberDef& memberDef = classDef->members[memberIndex];
-   if ((memberDef.type.id != TypeID::TYPEID_VOID) && (pVarResult == nullptr))
-      return E_POINTER;
 
    // Convert all incoming COM arguments to ScriptVariants
    ScriptVariant args[PSC_CALL_MAX_ARG_COUNT];
@@ -995,8 +993,11 @@ HRESULT DynamicTypeLibrary::Invoke(const ScriptClassDef * classDef, void* native
    // Convert then dispose the return value if any
    if (memberDef.type.id != TypeID::TYPEID_VOID)
    {
-      assert(V_VT(pVarResult) == VT_EMPTY);
-      ScriptToCOMVariant(memberDef.type, retValue, pVarResult);
+      if (pVarResult)
+      {
+         assert(V_VT(pVarResult) == VT_EMPTY);
+         ScriptToCOMVariant(memberDef.type, retValue, pVarResult);
+      }
       ReleaseScriptVariant(memberDef.type, retValue);
    }
 


### PR DESCRIPTION
Fix https://vpuniverse.com/files/file/22310-medieval-castel-v10/ It seems that Getter called without using returned value is legal in VBS (and not in VBA)