### PR TITLE
b2slegacy: start LED digits blank

### DIFF
--- a/plugins/b2slegacy/controls/B2SLEDBox.h
+++ b/plugins/b2slegacy/controls/B2SLEDBox.h
@@ -27,7 +27,7 @@ private:
    uint32_t m_litLEDSegmentColor;
    uint32_t m_darkLEDSegmentColor;
    eLEDType m_ledType;
-   int m_value;
+   int m_value = 0;
    string m_text;
 };
 


### PR DESCRIPTION
`B2SLEDBox::m_value` was uninitialized, so LED displays showed random segments until the controller updated each digit. The VB.NET original zero-initialized the field implicitly; the port lost that.

fixes #1393