### PR TITLE
cli: run headless commands without the video subsystem

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -197,16 +197,9 @@ extern "C" int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, 
       cmdLine.ProcessCommandLine();
       theApp.InitInstance();
 
-      SDL_SetHint(SDL_HINT_WINDOW_ALLOW_TOPMOST, "0");
-      if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
-      {
-         PLOGE << "SDL_InitSubSystem(SDL_INIT_VIDEO) failed: " << SDL_GetError();
-         // FIXME this is not correct as we may be running something else than the player (extract vbs, ...)
-         exit(1);
-      }
-      if (const char* const drv = SDL_GetCurrentVideoDriver()) {
-         PLOGI << "SDL video driver: " << drv;
-      }
+      // The video subsystem is initialized lazily when a window is created (see VPX::Window), so
+      // headless commands (info, script/POV export, audit, tournament validation) run without a
+      // display or a working video driver.
 
       // Run the application
       if (cmdLine.m_command)
@@ -221,8 +214,6 @@ extern "C" int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, 
 
       retval = -1;
    }
-
-   SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
    #ifdef __STANDALONE__
       TTF_Quit();

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -50,10 +50,30 @@ static int GetPixelFormatDepth(SDL_PixelFormat format)
    }
 }
 
+// Initialize the SDL video subsystem on first window creation. Doing it here rather than at
+// application startup lets headless commands (info, script/POV export, audit, tournament
+// validation) run without a display or a working video driver. Refcounted, released in ~Window().
+static void EnsureVideoSubsystem()
+{
+   const bool wasInit = SDL_WasInit(SDL_INIT_VIDEO);
+   if (!wasInit)
+      SDL_SetHint(SDL_HINT_WINDOW_ALLOW_TOPMOST, "0");
+   if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
+   {
+      PLOGE << "SDL_InitSubSystem(SDL_INIT_VIDEO) failed: " << SDL_GetError();
+      exit(1);
+   }
+   if (!wasInit)
+      if (const char* const drv = SDL_GetCurrentVideoDriver())
+         PLOGI << "SDL video driver: " << drv;
+}
+
 Window::Window(const int width, const int height)
    : m_windowId(VPXWindowId::VPXWINDOW_Playfield)
    , m_isVR(true)
 {
+   EnsureVideoSubsystem();
+
    m_width = width;
    m_height = height;
    m_pixelWidth = width;
@@ -74,6 +94,8 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
    : m_windowId(windowId)
    , m_isVR(false)
 {
+   EnsureVideoSubsystem();
+
 #ifdef ENABLE_BGFX
    m_fullscreen = false;
 #else
@@ -296,6 +318,8 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
 
 Window::~Window()
 {
+   SDL_QuitSubSystem(SDL_INIT_VIDEO); // Balances the init done in the constructor (refcounted)
+
    if (m_isVR)
       return;
 


### PR DESCRIPTION
Help, version, script/POV export, audit and tournament validation do not open a window, but they were gated behind a fatal SDL_INIT_VIDEO init and failed when no display or a broken video driver was present. 

Add AppCommand::RequiresVideo() (false for these commands) and only init the video subsystem when the command needs it.

before:

```
❯ SDL_VIDEO_DRIVER="doesnotexist" ./build/VPinballX_BGFX -help                            
2026-06-04 21:08:32.290 INFO  [3602805] [VPApp::InitInstance@316] Starting VPX - v10.8.1 Beta (Rev. 9999 (unknown), linux BGFX 64bits)
2026-06-04 21:08:32.290 INFO  [3602805] [VPApp::InitInstance@317] Settings file was loaded from /home/me/.local/share/VPinballX/10.8/VPinballX.ini
2026-06-04 21:08:32.290 INFO  [3602805] [VPApp::InitInstance@318] Number of logical CPU cores: 32
2026-06-04 21:08:32.290 INFO  [3602805] [VPApp::InitInstance@319] Application path: /home/me/workspace/somatik/vpinball/build/
2026-06-04 21:08:32.290 INFO  [3602805] [VPApp::InitInstance@320] Preference path: /home/me/.local/share/VPinballX/10.8
2026-06-04 21:08:32.293 ERROR [3602805] [WinMain@203] SDL_InitSubSystem(SDL_INIT_VIDEO) failed: doesnotexist not available
```

after:
```
❯ SDL_VIDEO_DRIVER="doesnotexist" ./build/VPinballX_BGFX -help
2026-06-04 21:29:14.015 INFO  [3611088] [VPApp::InitInstance@316] Starting VPX - v10.8.1 Beta (Rev. 9999 (unknown), linux BGFX 64bits)
2026-06-04 21:29:14.015 INFO  [3611088] [VPApp::InitInstance@317] Settings file was loaded from /home/me/.local/share/VPinballX/10.8/VPinballX.ini
2026-06-04 21:29:14.015 INFO  [3611088] [VPApp::InitInstance@318] Number of logical CPU cores: 32
2026-06-04 21:29:14.015 INFO  [3611088] [VPApp::InitInstance@319] Application path: /home/me/workspace/somatik/vpinball/build/
2026-06-04 21:29:14.015 INFO  [3611088] [VPApp::InitInstance@320] Preference path: /home/me/.local/share/VPinballX/10.8
Visual Pinball Usage

-h  
-help  
-?  
-Play  [filename]  Load and play file
-PovEdit  [filename]  Load and run file in live editing mode, then export new pov on exit
-Pov  [filename]  Load, export pov and close
...
-ExtractVBS  [filename]  Load, export table script and close
```