### PR TITLE
renderer: fix assertion failing on startup for fractional display scaling

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -500,7 +500,15 @@ Window::DisplayConfig Window::GetDisplayConfig(const string& display)
 
 void Window::SetBackBuffer(RenderTarget* rt, const bool wcgBackbuffer)
 {
-   assert(rt == nullptr || (rt->GetWidth() == m_pixelWidth && rt->GetHeight() == m_pixelHeight));
+   if (rt != nullptr)
+   {
+      // The backbuffer is created from the actual swapchain extent, which the compositor may round to
+      // a slightly different size than SDL reports (SDL_GetWindowSizeInPixels) under fractional display
+      // scaling. The swapchain is what gets presented, so treat its size as authoritative and sync the
+      // window pixel size to it, keeping the renderer viewport aligned with the surface.
+      m_pixelWidth = rt->GetWidth();
+      m_pixelHeight = rt->GetHeight();
+   }
    m_backBuffer = rt;
    m_wcgBackbuffer = wcgBackbuffer;
 }


### PR DESCRIPTION
This fixes an assertion error on displays with fractional scaling. Vpinball would just not start after saving the window size (development).

Under fractional display scaling, the Vulkan swapchain extent can be a pixel off from SDL_GetWindowSizeInPixels (e.g. a 1920px window on a 1.75x display giving a 3361px backbuffer vs 3360px reported), tripping the SetBackBuffer assertion in debug builds. The swapchain is what gets presented, so treat its size as authoritative and sync the window pixel size to it; 

A different fix could be storing physical sizes?