### PR TITLE
render: fix bloom bleeding into embedded ancillary windows

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -3396,6 +3396,12 @@ void Renderer::RenderAncillaryWindow(VPXWindowId window, const VPX::RenderOutput
    if (outputRT == nullptr)
       return;
 
+   // Keep the embedded ancillary content ordered after bloom: it writes the back buffer that bloom
+   // already sampled with this region cleared, so without this dependency the sorter may run it before
+   // the bloom sample and bloom bleeds the content into the region. No-op if bloom did not run.
+   if (output.GetMode() == VPX::RenderOutput::OM_EMBEDDED)
+      rd->AddRenderTargetDependency(GetBloomBufferTexture());
+
    rd->ResetRenderState();
    if (output.GetMode() == VPX::RenderOutput::OM_WINDOW)
       rd->Clear(clearType::TARGET | clearType::ZBUFFER, 0x00000000);


### PR DESCRIPTION
Embedded backglass/scoreview content is drawn into the shared back buffer after bloom has sampled it with the region cleared (ClearEmbeddedAncillaryWindow runs before UpdateBloom). The content pass had no dependency on the bloom pass, so the frame sorter could place it before the bloom sample on frames where the pass set changed (e.g. ball motion blur), making bloom bleed the ancillary content into the region: an intermittent brightness strobe on embedded ancillary windows.

Make the embedded ancillary content pass depend on the bloom pass so it is always ordered after the bloom sample.

fixes #3467
That table had a 1.8 bloom value that was affecting backglass and score view