### PR TITLE
texture: font texture atlas mip map issues

### DIFF
--- a/src/renderer/Texture.cpp
+++ b/src/renderer/Texture.cpp
@@ -412,6 +412,19 @@ std::shared_ptr<BaseTexture> BaseTexture::CreateFromFreeImage(FIBITMAP* dib, con
       FreeImage_Unload(dibResized);
    FreeImage_Unload(dib);
 
+   // Clear the colour of fully transparent texels. Some images (e.g. dot matrix reel font atlases)
+   // store transparent areas as opaque-coloured (often white), which bilinear filtering and mip
+   // generation then bleed into the visible edges as a halo/seam. Zeroing them makes any filtering
+   // blend toward black instead, and is invisible since these texels have zero alpha.
+   if (tex && (tex->m_format == RGBA || tex->m_format == SRGBA))
+   {
+      uint8_t* const d = tex->m_data;
+      const size_t numPixels = (size_t)tex->m_width * tex->m_height;
+      for (size_t i = 0; i < numPixels; ++i)
+         if (d[i * 4 + 3] == 0)
+            d[i * 4 + 0] = d[i * 4 + 1] = d[i * 4 + 2] = 0;
+   }
+
    return tex;
 }
 


### PR DESCRIPTION
TNA renders it's desktop DMD like below on standalone. On windows these grey bars are not visible.

This is among others caused by the first square in the atlas being `FFFFFF00`

<img width="400" alt="Screenshot_2026-06-16_00-11-10" src="https://github.com/user-attachments/assets/c20808d4-a3be-459d-9928-6951b333db6a" />


Some images store transparent areas as opaque-coloured zero alpha. Bilinear filtering and mip generation then bleed that colour into the visible glyph edges as white seams (notably on the BGFX backend). Zero the rgb of fully transparent texels at load so filtering blends toward black; invisible since the texels have zero alpha.

`SF_NONE` is another option but that degrades now smooth looking white reels with numbers

*I'm not convinced any of these are the right fix but it at least starts the conversation*

This mostly fixes https://vpuniverse.com/files/file/14359-total-nuclear-annihilation-spooky-2017-vpw/

<img width="756" alt="Screenshot_2026-06-16_00-00-43" src="https://github.com/user-attachments/assets/7577fee8-cb3d-4456-a923-e5bedbb248af" />

After

<img width="1631" height="514" alt="Screenshot_2026-06-16_00-06-45" src="https://github.com/user-attachments/assets/f2e9ada8-b361-4aa9-94f3-23edeb5eaabb" />

Still not perfect, low contrast lines remain