### PR TITLE
pup: resolve images in playlist subfolders

### DIFF
--- a/plugins/pup/PUPLabel.cpp
+++ b/plugins/pup/PUPLabel.cpp
@@ -190,11 +190,13 @@ void PUPLabel::SetCaption(const string& szCaption)
          if (szExt == "gif" || szExt == "png" || szExt == "apng" || szExt == "bmp" || szExt == "jpg" || szExt == "jpeg")
          {
             std::filesystem::path fs_path(normalize_path_separators(szText));
-            string playlistFolder = fs_path.parent_path().string();
-            PUPPlaylist* pPlaylist = m_pScreen->GetPlaylist(playlistFolder);
+            // The playlist is the first path component, the rest is the file path inside
+            // the playlist folder (which may contain subfolders, e.g. playlist\player2\foo.png)
+            const std::filesystem::path playlistFolder = *fs_path.begin();
+            PUPPlaylist* pPlaylist = m_pScreen->GetPlaylist(playlistFolder.string());
             std::filesystem::path szPath;
             if (pPlaylist)
-               szPath = pPlaylist->GetPlayFilePath(fs_path.filename());
+               szPath = pPlaylist->GetPlayFilePath(fs_path.lexically_relative(playlistFolder));
             if (!szPath.empty())
             {
                m_szPath = szPath;

--- a/plugins/pup/PUPPlaylist.cpp
+++ b/plugins/pup/PUPPlaylist.cpp
@@ -55,11 +55,14 @@ PUPPlaylist::PUPPlaylist(PUPManager* manager, const std::filesystem::path& szFol
       return;
    }
 
-   for (const auto& entry : std::filesystem::directory_iterator(m_szBasePath)) {
+   for (const auto& entry : std::filesystem::recursive_directory_iterator(m_szBasePath)) {
       if (entry.is_regular_file()) {
-         std::filesystem::path szFilename = entry.path().filename();
+         std::filesystem::path szFilename = entry.path().lexically_relative(m_szBasePath);
          if (!szFilename.empty() && szFilename != ".") {
-            m_files.push_back(szFilename);
+            // Only top level files take part in the playlist rotation, files in subfolders
+            // can still be requested explicitly (e.g. LabelSet with playlist\subdir\file.png)
+            if (szFilename.parent_path().empty())
+               m_files.push_back(szFilename);
             m_fileMap[lowerCase(szFilename)] = szFilename;
          }
       }
@@ -133,9 +136,6 @@ const std::filesystem::path& PUPPlaylist::GetNextPlayFile()
 
 std::filesystem::path PUPPlaylist::GetPlayFilePath(const std::filesystem::path& szFilename)
 {
-   if (m_files.empty())
-      return emptyPath;
-
    if (!szFilename.empty()) {
       ankerl::unordered_dense::map<std::filesystem::path, std::filesystem::path>::const_iterator it = m_fileMap.find(lowerCase(szFilename));
       if (it != m_fileMap.end())
@@ -143,8 +143,11 @@ std::filesystem::path PUPPlaylist::GetPlayFilePath(const std::filesystem::path& 
       else
          return emptyPath;
    }
-   else
-      return m_szBasePath / GetNextPlayFile();
+
+   if (m_files.empty())
+      return emptyPath;
+
+   return m_szBasePath / GetNextPlayFile();
 }
 
 bool PUPPlaylist::IsResting() const


### PR DESCRIPTION
Playlists indexed their folder one level deep and labels resolved the playlist from the full parent path, so a caption like playlist\player2\foo.png never matched. Index recursively (subfolder files do not join the playlist rotation) and resolve the playlist from the first path component, looking up the rest inside it.

fixes #2416