### PR TITLE
pup: render backglass for packs with a positioned screen 2

### DIFF
--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -631,8 +631,11 @@ int PUPManager::Render(VPXRenderContext2D* const renderCtx, void* context)
       padBottom = pupTopperPadBottom_Get();
       break;
    case VPXWindowId::VPXWINDOW_Backglass:
-      rootScreen = me->GetScreen(2); // select 2 or 6 (user settings ?)
-      if (rootScreen == nullptr || rootScreen->GetCustomPos() != nullptr)
+      // Prefer screen 2, falling back to 6. A screen with a custom position but no children is a
+      // positioned element rather than a backglass canvas, so skip it; a custom positioned screen
+      // that does host children (the overlays/videos) is a valid canvas and kept as root.
+      rootScreen = me->GetScreen(2);
+      if (rootScreen == nullptr || (rootScreen->GetCustomPos() != nullptr && !rootScreen->HasChildren()))
          rootScreen = me->GetScreen(6);
       padLeft = pupBGPadLeft_Get();
       padRight = pupBGPadRight_Get();
@@ -640,8 +643,8 @@ int PUPManager::Render(VPXRenderContext2D* const renderCtx, void* context)
       padBottom = pupBGPadBottom_Get();
       break;
    case VPXWindowId::VPXWINDOW_ScoreView:
-      rootScreen = me->GetScreen(5); // select 1 or 5 (user settings ?)
-      if (rootScreen == nullptr || rootScreen->GetCustomPos() != nullptr)
+      rootScreen = me->GetScreen(5);
+      if (rootScreen == nullptr || (rootScreen->GetCustomPos() != nullptr && !rootScreen->HasChildren()))
          rootScreen = me->GetScreen(1);
       padLeft = pupSVPadLeft_Get();
       padRight = pupSVPadRight_Get();
@@ -650,7 +653,7 @@ int PUPManager::Render(VPXRenderContext2D* const renderCtx, void* context)
       break;
    default: break;
    }
-   if (rootScreen == nullptr || rootScreen->GetCustomPos() != nullptr)
+   if (rootScreen == nullptr || (rootScreen->GetCustomPos() != nullptr && !rootScreen->HasChildren()))
       return false;
 
    if (!LibAV::LibAV::GetInstance().isLoaded)
@@ -680,7 +683,9 @@ int PUPManager::Render(VPXRenderContext2D* const renderCtx, void* context)
          screens.push_back(screen);
    }
    // Render order - two tiers (non-topmost, topmost) mirroring Win32 HWND_TOPMOST behavior.
-   // Within each tier: non-popup video, non-popup overlay, popups.
+   // In the back (non-topmost) tier the popup video is drawn before the non-popup overlay so that
+   // a full-window frame/overlay (e.g. a decorative backglass border) stays above the background
+   // videos. In the front (topmost) tier popups are drawn last so callouts stay on top.
    auto renderScreens = [&renderCtx, &screens](bool popup, bool topmost, int startPass, int endPass)
    {
       for (int pass = startPass; pass <= endPass; pass++)
@@ -693,8 +698,8 @@ int PUPManager::Render(VPXRenderContext2D* const renderCtx, void* context)
    };
 
    renderScreens(false, false, 0, 1);
-   renderScreens(false, false, 2, 3);
    renderScreens(true, false, 0, 3);
+   renderScreens(false, false, 2, 3);
    renderScreens(false, true, 0, 1);
    renderScreens(false, true, 2, 3);
    renderScreens(true, true, 0, 3);

--- a/plugins/pup/PUPScreen.h
+++ b/plugins/pup/PUPScreen.h
@@ -80,6 +80,7 @@ public:
    void AddChild(std::shared_ptr<PUPScreen> pScreen);
    void ReplaceChild(std::shared_ptr<PUPScreen> pChild, std::shared_ptr<PUPScreen> pScreen);
    PUPScreen* GetParent() const { return m_pParent; }
+   bool HasChildren() const { return !m_children.empty(); }
 
    void AddTrigger(PUPTrigger* pTrigger);
    vector<PUPTrigger*>* GetTriggers(const string& szTrigger);


### PR DESCRIPTION
Packs that put backglass content on screen 2 *with* a custom position (and
leave screen 6 empty) rendered a black backglass: PUP rejected any
custom-positioned screen as root and fell back to the empty screen 6/1.

- Root selection: only skip a custom-positioned screen when it has no
  children. One that hosts children is a valid canvas, so screen 2 (frame,
  video, callouts) renders.
- Back-tier z-order: draw the popup video before the overlay so a full-window
  frame stays above the background video.

Tested with the https://vpuniverse.com/files/file/23628-big-lebowski-pup-pack/