### PR TITLE
b2slegacy: render the embedded DMD with the ScoreView glass overlay

### DIFF
--- a/make/CMakeLists_plugin_B2S.txt
+++ b/make/CMakeLists_plugin_B2S.txt
@@ -17,6 +17,7 @@ set(B2S_PLUGIN_SOURCES
    plugins/b2s/B2SRenderer.cpp
    plugins/b2s/B2SServer.h
    plugins/b2s/B2SServer.cpp
+   plugins/plugins/DMDDisplay.h
    plugins/plugins/ResURIResolver.h
    plugins/plugins/ResURIResolver.cpp
    third-party/include/tinyxml2/tinyxml2.h

--- a/make/CMakeLists_plugin_B2SLegacy.txt
+++ b/make/CMakeLists_plugin_B2SLegacy.txt
@@ -102,6 +102,7 @@ set(B2SLEGACY_PLUGIN_SOURCES
    plugins/b2slegacy/forms/FormBackglass.cpp
    plugins/b2slegacy/forms/FormDMD.h
    plugins/b2slegacy/forms/FormDMD.cpp
+   plugins/plugins/DMDDisplay.h
    plugins/plugins/ResURIResolver.h
    plugins/plugins/ResURIResolver.cpp
 

--- a/plugins/b2s/B2SDMDOverlay.cpp
+++ b/plugins/b2s/B2SDMDOverlay.cpp
@@ -3,6 +3,7 @@
 #include "common.h"
 
 #include "B2SDMDOverlay.h"
+#include "plugins/DMDDisplay.h"
 
 #include <cmath>
 #include <vector>
@@ -133,14 +134,7 @@ void B2SDMDOverlay::Render(VPXRenderContext2D* ctx)
    vec4 glassTint(1.f, 1.f, 1.f, 1.f);
    vec4 glassPad(0.f, 0.f, 0.f, 0.f);
    vec4 dmdTint(1.f, 1.f, 1.f, 1.f);
-   VPXDisplayRenderStyle style = VPXDisplayRenderStyle::VPXDMDStyle_Plasma;
-   switch (dmd.source->hardware & 0xFFFF0000)
-   {
-   case CTLPI_DISPLAY_HARDWARE_NEON_PLASMA: style = VPXDisplayRenderStyle::VPXDMDStyle_Plasma; break;
-   case CTLPI_DISPLAY_HARDWARE_RED_LED: style = VPXDisplayRenderStyle::VPXDMDStyle_RedLED; break;
-   case CTLPI_DISPLAY_HARDWARE_RGB_LED: style = VPXDisplayRenderStyle::VPXDMDStyle_GenLED; break;
-   case CTLPI_DISPLAY_HARDWARE_CRT_DISPLAY: style = VPXDisplayRenderStyle::VPXDMDStyle_CRT; break;
-   }
+   const VPXDisplayRenderStyle style = DMDStyleFromHardware(dmd.source->hardware);
    ctx->DrawDisplay(ctx, style,
       // First layer: glass
       nullptr, glassTint.x, glassTint.y, glassTint.z, 0.f, // Glass texture, tint and roughness

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -2,6 +2,7 @@
 
 #include "DMDOverlay.h"
 #include "VPXGraphics.h"
+#include "plugins/DMDDisplay.h"
 
 #include <cmath>
 #include <vector>
@@ -143,14 +144,7 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
    vec4 glassTint(1.f, 1.f, 1.f, 1.f);
    vec4 glassPad(0.f, 0.f, 0.f, 0.f);
    vec4 dmdTint(1.f, 1.f, 1.f, 1.f);
-   VPXDisplayRenderStyle style = VPXDisplayRenderStyle::VPXDMDStyle_Plasma;
-   switch (dmd.source->hardware & 0xFFFF0000)
-   {
-   case CTLPI_DISPLAY_HARDWARE_NEON_PLASMA: style = VPXDisplayRenderStyle::VPXDMDStyle_Plasma; break;
-   case CTLPI_DISPLAY_HARDWARE_RED_LED: style = VPXDisplayRenderStyle::VPXDMDStyle_RedLED; break;
-   case CTLPI_DISPLAY_HARDWARE_RGB_LED: style = VPXDisplayRenderStyle::VPXDMDStyle_GenLED; break;
-   case CTLPI_DISPLAY_HARDWARE_CRT_DISPLAY: style = VPXDisplayRenderStyle::VPXDMDStyle_CRT; break;
-   }
+   const VPXDisplayRenderStyle style = DMDStyleFromHardware(dmd.source->hardware);
    ctx->DrawDisplay(ctx, style,
       // First layer: glass
       nullptr, glassTint.x, glassTint.y, glassTint.z, 0.f, // Glass texture, tint and roughness

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -2,7 +2,6 @@
 
 #include "DMDOverlay.h"
 #include "VPXGraphics.h"
-#include "plugins/DMDDisplay.h"
 
 #include <cmath>
 #include <vector>
@@ -144,10 +143,20 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
    vec4 glassTint(1.f, 1.f, 1.f, 1.f);
    vec4 glassPad(0.f, 0.f, 0.f, 0.f);
    vec4 dmdTint(1.f, 1.f, 1.f, 1.f);
+   // Glass overlay, using the same texture and parameters as the ScoreView DMD so both render identically
+   VPXTexture glassTex = nullptr;
+   float glassRoughness = 0.f;
+   if ((glassTex = m_glass.Get(m_vpxApi)) != nullptr)
+   {
+      glassRoughness = 0.1f;
+      glassArea = vec4(0.f, 0.f, 1.f, 1.f); // full glass texture
+      const float amb = DMDsRGBToLinear(0.4f);
+      glassAmbient = vec4(amb, amb, amb, 1.f);
+   }
    const VPXDisplayRenderStyle style = DMDStyleFromHardware(dmd.source->hardware);
    ctx->DrawDisplay(ctx, style,
       // First layer: glass
-      nullptr, glassTint.x, glassTint.y, glassTint.z, 0.f, // Glass texture, tint and roughness
+      glassTex, glassTint.x, glassTint.y, glassTint.z, glassRoughness, // Glass texture, tint and roughness
       glassArea.x, glassArea.y, glassArea.z, glassArea.w, // Glass texture coordinates (inside overall glass texture)
       glassAmbient.x, glassAmbient.y, glassAmbient.z, // Glass lighting from room
       // Second layer: emitter

--- a/plugins/b2slegacy/utils/DMDOverlay.h
+++ b/plugins/b2slegacy/utils/DMDOverlay.h
@@ -4,6 +4,7 @@
 
 #include "../common.h"
 #include "plugins/ResURIResolver.h"
+#include "plugins/DMDDisplay.h"
 
 namespace B2SLegacy {
    
@@ -28,6 +29,7 @@ private:
 
    ivec4 m_frame;
    bool m_enable = false;
+   DMDGlassTexture m_glass;
 
    bool m_detectDmdFrame = false;
    VPXTexture m_backImage;

--- a/plugins/plugins/DMDDisplay.h
+++ b/plugins/plugins/DMDDisplay.h
@@ -2,9 +2,13 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <vector>
 
-#include "plugins/VPXPlugin.h"        // VPXDisplayRenderStyle
+#include "plugins/VPXPlugin.h"        // VPXDisplayRenderStyle, VPXPluginAPI
 #include "plugins/ControllerPlugin.h" // CTLPI_DISPLAY_HARDWARE_*
 
 // Map a controller display hardware hint (CTLPI_DISPLAY_HARDWARE_*) to the matching DMD render style.
@@ -20,3 +24,42 @@ inline VPXDisplayRenderStyle DMDStyleFromHardware(uint32_t hardware)
    default:                                 return VPXDisplayRenderStyle::VPXDMDStyle_Plasma;
    }
 }
+
+// sRGB to linear, for glass ambient values that are authored in sRGB but passed to the shader in linear.
+inline float DMDsRGBToLinear(float x) { return (x <= 0.04045f) ? (x * (1.f / 12.92f)) : powf(x * (1.f / 1.055f) + (0.055f / 1.055f), 2.4f); }
+
+// Lazily loads, caches and frees the DMD glass overlay texture (the dirty-glass cover shipped with the
+// ScoreView plugin). Hold one as a member and call Get() each frame; the texture is loaded once.
+class DMDGlassTexture final
+{
+public:
+   DMDGlassTexture() = default;
+   ~DMDGlassTexture() { if (m_tex && m_vpxApi) m_vpxApi->DeleteTexture(m_tex); }
+   DMDGlassTexture(const DMDGlassTexture&) = delete;
+   DMDGlassTexture& operator=(const DMDGlassTexture&) = delete;
+
+   VPXTexture Get(VPXPluginAPI* vpxApi)
+   {
+      if (m_loaded)
+         return m_tex;
+      m_loaded = true;
+      m_vpxApi = vpxApi;
+      VPXInfo vpxInfo {};
+      vpxApi->GetVpxInfo(&vpxInfo);
+      const std::filesystem::path path = std::filesystem::path(vpxInfo.path) / "plugins" / "scoreview" / "layouts" / "Glass-Dirty-1.webp";
+      std::ifstream file(path, std::ios::binary | std::ios::ate);
+      if (!file.is_open())
+         return nullptr;
+      const std::streamsize size = file.tellg();
+      file.seekg(0, std::ios::beg);
+      std::vector<uint8_t> buffer(static_cast<size_t>(size));
+      if (file.read(reinterpret_cast<char*>(buffer.data()), size))
+         m_tex = vpxApi->CreateTexture(buffer.data(), static_cast<int>(size));
+      return m_tex;
+   }
+
+private:
+   VPXTexture m_tex = nullptr;
+   bool m_loaded = false;
+   VPXPluginAPI* m_vpxApi = nullptr;
+};

--- a/plugins/plugins/DMDDisplay.h
+++ b/plugins/plugins/DMDDisplay.h
@@ -1,0 +1,22 @@
+// license:GPLv3+
+
+#pragma once
+
+#include <cstdint>
+
+#include "plugins/VPXPlugin.h"        // VPXDisplayRenderStyle
+#include "plugins/ControllerPlugin.h" // CTLPI_DISPLAY_HARDWARE_*
+
+// Map a controller display hardware hint (CTLPI_DISPLAY_HARDWARE_*) to the matching DMD render style.
+// Shared so every DMD consumer (B2S, B2S legacy, ...) selects the style identically.
+inline VPXDisplayRenderStyle DMDStyleFromHardware(uint32_t hardware)
+{
+   switch (hardware & CTLPI_DISPLAY_HARDWARE_FAMILY_MASK)
+   {
+   case CTLPI_DISPLAY_HARDWARE_RED_LED:     return VPXDisplayRenderStyle::VPXDMDStyle_RedLED;
+   case CTLPI_DISPLAY_HARDWARE_RGB_LED:     return VPXDisplayRenderStyle::VPXDMDStyle_GenLED;
+   case CTLPI_DISPLAY_HARDWARE_CRT_DISPLAY: return VPXDisplayRenderStyle::VPXDMDStyle_CRT;
+   case CTLPI_DISPLAY_HARDWARE_NEON_PLASMA:
+   default:                                 return VPXDisplayRenderStyle::VPXDMDStyle_Plasma;
+   }
+}


### PR DESCRIPTION
The legacy B2S embedded DMD (FullDMD / backglass overlay) drew the dots without the glass cover the ScoreView DMD applies, so it looked flat and sharp while the ScoreView DMD rendered glowy. Load the same glass texture and use the same parameters (roughness, area, ambient) so the embedded DMD matches the ScoreView.

The glass image is read from the ScoreView plugin's layouts folder.

This unifies both, literally embedding the score view.

Before

<img width="2159" height="875" alt="image" src="https://github.com/user-attachments/assets/b644cb38-0f56-4c77-8ace-a9045472e2a2" />

After

<img width="2000" height="850" alt="image" src="https://github.com/user-attachments/assets/dccba115-ec50-4ec1-a9b3-0b850e2c9147" />

_In the future we would probably want to make this tweakable from the ui, disabling, changing to non-dirty glass, style selection, save per table._