### PR TITLE
pinmame: fix hang on table exit for time-fence tables

### DIFF
--- a/plugins/pinmame/Controller.cpp
+++ b/plugins/pinmame/Controller.cpp
@@ -126,7 +126,11 @@ void Controller::Run(long hParentWnd, int nMinVersion)
 
 void Controller::Stop()
 {
-   PinmameSetTimeFence(0.0);
+   // Do not disable the time fence here (the previous PinmameSetTimeFence(0.0)): while a fence is
+   // active the PinMAME OSD throttle bails out, but disabling it makes the throttle (or, unthrottled,
+   // the audio update) run away inside updatescreen(), which then never returns - so the emulation
+   // thread never re-checks the stop flag and PinmameStop() hangs joining it. Leaving the fence at its
+   // last value keeps the throttle bailing and the emulation fence-paced, so it observes the stop.
    if (PinmameIsRunning())
    {
       PinmameStop();


### PR DESCRIPTION
Exiting a PinMAME table could hang the whole app: `Controller::Stop()` ->
`PinmameStop()` blocks forever joining the emulation thread.

`Stop()` disabled the time fence first (`PinmameSetTimeFence(0.0)`). While a
fence is active the PinMAME OSD throttle bails out, so its frame timing sits
stale; disabling it makes the throttle busy-spin inside `updatescreen()`, which
never returns, so the emulation thread never sees the stop flag.

Fix: leave the fence alone - the throttle keeps bailing and the emulation stays
fence-paced, so it observes the stop and exits cleanly. libpinmame resets the
fence itself on stop.

Notes:
- The `PinmameSetTimeFence(0.0)` line dates back to the plugin's first commit
  (a16e5d224) and was never a deliberate fix.
- Not table-specific: `controller.vbs`/`core.vbs` enable the time fence on the
  standalone plugin, so any PinMAME table is exposed; some slip through, others
  (Haunted Hotel) hang every time.
- The Windows/COM path has the same bug upstream
  (vbousquet/pinmame `src/win32com/Controller.cpp` `put_TimeFence(0.0)` in
  `CController::Stop()`, commit `169239a4`) and needs the same fix there?

Reproduced with 

* Haunted Hotel (LTD) (a generally messy table, also #1277):
   https://www.vpforums.org/index.php?app=downloads&showfile=16218
* Alien warrior (same author)
   https://www.vpforums.org/index.php?app=downloads&showfile=15941

### Where it hangs

```
  Main thread - blocked joining the PinMAME emulation thread:
  Player::~Player()                          (player.cpp:839, "Closing player...")
    PinTable::FireDispID()                   -> script runs Controller.Stop on exit
      B2SLegacy::PinMAMEAPI::HandleCall()    
        PinMAME::Controller::Stop()          (Controller.cpp:127)
          PinmameStop()
            std::thread::join()              <- parked here forever

  The emulation thread it's waiting for (Thread 116) - stuck spinning, never returns to check the stop flag:
  StartGame -> run_game -> cpu_run -> ... -> updatescreen()
    update_video_and_audio()
      osd_update_video_and_audio()
        usleep()                             <- busy-spinning in the OSD throttle
```
