### PR TITLE
linux: keep the executable name as the process name

### DIFF
--- a/src/core/VPApp.cpp
+++ b/src/core/VPApp.cpp
@@ -137,7 +137,13 @@ VPApp::VPApp()
 {
    g_app = this;
 
+   // On Linux the main thread name is the process comm, which is what task
+   // monitors (top, btop, ...) display, so leave it as the executable name.
+   // Elsewhere the thread name is separate from the process name and a label
+   // is useful in debuggers.
+#if !defined(__linux__) && !defined(__ANDROID__)
    SetThreadName("Main"s);
+#endif
 
    #ifdef CRASH_HANDLER
       rde::CrashHandler::Init();


### PR DESCRIPTION
The main thread name is the process comm (the kernel's short command name for a process) on Linux, which is what task monitors display, so naming it Main hid the binary name. Skip the rename on Linux/Android; keep it elsewhere where it is only a debugger label.


Before

<img width="500" alt="Screenshot_2026-06-13_21-37-56" src="https://github.com/user-attachments/assets/e14c6e3b-7332-4584-9171-58d4103e4857" />

After

<img width="500"  alt="Screenshot_2026-06-13_21-36-19" src="https://github.com/user-attachments/assets/5ec84a63-e86d-4dca-b766-1cb2106f292b" />