### PR TITLE
pup: fix label flicker when shown in two locations

### DIFF
--- a/plugins/pup/PUPLabel.cpp
+++ b/plugins/pup/PUPLabel.cpp
@@ -777,6 +777,13 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       m_dirty = true;
    }
 
+   // A text label is sized as a percentage of the output height, so the big backglass and the small
+   // scoreview need different pixel sizes from the same label. They share one cached texture, which
+   // would regenerate every frame as the two outputs alternate rect.h - each invalidating the other,
+   // the shared texture flickering between the two sizes. Prerender once at the largest height seen and
+   // scale the draw down to each output's height, so the cache is stable and neither output evicts it.
+   m_canonHeight = std::max(m_canonHeight, rect.h);
+
    if (m_pendingTextureUpdate.valid())
    {
       if (m_pendingTextureUpdate.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
@@ -787,7 +794,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       }
    }
    else if (m_dirty
-      || (m_szPath.empty() && rect.h != m_renderState.m_prerenderedHeight)
+      || (m_szPath.empty() && m_canonHeight != m_renderState.m_prerenderedHeight)
       || (m_szPath.empty() && fontColor != m_renderState.m_prerenderedColor))
    {
       m_dirty = false;
@@ -801,7 +808,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
       else if (m_pFont)
          m_pendingTextureUpdate = std::async(std::launch::async, [this, rect, fontColor]() {
             std::lock_guard lock(m_mutex);
-            return UpdateLabelTexture(rect.h, m_pFont, m_szCaption, m_size, fontColor, m_shadowType, m_shadowColor, { m_xoffset, m_yoffset} );
+            return UpdateLabelTexture(m_canonHeight, m_pFont, m_szCaption, m_size, fontColor, m_shadowType, m_shadowColor, { m_xoffset, m_yoffset} );
          });
    }
 
@@ -864,10 +871,14 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
 
    float width;
    float height;
+   // The text texture is prerendered at m_canonHeight (the largest output); scale it down to this
+   // output's height so a single shared cache serves every output without regenerating.
+   float textScale = 1.f;
    if (m_type == PUP_LABEL_TYPE_TEXT)
    {
-      width = m_renderState.m_width;
-      height = m_renderState.m_height;
+      textScale = m_renderState.m_prerenderedHeight > 0 ? static_cast<float>(rect.h) / static_cast<float>(m_renderState.m_prerenderedHeight) : 1.f;
+      width = m_renderState.m_width * textScale;
+      height = m_renderState.m_height * textScale;
    }
    else
    {
@@ -906,7 +917,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    const float yPosOffset = static_cast<float>(rect.h) * yposPercent;
    dest.y += yPosOffset;
 
-   const float alignHeight = (m_type == PUP_LABEL_TYPE_TEXT && m_renderState.m_logicalHeight > 0) ? m_renderState.m_logicalHeight : height;
+   const float alignHeight = (m_type == PUP_LABEL_TYPE_TEXT && m_renderState.m_logicalHeight > 0) ? m_renderState.m_logicalHeight * textScale : height;
    float alignOffset = 0.f;
    if (m_yAlign == PUP_LABEL_YALIGN_CENTER)
       alignOffset = -(alignHeight / 2.f);
@@ -915,7 +926,7 @@ void PUPLabel::Render(VPXRenderContext2D* const ctx, const SDL_Rect& rect, int p
    dest.y += alignOffset;
 
    if (m_type == PUP_LABEL_TYPE_TEXT)
-      dest.y += m_renderState.m_baselineOffset;
+      dest.y += m_renderState.m_baselineOffset * textScale;
 
    if (m_shadowType == 2)
    {

--- a/plugins/pup/PUPLabel.h
+++ b/plugins/pup/PUPLabel.h
@@ -237,6 +237,7 @@ private:
    bool m_dirty = true;
    std::unique_ptr<Animation> m_animation;
    RenderState m_renderState;
+   int m_canonHeight = 0; // largest output height seen; text is prerendered at this height and scaled down per output
    int m_animationFrame = 0;
    uint64_t m_animationStart = 0;
    std::future<RenderState> m_pendingTextureUpdate;


### PR DESCRIPTION
### Issue

some tables can have multiple pup outputs. One example is https://vpuniverse.com/files/file/21216-bud-spencer-terence-hill-table-pup-pack/ where there is a hidden `VR_backglass` primitive, this is replaced with a `VR_backglass001` flasher with image "backglass". Combine that with the normal Backglass window and you have 2 different sized outputs fighting for the buffers. Video gets stretched frames, shows old frames between new frames and so on.

One of those broken frames below

<img width="1239" height="698" alt="Screenshot_2026-06-16_16-17-54" src="https://github.com/user-attachments/assets/ab866369-c913-46e1-aacb-f1892e2eefbc" />

This also is visible for labels, again fights, buffer resizing and the winning buffer being rendered causing big-small label flicker.

There are multiple options to fix this:

* Allow only one pup output, skip the second and log an error
* Render the pup once in the biggest format and blit to other surfaces (bad quality)
* Have each pup independent, independent video decode, independent buffers
* Something in between where parts are shared like for the labels currently in this pr we keep only the biggest buffers for each item.

In any case we don't want to see flicker. And if there are restriction the table author should get some feedback when he does it the wrong way.

Is this actually a supported use case? Eg VR where the table is also shown on the desktop?