### PR TITLE
alphadmd: fix out-of-bounds write past renderFrame

### DIFF
--- a/plugins/alphadmd/alphadmd.cpp
+++ b/plugins/alphadmd/alphadmd.cpp
@@ -267,7 +267,11 @@ static void DrawChar(const int x, const int y, const segDisplay& display, const 
       for (int i = 0; i < display.segs[seg].nDots; i++)
       {
          const int pos = 128 * (y + display.segs[seg].dots[i][1]) + (x + display.segs[seg].dots[i][0]);
-         renderFrame[pos] = std::min(renderFrame[pos] + v, 1.f);
+         // Clip dots that fall outside the 128x32 frame: some layouts place the bottom row of glyphs past
+         // the end of renderFrame, and the unchecked write corrupted the globals stored right after it
+         // (e.g. dmd128Id), which later crashed consumers of that display source descriptor
+         if (pos >= 0 && pos < 128 * 32)
+            renderFrame[pos] = std::min(renderFrame[pos] + v, 1.f);
       }
    }
 }


### PR DESCRIPTION
DrawChar() computed the dot position into the 128x32 renderFrame without bounds checking. Some segment-display layouts (e.g. the 6x4+2x2 layout used by Williams System 11 bowl games such as Alley Cats) place the bottom row of glyphs one row past the frame, so the write landed in the globals stored right after renderFrame
- notably dmd128Id, the DisplaySrcId descriptor AlphaDMD exposes for its combined DMD. Corrupting that descriptor (its GetRenderFrame pointer and overrideId became ~0.01f garbage, the clamp floor) later hung or crashed every consumer of the display source: the ScoreView resolver looped forever on the bogus override chain or called the garbage GetRenderFrame pointer.

Clip dots outside the frame instead of writing out of bounds.

Discovered while requesting a capture of `Alley Cats` https://virtualpinballspreadsheet.github.io/games?game=pOQqr7_D