### PR TITLE
dmd: Fix standalone DMD crashes from rendering on consumer threads

### DIFF
--- a/plugins/dmdutil/DMDUtilPlugin.cpp
+++ b/plugins/dmdutil/DMDUtilPlugin.cpp
@@ -110,42 +110,48 @@ static void UpdateThread()
       // Fixed update at 60 FPS
       std::this_thread::sleep_for(std::chrono::microseconds(16666));
 
-      std::lock_guard<std::mutex> lock(sourceMutex);
+      // Copy the shared source/display state under the lock, then release it before rendering.
+      // The state can be reset (e.g. the source removed during teardown, clearing GetRenderFrame)
+      // concurrently with this thread, so skip until it is valid. The render itself can take a
+      // millisecond or more (FlexDMD renders its scene in GetRenderFrame); holding sourceMutex
+      // across it would stall the main thread, which takes the same lock in onDmdSrcChanged.
+      DisplaySrcId dmdId;
+      {
+         std::lock_guard<std::mutex> lock(sourceMutex);
+         if (pDmd == nullptr || selectedDmdId.id.id == 0 || selectedDmdId.GetRenderFrame == nullptr)
+            continue;
+         dmdId = selectedDmdId;
+      }
 
-      // Read the shared source/display state under the lock: it can be reset (e.g. the source removed
-      // during teardown, clearing GetRenderFrame) concurrently with this thread. Skip until it is valid.
-      if (pDmd == nullptr || selectedDmdId.id.id == 0 || selectedDmdId.GetRenderFrame == nullptr)
-         continue;
-
-      const DisplayFrame frame = selectedDmdId.GetRenderFrame(selectedDmdId.id);
+      const DisplayFrame frame = dmdId.GetRenderFrame(dmdId.id);
       if (lastFrameID == frame.frameId)
          continue;
       lastFrameID = frame.frameId;
 
-      switch(selectedDmdId.frameFormat) {
+      switch(dmdId.frameFormat) {
          case CTLPI_DISPLAY_FORMAT_LUM32F:
          {
             const float* const __restrict luminanceData = static_cast<const float*>(frame.frame);
-            uint8_t* const __restrict rgb24Data = new uint8_t[selectedDmdId.width * selectedDmdId.height * 3];
+            uint8_t* const __restrict rgb24Data = new uint8_t[dmdId.width * dmdId.height * 3];
 
-            for (unsigned int i = 0; i < selectedDmdId.width * selectedDmdId.height; ++i) {
+            for (unsigned int i = 0; i < dmdId.width * dmdId.height; ++i) {
                 const float lum = luminanceData[i];
                 rgb24Data[i * 3    ] = (uint8_t)(lum * (float)tintR);
                 rgb24Data[i * 3 + 1] = (uint8_t)(lum * (float)tintG);
                 rgb24Data[i * 3 + 2] = (uint8_t)(lum * (float)tintB);
             }
 
-            pDmd->UpdateRGB24Data(rgb24Data, selectedDmdId.width, selectedDmdId.height);
+            pDmd->UpdateRGB24Data(rgb24Data, dmdId.width, dmdId.height);
             delete [] rgb24Data;
          }
          break;
 
          case CTLPI_DISPLAY_FORMAT_SRGB888:
-            pDmd->UpdateRGB24Data(static_cast<const uint8_t*>(frame.frame), selectedDmdId.width, selectedDmdId.height);
+            pDmd->UpdateRGB24Data(static_cast<const uint8_t*>(frame.frame), dmdId.width, dmdId.height);
             break;
 
          case CTLPI_DISPLAY_FORMAT_SRGB565:
-            pDmd->UpdateRGB16Data((const uint16_t*)frame.frame, selectedDmdId.width, selectedDmdId.height);
+            pDmd->UpdateRGB16Data((const uint16_t*)frame.frame, dmdId.width, dmdId.height);
             break;
       }
    }

--- a/plugins/flexdmd/FlexDMD.cpp
+++ b/plugins/flexdmd/FlexDMD.cpp
@@ -194,16 +194,60 @@ void FlexDMD::UpdateRGBAFrame()
 
 const std::vector<uint32_t>& FlexDMD::GetDmdColoredPixels()
 {
+   const unsigned int before = m_frameId;
    Render();
    UpdateRGBAFrame();
+   if (m_frameId != before) // keep the cross-thread snapshot in sync with this main-thread render
+      PublishFrame();
    return m_rgbaFrame;
 }
 
 const std::vector<uint8_t>& FlexDMD::GetDmdPixels()
 {
+   const unsigned int before = m_frameId;
    Render();
    UpdateLumFrame();
+   if (m_frameId != before)
+      PublishFrame();
    return m_lumFrame;
+}
+
+void FlexDMD::RenderAndPublish()
+{
+   const unsigned int before = m_frameId;
+   Render();
+   if (m_frameId != before) // Render() is gated, only publish when it produced a new frame
+      PublishFrame();
+}
+
+void FlexDMD::PublishFrame()
+{
+   const int back = 1 - m_pubIndex.load(std::memory_order_relaxed);
+   std::vector<uint8_t>& buf = m_pubFrame[back];
+   if (m_renderMode == RenderMode_DMD_RGB)
+   {
+      const uint8_t* const __restrict src = UpdateRGBFrame();
+      buf.assign(src, src + static_cast<size_t>(m_width) * m_height * 3);
+   }
+   else if ((m_renderMode == RenderMode_DMD_GRAY_2) || (m_renderMode == RenderMode_DMD_GRAY_4))
+   {
+      const float* const __restrict src = UpdateLumFP32Frame();
+      const size_t bytes = static_cast<size_t>(m_width) * m_height * sizeof(float);
+      buf.resize(bytes);
+      memcpy(buf.data(), src, bytes);
+   }
+   else
+      return; // segment modes have no render frame
+   m_pubFrameId[back] = m_frameId;
+   m_pubIndex.store(back, std::memory_order_release);
+}
+
+FlexDMD::RenderSnapshot FlexDMD::GetRenderSnapshot() const
+{
+   const int idx = m_pubIndex.load(std::memory_order_acquire);
+   if (m_pubFrame[idx].empty())
+      return { 0, nullptr };
+   return { m_pubFrameId[idx], m_pubFrame[idx].data() };
 }
 
 void FlexDMD::SetSegments(const std::vector<uint16_t>& segments)

--- a/plugins/flexdmd/FlexDMD.h
+++ b/plugins/flexdmd/FlexDMD.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "common.h"
 #include "SurfaceGraphics.h"
 #include "plugins/VPXPlugin.h"
@@ -77,6 +79,13 @@ public:
    const std::vector<uint32_t>& GetDmdColoredPixels();
    const std::vector<uint8_t>& GetDmdPixels();
 
+   // Render the scene and publish a thread-safe snapshot of the source frame. Main thread only.
+   void RenderAndPublish();
+   // Thread-safe accessor for the last published source frame (RGB888 in RGB mode, LUM32F in gray
+   // modes). The pointer is owned by this FlexDMD and stays valid; { 0, nullptr } until first render.
+   struct RenderSnapshot { unsigned int frameId; const void* frame; };
+   RenderSnapshot GetRenderSnapshot() const;
+
    void SetSegments(const std::vector<uint16_t>& segments);
 
    void LockRenderThread() { m_renderLockCount++; }
@@ -148,6 +157,13 @@ private:
    void UpdateLumFrame();
    std::vector<uint8_t> m_lumFrame;
    bool m_lumFrameDirty = true;
+
+   // Published source-format frame, double buffered so GetRenderSnapshot can be called from any
+   // thread (scoreview / dmdutil worker) while the main thread renders into the other buffer.
+   void PublishFrame();
+   std::vector<uint8_t> m_pubFrame[2];
+   unsigned int m_pubFrameId[2] = { 0, 0 };
+   std::atomic<int> m_pubIndex = 0;
 
    string m_szGameName;
    uint64_t m_lastRenderTick = 0;

--- a/plugins/flexdmd/FlexDMD.h
+++ b/plugins/flexdmd/FlexDMD.h
@@ -67,7 +67,7 @@ public:
    void SetHeight(int h) { if (m_height == h) return; m_height = h; m_pStage->SetSize(m_width, m_height); DiscardFrames(); if (m_run && m_show) OnDMDChanged(); }
 
    RenderMode GetRenderMode() const { return m_renderMode; }
-   void SetRenderMode(RenderMode renderMode) { m_renderMode = renderMode; DiscardFrames(); if (m_run && m_show) OnDMDChanged(); }
+   void SetRenderMode(RenderMode renderMode) { if (m_renderMode == renderMode) return; m_renderMode = renderMode; DiscardFrames(); if (m_run && m_show) OnDMDChanged(); }
 
    const string& GetProjectFolder() const { return m_pAssetManager->GetBasePath(); }
    void SetProjectFolder(const string& folder) { m_pAssetManager->SetBasePath(folder); }

--- a/plugins/flexdmd/FlexDMDPlugin.cpp
+++ b/plugins/flexdmd/FlexDMDPlugin.cpp
@@ -518,23 +518,33 @@ static void onGetSegSrc(const unsigned int eventId, void* userData, void* msgDat
 // DMD & Displays
 
 static bool hasDMD = false;
-static unsigned int getDmdSrcId, onDmdSrcChangeId;
+static unsigned int getDmdSrcId, onDmdSrcChangeId, onPrepareFrameId;
 
+// Thread safe per the display source contract: only returns the snapshot published on the main
+// thread by onPrepareFrame, never renders or touches the scene/surface off the main thread.
 static DisplayFrame GetRenderFrame(const CtlResId id)
 {
    for (FlexDMD* pFlex : flexDmds)
    {
       if ((endpointId == id.endpointId) && (pFlex->GetId() == id.resId))
       {
-         pFlex->Render();
-         if (pFlex->GetRenderMode() == RenderMode_DMD_RGB)
-            return { pFlex->GetFrameId(), pFlex->UpdateRGBFrame() };
-         else if ((pFlex->GetRenderMode() == RenderMode_DMD_GRAY_2) || (pFlex->GetRenderMode() == RenderMode_DMD_GRAY_4))
-            return { pFlex->GetFrameId(), pFlex->UpdateLumFP32Frame() };
-         return { 0, nullptr };
+         const FlexDMD::RenderSnapshot snap = pFlex->GetRenderSnapshot();
+         return { snap.frameId, snap.frame };
       }
    }
    return { 0, nullptr };
+}
+
+// Render the shown DMDs once per frame on the main render thread and publish their snapshot, so that
+// GetRenderFrame consumers (scoreview on the main thread, dmdutil on its worker thread) never drive
+// rendering off the main thread.
+static void onPrepareFrame(const unsigned int eventId, void* userData, void* msgData)
+{
+   for (FlexDMD* pFlex : flexDmds)
+   {
+      if (pFlex->GetShow() && ((pFlex->GetRenderMode() == RenderMode_DMD_GRAY_2) || (pFlex->GetRenderMode() == RenderMode_DMD_GRAY_4) || (pFlex->GetRenderMode() == RenderMode_DMD_RGB)))
+         pFlex->RenderAndPublish();
+   }
 }
 
 static void onGetRenderDMDSrc(const unsigned int eventId, void* userData, void* msgData)
@@ -587,9 +597,15 @@ static void OnShowChanged(FlexDMD* pFlexI)
    if (hasDMD != hadDMD)
    {
       if (hasDMD)
+      {
          msgApi->SubscribeMsg(endpointId, getDmdSrcId, onGetRenderDMDSrc, nullptr);
+         msgApi->SubscribeMsg(endpointId, onPrepareFrameId, onPrepareFrame, nullptr);
+      }
       else
+      {
          msgApi->UnsubscribeMsg(getDmdSrcId, onGetRenderDMDSrc, nullptr);
+         msgApi->UnsubscribeMsg(onPrepareFrameId, onPrepareFrame, nullptr);
+      }
    }
    msgApi->BroadcastMsg(endpointId, onDmdSrcChangeId, nullptr);
    if (hasAlpha != hadAlpha)
@@ -627,6 +643,7 @@ MSGPI_EXPORT void MSGPIAPI FlexDMDPluginLoad(const uint32_t sessionId, const Msg
    getDmdSrcId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_DISPLAY_GET_SRC_MSG);
    onSegSrcChangedId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_SEG_ON_SRC_CHG_MSG);
    getSegSrcId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_SEG_GET_SRC_MSG);
+   onPrepareFrameId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_EVT_ON_PREPARE_FRAME);
 
    unsigned int getVpxApiId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_MSG_GET_API);
    msgApi->BroadcastMsg(endpointId, getVpxApiId, &vpxApi);
@@ -755,6 +772,7 @@ MSGPI_EXPORT void MSGPIAPI FlexDMDPluginUnload()
    msgApi->ReleaseMsgID(getSegSrcId);
    msgApi->ReleaseMsgID(onDmdSrcChangeId);
    msgApi->ReleaseMsgID(getDmdSrcId);
+   msgApi->ReleaseMsgID(onPrepareFrameId);
 
    scriptApi = nullptr;
    msgApi = nullptr;

--- a/src/core/VPXPluginAPIImpl.cpp
+++ b/src/core/VPXPluginAPIImpl.cpp
@@ -602,6 +602,12 @@ void VPXPluginAPIImpl::UpdateDMDSource(Flasher* flasher, bool isAdd)
 
 DisplayFrame VPXPluginAPIImpl::ControllerOnGetRenderDMD(const CtlResId id)
 {
+   // Keep the returned frame (texture or its SRGB alias) alive for the calling thread until its next
+   // call here. GetRenderFrame is called from consumer threads (e.g. the dmdutil worker), which read
+   // the returned pointer after this returns; without holding a reference the main thread could free
+   // the texture/alias (texture swap, alias cache clear) before the consumer copies it.
+   thread_local std::shared_ptr<BaseTexture> s_held;
+
    VPXPluginAPIImpl& me = g_pplayer->m_pluginAPI;
 
    if ((g_pplayer == nullptr) || (id.endpointId != me.m_vpxPlugin->m_endpointId))
@@ -625,11 +631,12 @@ DisplayFrame VPXPluginAPIImpl::ControllerOnGetRenderDMD(const CtlResId id)
 
    switch (dmdFrame->m_format)
    {
-   case BaseTexture::BW_FP32: result.frame = dmdFrame->data(); break;
-   case BaseTexture::SRGB: result.frame = dmdFrame->data(); break;
-   case BaseTexture::SRGBA: result.frame = dmdFrame->GetAlias(BaseTexture::SRGB)->data(); break;
+   case BaseTexture::BW_FP32: s_held = dmdFrame; break;
+   case BaseTexture::SRGB: s_held = dmdFrame; break;
+   case BaseTexture::SRGBA: s_held = dmdFrame->GetAlias(BaseTexture::SRGB); break;
    default: assert(false); return { 0, nullptr };  // Not yet supported
    }
+   result.frame = s_held->data();
 
    return result;
 }

--- a/src/core/VPXPluginAPIImpl.cpp
+++ b/src/core/VPXPluginAPIImpl.cpp
@@ -512,6 +512,7 @@ void VPXPluginAPIImpl::UpdateSetting(const std::string& pluginId, MsgPI::MsgPlug
 void VPXPluginAPIImpl::OnGameStart()
 {
    assert(m_dmdSources.empty());
+   m_globalDmdSrc = {};
    const auto& msgApi = m_msgApi;
 
    msgApi.SubscribeMsg(GetVPXEndPointId(), m_onDisplayGetSrcMsgId, &ControllerOnGetDMDSrc, this);
@@ -555,6 +556,7 @@ void VPXPluginAPIImpl::OnGameEnd()
    msgApi.UnsubscribeMsg(m_onDisplayGetSrcMsgId, &ControllerOnGetDMDSrc, this);
 
    m_dmdSources.clear();
+   m_globalDmdSrc = {};
 
    msgApi.BroadcastMsg(GetVPXEndPointId(), m_onDisplaySrcChgMsgId, nullptr);
 
@@ -579,6 +581,19 @@ void VPXPluginAPIImpl::UpdateDMDSource(Flasher* flasher, bool isAdd)
             return;
          RemoveFromVectorSingle(m_dmdSources, flasher);
       }
+   }
+   else
+   {
+      // Global script DMD: DMDPixels/DMDColoredPixels call this on every frame, but only the
+      // content changes, not the source set. Only broadcast when the descriptor actually changes
+      // (first appearance, or a size/format change), otherwise consumers re-scan/reset every frame.
+      const decltype(m_globalDmdSrc) cur = (g_pplayer && g_pplayer->m_dmdFrame)
+         ? decltype(m_globalDmdSrc){ true, g_pplayer->m_dmdFrame->width(), g_pplayer->m_dmdFrame->height(), g_pplayer->m_dmdFrame->m_format }
+         : decltype(m_globalDmdSrc){};
+      if (cur.present == m_globalDmdSrc.present && cur.width == m_globalDmdSrc.width
+         && cur.height == m_globalDmdSrc.height && cur.format == m_globalDmdSrc.format)
+         return;
+      m_globalDmdSrc = cur;
    }
 
    const auto& msgApi = m_msgApi;

--- a/src/core/VPXPluginAPIImpl.h
+++ b/src/core/VPXPluginAPIImpl.h
@@ -121,6 +121,9 @@ private:
 
    // Contribute VPX script controlled DMD through controller plugin API
    vector<Flasher*> m_dmdSources;
+   // Last announced descriptor of the global script DMD, to avoid re-broadcasting a source
+   // change on every per-frame content push (DMDPixels/DMDColoredPixels).
+   struct { bool present; unsigned int width, height; int format; } m_globalDmdSrc = {};
    static void ControllerOnGetDMDSrc(const unsigned int msgId, void* userData, void* msgData);
    static DisplayFrame ControllerOnGetRenderDMD(const CtlResId id);
    const unsigned int m_onDisplaySrcChgMsgId;

--- a/src/renderer/Texture.cpp
+++ b/src/renderer/Texture.cpp
@@ -463,7 +463,10 @@ void BaseTexture::Update(std::shared_ptr<BaseTexture>& tex, const unsigned int w
          assert(tex->pitch() * tex->height() == width * height * pixelSize);
          if (tex->data() != image && image)
             memcpy(tex->data(), image, width * height * pixelSize);
-         tex->m_aliases.clear();
+         {
+            std::lock_guard<std::mutex> lock(tex->m_aliasMutex);
+            tex->m_aliases.clear();
+         }
          if (g_pplayer)
             g_pplayer->m_renderer->m_renderDevice->m_texMan.SetDirty(tex.get());
          return;
@@ -491,7 +494,10 @@ void BaseTexture::FlipY()
       memcpy(m_data + i * pitch, m_data + (m_height - 1 - i) * pitch, pitch);
       memcpy(m_data + (m_height - 1 - i) * pitch, bits, pitch);
    }
-   m_aliases.clear();
+   {
+      std::lock_guard<std::mutex> lock(m_aliasMutex);
+      m_aliases.clear();
+   }
 }
 
 bool BaseTexture::Save(const std::filesystem::path& filepath) const
@@ -578,6 +584,7 @@ bool BaseTexture::Save(const std::filesystem::path& filepath) const
 
 std::shared_ptr<BaseTexture> BaseTexture::GetAlias(Format format) const
 {
+   std::lock_guard<std::mutex> lock(m_aliasMutex);
    auto it = m_aliases.find(format);
    if (it == m_aliases.end())
    {

--- a/src/renderer/Texture.h
+++ b/src/renderer/Texture.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "unordered_dense.h"
 
 #include "parts/pinbinary.h"
@@ -137,6 +139,9 @@ private:
    mutable bool m_isOpaqueDirty = true;
    mutable bool m_isOpaque = true;
    mutable ankerl::unordered_dense::map<Format, std::shared_ptr<BaseTexture>> m_aliases;
+   // The alias cache is read on the DMD consumer thread (e.g. dmdutil worker via GetAlias) while the
+   // owning thread rewrites the texture and clears it, so all m_aliases access must be serialized.
+   mutable std::mutex m_aliasMutex;
 };
 
 


### PR DESCRIPTION
What does this solve

* random crashes on exiting a table
* artifacts/flicker on backglass / dmd during gameplay
* choppy gameplay

The DMD source `GetRenderFrame` callback is documented as thread safe, but the
standalone implementations rendered / touched live render state on the calling
thread. The dmdutil worker thread and the main-thread scoreview/flasher pulls
drove that concurrently, causing intermittent (some Release-only) crashes:

- `FlexDMD::Render` -> `Group::Draw` (SDL blit): the dmdutil worker rendered the
  FlexDMD scene while the main thread mutated and drew it (e.g. the end-of-game
  match sequence), also producing DMD corruption.
- `BaseTexture::GetAlias` (shared_ptr release): the worker read the global/flasher
  DMD alias cache while the main thread rewrote the texture and cleared it.

### Changes

- FlexDMD renders only on the main thread (`OnPrepareFrame`) and publishes a
  double-buffered snapshot; `GetRenderFrame` just returns it, never touching the
  scene/surface off the main thread.
- Global/flasher DMD (`ControllerOnGetRenderDMD`): serialize the texture alias
  cache with a per-texture mutex, and keep the returned frame alive in a
  `thread_local shared_ptr` so it can't be freed before the consumer copies it.
- Skip redundant `FlexDMD.RenderMode` sets: some tables re-assert it every frame
  (the Thunderbirds match sequence does), which tore down the DMD surface and
  re-broadcast "display source changed" every frame. Now a no-op when unchanged,
  matching `SetWidth`/`SetHeight`.

<details>
<summary>Expand for crash backtraces encountered when trying to reproduce issues reported by users</summary>

FlexDMD scene rendered on the dmdutil worker thread:

```
SDL_BlitSurfaceScaled
Flex::SurfaceGraphics::DrawImage   SurfaceGraphics.cpp:36
Flex::Font::DrawText_              Font.cpp:201
Flex::Group::Draw                  Group.cpp:60
Flex::FlexDMD::Render              FlexDMD.cpp:79
Flex::GetRenderFrame               FlexDMDPlugin.cpp:529
DMDUtilPlugin::UpdateThread        DMDUtilPlugin.cpp:120
```

Same race seen from the main thread (scoreview/flasher pull) while the worker
renders concurrently:

```
Flex::Group::Draw                  Group.cpp:60
Flex::FlexDMD::Render              FlexDMD.cpp:79
Flex::GetRenderFrame               FlexDMDPlugin.cpp:529
ResURIResolver::GetDisplayState    ResURIResolver.cpp:318
Flasher::Render                    flasher.cpp:1317
Renderer::RenderItem               Renderer.cpp:1668
Player::PrepareFrame               player.cpp:2127
```

Global/flasher DMD alias cache read on the dmdutil worker thread:

```
std::_Sp_counted_base::_M_release            shared_ptr_base.h:414
BaseTexture::GetAlias                         Texture.cpp:589
VPXPluginAPIImpl::ControllerOnGetRenderDMD    VPXPluginAPIImpl.cpp:630
DMDUtilPlugin::UpdateThread                   DMDUtilPlugin.cpp:126
```

</details>

Reproduce on these tables, with on-playfield backglass/scoreview, requires multiple game playthroughs sometimes. (I know that it's not the best coded tables but still should not crash vpinball)
https://vpuniverse.com/files/file/9417-thunderbirds-homepin-2018/
https://vpuniverse.com/files/file/25442-thunderbirds-are-go/