### PR TITLE
standalone: hide the in-player mouse cursor via SDL

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -826,6 +826,24 @@ Player::Player(PinTable *const table, const PlayMode playMode)
    }
 }
 
+// Show or hide the mouse cursor. The native build uses the Win32 ShowCursor
+// counter; the standalone build uses SDL on every platform, since there
+// ShowCursor is only a no-op stub.
+static void SetMouseCursorVisible(const bool visible)
+{
+#ifndef __STANDALONE__
+   if (visible)
+      while (ShowCursor(TRUE) < 0); // FIXME on a system without a mouse, it looks like this may result in an infinite loop
+   else
+      while (ShowCursor(FALSE) >= 0);
+#else
+   if (visible)
+      SDL_ShowCursor();
+   else
+      SDL_HideCursor();
+#endif
+}
+
 Player::~Player()
 {
    assert(g_pplayer == this && g_pplayer->m_closing != CS_CLOSED);
@@ -1075,8 +1093,7 @@ Player::~Player()
 
    m_ptable->Release();
 
-   while (ShowCursor(FALSE) >= 0);
-   while (ShowCursor(TRUE) < 0);
+   SetMouseCursorVisible(true);
    PLOGI << "Player closed.";
 
 #ifdef __LIBVPINBALL__
@@ -1212,14 +1229,7 @@ void Player::ApplyPlayingState(const bool play)
 
 void Player::UpdateCursorState() const
 {
-   if (m_drawCursor || !IsPlaying())
-   {
-      while (ShowCursor(TRUE) < 0); // FIXME on a system without a mouse, it looks like this may result in an infinite loop
-   }
-   else
-   {
-      while (ShowCursor(FALSE) >= 0);
-   }
+   SetMouseCursorVisible(m_drawCursor || !IsPlaying());
 }
 
 void Player::OnScriptError(ScriptInterpreter::ErrorType type, int line, int column, const string &description, const vector<string> &stackDump)


### PR DESCRIPTION
ShowCursor is a no-op stub on standalone, so the player never actually hid the cursor. Drive it through `SDL_HideCursor`/`SDL_ShowCursor` instead.

fixes #2698