### PR TITLE
liveui: fix crash when switching a display window to embedded

### DIFF
--- a/src/ui/live/ingameui/InGameUIPage.cpp
+++ b/src/ui/live/ingameui/InGameUIPage.cpp
@@ -620,6 +620,13 @@ void InGameUIPage::Render(float elapsedS)
    const float circleTextWidth = ImGui::CalcTextSize(ICON_FK_CIRCLE, nullptr, true).x + style.FramePadding.x * 2.0f;
    for (int i = 0; i < (int)m_items.size(); i++)
    {
+      // A value change handled while rendering a previous item may have requested a page rebuild (e.g.
+      // switching a window output to embedded destroys the window that the following items query). The
+      // rebuild is deferred to the next frame, so stop here to avoid evaluating the now-stale items
+      // (their live getters would dereference freed state).
+      if (m_needsRebuild)
+         break;
+
       using enum InGameUIItem::Type;
       const auto& item = m_items[i];
 


### PR DESCRIPTION
Switching the backglass (or scoreview/topper) output from a separate window to embedded in the in-game display settings would crash the game. Changing that setting closes the window immediately, but the settings page kept showing the old window's size and position controls for the rest of that frame, so it tried to read values from a window that no longer existed.

The page now stops drawing its controls as soon as a setting change asks it to rebuild, and the refreshed page (with the embedded controls) comes up on the next frame. This also guards any other setting whose change adds or removes other controls on the same page.

https://vpuniverse.com/files/file/6253-ace-of-speed/