### PR TITLE
linux/Wayland: give the playfield keyboard focus at startup

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -778,6 +778,20 @@ Player::Player(PinTable *const table, const PlayMode playMode)
    // This is done after starting the script and firing the Init event to allow script to adjust static parts on startup
    wintimer_init();
    m_physics->StartPhysics();
+
+#if defined(__linux__) && !defined(__ANDROID__)
+   // On Wayland the playfield must be the FIRST toplevel mapped so it gets keyboard focus.
+   // RenderFrame() below lazily reveals the ancillary windows (backglass / score view / topper)
+   // as soon as they have content (Renderer::RenderAncillaryWindow). Those are SDL_WINDOW_NOT_FOCUSABLE,
+   // but Wayland hands the single startup activation token to whichever toplevel maps first: if that is
+   // an ancillary window, the token is consumed there and the playfield - mapped last at the Show()
+   // further down - never receives input focus. The sim is then gated off (willPlay = m_playing &&
+   // m_playfieldWnd->IsFocused()), so the table stays paused and the DMD / backglass never animate
+   // until the user manually clicks the playfield. Showing the playfield here, before the first frame,
+   // makes it the toplevel that grabs the activation token / focus. No-op on the later Show().
+   m_playfieldWnd->Show();
+#endif
+
    m_renderer->RenderFrame();
 
    // Reset the perf counter to start time when physics starts


### PR DESCRIPTION
On a Linux **Wayland** cabinet (GNOME/Mutter, multiple monitors) the playfield launches
**without keyboard focus**. The simulation is gated on playfield focus
(`willPlay = m_playing && m_playfieldWnd->IsFocused()`), so the table stays **paused**: the
DMD/backglass don't animate until you manually click the playfield. Easy to misread as a
render/DMD bug.

## Cause — the playfield is mapped last

Wayland grants keyboard focus to a newly launched app through a single startup **activation
token**, which SDL forwards to the **first** window it maps. But in `Player::Player()` the
ancillary windows (backglass / score view / topper) are revealed from the first
`m_renderer->RenderFrame()` — *before* the playfield's own `m_playfieldWnd->Show()` further
down. So an ancillary window is the first toplevel mapped and receives/consumes the token;
worse, those windows are `SDL_WINDOW_NOT_FOCUSABLE`, so the token is wasted. The playfield,
mapped last, never gets focus, and a later `SDL_RaiseWindow()` doesn't recover it on Mutter.

## Fix

Show the playfield **before** the first `RenderFrame()`, so it is the first toplevel mapped
and receives the activation token / focus. Linux-only; the ancillary windows stay lazy and
`NOT_FOCUSABLE`, and the existing later `Show()` becomes a no-op once it is already visible.

```cpp
   m_physics->StartPhysics();

#if defined(__linux__) && !defined(__ANDROID__)
   m_playfieldWnd->Show();   // be the first toplevel mapped so Wayland gives us focus
#endif

   m_renderer->RenderFrame();
```

Verified on a GNOME Wayland / NVIDIA / 3-monitor cabinet: launched with a real activation
token (as a front-end does), the playfield takes focus on startup and the table runs without
a manual click.
