### PR TITLE
Display list: show native pixel resolution instead of logical

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -450,6 +450,13 @@ vector<Window::DisplayConfig> Window::GetDisplays()
          displayConf.height = displayBounds.h;
          displayConf.isPrimary = primaryID != 0 ? displayIDs[i] == primaryID : (displayBounds.x == 0) && (displayBounds.y == 0);
          const SDL_DisplayMode* mode = SDL_GetDesktopDisplayMode(displayIDs[i]);
+         // The display bounds are in logical points (e.g. a 4K display at 1.75x reports 2194x1234). The
+         // native pixel resolution is the largest fullscreen mode, which is reported directly in pixels.
+         int modeCount = 0;
+         SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(displayIDs[i], &modeCount);
+         displayConf.pixelWidth = modeCount > 0 ? modes[0]->w : displayBounds.w;
+         displayConf.pixelHeight = modeCount > 0 ? modes[0]->h : displayBounds.h;
+         SDL_free(modes);
          displayConf.depth = GetPixelFormatDepth(mode->format);
          displayConf.refreshrate = mode->refresh_rate;
          displays.push_back(displayConf);

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -99,8 +99,10 @@ public:
    {
       int top;
       int left;
-      int width;
+      int width;  // logical size (points); on Wayland fractional scaling this is smaller than the physical resolution
       int height;
+      int pixelWidth;  // native pixel resolution (largest fullscreen mode); equals width unless the display is scaled
+      int pixelHeight;
       int depth;
       float refreshrate;
       bool isPrimary; // Default display (used when no display is selected in the settings)

--- a/src/ui/live/ingameui/DisplaySettingsPage.cpp
+++ b/src/ui/live/ingameui/DisplaySettingsPage.cpp
@@ -83,7 +83,15 @@ DisplaySettingsPage::DisplaySettingsPage(VPXWindowId wndId)
 {
    m_displays = VPX::Window::GetDisplays();
    for (const auto& display : m_displays)
-      m_displayNames.push_back((display.isPrimary ? '*' : ' ') + std::to_string(display.width) + 'x' + std::to_string(display.height) + " [" + display.displayName + ']');
+   {
+      string label = (display.isPrimary ? '*' : ' ') + std::to_string(display.pixelWidth) + 'x' + std::to_string(display.pixelHeight);
+      // Show the display scale when the panel is scaled, so the logical window sizes (smaller than the native
+      // resolution) make sense to the user, e.g. a 4K panel at 1.75x reads as 3840x2160 @175%.
+      if (display.width > 0 && display.pixelWidth != display.width)
+         label += " @" + std::to_string((display.pixelWidth * 100 + display.width / 2) / display.width) + '%';
+      label += " [" + display.displayName + ']';
+      m_displayNames.push_back(label);
+   }
    ResetARLock();
 }
 


### PR DESCRIPTION
On Wayland fractional scaling the display bounds are logical points (e.g. a 4K panel at 1.75x reports 2194x1234), so the monitor was listed at the scaled resolution. Use the largest fullscreen mode (reported directly in pixels) for the display label; window sizing keeps using the logical bounds.

### Before

<img width="1613" height="271" alt="image" src="https://github.com/user-attachments/assets/9198386f-bf92-47ae-b285-bb5a4f474703" />

### After

<img width="1613" height="271" alt="image" src="https://github.com/user-attachments/assets/c3a7909a-7962-41f5-82a1-7d70756d29e2" />
