### PR TITLE
shaders: fix SMAA crash and broken render on Vulkan

### DIFF
--- a/src/shaders/bgfx/SMAA.sh
+++ b/src/shaders/bgfx/SMAA.sh
@@ -11,6 +11,22 @@ uniform vec4 w_h_height;
 
 #if BGFX_SHADER_LANGUAGE_GLSL
 #define SMAA_GLSL_3
+#elif BGFX_SHADER_LANGUAGE_SPIRV
+// Vulkan: the HLSL path declares standalone SamplerState (Linear/PointSampler) that bgfx does not
+// add to the pipeline layout, so RADV crashes compiling the pipeline and the AA renders broken.
+// Use a custom porting that samples through bgfx combined samplers (like the working OpenGL build),
+// while keeping bgfx's HLSL-style types (the GLSL path would redefine bvec2/float2 and clash).
+#define SMAA_CUSTOM_SL
+#define SMAATexture2D(tex) sampler2D tex
+#define SMAATexturePass2D(tex) tex
+#define SMAASampleLevelZero(tex, coord) texture2DLod(tex, coord, 0.0)
+#define SMAASampleLevelZeroPoint(tex, coord) texture2DLod(tex, coord, 0.0)
+#define SMAASampleLevelZeroOffset(tex, coord, offset) texture2DLodOffset(tex, coord, 0.0, offset)
+#define SMAASample(tex, coord) texture2D(tex, coord)
+#define SMAASamplePoint(tex, coord) texture2D(tex, coord)
+#define SMAASampleOffset(tex, coord, offset) texture2DLodOffset(tex, coord, 0.0, offset)
+#define SMAA_FLATTEN
+#define SMAA_BRANCH
 #else
 #define SMAA_HLSL_4_1
 #endif

--- a/src/shaders/bgfx/fs_pp_smaa_BlendingWeightCalculation.sc
+++ b/src/shaders/bgfx/fs_pp_smaa_BlendingWeightCalculation.sc
@@ -19,7 +19,7 @@ void main()
 	offset[1] = v_texcoord3;
 	offset[2] = v_texcoord4;
 	vec4 subsampleIndices = vec4_splat(0.0);
-#if BGFX_SHADER_LANGUAGE_GLSL
+#if BGFX_SHADER_LANGUAGE_GLSL || BGFX_SHADER_LANGUAGE_SPIRV
 	gl_FragColor = SMAABlendingWeightCalculationPS(v_texcoord0, v_texcoord1, offset, edgesTex, areaTex, searchTex, subsampleIndices);
 #else
 	gl_FragColor = SMAABlendingWeightCalculationPS(v_texcoord0, v_texcoord1, offset, edgesTex.m_texture, areaTex.m_texture, searchTex.m_texture, subsampleIndices);

--- a/src/shaders/bgfx/fs_pp_smaa_EdgeDetection.sc
+++ b/src/shaders/bgfx/fs_pp_smaa_EdgeDetection.sc
@@ -16,7 +16,7 @@ void main()
 	offset[0] = v_texcoord2;
 	offset[1] = v_texcoord3;
 	offset[2] = v_texcoord4;
-#if BGFX_SHADER_LANGUAGE_GLSL
+#if BGFX_SHADER_LANGUAGE_GLSL || BGFX_SHADER_LANGUAGE_SPIRV
 	vec2 rg = SMAAColorEdgeDetectionPS(v_texcoord0, offset, tex_fb_filtered);
 #else
 	vec2 rg = SMAAColorEdgeDetectionPS(v_texcoord0, offset, tex_fb_filtered.m_texture);

--- a/src/shaders/bgfx/fs_pp_smaa_NeighborhoodBlending.sc
+++ b/src/shaders/bgfx/fs_pp_smaa_NeighborhoodBlending.sc
@@ -13,7 +13,7 @@ SAMPLER2D(blendTex,        8);
 
 void main()
 {
-#if BGFX_SHADER_LANGUAGE_GLSL
+#if BGFX_SHADER_LANGUAGE_GLSL || BGFX_SHADER_LANGUAGE_SPIRV
 	gl_FragColor = SMAANeighborhoodBlendingPS(v_texcoord0, v_texcoord2, tex_fb_filtered, blendTex);
 #else
 	gl_FragColor = SMAANeighborhoodBlendingPS(v_texcoord0, v_texcoord2, tex_fb_filtered.m_texture, blendTex.m_texture);


### PR DESCRIPTION
On the Vulkan (SPIR-V) build the SMAA shaders went through the HLSL path, which
declares standalone `SamplerState` objects (`LinearSampler`/`PointSampler`).
bgfx does not add those to the pipeline layout, so the SPIR-V references sampler
bindings the layout never declares. On RADV this crashes while compiling the
pipeline (`lower_immediate_samplers`); when it does not crash, the AA samples an
invalid descriptor and renders dark/washed. OpenGL is unaffected because it
already uses the combined-sampler GLSL path.

Route the SPIR-V build through a custom SMAA porting (`SMAA_CUSTOM_SL`) that
samples via bgfx combined samplers, like the working OpenGL build, while keeping
bgfx's HLSL-style types (the plain GLSL path would redefine `bvec2`/`float2` and
clash). Validation (`VUID-VkGraphicsPipelineCreateInfo-layout-07988`,
`VUID-vkCmdDraw-None-08114`) is clean afterwards and the SPIR-V no longer
references the standalone samplers.

Only the SPIR-V path changes; Direct3D and Metal are untouched.

⚠️ _Direct3D 11/12 hit the same standalone-sampler problem - `Shader.cpp` already
notes it ("Direct3D 11 & 12 have issues with SMAA and DMD display shaders") and
carries a debug-build workaround that skips the `Point`/`Linear` SMAA samplers
during uniform validation (`Shader.cpp:1369`). This PR does not change the HLSL
path, so D3D is left as a known follow-up; the same `SMAA_CUSTOM_SL`
combined-sampler approach should fix it there too (after which that skip can go)._

Only the three SMAA `spv` blobs in `bgfx_antialiasing.h` are regenerated (the
source change affects only the SPIR-V path). They were verified byte-identical
to a full regeneration from the `vpinball-bgfx-shaders` CI workflow, so the
header is canonical for this change. The other targets' blobs are intentionally
left untouched: regenerating them would only introduce non-deterministic
DXBC-hash churn unrelated to this fix.

fixes #2133

Table overrides SMAA, see #3477 

Before below or black screen (F12 works and overlay visible)

<img width="1195" height="647" alt="image" src="https://github.com/user-attachments/assets/1805867e-a260-40c4-bb49-179f290f9434" />

After

<img width="1195" height="647" alt="image" src="https://github.com/user-attachments/assets/5c784457-55a5-4238-9d3a-0f7aa15624b1" />

