### PR TITLE
Wayland: keep keyboard focus on the playfield (priming frame + focus handler)

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -798,6 +798,36 @@ Player::Player(PinTable *const table, const PlayMode playMode)
 
    m_progressDialog.SetProgress("Starting..."s, 100);
 
+#if defined(__linux__) && !defined(__ANDROID__) && defined(ENABLE_BGFX)
+   // Priming frame for Wayland: a toplevel is only mapped when its first buffer is
+   // committed (the first Vulkan present, not SDL_ShowWindow), and the compositor
+   // gives keyboard focus to the last mapped toplevel of the active application
+   // (SDL_WINDOW_NOT_FOCUSABLE cannot be honored by the protocol). Ancillary windows
+   // normally present their first frame seconds after the playfield, when their
+   // content shows up, which steals the playfield focus and pauses the table.
+   // So present a black frame on every ancillary window NOW, before the playfield's
+   // first present: they get mapped first and the playfield, committed last through
+   // the same ordered client socket, naturally ends up with the keyboard focus.
+   {
+      bool primed = false;
+      for (VPX::RenderOutput* out : { &m_backglassOutput, &m_scoreViewOutput, &m_topperOutput })
+      {
+         if (out->GetMode() == VPX::RenderOutput::OM_WINDOW && out->GetWindow() != nullptr)
+         {
+            out->GetWindow()->Show();
+            m_renderer->m_renderDevice->SetRenderTarget("Prime Ancillary"s, out->GetWindow()->GetBackBuffer(), false, true);
+            m_renderer->m_renderDevice->Clear(clearType::TARGET, 0x00000000);
+            primed = true;
+         }
+      }
+      if (primed)
+      {
+         SubmitFrame();
+         LockFrameMutex();
+      }
+   }
+#endif
+
    if (m_renderer->IsUsingStaticPrepass())
    {
       // Perform a quick render to avoid displaying a blank screen while the static prerendering will be performed
@@ -1187,6 +1217,20 @@ void Player::OnFocusChanged()
       }
 #else
       PLOGI << "Playfield window lost focus.";
+
+      #if defined(__linux__) && !defined(__ANDROID__)
+      // On Wayland SDL_WINDOW_NOT_FOCUSABLE cannot be honored (the protocol has no way for
+      // a client to refuse keyboard focus, and the compositor focuses the last mapped
+      // toplevel of the focused application), so lazily revealing an ancillary window
+      // steals focus from the playfield and pauses the table. When the focus went to
+      // another window of this application (never a legitimate user target since all
+      // ancillary windows are output only), take it back.
+      if (SDL_GetKeyboardFocus() != nullptr)
+      {
+         PLOGI << "Focus was taken by an ancillary window, handing it back to the playfield";
+         m_playfieldWnd->RaiseAndFocus();
+      }
+      #endif
 #endif
    }
 }


### PR DESCRIPTION
## Problem

On native Wayland the playfield loses keyboard focus a few seconds after startup, which pauses the table (`willPlay` gates on `IsFocused()`): DMD and backglass appear frozen while the ROM keeps playing sound. Cabinet setup: GNOME/mutter 46, NVIDIA, 3 displays, SDL video driver forced to `wayland`.

Root cause, established with a compositor-side trace of the map/focus sequence:

- On Wayland a toplevel is only **mapped when its first buffer is committed** — that is the first Vulkan present, *not* `SDL_ShowWindow()`. So the mapping order cannot be controlled by the order of the `Show()` calls.
- Ancillary windows are revealed lazily, when their content first shows up (typically 1–2 s after the playfield, once PinMAME/B2S produce frames). Their deferred first present maps them *after* the playfield…
- …and mutter gives keyboard focus to the **last mapped toplevel of the active application**. `SDL_WINDOW_NOT_FOCUSABLE` cannot help here: the Wayland protocol has no way for a client to refuse keyboard focus (it works on X11/XWayland, which is why the bug only shows on native Wayland).
- Handing focus back afterwards via `xdg_activation` is unreliable: at that instant SDL usually holds no valid input event serial, so the compositor is entitled to reject the activation (same anti-focus-stealing rule that affects launcher tokens).

## Fix (both parts Linux-gated)

1. **Priming frame** (`Player::Player`, right before the playfield's first present): render a black clear on every windowed ancillary output and submit that frame. Only the touched swapchains get presented, so the ancillary toplevels are mapped (black) first, and the playfield — committed last through the same ordered client socket — naturally ends up with the keyboard focus. Deterministic, no token needed.
2. **Focus handler** (`Player::OnFocusChanged`): if the playfield still loses focus to another window of the application (never a legitimate user target, ancillary windows are output-only), raise it back. With the priming frame in place this only catches a rare transient steal during startup and resolves it in ~100 ms.

Validated on the cabinet through full game sessions (launcher → table start → gameplay): the playfield gets and keeps the keyboard focus, the table never pauses, DMD/backglass animate.

## Context: previous attempt #3608

I closed #3608 because the problem suddenly appeared to be fixed. That was a false positive: SDL had silently fallen back to **XWayland** (SDL prefers x11 when the compositor lacks the `fifo-v1` protocol, i.e. GNOME < 48), and on X11 `SDL_WINDOW_NOT_FOCUSABLE` works, masking the whole issue. Under a real native Wayland session (`SDL_VIDEO_DRIVER=wayland`) the bug is always there; this PR addresses the actual mapping/focus mechanics instead of the show ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSBKQPTy9VSD53FZLjoS4y
