### PR TITLE
vni plugin: read identifyFormat to select 2-bit vs 4-bit frame decode

### DIFF
--- a/plugins/vni/vni.cpp
+++ b/plugins/vni/vni.cpp
@@ -93,7 +93,8 @@ static void ColorizeThread()
       if (frame.frameId != lastFrameId)
       {
          lastFrameId = frame.frameId;
-         const uint32_t result = Vni_Colorize(pVni, static_cast<const uint8_t*>(frame.frame), dmdId.width, dmdId.height, 2);
+         const uint8_t bitlen = dmdId.identifyFormat == CTLPI_DISPLAY_ID_FORMAT_BITPLANE4 ? 4 : 2;
+         const uint32_t result = Vni_Colorize(pVni, static_cast<const uint8_t*>(frame.frame), dmdId.width, dmdId.height, bitlen);          
          if (result)
          {
             const Vni_Frame_Struc* vniFrame = Vni_GetFrame(pVni);


### PR DESCRIPTION
## Issue

The native VNI plugin (`plugins/vni/vni.cpp`) hardcodes a bit depth of 2 when calling
`Vni_Colorize()`:

    const uint32_t result = Vni_Colorize(pVni, static_cast<const uint8_t*>(frame.frame), dmdId.width, dmdId.height, 2);

This is correct for older (Whitestar-era and earlier) DMD hardware, which is natively
2-bit/4-shade. However, the Stern SAM system (and Stern Spike) natively output 4-bit/16-shade
DMD frames. When a VNI/PAL colorization file is loaded for a SAM-era table, this plugin
misinterprets the raw frame data (only 2 of the real 4 bit-planes get extracted), which
corrupts the checksums used for animation/mask matching inside libvni and results in an incorrectly rendered DMD, sometimes subtle, sometimes making it difficult to read text.

The `DisplaySrcId` struct already exposes an `identifyFormat` field
(`CTLPI_DISPLAY_ID_FORMAT_BITPLANE2` / `CTLPI_DISPLAY_ID_FORMAT_BITPLANE4`) specifically
for this purpose, but `ColorizeThread()` never reads it before choosing the bitlen.

### Steps to reproduce
1. Load the X-Men (LE) table (Stern, 2012), ROM `xmn_151h`.
2. Install the VNI colorization pack for this table: https://vpuniverse.com/files/file/5506-x-men-le-stern-colorization/
3. Run on a recent BGFX nightly build with the native VNI plugin active. I ran on 10.8.1.5300.2e0ba2c0b https://github.com/vpinball/vpinball/actions/runs/29021606316
4. Observe the DMD renders incorrectly. For example, the "REPLAY AT" screen should have white text with a magenta border on the edge of the DMD, but instead the native VNI plugin renders this as magenta text with a magenta border (see the attached screenshots.
5. For comparison, the same table/colorization renders correctly on 10.8.0 (which uses the
   external DmdExtensions colorization path instead of the native VNI plugin). The text is white and the border is magenta.

Screenshots attached:

- 10.8.0 (correct, DmdExtensions path) 
<img width="1293" height="303" alt="xmn_151h 10 8 0" src="https://github.com/user-attachments/assets/61f392ca-ca81-4727-a49e-b6fc3a1cd709" />
- 10.8.1 nightly, VNI plugin, unpatched (broken) 
<img width="1364" height="342" alt="xmn_151h 10 8 1 plugin unpatched" src="https://github.com/user-attachments/assets/e4e5e69f-35f8-4acc-947e-a7693f018c89" />
- 10.8.1 nightly, VNI plugin, patched with this fix (correct) 
<img width="1363" height="340" alt="xmn_151h 10 8 1 plugin patched" src="https://github.com/user-attachments/assets/5eea60c0-198f-443a-9a76-a91c96a3393e" />

This is likely not limited to X-Men — any Stern SAM-system title with a VNI/PAL colorization
installed should hit the same issue, since the 2-bit-vs-4-bit distinction is a hardware
generation difference, not a per-ROM one.

## Fix

Read `dmdId.identifyFormat` and select bitlen 2 or 4 accordingly, instead of hardcoding 2:

    const uint8_t bitlen = dmdId.identifyFormat == CTLPI_DISPLAY_ID_FORMAT_BITPLANE4 ? 4 : 2;
    const uint32_t result = Vni_Colorize(pVni, static_cast<const uint8_t*>(frame.frame), dmdId.width, dmdId.height, bitlen);

## Testing

Manually tested with X-Men (LE), ROM `xmn_151h`, VNI colorization pack linked above, on a
local Release/BGFX build. Confirmed the DMD renders correctly (matching 10.8.0's output)
after the change, versus the corrupted rendering beforehand. Have not tested other SAM-era
titles or verified there isn't a secondary issue in libvni's LCM buffer-clearing logic that
could still surface on some tables — this PR addresses the specific bitlen mismatch only.

## Discussion / risks

This only changes behavior for sources reporting `CTLPI_DISPLAY_ID_FORMAT_BITPLANE4`;
2-bit sources (the previous universal assumption) are unaffected, so this should be
low-risk for existing non-SAM tables. I have not audited whether any other consumer of
`dmdId` in this file makes the same 2-bit assumption elsewhere.

## AI disclosure

The root-cause diagnosis and this fix were developed with the assistance of an AI
assistant (Claude), by tracing the call path from the VPX-side VNI plugin into the
libvni source, and cross-checking against community documentation on Stern DMD hardware
generations. I've reviewed the change and validated it against the X-Men repro case above,
but have not done a broader audit of the surrounding code. Per CONTRIBUTING.md's
"AI-Generated Fixes for Identified Issues" policy, submitting as a **draft PR** — offered
as a starting point/reference, not a finished or fully human-validated contribution.