### PR TITLE
b2slegacy: clear backglass running flag when the form is destroyed

### DIFF
--- a/plugins/b2slegacy/Server.cpp
+++ b/plugins/b2slegacy/Server.cpp
@@ -1737,6 +1737,10 @@ void Server::HideBackglassForm()
 
 void Server::KillBackglassForm()
 {
+   // Clear the running flag before destroying the form, like the B2S server does. The data
+   // setters gate on IsBackglassRunning(), so a script that keeps pushing B2S data after the
+   // backglass is killed then stops touching the freed form instead of dereferencing it.
+   m_pB2SData->SetBackglassVisible(false);
    if (m_pFormBackglass) {
       delete m_pFormBackglass;
       m_pFormBackglass = nullptr;


### PR DESCRIPTION
KillBackglassForm now clears the visible/running flag, matching the B2S backglass server. The B2S data setters gate on IsBackglassRunning(), so a script that keeps pushing B2S data after stopping the backglass (e.g. a table that calls Controller.stop during init) no longer dereferences the freed form and crashes.

https://www.vpforums.org/index.php?app=downloads&showfile=15165

The table ships with UserOptionsSet = 0 (line 206, the default). At the end of Table1_Init there's a gate:

```vbscript
  If UserOptionsSet = 0 Then
     MsgBox "Hello, This table requires VPX 10.8.0 or higher..."
     MsgBox "This table uses a VPM ROM Alias..."
     MsgBox "PLAYER OPTIONS HAVE NOT BEEN SET..."
     MsgBox "...The table will now Halt..."
     MsgBox "Now, go and set your options..."
     Table1_Exit
  End If
```