### PR TITLE
table: warn on a missing backdrop image

### DIFF
--- a/src/core/def.h
+++ b/src/core/def.h
@@ -801,6 +801,9 @@ CONSTEXPR inline void StrToUpper(string& str)
    std::ranges::transform(str.begin(), str.end(), str.begin(), cUpper);
 }
 
+// Sentinel stored in image/sound/material droplist references to mean "no selection".
+inline constexpr char g_szNoneSelection[] = "<None>";
+
 inline bool StrCompareNoCase(const string& strA, const string& strB)
 {
    return strA.length() == strB.length()

--- a/src/parts/dispreel.cpp
+++ b/src/parts/dispreel.cpp
@@ -278,7 +278,7 @@ void DispReel::UpdateAnimation(const float diff_time_msec)
             m_reelInfo[i].motorOffset = 0;
 
             // play the sound (if any) for each click of the reel
-            if (!m_d.m_szSound.empty() && (m_d.m_szSound != "<None>"))
+            if (!m_d.m_szSound.empty() && (m_d.m_szSound != g_szNoneSelection))
             {
                const BSTR mySoundBSTR = MakeWideBSTR(m_d.m_szSound);
                m_ptable->PlaySound(mySoundBSTR, 0, 1.0f, 0.f, 0.f, 0, VARIANT_FALSE, VARIANT_TRUE, 0.f);

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -2155,6 +2155,12 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
             m_BG_image[i] = m_BG_image[BG_DESKTOP];
       }
 
+   // Warn if the backdrop used by the active view mode references an image that is not in the
+   // table: it would render black. An empty name or the "<None>" sentinel means no backdrop is set.
+   if (const string& bg = m_BG_image[GetViewMode()];
+       !bg.empty() && !StrCompareNoCase(bg, g_szNoneSelection) && GetImage(bg) == nullptr)
+      PLOGW << "Backdrop image '" << bg << "' set for the active view mode was not found in the table (renders black)";
+
    Settings::SetTableOverride_Difficulty_Default(m_difficulty);
    m_globalDifficulty = m_settings.GetTableOverride_Difficulty();
 
@@ -4724,6 +4730,13 @@ string PinTable::AuditTable(bool log) const
       totalGpuSize += gpuSize;
    }
    ss << ". Total image size: " << SizeToReadable(totalSize) << " in VPX file, at least " << SizeToReadable(totalGpuSize) << " in GPU memory when played\r\n";
+
+   // Backdrop images referenced per view mode but not present in the table would render black.
+   // An empty name or the "<None>" sentinel means no backdrop is set.
+   static const char* const bgSetNames[NUM_BG_SETS] = { "Desktop", "Cabinet", "Full Single Screen" };
+   for (unsigned int i = 0; i < NUM_BG_SETS; ++i)
+      if (const string& bg = m_BG_image[i]; !bg.empty() && !StrCompareNoCase(bg, g_szNoneSelection) && GetImage(bg) == nullptr)
+         ss << ". Warning: " << bgSetNames[i] << " backdrop image '" << bg << "' is not present in the table (renders black)\r\n";
 
    int nPrimTris = 0, primMemSize = 0;
    for (const auto part : m_vedit)


### PR DESCRIPTION
A backdrop image name that points at an image not present in the table renders black with no hint why. Warn for the active view mode at load, and report every view mode in the table audit. The "<None>" droplist sentinel and an empty name both mean "no backdrop", so they are skipped; add a g_szNoneSelection constant for that sentinel.