### PR TITLE
ui: apply renderer priority changes directly, allow per table save

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -2290,20 +2290,36 @@ void Player::OnAuxRendererChanged(const unsigned int msgId, void* userData, void
       me->m_ancillaryWndRenderers[window].resize(getAuxRendererMsg.count);
       getAuxRendererMsg = { window, getAuxRendererMsg.count, 0, me->m_ancillaryWndRenderers[window].data() };
       m_msgApi->BroadcastMsg(me->m_pluginAPI.GetVPXEndPointId(), me->m_getAuxRendererId, &getAuxRendererMsg);
+      auto& priorities = me->m_ancillaryWndRendererPriorities[window];
       for (const auto& renderer : me->m_ancillaryWndRenderers[window])
+      {
          Settings::GetRegistry().Register(std::make_unique<VPX::Properties::IntPropertyDef>(section, "Priority."s.append(renderer.id), renderer.name,
             "A value that will be used to select if the '"s + renderer.name + "' renderer should be used on the "s + section + " display. Higher values are priorized other lower ones."s,
             false, 0, 100, 0));
-      std::ranges::sort(me->m_ancillaryWndRenderers[window],
+         // Seed the live priority from settings, keeping any live (unsaved) adjustment made through the in game UI
+         priorities.try_emplace(renderer.id, me->m_ptable->m_settings.GetInt(Settings::GetRegistry().GetPropertyId(section, "Priority."s.append(renderer.id)).value()));
+      }
+      std::ranges::stable_sort(me->m_ancillaryWndRenderers[window],
          [&](const AncillaryRendererDef &a, const AncillaryRendererDef &b)
-         {
-            int pa = me->m_ptable->m_settings.GetInt(Settings::GetRegistry().GetPropertyId(section, "Priority."s.append(a.id)).value());
-            int pb = me->m_ptable->m_settings.GetInt(Settings::GetRegistry().GetPropertyId(section, "Priority."s.append(b.id)).value());
-            return pa > pb; // Sort in descending order (first is the most wanted)
-         });
+         { return priorities[a.id] > priorities[b.id]; }); // Sort in descending order (first is the most wanted)
       std::erase_if(me->m_ancillaryWndRenderers[window],
-         [section, me](const AncillaryRendererDef &a) { return me->m_ptable->m_settings.GetInt(Settings::GetRegistry().GetPropertyId(section, "Priority."s.append(a.id)).value()) < 0; });
+         [&priorities](const AncillaryRendererDef &a) { return priorities[a.id] < 0; });
    }
+}
+
+int Player::GetAncillaryRendererPriority(VPXWindowId window, const string& id) const
+{
+   const auto& priorities = m_ancillaryWndRendererPriorities[window];
+   const auto entry = priorities.find(id);
+   return entry != priorities.end() ? entry->second : 0;
+}
+
+void Player::SetAncillaryRendererPriority(VPXWindowId window, const string& id, int priority)
+{
+   m_ancillaryWndRendererPriorities[window][id] = priority;
+   // Re-collect and re-sort so the change is directly applied (also restores renderers
+   // previously dropped for a negative priority)
+   OnAuxRendererChanged(0, this, nullptr);
 }
 
 void Player::UpdateVolume()

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -189,6 +189,8 @@ public:
    Renderer *m_renderer = nullptr;
    VRDevice *m_vrDevice = nullptr;
    vector<AncillaryRendererDef> m_ancillaryWndRenderers[VPXWindowId::VPXWINDOW_Topper + 1];
+   int GetAncillaryRendererPriority(VPXWindowId window, const string& id) const;
+   void SetAncillaryRendererPriority(VPXWindowId window, const string& id, int priority);
 
    bool IsVR() const { return m_vrDevice != nullptr; }
 
@@ -204,6 +206,8 @@ private:
 
    static void OnAuxRendererChanged(const unsigned int msgId, void *userData, void *msgData);
    unsigned int m_getAuxRendererId = 0, m_onAuxRendererChgId = 0;
+   // Live (unsaved) renderer priorities, seeded from settings when renderers are collected
+   std::map<string, int, std::less<>> m_ancillaryWndRendererPriorities[VPXWindowId::VPXWINDOW_Topper + 1];
 
    int m_cabinetAutoFitMode = 0;
    float m_cabinetAutoFitPos = 0.05f;

--- a/src/ui/live/ingameui/DisplaySettingsPage.cpp
+++ b/src/ui/live/ingameui/DisplaySettingsPage.cpp
@@ -171,17 +171,19 @@ void DisplaySettingsPage::BuildPage()
    {
       if (std::optional<VPX::Properties::PropertyRegistry::PropId> propId = Settings::GetRegistry().GetPropertyId(section, "Priority."s.append(renderer.id)); propId)
       {
-         // TODO this property is directly persisted. It does not follow the overall UI design: App/Table/Live state => Implement live state (will also enable table override)
+         const string id = renderer.id;
          AddItem(std::make_unique<InGameUIItem>(
-                    propId.value(),
-                    "%d", //
-                    [this, propId]() { return m_player->m_ptable->m_settings.GetInt(propId.value()); }, //
-                    [this, propId](int, int v)
+                    *Settings::GetRegistry().GetIntProperty(propId.value()),
+                    "%d"s, //
+                    [this, id]() { return m_player->GetAncillaryRendererPriority(m_wndId, id); }, // Live
+                    [propId](const Settings& settings) { return settings.GetInt(propId.value()); }, // Stored
+                    [this, id](int, int v)
                     {
-                       m_delayApplyNotifId = m_player->m_liveUI->PushNotification("This change will be applied after restarting the game"s, 5000, m_delayApplyNotifId);
-                       m_player->m_ptable->m_settings.Set(propId.value(), v, false);
+                       m_player->SetAncillaryRendererPriority(m_wndId, id, v);
                        BuildPage();
-                    }))
+                    }, //
+                    [propId](Settings& settings) { settings.Reset(propId.value()); }, //
+                    [propId](int v, Settings& settings, bool asTableOverride) { settings.Set(propId.value(), v, asTableOverride); }))
             .m_excludeFromDefault = true;
       }
    }


### PR DESCRIPTION
Changing a renderer priority in the display settings now re-sorts the window's renderer chain immediately instead of asking for a restart, and the value goes through the regular App/Table/Live save flow instead of being silently persisted to the global settings.