### PR TITLE
profiler: fix mislabeled render-thread sections in worst-frame log

### DIFF
--- a/src/ui/live/PerfUI.cpp
+++ b/src/ui/live/PerfUI.cpp
@@ -35,6 +35,8 @@ void PerfUI::NextPerfMode()
    {
       m_player->InitFPS();
       m_player->m_logicProfiler.EnableWorstFrameLogging(true);
+      if (m_player->m_renderProfiler != &m_player->m_logicProfiler)
+         m_player->m_renderProfiler->EnableWorstFrameLogging(true);
    }
    if (m_showPerf == PerfMode::PM_DISABLED)
       m_player->m_renderer->m_renderDevice->LogNextFrame();
@@ -193,6 +195,8 @@ void PerfUI::RenderStats() const
       "(Sleep to synchronise on user selected FPS)"s,
       #endif
    };
+   static_assert(std::size(infoLabels) == FrameProfiler::PROFILE_RENDER_SLEEP + 1, "infoLabels[] is out of sync with the ProfileSection enum");
+   static_assert(std::size(infoLabels2) == FrameProfiler::PROFILE_RENDER_SLEEP + 1, "infoLabels2[] is out of sync with the ProfileSection enum");
    static constexpr FrameProfiler::ProfileSection sections[] = {
       FrameProfiler::PROFILE_RENDER_SLEEP,
       FrameProfiler::PROFILE_RENDER_WAIT,

--- a/src/utils/wintimer.h
+++ b/src/utils/wintimer.h
@@ -111,18 +111,20 @@ public:
          "Custom 2:      "s,
          "Custom 3:      "s,
          // Render thread
-         "Render Wait:   "s, 
+         "Render Wait:   "s,
+         "Render WaitSC: "s,
          "Render Submit: "s,
          "Render Flip:   "s,
          "Render Sleep:  "s,
       };
+      static_assert(sizeof(labels) / sizeof(labels[0]) == PROFILE_RENDER_SLEEP + 1, "labels[] is out of sync with the ProfileSection enum");
       for (unsigned int i = 0; i < N_WORST; i++)
       {
          if (m_profileWorstData[i][PROFILE_FRAME] == 0)
             break;
          PLOGI << "Long Frame of " << std::setw(5) << std::fixed << std::setprecision(1) << (m_profileWorstData[i][PROFILE_FRAME] * 1e-3) << "ms happened after " 
                << std::setw(5) << std::fixed << (m_profileWorstGameTime[i] * 1e-3) << "s:";
-         for (int j = PROFILE_MISC; j <= PROFILE_CUSTOM3; j++)
+         for (int j = PROFILE_MISC; j <= PROFILE_RENDER_SLEEP; j++)
             if (m_profileWorstData[i][j] > 100) // only log impacting timings (above 0.1 ms)
             {
                PLOGI << "  . " << labels[j] << std::setw(6) << std::fixed << std::setprecision(1) << (m_profileWorstData[i][j] * 1e-3) << "ms";


### PR DESCRIPTION
labels[] was missing the PROFILE_RENDER_WAIT_SC entry, shifting every render label by one so present-block time printed as 'Render Sleep'. Add the missing label and static_assert the label arrays against the ProfileSection enum so a future mismatch fails to compile.

Also print the render-thread sections in the worst-frame dump (was logic-only) and enable worst-frame logging on the render profiler.