### PR TITLE
pinmame plugin: return VPinMAME defaults for settings

### DIFF
--- a/plugins/b2s/B2SPlugin.cpp
+++ b/plugins/b2s/B2SPlugin.cpp
@@ -42,6 +42,16 @@ PSC_CLASS_START(B2S_GameSettings, GameSettings)
    PSC_PROXY_PROP_RW_ARRAY1(m_gameSettingsProxy.get(), int, Value, string)
 PSC_CLASS_END()
 
+// Proxy class for PinMAME Settings
+static std::unique_ptr<ScriptablePlugin::ScriptClassProxy> m_settingsProxy;
+class Settings { PSC_IMPLEMENT_REFCOUNT() }; // Dummy class as we directly use the proxied object
+PSC_CLASS_START(B2S_Settings, Settings)
+   members.clear();
+   PSC_PROXY_PROP_R(m_settingsProxy.get(), uint32, AddRef)
+   PSC_PROXY_PROP_R(m_settingsProxy.get(), uint32, Release)
+   PSC_PROXY_PROP_RW_ARRAY1(m_settingsProxy.get(), int, Value, string)
+PSC_CLASS_END()
+
 // Proxy class for PinMAME Game
 static std::unique_ptr<ScriptablePlugin::ScriptClassProxy> m_gameProxy;
 class Game { PSC_IMPLEMENT_REFCOUNT() }; // Dummy class as we directly use the proxied object
@@ -141,6 +151,7 @@ PSC_CLASS_START(B2S_Server, B2SServer)
    PSC_PROXY_PROP_RW(me, bool, ShowTitle)
    PSC_PROXY_PROP_RW(me, bool, HandleKeyboard)
    PSC_PROXY_PROP_RW(me, bool, HandleMechanics)
+   PSC_PROXY_PROP_R(me, B2S_Settings, Settings)
    PSC_PROXY_PROP_RW_ARRAY1(me, int32, SolMask, int)
    // Run/Pause/Stop
    PSC_PROXY_FUNCTION0(me, void, Run)
@@ -247,12 +258,14 @@ MSGPI_EXPORT void MSGPIAPI B2SPluginLoad(const uint32_t sessionId, const MsgPlug
    auto arrayLambda = [](ScriptArrayDef* sad) { scriptApi->RegisterScriptArrayType(sad); };
    RegisterB2S_Server(classLambda);
    RegisterB2S_GameSettings(classLambda);
+   RegisterB2S_Settings(classLambda);
    RegisterB2S_Game(classLambda);
    RegisterB2S_ByteArray(arrayLambda);
    RegisterB2S_IntArray(arrayLambda);
    RegisterB2S_StructArray(arrayLambda);
    m_gameProxy = std::make_unique<ScriptablePlugin::ScriptClassProxy>(msgApi, endpointId, "PinMAME_", "PinMAME_Game", "B2S_", B2S_Game_SCD);
    m_gameSettingsProxy = std::make_unique<ScriptablePlugin::ScriptClassProxy>(msgApi, endpointId, "PinMAME_", "PinMAME_GameSettings", "B2S_", B2S_GameSettings_SCD);
+   m_settingsProxy = std::make_unique<ScriptablePlugin::ScriptClassProxy>(msgApi, endpointId, "PinMAME_", "PinMAME_Settings", "B2S_", B2S_Settings_SCD);
    B2S_Server_SCD->CreateObject = []()
    {
       if (nServer > 0)
@@ -274,11 +287,13 @@ MSGPI_EXPORT void MSGPIAPI B2SPluginUnload()
    auto arrayLambda = [](ScriptArrayDef* sad) { scriptApi->UnregisterScriptArrayType(sad); };
    m_gameProxy = nullptr;
    m_gameSettingsProxy = nullptr;
+   m_settingsProxy = nullptr;
    UnregisterB2S_ByteArray(arrayLambda);
    UnregisterB2S_IntArray(arrayLambda);
    UnregisterB2S_StructArray(arrayLambda);
    UnregisterB2S_Game(classLambda);
    UnregisterB2S_GameSettings(classLambda);
+   UnregisterB2S_Settings(classLambda);
    UnregisterB2S_Server(classLambda);
    
    msgApi->ReleaseMsgID(getVpxApiId);

--- a/plugins/b2slegacy/B2SLegacyPlugin.cpp
+++ b/plugins/b2slegacy/B2SLegacyPlugin.cpp
@@ -39,6 +39,16 @@ PSC_CLASS_START(B2SLegacy_GameSettings, GameSettings)
    PSC_PROXY_PROP_RW_ARRAY1(m_gameSettingsProxy.get(), int, Value, string)
 PSC_CLASS_END()
 
+// Proxy class for PinMAME Settings
+static std::unique_ptr<ScriptablePlugin::ScriptClassProxy> m_settingsProxy;
+class Settings { PSC_IMPLEMENT_REFCOUNT() }; // Dummy class as we directly use the proxied object
+PSC_CLASS_START(B2SLegacy_Settings, Settings)
+   members.clear();
+   PSC_PROXY_PROP_R(m_settingsProxy.get(), uint32, AddRef)
+   PSC_PROXY_PROP_R(m_settingsProxy.get(), uint32, Release)
+   PSC_PROXY_PROP_RW_ARRAY1(m_settingsProxy.get(), int, Value, string)
+PSC_CLASS_END()
+
 // Proxy class for PinMAME Game
 static std::unique_ptr<ScriptablePlugin::ScriptClassProxy> m_gameProxy;
 class Game { PSC_IMPLEMENT_REFCOUNT() }; // Dummy class as we directly use the proxied object
@@ -138,6 +148,7 @@ PSC_CLASS_START(B2SLegacy_Server, Server)
    PSC_PROXY_PROP_RW(me, bool, ShowTitle)
    PSC_PROXY_PROP_RW(me, bool, HandleKeyboard)
    PSC_PROXY_PROP_RW(me, bool, HandleMechanics)
+   PSC_PROXY_PROP_R(me, B2SLegacy_Settings, Settings)
    PSC_PROXY_PROP_RW_ARRAY1(me, int32, SolMask, int)
    // Run/Pause/Stop
    PSC_PROXY_FUNCTION0(me, void, Run)
@@ -210,12 +221,14 @@ MSGPI_EXPORT void MSGPIAPI B2SLegacyPluginLoad(const uint32_t sessionId, MsgPlug
    auto arrayLambda = [](ScriptArrayDef* sad) { scriptApi->RegisterScriptArrayType(sad); };
    RegisterB2SLegacy_Server(classLambda);
    RegisterB2SLegacy_GameSettings(classLambda);
+   RegisterB2SLegacy_Settings(classLambda);
    RegisterB2SLegacy_Game(classLambda);
    RegisterB2SLegacy_ByteArray(arrayLambda);
    RegisterB2SLegacy_IntArray(arrayLambda);
    RegisterB2SLegacy_StructArray(arrayLambda);
    m_gameProxy = std::make_unique<ScriptablePlugin::ScriptClassProxy>(msgApi, endpointId, "PinMAME_", "PinMAME_Game", "B2SLegacy_", B2SLegacy_Game_SCD);
    m_gameSettingsProxy = std::make_unique<ScriptablePlugin::ScriptClassProxy>(msgApi, endpointId, "PinMAME_", "PinMAME_GameSettings", "B2SLegacy_", B2SLegacy_GameSettings_SCD);
+   m_settingsProxy = std::make_unique<ScriptablePlugin::ScriptClassProxy>(msgApi, endpointId, "PinMAME_", "PinMAME_Settings", "B2SLegacy_", B2SLegacy_Settings_SCD);
    B2SLegacy_Server_SCD->CreateObject = []()
    {
       if (nServer > 0)
@@ -237,11 +250,13 @@ MSGPI_EXPORT void MSGPIAPI B2SLegacyPluginUnload()
    auto arrayLambda = [](ScriptArrayDef* sad) { scriptApi->UnregisterScriptArrayType(sad); };
    m_gameProxy = nullptr;
    m_gameSettingsProxy = nullptr;
+   m_settingsProxy = nullptr;
    UnregisterB2SLegacy_ByteArray(arrayLambda);
    UnregisterB2SLegacy_IntArray(arrayLambda);
    UnregisterB2SLegacy_StructArray(arrayLambda);
    UnregisterB2SLegacy_Game(classLambda);
    UnregisterB2SLegacy_GameSettings(classLambda);
+   UnregisterB2SLegacy_Settings(classLambda);
    UnregisterB2SLegacy_Server(classLambda);
    
    msgApi->ReleaseMsgID(getVpxApiId);

--- a/plugins/pinmame/Controller.cpp
+++ b/plugins/pinmame/Controller.cpp
@@ -34,8 +34,8 @@ Controller::~Controller()
    m_msgApi->ReleaseMsgID(m_getDmdSrcMsgId);
    if (m_onDestroyHandler)
       m_onDestroyHandler(this);
-   for (const auto& game : m_games)
-      game.second->Release();
+   for (const auto& settings : m_gameSettings)
+      settings.second->Release();
    if (m_settings)
       m_settings->Release();
    delete m_pPinmameGame;
@@ -55,29 +55,28 @@ string Controller::GetVersion() const
 
 Game* Controller::GetGames(const string& name) const
 {
-   const auto it = m_games.find(name);
-   if (it != m_games.end())
+   GameSettings* settings;
+   if (const auto it = m_gameSettings.find(name); it != m_gameSettings.end())
+      settings = it->second;
+   else
    {
-      it->second->AddRef();
-      return it->second;
+      // shared settings instance so values written through one Game object
+      // are seen by later Games(name) accesses
+      settings = new GameSettings();
+      m_gameSettings[name] = settings;
    }
    struct GameCBData
    {
       const Controller* controller;
+      GameSettings* settings;
       Game* game;
    };
-   GameCBData cbData { this, nullptr };
+   GameCBData cbData { this, settings, nullptr };
    PinmameGetGame(name.c_str(), [](PinmameGame* pPinmameGame, void* const pUserData)
       {
          GameCBData* pGame = static_cast<GameCBData*>(pUserData);
-         pGame->game = new Game(const_cast<Controller*>(pGame->controller), *pPinmameGame);
+         pGame->game = new Game(const_cast<Controller*>(pGame->controller), *pPinmameGame, pGame->settings);
       }, &cbData);
-   if (cbData.game)
-   {
-      // keep one reference for the cache, hand the initial one to the caller
-      cbData.game->AddRef();
-      m_games[name] = cbData.game;
-   }
    return cbData.game;
 }
 

--- a/plugins/pinmame/Controller.cpp
+++ b/plugins/pinmame/Controller.cpp
@@ -2,6 +2,7 @@
 
 #include "Controller.h"
 #include "Game.h"
+#include "Settings.h"
 #include <thread>
 #include <format>
 
@@ -33,6 +34,10 @@ Controller::~Controller()
    m_msgApi->ReleaseMsgID(m_getDmdSrcMsgId);
    if (m_onDestroyHandler)
       m_onDestroyHandler(this);
+   for (const auto& game : m_games)
+      game.second->Release();
+   if (m_settings)
+      m_settings->Release();
    delete m_pPinmameGame;
    delete m_pPinmameMechConfig;
 }
@@ -50,6 +55,12 @@ string Controller::GetVersion() const
 
 Game* Controller::GetGames(const string& name) const
 {
+   const auto it = m_games.find(name);
+   if (it != m_games.end())
+   {
+      it->second->AddRef();
+      return it->second;
+   }
    struct GameCBData
    {
       const Controller* controller;
@@ -61,7 +72,21 @@ Game* Controller::GetGames(const string& name) const
          GameCBData* pGame = static_cast<GameCBData*>(pUserData);
          pGame->game = new Game(const_cast<Controller*>(pGame->controller), *pPinmameGame);
       }, &cbData);
+   if (cbData.game)
+   {
+      // keep one reference for the cache, hand the initial one to the caller
+      cbData.game->AddRef();
+      m_games[name] = cbData.game;
+   }
    return cbData.game;
+}
+
+Settings* Controller::GetSettings()
+{
+   if (m_settings == nullptr)
+      m_settings = new Settings();
+   m_settings->AddRef();
+   return m_settings;
 }
 
 void Controller::SetGameName(const string& name)

--- a/plugins/pinmame/Controller.h
+++ b/plugins/pinmame/Controller.h
@@ -10,6 +10,7 @@
 namespace PinMAME {
 
 class Game;
+class GameSettings;
 class Settings;
 
 class Controller final
@@ -159,7 +160,7 @@ public:
 private:
    string m_vpmPath;
    string m_szGameName;
-   mutable std::unordered_map<string, Game*> m_games; // cache so per-game settings survive repeated Games(name) accesses
+   mutable std::unordered_map<string, GameSettings*> m_gameSettings; // shared per game so settings survive repeated Games(name) accesses
    Settings* m_settings = nullptr;
    PinmameGame* m_pPinmameGame = nullptr;
    PinmameMechConfig* m_pPinmameMechConfig = nullptr;

--- a/plugins/pinmame/Controller.h
+++ b/plugins/pinmame/Controller.h
@@ -5,9 +5,12 @@
 #include "common.h"
 #include "plugins/ControllerPlugin.h"
 
+#include <unordered_map>
+
 namespace PinMAME {
 
 class Game;
+class Settings;
 
 class Controller final
 {
@@ -26,6 +29,8 @@ public:
 
    // TODO may also be accessed as a collection object
    Game* GetGames(const string& name) const;
+
+   Settings* GetSettings();
 
    string GetGameName() const { return m_szGameName; }
    void SetGameName(const string& name);
@@ -154,6 +159,8 @@ public:
 private:
    string m_vpmPath;
    string m_szGameName;
+   mutable std::unordered_map<string, Game*> m_games; // cache so per-game settings survive repeated Games(name) accesses
+   Settings* m_settings = nullptr;
    PinmameGame* m_pPinmameGame = nullptr;
    PinmameMechConfig* m_pPinmameMechConfig = nullptr;
    vector<PinmameLampState> m_lampStates;

--- a/plugins/pinmame/Game.h
+++ b/plugins/pinmame/Game.h
@@ -15,11 +15,12 @@ namespace PinMAME {
 class Game final
 {
 public:
-   Game(Controller* pController, const PinmameGame& pinmameGame)
+   Game(Controller* pController, const PinmameGame& pinmameGame, GameSettings* pSettings)
       : m_pController(pController)
-      , m_settings(new GameSettings())
+      , m_settings(pSettings)
    {
       m_pController->AddRef();
+      m_settings->AddRef();
       memcpy(&m_pinmameGame, &pinmameGame, sizeof(PinmameGame));
    }
    ~Game()

--- a/plugins/pinmame/GameSettings.h
+++ b/plugins/pinmame/GameSettings.h
@@ -24,7 +24,7 @@ public:
    //void PutValue(const string& name, ScriptVariant v) { /* Not yet implemented */ }
    int GetValue(const string& key) const
    {
-      const string k = ToLowerKey(key);
+      const string k = string_to_lower(key);
       const auto it = m_values.find(k);
       if (it != m_values.end())
          return it->second;
@@ -34,7 +34,7 @@ public:
       LOGW(std::format("Unknown game setting '{}', returning 0", key));
       return 0;
    }
-   void SetValue(const string& key, int v) { m_values[ToLowerKey(key)] = v; }
+   void SetValue(const string& key, int v) { m_values[string_to_lower(key)] = v; }
    void SetDisplayPosition(float newValX, float newValY, void* hWnd = nullptr) { /* Not yet implemented */ }
    void ShowSettingsDlg(void* hParentWnd = nullptr) { /* Not yet implemented */ }
 

--- a/plugins/pinmame/GameSettings.h
+++ b/plugins/pinmame/GameSettings.h
@@ -4,6 +4,9 @@
 
 #include "common.h"
 #include "plugins/ScriptablePlugin.h"
+#include "SettingsDefaults.h"
+
+#include <unordered_map>
 
 namespace PinMAME {
 
@@ -15,14 +18,28 @@ public:
 
    PSC_IMPLEMENT_REFCOUNT()
 
-   void Clear() { /* Not yet implemented */ }
+   void Clear() { m_values.clear(); }
    // FIXME implement a dynamically typed variant
    //ScriptVariant GetValue(const string& name) const { return {}; /* Not yet implemented */ }
    //void PutValue(const string& name, ScriptVariant v) { /* Not yet implemented */ }
-   int GetValue(const string& key) const { return 0; }
-   void SetValue(const string& key, int v) { }
+   int GetValue(const string& key) const
+   {
+      const string k = ToLowerKey(key);
+      const auto it = m_values.find(k);
+      if (it != m_values.end())
+         return it->second;
+      int v;
+      if (TryGetSettingDefault(k, v))
+         return v;
+      LOGW(std::format("Unknown game setting '{}', returning 0", key));
+      return 0;
+   }
+   void SetValue(const string& key, int v) { m_values[ToLowerKey(key)] = v; }
    void SetDisplayPosition(float newValX, float newValY, void* hWnd = nullptr) { /* Not yet implemented */ }
    void ShowSettingsDlg(void* hParentWnd = nullptr) { /* Not yet implemented */ }
+
+private:
+   std::unordered_map<string, int> m_values;
 };
 
 }

--- a/plugins/pinmame/PinMAMEPlugin.cpp
+++ b/plugins/pinmame/PinMAMEPlugin.cpp
@@ -140,6 +140,7 @@ PSC_CLASS_START(PinMAME_Controller, Controller)
    PSC_PROP_RW(string, SplashInfoLine)
    PSC_PROP_RW(bool, HandleKeyboard)
    PSC_PROP_RW(bool, HandleMechanics)
+   PSC_PROP_R(PinMAME_Settings, Settings)
    PSC_PROP_RW_ARRAY1(int32, SolMask, int)
    // Run/Pause/Stop
    PSC_FUNCTION0(void, Run)

--- a/plugins/pinmame/Settings.h
+++ b/plugins/pinmame/Settings.h
@@ -20,7 +20,7 @@ public:
 
    int GetValue(const string& key) const
    {
-      const string k = ToLowerKey(key);
+      const string k = string_to_lower(key);
       const auto it = m_values.find(k);
       if (it != m_values.end())
          return it->second;
@@ -30,7 +30,7 @@ public:
       LOGW(std::format("Unknown setting '{}', returning 0", key));
       return 0;
    }
-   void SetValue(const string& key, int v) { m_values[ToLowerKey(key)] = v; }
+   void SetValue(const string& key, int v) { m_values[string_to_lower(key)] = v; }
 
 private:
    std::unordered_map<string, int> m_values;

--- a/plugins/pinmame/Settings.h
+++ b/plugins/pinmame/Settings.h
@@ -4,6 +4,9 @@
 
 #include "common.h"
 #include "plugins/ScriptablePlugin.h"
+#include "SettingsDefaults.h"
+
+#include <unordered_map>
 
 namespace PinMAME {
 
@@ -15,8 +18,22 @@ public:
 
    PSC_IMPLEMENT_REFCOUNT()
 
-   int GetValue(const string& key) const { return 0; }
-   void SetValue(const string& key, int v) { }
+   int GetValue(const string& key) const
+   {
+      const string k = ToLowerKey(key);
+      const auto it = m_values.find(k);
+      if (it != m_values.end())
+         return it->second;
+      int v;
+      if (TryGetSettingDefault(k, v))
+         return v;
+      LOGW(std::format("Unknown setting '{}', returning 0", key));
+      return 0;
+   }
+   void SetValue(const string& key, int v) { m_values[ToLowerKey(key)] = v; }
+
+private:
+   std::unordered_map<string, int> m_values;
 };
 
 }

--- a/plugins/pinmame/SettingsDefaults.h
+++ b/plugins/pinmame/SettingsDefaults.h
@@ -4,18 +4,9 @@
 
 #include "common.h"
 
-#include <algorithm>
-#include <cctype>
 #include <unordered_map>
 
 namespace PinMAME {
-
-inline string ToLowerKey(const string& key)
-{
-   string k(key);
-   std::transform(k.begin(), k.end(), k.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-   return k;
-}
 
 // Default values matching VPinMAME settings that were never explicitly set,
 // so table scripts relying on VPinMAME defaults behave the same as on

--- a/plugins/pinmame/SettingsDefaults.h
+++ b/plugins/pinmame/SettingsDefaults.h
@@ -1,0 +1,79 @@
+// license:GPLv3+
+
+#pragma once
+
+#include "common.h"
+
+#include <algorithm>
+#include <cctype>
+#include <unordered_map>
+
+namespace PinMAME {
+
+inline string ToLowerKey(const string& key)
+{
+   string k(key);
+   std::transform(k.begin(), k.end(), k.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+   return k;
+}
+
+// Default values matching VPinMAME settings that were never explicitly set,
+// so table scripts relying on VPinMAME defaults behave the same as on
+// Windows. Values taken from PinMAME src/windows/config.c (pinmame_opts)
+// and src/win32com/VPinMAMEConfig.cpp (vpinmame_opts).
+inline bool TryGetSettingDefault(const string& lowerKey, int& value)
+{
+   static const std::unordered_map<string, int> defaults = {
+      // DMD colors and intensities
+      { "dmd_red"s, 255 },
+      { "dmd_green"s, 88 },
+      { "dmd_blue"s, 32 },
+      { "dmd_perc0"s, 20 },
+      { "dmd_perc33"s, 33 },
+      { "dmd_perc66"s, 67 },
+      { "dmd_only"s, 0 },
+      { "dmd_compact"s, 0 },
+      { "dmd_antialias"s, 50 },
+      { "dmd_colorize"s, 0 },
+      { "dmd_red66"s, 225 },
+      { "dmd_green66"s, 15 },
+      { "dmd_blue66"s, 193 },
+      { "dmd_red33"s, 6 },
+      { "dmd_green33"s, 0 },
+      { "dmd_blue33"s, 214 },
+      { "dmd_red0"s, 0 },
+      { "dmd_green0"s, 0 },
+      { "dmd_blue0"s, 0 },
+      { "dmd_opacity"s, 100 },
+      // DMD window
+      { "dmd_border"s, 1 },
+      { "dmd_title"s, 1 },
+      { "dmd_pos_x"s, 0 },
+      { "dmd_pos_y"s, 0 },
+      { "dmd_width"s, 0 },
+      { "dmd_height"s, 0 },
+      { "dmd_doublesize"s, 0 },
+      { "showpindmd"s, 0 },
+      { "showwindmd"s, 1 },
+      // Sound
+      { "sound"s, 1 },
+      { "samples"s, 1 },
+      { "resampling_quality"s, 0 },
+      { "sound_mode"s, 0 },
+      { "force_stereo"s, 0 },
+      // Misc
+      { "rol"s, 0 },
+      { "ignore_rom_crc"s, 0 },
+      { "cabinet_mode"s, 0 },
+      { "threadpriority"s, 1 },
+      { "synclevel"s, 0 },
+      { "fastframes"s, -1 },
+   };
+   const auto it = defaults.find(lowerKey);
+   if (it == defaults.end())
+      return false;
+   value = it->second;
+   return true;
+}
+
+}

--- a/plugins/pinmame/common.h
+++ b/plugins/pinmame/common.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cstdarg>
 #include <cstdio>
 #include <filesystem>
@@ -35,6 +37,12 @@ LPI_USE_CPP();
 PSC_USE_ERROR();
 
 std::filesystem::path find_case_insensitive_directory_path(const std::filesystem::path& searchedFile);
+
+inline string string_to_lower(string str)
+{
+   std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+   return str;
+}
 
    // copies all characters of src incl. the null-terminator, BUT never more than dest_size-1, always null-terminates
 inline void strncpy_s(char* const __restrict dest, const size_t dest_size, const char* const __restrict src)


### PR DESCRIPTION
Table scripts read `Controller.Games(x).Settings.Value(...)` expecting the defaults VPinMAME ships on Windows (dmd_red=255, dmd_perc33=33, ...), but the plugin returned 0 for every key. This made FlexDMD-based tables that derive colors from these settings render a black DMD, and historically caused script crashes (vpx-standalone-scripts https://github.com/jsm174/vpx-standalone-scripts/pull/309 / https://github.com/jsm174/vpx-standalone-scripts/pull/445).

- Add a defaults table matching PinMAME src/windows/config.c and src/win32com/VPinMAMEConfig.cpp, used by Settings and GameSettings
- Store written values per instance so write-then-read round-trips
- Cache Game instances per name in the Controller so settings survive repeated Games(name) accesses
- Expose Controller.Settings (present in VPinMAME on Windows, used by tables like [Phantom of the Opera](https://github.com/jsm174/vpx-standalone-scripts/pull/137)) and proxy it in both B2S plugins

Verified on linux BGFX with a test table script: defaults returned, writes round-trip at both controller and game level.