### PR TITLE
Fix use-after-free crash when the static prepass is re-run (e.g. PUP pack start)

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -1705,7 +1705,11 @@ void Renderer::RenderStaticPrepass()
    const bool isNoBackdrop = m_noBackdrop || ((m_render_mask & Renderer::REFLECTION_PASS) != 0);
 
    // The code will fail if the static render target is MSAA (the copy operation we are performing is not allowed)
-   delete m_staticPrepassRT;
+   // Defer deletion to the render thread end-of-frame: already submitted frames may still hold copy
+   // commands sourcing this RT (e.g. the static prepass flush blit), and a synchronous delete here
+   // races their execution (dangling source -> crash in RenderTarget::CopyTo).
+   if (m_staticPrepassRT)
+      m_renderDevice->AddEndOfFrameCmd([rt = m_staticPrepassRT]() { delete rt; });
    m_staticPrepassRT = GetBackBufferTexture()->Duplicate("StaticPreRender"s);
    assert(!m_staticPrepassRT->IsMSAA());
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -1704,12 +1704,11 @@ void Renderer::RenderStaticPrepass()
    m_render_mask |= Renderer::STATIC_ONLY;
    const bool isNoBackdrop = m_noBackdrop || ((m_render_mask & Renderer::REFLECTION_PASS) != 0);
 
-   // The code will fail if the static render target is MSAA (the copy operation we are performing is not allowed)
-   // Defer deletion to the render thread end-of-frame: already submitted frames may still hold copy
-   // commands sourcing this RT (e.g. the static prepass flush blit), and a synchronous delete here
-   // races their execution (dangling source -> crash in RenderTarget::CopyTo).
+   // Defer deletion to the render thread end-of-frame: already submitted frames may still hold copy commands sourcing this RT
    if (m_staticPrepassRT)
       m_renderDevice->AddEndOfFrameCmd([rt = m_staticPrepassRT]() { delete rt; });
+   
+   // The code will fail if the static render target is MSAA (the copy operation we are performing is not allowed)
    m_staticPrepassRT = GetBackBufferTexture()->Duplicate("StaticPreRender"s);
    assert(!m_staticPrepassRT->IsMSAA());
 


### PR DESCRIPTION
### Fix
`RenderStaticPrepass` deletes `m_staticPrepassRT` synchronously on the game thread. With BGFX, already-submitted frames can still hold copy commands **sourcing** that RT (e.g. the static prepass flush blit at `Renderer::PrepareFrame`). If the prepass is invalidated and re-run after the first pass, the render thread executes a blit from the freed RT → crash in `RenderTarget::CopyTo`.

Defer the delete to the render thread's end-of-frame — the same idiom the function already uses for `accumulationSurface` a few lines below.

### Repro
Linux (Ubuntu 24.04) + BGFX, `mm` + the Medieval Madness PUP pack. The PUP plugin showing its ancillary windows at game start invalidates the prepass → re-entry → 100% reproducible SIGSEGV:

```
Thread 25 "RenderThread" received signal SIGSEGV
#0 RenderTarget::CopyTo(...)
#1 RenderCommand::Execute(int, bool)
#2 RenderPass::Execute(bool)
#3 RenderFrame::Execute(bool)
#4 RenderDevice::SubmitRenderFrame()
```

Faulting instruction reads `this->m_rd` (offset 0x30) from the freed source RT and gets reused-heap garbage (`0x1e`), then derefs it.

### Verification
Same tree, only this change: crash gone, table + PUP pack (backglass/topper/scoreview media, triggers) run normally.
