### PR TITLE
Fix #3666 - Plumb Damping setting displaying half value

### DIFF
--- a/src/physics/cabinet/PlumbHandler.cpp
+++ b/src/physics/cabinet/PlumbHandler.cpp
@@ -28,14 +28,13 @@ PlumbHandler::~PlumbHandler()
 
 float PlumbHandler::GetPlumbDamping() const
 {
-   return m_plumbAngularDamping0 / 2.5f;
-   //return m_plumbAngularDamping1 / 1.5f;
+   return m_plumbAngularDamping0 / m_dampingCoef0;
 }
 
 void PlumbHandler::SetPlumbDamping(float v)
 {
    m_plumbAngularDamping0 = m_dampingCoef0 * v;
-   m_plumbAngularDamping1 = m_dampingCoef0 * v;
+   m_plumbAngularDamping1 = m_dampingCoef1 * v;
 }
 
 void PlumbHandler::StepOneMillisecond(const Vertex2D& cabAcceleration)


### PR DESCRIPTION
Fixes #3666

Getters and setters are now logically consistent with the constructor so the Plumb Damping settings UI works properly:
* Fix `GetPlumbDamping` to divide by the same coefficient the constructor uses
* Fix `SetPlumbDamping` to multiply by the same coefficient the constructor uses

