### PR TITLE
ui: apply window resizes asynchronously

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1494,6 +1494,19 @@ void Player::ProcessOSMessages(const bool isInitialized)
          SetCloseState(Player::CloseState::CS_STOP_PLAY);
          break;
 
+      case SDL_EVENT_WINDOW_RESIZED:
+      case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+      {
+         SDL_Window* const wnd = SDL_GetWindowFromID(e.window.windowID);
+         if (m_playfieldWnd->GetCore() == wnd)
+            m_playfieldWnd->OnResized();
+         else
+            for (VPX::RenderOutput* const output : { &m_backglassOutput, &m_scoreViewOutput, &m_topperOutput })
+               if (output->GetMode() == VPX::RenderOutput::OM_WINDOW && output->GetWindow()->GetCore() == wnd)
+                  output->GetWindow()->OnResized();
+         break;
+      }
+
       case SDL_EVENT_KEY_UP:
       case SDL_EVENT_KEY_DOWN:
          isPFWnd = (SDL_GetWindowFromID(e.key.windowID) == m_playfieldWnd->GetCore()) || IsVR();

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -3263,6 +3263,8 @@ RenderTarget* Renderer::SetupAncillaryRenderTarget(
    else if (output.GetMode() == VPX::RenderOutput::OM_WINDOW)
    {
       outputRT = output.GetWindow()->GetBackBuffer();
+      if (outputRT == nullptr) // The swapchain is being recreated (see Window::OnResized), skip rendering this window
+         return nullptr;
       outputW = outputRT->GetWidth();
       outputH = outputRT->GetHeight();
       outputX = 0;

--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -357,25 +357,62 @@ void Window::SetSize(const int x, const int y)
       return;
    if (x == GetWidth() && y == GetHeight())
       return;
-   SDL_SetWindowSize(m_nwnd, x, y);
-   SDL_GetWindowSize(m_nwnd, &m_width, &m_height);
-   SDL_GetWindowSizeInPixels(m_nwnd, &m_pixelWidth, &m_pixelHeight);
-   #ifdef ENABLE_BGFX
-   // The RenderDevice automatically manages the backbuffer resize. For ancillary windows (BGFX only), we need to recreate the swapchain
-   if (m_backBuffer && g_pplayer && g_pplayer->m_playfieldWnd != this)
+   // The window manager applies resizes asynchronously (or not at all, e.g. tiled), so
+   // send a request and only send the next one once this one has been acknowledged by a
+   // resize event (see OnResized), collapsing intermediate sizes (e.g. a size slider).
+   // The timeout recovers from window managers that do not answer a request at all.
+   if (m_resizeRequestTick != 0 && SDL_GetTicks() - m_resizeRequestTick < 500)
    {
-      g_pplayer->m_renderer->m_renderDevice->AddEndOfFrameCmd(
-         [this]()
-         {
-            g_pplayer->m_renderer->m_renderDevice->RemoveWindow(this);
-            delete m_backBuffer;
-            m_backBuffer = nullptr;
-            // We must destroy the swapchain before attaching a new swapchain, so flush and flip now
-            g_pplayer->m_renderer->m_renderDevice->Flip();
-            g_pplayer->m_renderer->m_renderDevice->AddWindow(this);
-         });
+      m_pendingWidth = x;
+      m_pendingHeight = y;
+      return;
    }
-   #endif
+   m_resizeRequestTick = SDL_GetTicks();
+   m_pendingWidth = -1;
+   m_pendingHeight = -1;
+   SDL_SetWindowSize(m_nwnd, x, y);
+}
+
+void Window::OnResized()
+{
+   if (m_isVR)
+      return;
+   m_resizeRequestTick = 0;
+   int width, height, pixelWidth, pixelHeight;
+   SDL_GetWindowSize(m_nwnd, &width, &height);
+   SDL_GetWindowSizeInPixels(m_nwnd, &pixelWidth, &pixelHeight);
+   if (width != m_width || height != m_height || pixelWidth != m_pixelWidth || pixelHeight != m_pixelHeight)
+   {
+      m_width = width;
+      m_height = height;
+      m_pixelWidth = pixelWidth;
+      m_pixelHeight = pixelHeight;
+      #ifdef ENABLE_BGFX
+      // The RenderDevice automatically manages the backbuffer resize. For ancillary windows (BGFX only), we need to recreate the swapchain
+      if (m_backBuffer && g_pplayer && g_pplayer->m_playfieldWnd != this)
+      {
+         g_pplayer->m_renderer->m_renderDevice->AddEndOfFrameCmd(
+            [this]()
+            {
+               g_pplayer->m_renderer->m_renderDevice->RemoveWindow(this);
+               delete m_backBuffer;
+               m_backBuffer = nullptr;
+               // We must destroy the swapchain before attaching a new swapchain, so flush and flip now
+               g_pplayer->m_renderer->m_renderDevice->Flip();
+               g_pplayer->m_renderer->m_renderDevice->AddWindow(this);
+            });
+      }
+      #endif
+   }
+   // Apply the latest size requested while the acknowledged request was in flight
+   if (m_pendingWidth > 0 && m_pendingHeight > 0)
+   {
+      const int w = m_pendingWidth;
+      const int h = m_pendingHeight;
+      m_pendingWidth = -1;
+      m_pendingHeight = -1;
+      SetSize(w, h);
+   }
 }
 
 vector<Window::DisplayConfig> Window::GetDisplays()

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -70,7 +70,8 @@ public:
    float GetHDRHeadRoom() const { return m_hdrHeadRoom; } // Maximum luminance of display expressed in multiple of SDRWhitePoint (so 6 means 6 times the SDR whitepoint)
 
    void SetPos(const int x, const int y);
-   void SetSize(const int w, const int h); // This only changes the window size, without adjusting its backbuffer
+   void SetSize(const int w, const int h); // Request a new window size, applied asynchronously by the window manager (acknowledged through OnResized)
+   void OnResized(); // To be called when the window manager resized the window: updates the cached sizes and recreates the swapchain of ancillary windows
    void Show(const bool show = true);
    bool IsVisible() const;
    void RaiseAndFocus();
@@ -126,6 +127,9 @@ private:
    const bool m_isVR;
 
    class RenderTarget* m_backBuffer = nullptr;
+
+   uint64_t m_resizeRequestTick = 0; // Last unacknowledged resize request, 0 for none (see SetSize/OnResized)
+   int m_pendingWidth = -1, m_pendingHeight = -1; // Size requested while another request was in flight
 
    SDL_Window* m_nwnd = nullptr;
 };


### PR DESCRIPTION
Resizing a floating ancillary window from the in-game settings locked the game
below 1 fps and could crash.

`SetSize` assumed resizes are synchronous, but the
[SDL_SetWindowSize](https://wiki.libsdl.org/SDL3/SDL_SetWindowSize) docs state:

> On some windowing systems, this request is asynchronous and the new window size
> may not have been applied immediately upon the return of this function. [...]
> Additionally, as this is just a request, it can be denied by the windowing
> system (e.g. tiled window managers).
>
> When the window size changes, an SDL_EVENT_WINDOW_RESIZED event will be emitted
> with the new window dimensions.

On Wayland this is protocol level: sizes arrive as
[configure events](https://wayland.app/protocols/xdg-shell#xdg_surface:event:configure) the client acknowledges. So the immediate read-back left the cached size stale,
and the settings UI kept re-firing the request, each one recreating the swapchain.

The resize flow now works like the underlying protocol: send one request, wait for
the resize event to acknowledge it before sending the next (with a timeout for
window managers that never answer). The resize event does the bookkeeping and a
single swapchain recreate, which also covers resizes initiated by the window
manager itself and display scale changes - previously not handled at all.
(`SDL_SyncWindow` would be the blocking alternative, but blocking the render loop
per request is the wrong trade and it still cannot help when the request is
denied.)

While the swapchain is being recreated the window is skipped for a frame instead
of crashing on its freed backbuffer; that race predates this change, fully
sequencing the recreate against the frame loop is a possible follow-up.

Tested on Wayland with a floating score view: rapid slider resizing went from a
sub-1 fps lockup to tracking the slider.

Related to #2772