### PR TITLE
dmdutil: guard against null frame data in UpdateThread (fixes a crash)

### DIFF
--- a/plugins/dmdutil/DMDUtilPlugin.cpp
+++ b/plugins/dmdutil/DMDUtilPlugin.cpp
@@ -118,6 +118,11 @@ static void UpdateThread()
          continue;
 
       const DisplayFrame frame = selectedDmdId.GetRenderFrame(selectedDmdId.id);
+
+      // frame.frame can be null (no frame yet, or the source torn down mid-race); every
+      // branch below dereferences it. Skip without marking seen, so the frameId re-arrives.
+      if (frame.frame == nullptr)
+         continue;
       if (lastFrameID == frame.frameId)
          continue;
       lastFrameID = frame.frameId;


### PR DESCRIPTION
> **⚠️ AI-generated fix — draft per [CONTRIBUTING.md](https://github.com/vpinball/vpinball/blob/master/CONTRIBUTING.md#ai-generated-fixes-for-identified-issues).**
> The crash was identified and reproduced on real hardware; the code change was AI-generated and is offered as a **starting point / reference**, not a finished, human-validated contribution.

Fixes #3672.

### Summary

`DMDUtilPlugin::UpdateThread` dereferences `frame.frame` with no null check. `GetRenderFrame()` can return a frame with a null data pointer (no frame yet, or the source torn down mid-race), and all three format branches dereference it immediately — a null read on a background thread that crashes the player.

### Motivation

Observed on a cabinet as `VPinballX_BGFX` segfaulting several times a day, six crashes at the identical instruction (`%rdx = 0`, the `LUM32F luminanceData[i]` load). Full disassembly and crash addresses in #3672.

### Technical overview

The code directly above already guards `pDmd`, `selectedDmdId.id.id` and `GetRenderFrame` against exactly this teardown race — only the frame *data* pointer was missed. This adds the matching guard immediately after `GetRenderFrame`, **before** the `frameId` dedup so the frame is skipped without being marked seen (the same `frameId` is re-processed when real data arrives):

```cpp
// frame.frame can be null (no frame yet, or the source torn down mid-race); every
// branch below dereferences it. Skip without marking seen, so the frameId re-arrives.
if (frame.frame == nullptr)
   continue;
```

One file, one concern, no added/removed/renamed files (no CMake/`.vcxproj` change).

### Testing

This exact guard has run on a real Linux (Batocera) standalone BGFX build; the previously-daily `plugin-dmdutil.so` segfault stopped. As an AI-generated change it still warrants a maintainer's eye on the concurrency reasoning (is skipping-without-advancing the intended contract for a transiently-null source?), which is why this is a draft.
