### PR TITLE
liveui: hide window position controls when positioning is unsupported

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -358,11 +358,32 @@ void Window::GetPos(int& x, int& y) const
    SDL_GetWindowPosition(m_nwnd, &x, &y);
 }
 
-void Window::SetPos(const int x, const int y)
+bool Window::SetPos(const int x, const int y)
 {
    if (m_isVR)
-      return;
-   SDL_SetWindowPosition(m_nwnd, x, y);
+      return false;
+   // SDL_SetWindowPosition reports failure when the backend cannot position windows (e.g. Wayland),
+   // which we cache so the UI can hide positioning controls without checking the video driver name.
+   const bool ok = SDL_SetWindowPosition(m_nwnd, x, y);
+   m_canSetPos = ok ? 1 : 0;
+   return ok;
+}
+
+bool Window::CanSetPos()
+{
+   if (m_canSetPos < 0)
+   {
+      if (m_isVR)
+         m_canSetPos = 0;
+      else
+      {
+         // Probe with a no-op move to the current position to learn the capability.
+         int x, y;
+         SDL_GetWindowPosition(m_nwnd, &x, &y);
+         SetPos(x, y);
+      }
+   }
+   return m_canSetPos == 1;
 }
 
 void Window::SetSize(const int x, const int y)

--- a/src/renderer/Window.h
+++ b/src/renderer/Window.h
@@ -69,7 +69,8 @@ public:
    float GetSDRWhitePoint() const { return m_sdrWhitePoint; } // Selected SDR White Point of display in multiple of 80nits (so 3 gives 240nits for SDR white)
    float GetHDRHeadRoom() const { return m_hdrHeadRoom; } // Maximum luminance of display expressed in multiple of SDRWhitePoint (so 6 means 6 times the SDR whitepoint)
 
-   void SetPos(const int x, const int y);
+   bool SetPos(const int x, const int y); // Returns false if the window manager does not honor app-driven positioning (e.g. Wayland)
+   bool CanSetPos(); // Whether app-driven positioning is honored, probed once through SetPos
    void SetSize(const int w, const int h); // Request a new window size, applied asynchronously by the window manager (acknowledged through OnResized)
    void OnResized(); // To be called when the window manager resized the window: updates the cached sizes and recreates the swapchain of ancillary windows
    void Show(const bool show = true);
@@ -128,6 +129,7 @@ private:
 
    class RenderTarget* m_backBuffer = nullptr;
 
+   int m_canSetPos = -1; // Whether the window manager honors SetPos: -1 unknown, 0 unsupported, 1 supported
    uint64_t m_resizeRequestTick = 0; // Last unacknowledged resize request, 0 for none (see SetSize/OnResized)
    int m_pendingWidth = -1, m_pendingHeight = -1; // Size requested while another request was in flight
 

--- a/src/ui/live/ingameui/DisplaySettingsPage.cpp
+++ b/src/ui/live/ingameui/DisplaySettingsPage.cpp
@@ -504,6 +504,13 @@ void DisplaySettingsPage::BuildWindowPage()
             .m_excludeFromDefault = true;
       }
 
+      // Window positioning is not honored by every backend (e.g. Wayland); skip the X/Y position
+      // controls and the drag hint below when the window manager will not let us move this window,
+      // as they would otherwise just show a useless slider stuck at 0.
+      Window* const posWnd = m_isMainWindow ? m_player->m_playfieldWnd : GetOutput(m_wndId).GetWindow();
+      if (!posWnd->CanSetPos())
+         return;
+
       Settings::GetRegistry().Register(Settings::GetWindow_WndX_Property(m_wndId)->WithRange(0, containerWidth - wndSize.x));
       AddItem(std::make_unique<InGameUIItem>(
                  Settings::m_propWindow_WndX[m_wndId], "%d"s, //


### PR DESCRIPTION
On backends that do not honor app-driven window positioning (e.g. Wayland), the X/Y position sliders were just stuck at 0 and did nothing. Detect the capability through SDL_SetWindowPosition's return value (cached on the window) and skip the position controls and drag hint when it is unsupported, without checking the video driver name.