### PR TITLE
renderer: fix EXC_BAD_ACCESS on shutdown

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -986,6 +986,12 @@ Player::~Player()
    delete m_physics;
    m_physics = nullptr;
 
+   // Stop the render thread before releasing any render resource below (render targets are freed by the
+   // RenderRelease() calls). Otherwise an in-flight frame on the render thread can use a freed render
+   // target and crash on exit (most easily reproduced with a second fullscreen window). The render device
+   // destructor also calls this, but that happens too late, after the resources below are already gone.
+   m_renderer->m_renderDevice->StopRenderLoop();
+
    #ifdef ENABLE_DX9
       m_renderer->m_renderDevice->m_basicShader->UnbindSamplers();
       m_renderer->m_renderDevice->m_DMDShader->UnbindSamplers();

--- a/src/renderer/RenderDevice.cpp
+++ b/src/renderer/RenderDevice.cpp
@@ -1791,16 +1791,27 @@ RenderDevice::RenderDevice(
    m_renderFrame = std::make_unique<RenderFrame>(this);
 }
 
-RenderDevice::~RenderDevice()
+void RenderDevice::StopRenderLoop()
 {
    #if defined(ENABLE_BGFX)
-      // Suspend rendering before deleting anything that could be used
+      if (m_renderLoopStopped)
+         return;
+      m_renderLoopStopped = true;
+      // Suspend rendering before anything the render thread could still be using is freed.
       m_renderDeviceAlive = false;
       m_frameReadySem.release();
       // Wait for the render thread to actually leave its render loop: it may still be mid-frame (using the
-      // shaders, meshes and textures freed below) since it only re-checks m_renderDeviceAlive between frames
+      // render targets, shaders, meshes and textures freed during shutdown) since it only re-checks
+      // m_renderDeviceAlive between frames.
       m_renderThreadStopped.acquire();
    #endif
+}
+
+RenderDevice::~RenderDevice()
+{
+   // Render resources are freed below (and in Player teardown before this); make sure the render thread
+   // has left its render loop first. Normally already done by Player::~Player, this is the backstop.
+   StopRenderLoop();
 
    m_quadMeshBuffer = nullptr;
 

--- a/src/renderer/RenderDevice.h
+++ b/src/renderer/RenderDevice.h
@@ -75,6 +75,11 @@ public:
    void AddWindow(VPX::Window* wnd);
    void RemoveWindow(VPX::Window* wnd);
 
+   // Stop the render thread's render loop and wait until it has left it, so render resources can be
+   // freed without racing an in-flight frame. Idempotent. Must be called before any render resource
+   // (render targets, shaders, textures, ...) is released during shutdown. The destructor calls it too.
+   void StopRenderLoop();
+
    #if defined(ENABLE_BGFX)
       enum PrimitiveTypes
       {
@@ -306,6 +311,7 @@ private:
    float m_renderLatency = 0.f;
 
    bool m_renderDeviceAlive;
+   bool m_renderLoopStopped = false; // guards StopRenderLoop() so it only stops the render loop once
    std::thread m_renderThread;
    vector<std::shared_ptr<Sampler>> m_pendingTextureUploads;
    std::unique_ptr<ShaderState> m_uniformState = nullptr;


### PR DESCRIPTION
Crash bug found on macOS when shutting down vpinball with 2 screens / windows

Player::~Player freed render resources (render targets via RenderProbe:: RenderRelease / IRenderable::RenderRelease) before deleting the render device, which is what stopped the render thread. An in-flight frame on the render thread could then dereference a freed RenderTarget and segfault on exit (RenderDevice::NextView via RenderTarget::Activate, EXC_BAD_ACCESS).

#3556 added the render-thread stop wait, but only inside ~RenderDevice, which runs after these resources are already freed. Extract that wait into an idempotent RenderDevice::StopRenderLoop() and call it at the start of the renderer teardown in Player::~Player, before any render resource is released. The destructor still calls it as a backstop.

Most easily reproduced with two fullscreen windows (playfield + backglass on separate displays), where the render thread is busy at every instant of shutdown; single-window vsync play rarely parked mid-frame so it seldom hit.