### PR TITLE
renderer: fix shutdown crash from freeing renderer while render thread runs

### DIFF
--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -497,6 +497,10 @@ void RenderDevice::RenderThread(RenderDevice* rd, bgfx::Init init)
 #endif
       rd->BGFXDesktopRenderLoop(init);
 
+   // Signal that the render loop has fully exited (no more rendering) so the destructor can free render
+   // resources without racing an in-flight frame still using them
+   rd->m_renderThreadStopped.release();
+
    // Wait until main thread has released all native resources
    rd->m_rendererInitialized.acquire();
    bgfx::shutdown();
@@ -1767,6 +1771,9 @@ RenderDevice::~RenderDevice()
       // Suspend rendering before deleting anything that could be used
       m_renderDeviceAlive = false;
       m_frameReadySem.release();
+      // Wait for the render thread to actually leave its render loop: it may still be mid-frame (using the
+      // shaders, meshes and textures freed below) since it only re-checks m_renderDeviceAlive between frames
+      m_renderThreadStopped.acquire();
    #endif
 
    m_quadMeshBuffer = nullptr;

--- a/src/renderer/RenderDevice.h
+++ b/src/renderer/RenderDevice.h
@@ -276,6 +276,7 @@ public:
 
    bool m_frameNoPresent = false; // Flag set when the next frame should be submitted without VBlank sync disabled
    std::binary_semaphore m_rendererInitialized { 0 }; // Semaphore to signal when the renderer is initialized
+   std::binary_semaphore m_renderThreadStopped { 0 }; // Semaphore signaled by the render thread when it has left its render loop, so the destructor can free render resources without racing in-flight rendering
    std::binary_semaphore m_frameReadySem { 0 }; // Semaphore to signal when a frame is ready to be submitted
    std::mutex m_frameMutex; // Mutex to lock acces to retained render frame between logic thread and render thread
 


### PR DESCRIPTION
I was capturing all my tables and some crashed on exit because of below issue.

RenderDevice::~RenderDevice() set m_renderDeviceAlive=false and immediately freed the shaders, meshes and textures, but the render thread only re-checks that flag between frames, so an in-flight frame could still be using those resources while they were deleted - a use-after-free / double-free crashing the app on exit.

Wait for the render thread to leave its render loop (new m_renderThreadStopped semaphore) before freeing render resources. Mostly hit by `-CaptureAttract`, which renders unthrottled so the render thread is busy at every instant of shutdown; vsync-paced normal play usually has it parked, so it rarely triggered there.