### PR TITLE
CaptureAttract: exit non-zero when capture is cancelled

### DIFF
--- a/src/core/AppCommands.cpp
+++ b/src/core/AppCommands.cpp
@@ -258,8 +258,17 @@ void CaptureAttractCommand::Execute()
    player->m_frameCaptureFPS = m_framesPerSecond;
    player->m_cutCaptureToLoop = m_cutToLoop;
    player->GameLoop();
+   const bool succeeded = player->m_captureSucceeded;
    player = nullptr;
    table->Release();
+
+   // The capture is cancelled on a script error (and a few other failures), which would otherwise
+   // exit with a success code and an empty/missing Capture folder, indistinguishable from success.
+   if (!succeeded)
+   {
+      PLOGE << "Video capture cancelled for table '" << m_tableFilename << "', no frames were produced";
+      exit(1);
+   }
 }
 
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1736,6 +1736,7 @@ private:
          return;
 
       // Capture is finished, process result and exit
+      m_player->m_captureSucceeded = true;
       m_player->SetCloseState(Player::CloseState::CS_CLOSE_APP);
       if (!m_player->m_cutCaptureToLoop)
          return;

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -299,6 +299,7 @@ public:
    int m_nFrameToCapture = 0;
    int m_frameCaptureFPS = 0;
    bool m_cutCaptureToLoop = true;
+   bool m_captureSucceeded = false; // set once all requested attract frames were captured; otherwise the capture was cancelled (e.g. on a script error)
 
    CComObject<ScriptInterpreter>* m_scriptInterpreter = nullptr;
    unsigned int m_nScriptErrorNotification = 0;


### PR DESCRIPTION
A cancelled capture (e.g. on a script error) still exited 0 with no Capture folder, indistinguishable from success for callers.