### PR TITLE
fix: BGFX fullscreen leaves menu bar and Dock visible on macOS

### DIFF
--- a/src/renderer/Window.cpp
+++ b/src/renderer/Window.cpp
@@ -278,12 +278,17 @@ Window::Window(const string& title, const Settings& settings, VPXWindowId window
    m_hdrHeadRoom = SDL_GetFloatProperty(props, SDL_PROP_WINDOW_HDR_HEADROOM_FLOAT, 1.0f);
 
    // Switch to request fullscreen display mode (must be done after window creation)
+   // BGFX owns the fullscreen/mode decision internally; SDL must not request an exclusive
+   // mode change here (SDL_SetWindowFullscreenMode sets fullscreen_exclusive=true which
+   // overrides platform fullscreen behavior, e.g. bypassing macOS Spaces fullscreen).
+#ifndef ENABLE_BGFX
    if (fullscreenDisplayMode)
    {
       SDL_SetWindowFullscreenMode(m_nwnd, fullscreenDisplayMode);
       SDL_SetWindowFullscreen(m_nwnd, true);
       SDL_SyncWindow(m_nwnd);
    }
+#endif
    SDL_free(displayModes);
 
    SDL_GetWindowSizeInPixels(m_nwnd, &m_pixelWidth, &m_pixelHeight);


### PR DESCRIPTION
When running fullscreen in BGFX on MacOS, I observed the menu bar and dock sitting on top of the game window.

For BGFX builds, fullscreenDisplayMode is set to the current display mode (to read screen dimensions) and was then passed to SDL_SetWindowFullscreenMode. This sets window->fullscreen_exclusive=true in SDL3, which causes the macOS Cocoa backend to bypass Spaces fullscreen and fall back to a plain borderless window — one that doesn't hide the menu bar or Dock.

BGFX owns the fullscreen/mode decision internally and does not need SDL to request an exclusive mode change. Guard the SDL_SetWindowFullscreenMode / SDL_SetWindowFullscreen / SDL_SyncWindow block with #ifndef ENABLE_BGFX, consistent with the existing #ifndef ENABLE_BGFX guards in the same function that already express this same design boundary.

I tested by building locally on my Mac, and the menubar+dock are now properly hidden.  I don't believe this is harmful for other platforms using BGFX.

Please let me know if this isn't the right way to send in external contributions and happy to change it.