### PR TITLE
cli: clear error for an invalid table argument

### DIFF
--- a/src/core/AppCommands.cpp
+++ b/src/core/AppCommands.cpp
@@ -4,6 +4,7 @@
 #include "AppCommands.h"
 
 #include <iostream>
+#include <fstream>
 
 #include "extern.h"
 #include "core/TournamentFile.h"
@@ -415,6 +416,25 @@ void CommandLineProcessor::OnCommandLineError(const string& title, const string&
    #endif
 }
 
+// A Visual Pinball table is an OLE compound file (CFB). Validate the signature so passing a
+// non-table file (wrong type, or a path typo resolving to something else) reports a clear error
+// instead of loading into a black screen.
+static bool IsTableFile(const std::filesystem::path& path)
+{
+   std::ifstream f(path, std::ios::binary);
+   if (!f.is_open())
+      return false;
+   unsigned char sig[8] = {};
+   f.read(reinterpret_cast<char*>(sig), sizeof(sig));
+   static constexpr unsigned char cfb[8] = { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
+   if (f.gcount() != static_cast<std::streamsize>(sizeof(sig)))
+      return false;
+   for (size_t k = 0; k < sizeof(sig); ++k)
+      if (sig[k] != cfb[k])
+         return false;
+   return true;
+}
+
 void CommandLineProcessor::ProcessCommandLine()
 {
 #ifndef __STANDALONE__
@@ -450,15 +470,24 @@ void CommandLineProcessor::ProcessCommandLine(int nArgs, const char* szArglist[]
       switch (opt)
       {
       case OPTION_INVALID:
-         // If the only parameter passed is a vpx table, consider it as /play command
+         // If the only parameter passed is a table, consider it a /play command. Play or fail the
+         // same on every platform: a missing, directory or non-table argument is an error rather
+         // than falling back to the editor.
          if ((nArgs == 2) && (i == 1))
          {
             std::filesystem::path filename = GetPathFromArg(szArglist[i]);
-            if (lowerCase(filename.extension().string()) == ".vpx" && FileExists(filename))
+            if (!std::filesystem::exists(filename))
             {
-               commands.push_back(std::make_unique<PlayTableCommand>(filename));
-               i++;
+               OnCommandLineError("Command Line Error"s, "Table file '" + filename.string() + "' was not found");
+               exit(1);
             }
+            if (!IsTableFile(filename))
+            {
+               OnCommandLineError("Command Line Error"s, "'" + filename.string() + "' is not a Visual Pinball table (.vpx)");
+               exit(1);
+            }
+            commands.push_back(std::make_unique<PlayTableCommand>(filename));
+            i++;
             break;
          }
          // ignore stuff (directories) that is passed in via frontends (not considered as invalid)
@@ -638,6 +667,11 @@ void CommandLineProcessor::ProcessCommandLine(int nArgs, const char* szArglist[]
             OnCommandLineError("Command Line Error"s, "Table file '" + tableFileName.string() + "' was not found");
             exit(1);
          }
+         else if (!IsTableFile(tableFileName))
+         {
+            OnCommandLineError("Command Line Error"s, "'" + tableFileName.string() + "' is not a Visual Pinball table (.vpx)");
+            exit(1);
+         }
          else
          {
             switch (opt)
@@ -680,6 +714,11 @@ void CommandLineProcessor::ProcessCommandLine(int nArgs, const char* szArglist[]
             OnCommandLineError("Command Line Error"s, "Table file '" + tableFileName.string() + "' was not found");
             exit(1);
          }
+         if (!IsTableFile(tableFileName))
+         {
+            OnCommandLineError("Command Line Error"s, "'" + tableFileName.string() + "' is not a Visual Pinball table (.vpx)");
+            exit(1);
+         }
          bool captureAttractLoop = true;
          if (i + 4 < nArgs && StrCompareNoCase("noloop"s, szArglist[i + 4]))
          {
@@ -707,6 +746,11 @@ void CommandLineProcessor::ProcessCommandLine(int nArgs, const char* szArglist[]
          if (!FileExists(tableFileName))
          {
             OnCommandLineError("Command Line Error"s, "Table file '" + tableFileName.string() + "' was not found");
+            exit(1);
+         }
+         if (!IsTableFile(tableFileName))
+         {
+            OnCommandLineError("Command Line Error"s, "'" + tableFileName.string() + "' is not a Visual Pinball table (.vpx)");
             exit(1);
          }
          const std::filesystem::path tournamentFileName = GetPathFromArg(szArglist[i + 2]);
@@ -740,14 +784,16 @@ void CommandLineProcessor::ProcessCommandLine(int nArgs, const char* szArglist[]
    if (defaultToWin32Editor && commands.empty())
       commands.push_back(std::make_unique<Win32EditCommand>());
    #endif
-   
+
    if (commands.size() > 1)
    {
       OnCommandLineError("Command Line Error"s, "Multiple command options specified. Please specify only one");
       exit(1);
    }
+   // With no actionable command (and no editor was opened above), show usage instead of starting up
+   // and immediately exiting with no output.
    if (commands.empty())
-      return;
+      commands.push_back(std::make_unique<ShowInfoAndExitCommand>("Visual Pinball Usage"s, GetCommandLineHelp(), 0));
    m_command = std::move(commands[0]);
 
    #ifndef __STANDALONE__


### PR DESCRIPTION
Running `-play <file>` with a file that exists but is not a Visual Pinball table
- e.g. accidentally pointing at the table's `.ini` sidecar instead of the `.vpx`
- loaded into a black screen with only a dialog written to the log, no useful
feedback. It now reports a clear command line error:

```
Command Line Error

'/path/Table.ini' is not a Visual Pinball table (.vpx)
```

A VPX table is an OLE compound file (CFB), so the file is validated by its
signature. This also catches a file that has a `.vpx` extension but is not
actually a table, which an extension-only check would miss.

The same validation applies to every argument that names a table - a bare table
argument, `-play`, `-povedit`, `-audit`, `-pov`, `-extractvbs`, `-captureattract`
and `-tournament`. A table argument now **plays or fails identically on all
platforms**: a missing, directory or non-table argument is an error, not a silent
no-op nor a fall-back to the editor.

A bare launch with no arguments now shows the usage instead of starting up and
immediately exiting. (On Windows a no-command launch still opens the editor.)
