### PR TITLE
build: auto-select the target, defaulting to bgfx for the host

### DIFF
--- a/.github/workflows/vpinball.yml
+++ b/.github/workflows/vpinball.yml
@@ -189,27 +189,26 @@ jobs:
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha_short }}/g" src/core/git_version.h
       - name: Build
         run: |
-          TYPE=$(echo "${{ matrix.type }}" | tr '[:upper:]' '[:lower:]')
-          cp make/CMakeLists_${TYPE}-${{ matrix.platform }}-${{ matrix.arch }}.txt CMakeLists.txt
+          CMAKE_ARGS="-DTARGET=${{ matrix.type }} -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }}"
           if [[ "${{ matrix.platform }}" == "windows-mingw" ]]; then
             CURRENT_DIR="$(pwd)"
             MSYSTEM=UCRT64 /c/msys64/usr/bin/bash.exe -l -c "
               cd \"${CURRENT_DIR}\" &&
-              cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build/${{ matrix.config }} &&
+              cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build/${{ matrix.config }} &&
               cmake --build build/${{ matrix.config }} -- -j\$(nproc)
             "
           elif [[ "${{ matrix.platform }}" == "windows" ]]; then
             if [[ "${{ matrix.arch }}" == "x64" ]]; then
-              cmake -G "Visual Studio 18 2026" -A x64 -B build
+              cmake ${CMAKE_ARGS} -G "Visual Studio 18 2026" -A x64 -B build
             else
-              cmake -G "Visual Studio 18 2026" -A Win32 -B build
+              cmake ${CMAKE_ARGS} -G "Visual Studio 18 2026" -A Win32 -B build
             fi
             cmake --build build --config ${{ matrix.config }} --parallel
           elif [[ "${{ matrix.platform }}" == "macos" ]]; then
-            cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build/${{ matrix.config }}
+            cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build/${{ matrix.config }}
             cmake --build build/${{ matrix.config }} -- -j$(sysctl -n hw.ncpu)
           else
-            cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build/${{ matrix.config }}
+            cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build/${{ matrix.config }}
             cmake --build build/${{ matrix.config }} -- -j$(nproc)
           fi
       - if: (matrix.platform == 'macos')
@@ -340,11 +339,11 @@ jobs:
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha_short }}/g" src/core/git_version.h
       - name: Build
         run : |
-          cp make/CMakeLists_dx9-${{ matrix.platform }}-${{ matrix.arch }}.txt CMakeLists.txt
+          CMAKE_ARGS="-DTARGET=DX9 -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }}"
           if [[ "${{ matrix.arch }}" == "x64" ]]; then
-            cmake -G "Visual Studio 18 2026" -A x64 -B build
+            cmake ${CMAKE_ARGS} -G "Visual Studio 18 2026" -A x64 -B build
           else
-            cmake -G "Visual Studio 18 2026" -A Win32 -B build
+            cmake ${CMAKE_ARGS} -G "Visual Studio 18 2026" -A Win32 -B build
           fi
           cmake --build build --config ${{ matrix.config }}
       - name: Stage artifacts
@@ -411,15 +410,13 @@ jobs:
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha_short }}/g" src/core/git_version.h
       - name: Build
         run: |
-          TYPE=$(echo "${{ matrix.type }}" | tr '[:upper:]' '[:lower:]')
-          cp make/CMakeLists_${TYPE}-${{ matrix.platform }}-${{ matrix.arch }}.txt CMakeLists.txt
           OPTIONS=""
           if [[ "${{ matrix.board }}" == "rpi" ]]; then
             OPTIONS="-DBUILD_RPI=ON"
           elif [[ "${{ matrix.board }}" == "rk3588" ]]; then
             OPTIONS="-DBUILD_RK3588=ON"
           fi
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} ${OPTIONS} -B build/${{ matrix.config }}
+          cmake -DTARGET=${{ matrix.type }} -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }} -DCMAKE_BUILD_TYPE=${{ matrix.config }} ${OPTIONS} -B build/${{ matrix.config }}
           cmake --build build/${{ matrix.config }} -- -j$(nproc)
       - name: Stage artifacts
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ fastlane/
 
 tmp
 
-CMakeLists.txt
 external
 third-party/*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.25)
+
+# CMake requires a literal project() call in the top-level file, and CMAKE_PROJECT_VERSION is
+# taken from it, so read the real version here (the selected per-target file calls project()
+# again with the same version).
+file(READ src/core/vpversion.h _vpx_version)
+string(REGEX MATCH "VP_VERSION_MAJOR[ ]+([0-9]+)" _tmp ${_vpx_version})
+set(_vpx_major "${CMAKE_MATCH_1}")
+string(REGEX MATCH "VP_VERSION_MINOR[ ]+([0-9]+)" _tmp ${_vpx_version})
+set(_vpx_minor "${CMAKE_MATCH_1}")
+string(REGEX MATCH "VP_VERSION_REV[ ]+([0-9]+)" _tmp ${_vpx_version})
+set(_vpx_rev "${CMAKE_MATCH_1}")
+project(vpinball VERSION "${_vpx_major}.${_vpx_minor}.${_vpx_rev}")
+
+# Top-level dispatcher.
+#
+# Selects one of the per-target build files in make/ from three cache variables:
+#   TARGET    renderer backend: BGFX (default), GL or DX9
+#   PLATFORM  linux, macos, windows, windows-mingw, ... (defaults to the host)
+#   ARCH      x64, x86, arm64, aarch64, ... (defaults to the host)
+# All three default to the BGFX renderer for the current host, so a plain `cmake -B build`
+# just works. Override any of them, e.g.:
+#
+#     cmake -DTARGET=GL -B build
+#     cmake -DPLATFORM=windows -DARCH=x86 -B build
+#
+# The iOS/Android library builds are not selected here: they must set their cross-compile
+# toolchain before project(), which this dispatcher cannot do, so they use
+# make/CMakeLists_bgfx_lib.txt directly (with -DPLATFORM/-DARCH).
+
+# --- Detect the host platform --------------------------------------------------------------
+if(CMAKE_HOST_APPLE)
+   set(_vpx_host_platform "macos")
+elseif(CMAKE_HOST_WIN32)
+   set(_vpx_host_platform "windows")
+elseif(CMAKE_HOST_UNIX)
+   set(_vpx_host_platform "linux")
+else()
+   set(_vpx_host_platform "")
+endif()
+
+# --- Detect the host architecture ----------------------------------------------------------
+cmake_host_system_information(RESULT _vpx_host_arch_raw QUERY OS_PLATFORM)
+string(TOLOWER "${_vpx_host_arch_raw}" _vpx_host_arch_raw)
+if(_vpx_host_arch_raw MATCHES "arm64|aarch64")
+   # the per-target files spell this differently per platform (macos: arm64, linux: aarch64)
+   if(_vpx_host_platform STREQUAL "macos")
+      set(_vpx_host_arch "arm64")
+   else()
+      set(_vpx_host_arch "aarch64")
+   endif()
+elseif(_vpx_host_arch_raw MATCHES "x86_64|amd64")
+   set(_vpx_host_arch "x64")
+elseif(_vpx_host_arch_raw MATCHES "i[3-6]86|x86")
+   set(_vpx_host_arch "x86")
+else()
+   set(_vpx_host_arch "")
+endif()
+
+set(TARGET "BGFX" CACHE STRING "Renderer backend: BGFX, GL or DX9")
+set(PLATFORM "${_vpx_host_platform}" CACHE STRING "Target platform; defaults to the host")
+set(ARCH "${_vpx_host_arch}" CACHE STRING "Target architecture; defaults to the host")
+
+if(PLATFORM STREQUAL "" OR ARCH STREQUAL "")
+   message(FATAL_ERROR "Could not detect the host platform/architecture; pass -DPLATFORM=<platform> -DARCH=<arch> (and optionally -DTARGET=<backend>).")
+endif()
+
+string(TOLOWER "${TARGET}" _vpx_backend)
+
+# --- Resolve and include the selected per-target build file ---------------------------------
+set(_vpx_target_file "${CMAKE_CURRENT_LIST_DIR}/make/CMakeLists_${_vpx_backend}-${PLATFORM}-${ARCH}.txt")
+
+if(NOT EXISTS "${_vpx_target_file}")
+   file(GLOB _vpx_files RELATIVE "${CMAKE_CURRENT_LIST_DIR}/make"
+        "${CMAKE_CURRENT_LIST_DIR}/make/CMakeLists_*-*.txt")
+   set(_vpx_available "")
+   foreach(_f IN LISTS _vpx_files)
+      string(REGEX REPLACE "^CMakeLists_(.+)\\.txt$" "\\1" _t "${_f}")
+      string(APPEND _vpx_available "\n  ${_t}")
+   endforeach()
+   message(FATAL_ERROR "No build file for TARGET=${TARGET} PLATFORM=${PLATFORM} ARCH=${ARCH} (expected ${_vpx_target_file}).\nAvailable <backend>-<platform>-<arch> targets:${_vpx_available}\n(iOS/Android use make/CMakeLists_bgfx_lib.txt directly.)")
+endif()
+
+# The heavy third-party dependencies (SDL, bgfx, FreeImage, ...) are not committed; they are
+# fetched and built into third-party/ by the platform script. Fail early with a clear message
+# instead of a confusing missing-header error deep in the build. SDL3 is used by every backend.
+if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/third-party/include/SDL3/SDL.h")
+   message(FATAL_ERROR "Third-party dependencies not found in third-party/. Build them for this target first:\n  platforms/${PLATFORM}-${ARCH}/external.sh")
+endif()
+
+message(STATUS "VPX build: TARGET=${TARGET} PLATFORM=${PLATFORM} ARCH=${ARCH}")
+include("${_vpx_target_file}")

--- a/make/README.md
+++ b/make/README.md
@@ -39,17 +39,29 @@ Note that you may need to point bash to the tools folder via `PATH`, e.g. `/c/Pr
 
 ## Building via CMake
 
-Each target/platform combination has a `CMakeLists_[target]_[platform].txt` file in the `make` directory. Copy this file to `CMakeLists.txt` at the root of the project.
-
-* `target` can be one of the following:
-  * `bgfx` (recommended) - uses [bgfx](https://github.com/bkaradzic/bgfx) to support multiple rendering backends
-  * `gl` - OpenGL
-  * `dx9` - DirectX 9
-* `platform` should be the same one as you used to build the external dependencies.
+By default the build targets the BGFX renderer for the current host platform and architecture, so from the project root a plain configure just works:
 
 ```bash
-cp make/CMakeLists_[target]_[platform].txt CMakeLists.txt
+cmake -DCMAKE_BUILD_TYPE=Release -B build
 ```
+
+To build a different backend, platform or architecture, override `-DTARGET`, `-DPLATFORM` and/or `-DARCH`:
+
+```bash
+cmake -DTARGET=GL -DCMAKE_BUILD_TYPE=Release -B build
+cmake -DPLATFORM=windows -DARCH=x86 -B build
+```
+
+* `TARGET` is the renderer backend:
+  * `BGFX` (recommended) - uses [bgfx](https://github.com/bkaradzic/bgfx) to support multiple rendering backends
+  * `GL` - OpenGL
+  * `DX9` - DirectX 9
+* `PLATFORM` defaults to the host (`linux`, `macos`, `windows`, ...) and should match the one you used to build the external dependencies.
+* `ARCH` defaults to the host (`x64`, `arm64`, ...).
+
+These select a `make/CMakeLists_<target>-<platform>-<arch>.txt` file; an unknown combination prints the list of available targets. The iOS/Android library builds are not handled by the dispatcher (they must set their cross-compile toolchain before `project()`); they use `make/CMakeLists_bgfx_lib.txt` directly - see those sections below.
+
+The previous flow of copying a per-target file over the root `CMakeLists.txt` (`cp make/CMakeLists_<target>.txt CMakeLists.txt`) still works as a fallback; the dispatcher just makes it unnecessary. Note that the root `CMakeLists.txt` is now tracked, so after such a copy run `git checkout CMakeLists.txt` to restore the dispatcher.
 
 #### Supported Platforms
 
@@ -59,7 +71,6 @@ cp make/CMakeLists_[target]_[platform].txt CMakeLists.txt
 ```
 pacman -S --noconfirm make diffutils nasm mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-libwinpthread mingw-w64-ucrt-x86_64-libiconv mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-tools
 platforms/windows-x64/external.sh
-cp make/CMakeLists_bgfx-windows-x64.txt CMakeLists.txt
 cmake -G "Visual Studio 18 2026" -A x64 -B build
 cmake --build build --config Release
 ```
@@ -71,8 +82,7 @@ cmake --build build --config Release
 ```
 pacman -S --noconfirm make diffutils nasm mingw-w64-i686-gcc mingw-w64-i686-zlib mingw-w64-i686-libwinpthread mingw-w64-i686-libiconv mingw-w64-i686-cmake
 platforms/windows-x86/external.sh
-cp make/CMakeLists_bgfx-windows-x86.txt CMakeLists.txt
-cmake -G "Visual Studio 18 2026" -A Win32 -B build
+cmake -G "Visual Studio 18 2026" -A Win32 -DARCH=x86 -B build
 cmake --build build --config Release
 ```
 </details>
@@ -85,7 +95,6 @@ sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 brew install autoconf automake libtool cmake bison curl
 export PATH="$(brew --prefix bison)/bin:$PATH"
 platforms/macos-arm64/external.sh
-cp make/CMakeLists_bgfx-macos-arm64.txt CMakeLists.txt
 cmake -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(sysctl -n hw.ncpu)
 
@@ -101,8 +110,7 @@ sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 brew install autoconf automake libtool cmake nasm bison curl
 export PATH="$(brew --prefix bison)/bin:$PATH"
 platforms/macos-x64/external.sh
-cp make/CMakeLists_bgfx-macos-x64.txt CMakeLists.txt
-cmake -DCMAKE_BUILD_TYPE=Release -B build
+cmake -DARCH=x64 -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(sysctl -n hw.ncpu)
 
 build/VPinballX_BGFX.app/Contents/MacOS/VPinballX_BGFX -play src/assets/exampleTable.vpx
@@ -116,7 +124,6 @@ build/VPinballX_BGFX.app/Contents/MacOS/VPinballX_BGFX -play src/assets/exampleT
 sudo apt-get update
 sudo apt install git build-essential pkg-config autoconf automake libtool cmake nasm bison curl zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev
 platforms/linux-x64/external.sh
-cp make/CMakeLists_bgfx-linux-x64.txt CMakeLists.txt
 cmake -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 
@@ -198,8 +205,7 @@ Build (entire build runs inside the MSYS2 UCRT64 shell):
 MSYSTEM=UCRT64 /c/msys64/usr/bin/bash.exe -l -c "
   cd \"$(pwd)\" &&
   ./platforms/windows-mingw-x64/external.sh &&
-  cp make/CMakeLists_bgfx-windows-mingw-x64.txt CMakeLists.txt &&
-  cmake -DCMAKE_BUILD_TYPE=Release -B build &&
+  cmake -DPLATFORM=windows-mingw -DCMAKE_BUILD_TYPE=Release -B build &&
   cmake --build build -- -j\$(nproc)
 "
 ```
@@ -212,7 +218,6 @@ MSYSTEM=UCRT64 /c/msys64/usr/bin/bash.exe -l -c "
 sudo dnf install @development-tools
 sudo dnf install gcc-c++ pkg-config autoconf automake libtool cmake nasm bison curl systemd-devel mesa-libGL-devel libX11-devel libXext-devel libXcursor-devel libXi-devel libXScrnSaver-devel libXtst-devel libxkbcommon-devel libxkbcommon-x11-devel libXrandr-devel zlib-ng-compat-static zlib-ng-compat-devel wayland-devel alsa-lib-devel pipewire-devel libgpiod-devel 
 platforms/linux-x64/external.sh
-cp make/CMakeLists_bgfx-linux-x64.txt CMakeLists.txt
 cmake -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 
@@ -228,7 +233,6 @@ build/VPinballX_BGFX -play src/assets/exampleTable.vpx
 sudo dnf install @development-tools
 sudo dnf install gcc-c++ pkg-config autoconf automake libtool cmake nasm bison curl systemd-devel mesa-libGL-devel libX11-devel libXext-devel ibXcursor-devel libXi-devel libXScrnSaver-devel libXtst-devel libxkbcommon-devel libxkbcommon-x11-devel zlib-ng-compat-static zlib-ng-compat-devel wayland-devel
 platforms/linux-aarch64/external.sh
-cp make/CMakeLists_bgfx-linux-aarch64.txt CMakeLists.txt
 cmake -DBUILD_RK3588=ON -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 
@@ -248,8 +252,7 @@ build/VPinballX_BGFX -play src/assets/exampleTable.vpx
 sudo apt-get update
 sudo apt install git pkg-config autoconf automake libtool cmake bison zlib1g-dev libdrm-dev libgbm-dev libgles2-mesa-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev libwayland-dev autotools-dev libdrm-etnaviv1 libegl-dev libglvnd-core-dev libltdl-dev libspa-0.2-dev libxrender-dev cmake-data libdrm-freedreno1 libffi-dev libglvnd-dev libpciaccess-dev libwayland-bin m4 libcap-dev libdrm-tegra0 libgles-dev libjsoncpp26 librhash1 libxfixes-dev libgpiod-dev
 platforms/linux-aarch64/external.sh
-cp make/CMakeLists_gl-linux-aarch64.txt CMakeLists.txt
-cmake -DBUILD_RPI=ON -DCMAKE_BUILD_TYPE=Release -B build
+cmake -DTARGET=GL -DBUILD_RPI=ON -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 
 build/VPinballX_GL -play src/assets/exampleTable.vpx
@@ -263,7 +266,6 @@ build/VPinballX_GL -play src/assets/exampleTable.vpx
 sudo apt-get update
 sudo apt install git pkg-config autoconf automake libtool cmake bison zlib1g-dev libdrm-dev libgbm-dev libgles2-mesa-dev libgles2-mesa libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev
 platforms/linux-aarch64/external.sh
-cp make/CMakeLists_bgfx-linux-aarch64.txt CMakeLists.txt
 cmake -DBUILD_RK3588=ON -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)
 


### PR DESCRIPTION
The build currently requires copying the right `make/CMakeLists_<target>.txt` over the root `CMakeLists.txt` before configuring. This adds a small tracked top-level `CMakeLists.txt` that picks that file for you: it detects the host platform and architecture and defaults to the BGFX renderer, so a plain `cmake -B build` just works.

Anything else is an override via `-DTARGET` (renderer backend), `-DPLATFORM` and `-DARCH`. An unknown combination fails with the list of available targets, and if the third-party dependencies have not been fetched yet it fails early pointing at the platform `external.sh` (instead of a confusing missing-header error deep in the build).

The CI jobs are migrated to the dispatcher (explicit `-DTARGET`/`-DPLATFORM`/`-DARCH`). iOS/Android keep using `make/CMakeLists_bgfx_lib.txt` directly, since they must set their cross-compile toolchain before `project()`, which the dispatcher cannot.

The previous flow of copying a per-target file over the root still works as a fallback (the per-target files are otherwise untouched). This is meant as a step toward a single unified `CMakeLists.txt`.