### PR TITLE
wayland: let display settings resize floating ancillary windows

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -382,6 +382,30 @@ void Window::SetSize(const int x, const int y)
    SDL_SetWindowSize(m_nwnd, x, y);
 }
 
+void Window::SetResizable(const bool resizable)
+{
+   if (m_isVR || m_nwnd == nullptr)
+      return;
+   // The display settings page rebuilds every frame, so guard against re-issuing the size hints (which
+   // would clobber an in-progress resize request every frame); only act on an actual state change.
+   if (((SDL_GetWindowFlags(m_nwnd) & SDL_WINDOW_RESIZABLE) != 0) == resizable)
+      return;
+   // The floating ancillary windows are created non-resizable, which on Wayland pins them to a fixed
+   // size (the compositor reverts SetSize on the next configure). They are made resizable only while
+   // their display settings page is open so resizes (slider or by hand) are honored; turning it back
+   // off makes SDL re-pin min==max at the current size, keeping it without allowing further resizing.
+   if (SDL_GetCurrentVideoDriver() == "wayland"sv)
+   {
+      SDL_SetWindowResizable(m_nwnd, resizable);
+      if (resizable)
+      {
+         // Drop any leftover fixed-size bounds so the window can be grown past its current size too.
+         SDL_SetWindowMinimumSize(m_nwnd, 0, 0);
+         SDL_SetWindowMaximumSize(m_nwnd, 0, 0);
+      }
+   }
+}
+
 void Window::OnResized()
 {
    if (m_isVR)

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -71,6 +71,7 @@ public:
 
    void SetPos(const int x, const int y);
    void SetSize(const int w, const int h); // Request a new window size, applied asynchronously by the window manager (acknowledged through OnResized)
+   void SetResizable(const bool resizable); // Toggle interactive resizability (only while the display settings page is open); the window is otherwise pinned to a fixed size on Wayland
    void OnResized(); // To be called when the window manager resized the window: updates the cached sizes and recreates the swapchain of ancillary windows
    void Show(const bool show = true);
    bool IsVisible() const;

--- a/src/ui/live/ingameui/DisplaySettingsPage.cpp
+++ b/src/ui/live/ingameui/DisplaySettingsPage.cpp
@@ -123,6 +123,10 @@ void DisplaySettingsPage::Close(bool isBackwardAnimation)
    InGameUIPage::Close(isBackwardAnimation);
    if (m_staticPrepassDisabled)
       m_player->m_renderer->DisableStaticPrePass(false);
+   // Pin the floating window again now that the page is closed (re-pins min==max at the current size).
+   if (m_wndId == VPXWINDOW_Backglass || m_wndId == VPXWINDOW_ScoreView || m_wndId == VPXWINDOW_Topper)
+      if (Window* const auxWnd = GetOutput(m_wndId).GetWindow())
+         auxWnd->SetResizable(false);
 }
 
 void DisplaySettingsPage::OnStaticRenderDirty()
@@ -248,6 +252,12 @@ void DisplaySettingsPage::BuildWindowPage()
       wndSize.x = wnd->GetWidth();
       wndSize.y = wnd->GetHeight();
    }
+
+   // Floating ancillary windows are resizable only while this settings page is open; closing it pins
+   // the size again (see Close). The slider keeps enforcing the aspect ratio lock in its own logic.
+   if (m_wndId == VPXWINDOW_Backglass || m_wndId == VPXWINDOW_ScoreView || m_wndId == VPXWINDOW_Topper)
+      if (Window* const auxWnd = GetOutput(m_wndId).GetWindow())
+         auxWnd->SetResizable(true);
 
    AddItem(std::make_unique<InGameUIItem>(
       VPX::Properties::EnumPropertyDef(""s, ""s, "Display"s, "Select the display output"s, false, 0, 0, m_displayNames), //


### PR DESCRIPTION
On Wayland the floating backglass/scoreview/topper windows are created non-resizable, so the compositor pins them to a fixed size (xdg_toplevel min==max) and reverts the in-game display settings resize on the next configure (focus loss, click outside).

Make them resizable while their display settings page is open and pin them again on close, so slider (and manual) resizes are honored and kept. The toggle is guarded against the per-frame page rebuilds so it does not clobber an in-progress resize.