### PR TITLE
fix: initialize SDL video before Win32 window-class registration (#3489)

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -98,6 +98,19 @@ Player::Player(PinTable *const table, const PlayMode playMode)
    g_pplayer = this;
    m_ptable->AddRef();
 
+   // Initialize the SDL video subsystem before anything that needs a display. This is done here
+   // (rather than at application startup) so headless commands, which never create a Player, run
+   // without a working video driver. It must happen before the Win32 SDL_RegisterApp / window
+   // creation below, hence at the very start of the Player. Released in the destructor.
+   SDL_SetHint(SDL_HINT_WINDOW_ALLOW_TOPMOST, "0");
+   if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
+   {
+      PLOGE << "SDL_InitSubSystem(SDL_INIT_VIDEO) failed: " << SDL_GetError();
+      exit(1);
+   }
+   if (const char* const drv = SDL_GetCurrentVideoDriver())
+      PLOGI << "SDL video driver: " << drv;
+
    // Load player plugins
 
    PLOGI << "Loading player plugins"; // For profiling
@@ -1043,6 +1056,8 @@ Player::~Player()
 
    delete m_vrDevice;
    m_vrDevice = nullptr;
+
+   SDL_QuitSubSystem(SDL_INIT_VIDEO); // Balances the init done in the constructor
 
    m_logicProfiler.LogWorstFrame();
    if (&m_logicProfiler != m_renderProfiler)

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -50,30 +50,10 @@ static int GetPixelFormatDepth(SDL_PixelFormat format)
    }
 }
 
-// Initialize the SDL video subsystem on first window creation. Doing it here rather than at
-// application startup lets headless commands (info, script/POV export, audit, tournament
-// validation) run without a display or a working video driver. Refcounted, released in ~Window().
-static void EnsureVideoSubsystem()
-{
-   const bool wasInit = SDL_WasInit(SDL_INIT_VIDEO);
-   if (!wasInit)
-      SDL_SetHint(SDL_HINT_WINDOW_ALLOW_TOPMOST, "0");
-   if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
-   {
-      PLOGE << "SDL_InitSubSystem(SDL_INIT_VIDEO) failed: " << SDL_GetError();
-      exit(1);
-   }
-   if (!wasInit)
-      if (const char* const drv = SDL_GetCurrentVideoDriver())
-         PLOGI << "SDL video driver: " << drv;
-}
-
 Window::Window(const int width, const int height)
    : m_windowId(VPXWindowId::VPXWINDOW_Playfield)
    , m_isVR(true)
 {
-   EnsureVideoSubsystem();
-
    m_width = width;
    m_height = height;
    m_pixelWidth = width;
@@ -94,8 +74,6 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
    : m_windowId(windowId)
    , m_isVR(false)
 {
-   EnsureVideoSubsystem();
-
 #ifdef ENABLE_BGFX
    m_fullscreen = false;
 #else
@@ -318,8 +296,6 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
 
 Window::~Window()
 {
-   SDL_QuitSubSystem(SDL_INIT_VIDEO); // Balances the init done in the constructor (refcounted)
-
    if (m_isVR)
       return;
 


### PR DESCRIPTION
22adfda moved SDL_INIT_VIDEO into VPX::Window, but on Windows the Player registers its window class (SDL_RegisterApp) before creating the window, so the video subsystem ended up initialized too late and bgfx::init failed, crashing every table to desktop.

Initialize the video subsystem at the start of the Player instead, before SDL_RegisterApp and window creation. Headless commands never create a Player, so they keep running without the video subsystem.

fixes #3489 