### PR TITLE
dmdutil: rate-limit DMD texture uploads to stop playfield stutter (proposed approach, needs review)

### DIFF
--- a/plugins/dmdutil/DMDUtilPlugin.cpp
+++ b/plugins/dmdutil/DMDUtilPlugin.cpp
@@ -120,6 +120,23 @@ static void UpdateThread()
       const DisplayFrame frame = selectedDmdId.GetRenderFrame(selectedDmdId.id);
       if (lastFrameID == frame.frameId)
          continue;
+
+      // Rate-limit uploads. PinMAME emits DMD frames on every score event — a flipper
+      // volley produces bursts well above any real DMD's refresh — and each one is a
+      // texture upload contending with the playfield on the same GPU queue. Profiled on
+      // a cab: with this plugin enabled the 119.9fps playfield dips to ~104-112 during
+      // flipper events (BGFX->GPU submission 0.1ms -> 0.9-1.8ms); with it disabled the
+      // dips vanish entirely. 40Hz is faster than the hardware ever was and caps the
+      // burst. The frameId is NOT recorded on a skipped frame, so the newest frame
+      // still lands on the next tick — nothing is lost, only coalesced.
+      {
+         static std::chrono::steady_clock::time_point lastUpload{};
+         const auto now = std::chrono::steady_clock::now();
+         if (now - lastUpload < std::chrono::milliseconds(25))
+            continue;
+         lastUpload = now;
+      }
+
       lastFrameID = frame.frameId;
 
       switch(selectedDmdId.frameFormat) {


### PR DESCRIPTION
> **⚠️ AI-generated change — draft per [CONTRIBUTING.md](https://github.com/vpinball/vpinball/blob/master/CONTRIBUTING.md#ai-generated-fixes-for-identified-issues).**
> This is a **take-it-or-leave-it proposed approach**, not a finished contribution. The goal was to reduce a real, measured playfield stutter (see #3675). The maintainers may well have a cleaner way to get the same result — that is genuinely expected here, and this PR is meant as a reference/starting point.

Addresses #3675.

### What this is trying to fix

On a 120 Hz cabinet the playfield stutters in a way that tracks gameplay. PinMAME emits a DMD frame on every score event, so flipper volleys burst DMD texture uploads far above any real DMD's refresh, and each upload contends with the playfield on the GPU queue. Measured: the 119.9 fps playfield dips to ~104–112 fps during scoring; disabling DMDUtil removes the dips entirely. Full table in #3675.

### The approach in this PR (one option)

Throttle uploads to 40 Hz — faster than any physical DMD — placed **after** the `frameId` dedup but **before** recording the id, so a rate-limited frame is skipped **without** being marked seen. The newest frame therefore lands on the next tick: bursts are **coalesced, never lost**, and the DMD stays current.

```cpp
{
   static std::chrono::steady_clock::time_point lastUpload{};
   const auto now = std::chrono::steady_clock::now();
   if (now - lastUpload < std::chrono::milliseconds(25))
      continue;
   lastUpload = now;
}
```

### Why it needs your scrutiny — open questions

- **Right layer?** This throttles on the consumer (plugin) side. Coalescing at the source (PinMAME emit) or a latest-wins single-slot buffer might be architecturally cleaner and avoid a fixed poll cadence.
- **Right cadence?** 40 Hz / 25 ms is a chosen constant. Should it be configurable, or derived from something?
- **`static` in `UpdateThread`.** Fine for the single update thread today, but it bakes in that assumption; a member on the plugin state would be more honest if that ever changes.
- **Interaction with real DMD content** (mode transitions, animations): 40 Hz should be imperceptible, but a maintainer who knows the DMD pipeline may see a case I don't.

### Testing

Ran on a real Linux (Batocera) standalone BGFX/Vulkan build, RTX 3080, 4K playfield @ 119.88 Hz: with the limiter the playfield holds a clean 119.9 fps through flipper volleys that previously dipped to ~104 fps (#3675 table, last row). The DMD looked unchanged in normal play. This is empirical on one rig, by eye for the DMD content — not a rigorous frame-accuracy check, which is part of why it is a draft.

### Note

Independent of the null-frame crash fix (#3672 / its PR), though both touch `UpdateThread` and one will need a trivial rebase after the other merges.
