### PR TITLE
pup: fix use-after-free of queued triggers on unload (fixes #3499)

### DIFF
--- a/plugins/pup/PUPManager.cpp
+++ b/plugins/pup/PUPManager.cpp
@@ -203,6 +203,10 @@ void PUPManager::LoadConfig(const string& szRomName)
 
 void PUPManager::Unload()
 {
+   // Run any still-queued trigger invokes (see QueueDOFEvent) while the triggers
+   // and screens they point to are still alive.
+   m_msgApi->FlushPendingCallbacks(m_endpointId);
+
    if (IsRunning())
       Stop();
 

--- a/plugins/pup/PUPPinDisplay.cpp
+++ b/plugins/pup/PUPPinDisplay.cpp
@@ -28,7 +28,9 @@ PUPPinDisplay::PUPPinDisplay(PUPManager& manager)
 
 PUPPinDisplay::~PUPPinDisplay()
 {
-   m_pupManager.Unload();
+   // This object is only a script proxy: tables may create and release several of
+   // them for the same game, so do not unload the manager here. Teardown happens
+   // on game end (see PUPPlugin OnGameEnd) or through an explicit CloseApp call.
 }
 
 void PUPPinDisplay::Init(int screenNum, const string& romName)


### PR DESCRIPTION
Releasing a `PinUpPlayer.PinDisplay` script proxy did a full unload, freeing triggers whose Invoke was still queued on the main thread; tables that recreate the proxy crashed in `PUPTrigger::Invoke` during load. The proxy destructor no longer unloads (game end / CloseApp handle teardown), and Unload now flushes pending callbacks while triggers are still alive.

fixes #3499 (I was able to reproduce this on Linux)