### PR TITLE
plugins: ignore game start with empty gameId (fixes DOF; defensive guard for altsound/serum/vni)

### DIFF
--- a/plugins/altsound/AltSoundPlugin.cpp
+++ b/plugins/altsound/AltSoundPlugin.cpp
@@ -189,6 +189,13 @@ static void OnControllerGameStart(const unsigned int eventId, void* userData, vo
     const CtlOnGameStartMsg* msg = static_cast<const CtlOnGameStartMsg*>(msgData);
     assert(msg != nullptr && msg->gameId != nullptr);
 
+    // The gameId can be an empty string on an early game-start broadcast.
+    if (msg->gameId[0] == '\0')
+    {
+       LOGW("Ignoring game start with empty gameId"s);
+       return;
+    }
+
     VPXTableInfo tableInfo;
     vpxApi->GetTableInfo(&tableInfo);
     std::filesystem::path tablePath = tableInfo.path;

--- a/plugins/dof/DOFPlugin.cpp
+++ b/plugins/dof/DOFPlugin.cpp
@@ -211,6 +211,13 @@ static void OnControllerGameStart(const unsigned int eventId, void* userData, vo
    const CtlOnGameStartMsg* msg = static_cast<const CtlOnGameStartMsg*>(msgData);
    assert(msg != nullptr && msg->gameId != nullptr);
 
+   // The gameId can be an empty string on an early game-start broadcast.
+   if (msg->gameId[0] == '\0')
+   {
+      LOGW("Ignoring game start with empty gameId"s);
+      return;
+   }
+
    // FIXME: Temp fix for issues 3298, 3309, and maybe 3322?
    if (isRunning)
    {

--- a/plugins/serum/serum.cpp
+++ b/plugins/serum/serum.cpp
@@ -335,6 +335,13 @@ static void OnControllerGameStart(const unsigned int eventId, void* userData, vo
    const CtlOnGameStartMsg* msg = static_cast<const CtlOnGameStartMsg*>(msgData);
    assert(msg != nullptr && msg->gameId != nullptr);
 
+   // The gameId can be an empty string on an early game-start broadcast.
+   if (msg->gameId[0] == '\0')
+   {
+      LOGW("Ignoring game start with empty gameId"s);
+      return;
+   }
+
    VPXTableInfo tableInfo;
    vpxApi->GetTableInfo(&tableInfo);
    std::filesystem::path tablePath = tableInfo.path;

--- a/plugins/vni/vni.cpp
+++ b/plugins/vni/vni.cpp
@@ -208,6 +208,13 @@ static void OnControllerGameStart(const unsigned int eventId, void* userData, vo
    const CtlOnGameStartMsg* msg = static_cast<const CtlOnGameStartMsg*>(msgData);
    assert(msg != nullptr && msg->gameId != nullptr);
 
+   // The gameId can be an empty string on an early game-start broadcast.
+   if (msg->gameId[0] == '\0')
+   {
+      LOGW("Ignoring game start with empty gameId"s);
+      return;
+   }
+
    VPXTableInfo tableInfo;
    vpxApi->GetTableInfo(&tableInfo);
    std::filesystem::path tablePath = tableInfo.path;


### PR DESCRIPTION
> **⚠️ AI-generated fix — draft per [CONTRIBUTING.md](https://github.com/vpinball/vpinball/blob/master/CONTRIBUTING.md#ai-generated-fixes-for-identified-issues).**
> The issue was identified and reproduced on real hardware; the code change was AI-generated and is offered as a **starting point / reference**, not a finished, human-validated contribution.

Fixes #3670.

### Summary

An empty `gameId` is never valid input to a game-start handler, but a B2S-backed ROM table broadcasts `CTLPI_EVT_ON_GAME_START` before the ROM name is committed, so the first event carries one. This adds the guard **PUP already has** to the other four game-start consumers.

### Two tiers — stated honestly

- **DOF (bug fix).** DOF sets `isRunning` unconditionally on the empty event, so the real ROM-named start ~18 ms later is dropped as "already running" and the session runs with no ROM: `0 of 63 outputs resolved`, no solenoids. Reproduced on Medieval Madness (`mm_109c`) — see #3670 for the full log.
- **altsound / serum / vni (defensive, not a bug fix).** These commit `isRunning` only after matching an asset file, so today the empty event returns early and the real start still processes (the `Serum … mm_109c` line in #3670 confirms Serum self-recovers). They are guarded anyway because an empty `gameId` should never reach path-building at all — it produces pointless filesystem lookups, and altsound's empty path can resolve to the `altsound/` directory itself. This is hardening for consistency with PUP, **not** a claim that they are currently broken.

`dmdutil` is intentionally excluded: its `isRunning` is DMD-source-driven, not `gameId`-driven.

### Technical overview

Immediately after each handler's existing `assert(msg->gameId != nullptr)`, add PUP's exact early-out:

```cpp
// The gameId can be an empty string on an early game-start broadcast.
if (msg->gameId[0] == '\0')
{
   LOGW("Ignoring game start with empty gameId"s);
   return;
}
```

Same wording and log line as PUP, for consistency. No behavioral change on the normal (non-empty) path. No files added/removed/renamed → no CMake/`.vcxproj` changes.

### Testing

- **DOF**: this exact guard has run on a real Linux (Batocera) standalone BGFX build and fixed the dead-solenoid regression on `mm_109c` — the real ROM start is accepted and DOF loads the table config.
- **altsound / serum / vni**: **not independently exercised.** Applied as defensive guards; their correctness is argued from the code (early-return on empty is a no-op relative to today's behavior), not from a reproduced scenario. Flagged honestly — part of why this is a draft.

### Discussion

The alternative long-term fix is to stop broadcasting the empty-`gameId` start at the source so no consumer needs the guard (PUP, and now these, could then drop it). This PR takes the consistent-with-PUP consumer-side path.