### PR TITLE
Non-zero start PTS fix, misc cleanup

### DIFF
--- a/plugins/pup/PUPMediaPlayer.cpp
+++ b/plugins/pup/PUPMediaPlayer.cpp
@@ -185,6 +185,8 @@ void PUPMediaPlayer::Play(const std::filesystem::path& filename, float volume)
          m_pFormatContext = pFormatContext;
          m_videoStream = videoStream;
          m_pVideoContext = pVideoContext;
+         m_videoPtsBaseValid = false;
+         m_videoPtsBase = 0.0;
          m_audioStream = audioStream;
          m_pAudioContext = pAudioContext;
          m_running = true;
@@ -611,7 +613,16 @@ void PUPMediaPlayer::HandleVideoFrame(AVFrame* frame)
       std::lock_guard lock(m_mutex);
       m_libAv._av_frame_copy_props(selectedFrame.frame, frame);
       selectedFrame.age = 0;
-      selectedFrame.pts = (static_cast<double>(selectedFrame.frame->pts) * m_pVideoContext->pkt_timebase.num) / m_pVideoContext->pkt_timebase.den;
+      int64_t framePts = frame->best_effort_timestamp != AV_NOPTS_VALUE ? frame->best_effort_timestamp : frame->pts;
+      const double framePtsSeconds = (framePts == AV_NOPTS_VALUE)
+         ? GetPlayTime()
+         : (static_cast<double>(framePts) * m_pVideoContext->pkt_timebase.num) / m_pVideoContext->pkt_timebase.den;
+      if (!m_videoPtsBaseValid)
+      {
+         m_videoPtsBase = framePtsSeconds;
+         m_videoPtsBaseValid = true;
+      }
+      selectedFrame.pts = framePtsSeconds - m_videoPtsBase;
       selectedFrame.uploaded = false;
       selectedFrame.valid = true;
       //LOGD(std::format("{} Decoded with Video PTS: {:5.3f} / Slot: {}", m_filename.filename().string(), selectedFrame.pts, selectedFrameSlot));

--- a/plugins/pup/PUPMediaPlayer.h
+++ b/plugins/pup/PUPMediaPlayer.h
@@ -64,6 +64,8 @@ private:
 
    int m_videoStream = -1;
    AVCodecContext* m_pVideoContext = nullptr;
+   bool m_videoPtsBaseValid = false;
+   double m_videoPtsBase = 0.0;
 
    // Slots of unordered decoded frames
    struct FrameInfo

--- a/plugins/upscaledmd/xbrz/xbrz.cpp
+++ b/plugins/upscaledmd/xbrz/xbrz.cpp
@@ -1113,8 +1113,6 @@ struct ColorDistanceARGB
     {
         const float a1 = (float)getAlpha(pix1) / 255.0f ;
         const float a2 = (float)getAlpha(pix2) / 255.0f ;
-        /*
-        Requirements for a color distance handling alpha channel: with a1, a2 in [0, 1]
 
         /*  Requirements for a color distance handling alpha channel: with a1, a2 in [0, 1]
 

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -2158,8 +2158,9 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
    // Warn if the backdrop used by the active view mode references an image that is not in the
    // table: it would render black. An empty name or the "<None>" sentinel means no backdrop is set.
    if (const string& bg = m_BG_image[GetViewMode()];
-       !bg.empty() && !StrCompareNoCase(bg, g_szNoneSelection) && GetImage(bg) == nullptr)
+       !bg.empty() && !StrCompareNoCase(bg, g_szNoneSelection) && GetImage(bg) == nullptr) {
       PLOGW << "Backdrop image '" << bg << "' set for the active view mode was not found in the table (renders black)";
+   }
 
    Settings::SetTableOverride_Difficulty_Default(m_difficulty);
    m_globalDifficulty = m_settings.GetTableOverride_Difficulty();


### PR DESCRIPTION
On discord it was reported an AFM pup pack would not play m4v videos correctly. Some would show their first frame and then freeze. 

I tried to play these videos via chrome on MacOS and they would not play.

After some research, it turns out they have non-zero start PTS.

This PR also fixes two compiler warnings.