### PR TITLE
Fix random LiveUI draw order breaking UI rendering

### DIFF
--- a/src/parts/primitive.cpp
+++ b/src/parts/primitive.cpp
@@ -1108,11 +1108,11 @@ void Primitive::Render(const unsigned int renderMask)
       // FIXME use correct point for depth sorting
       if (renderMask & Renderer::UI_FILL)
          m_renderer->m_renderDevice->DrawMesh(
-            m_renderer->m_renderDevice->m_basicShader, true, Vertex3Ds(), 10000.f, m_meshBuffer, RenderDevice::TRIANGLELIST, 0, m_groupdRendering ? m_numGroupIndices : (uint32_t)m_mesh.NumIndices());
+            m_renderer->m_renderDevice->m_basicShader, true, Vertex3Ds(0.f, 0.f, 0.f), 10000.f, m_meshBuffer, RenderDevice::TRIANGLELIST, 0, m_groupdRendering ? m_numGroupIndices : (uint32_t)m_mesh.NumIndices());
       if (renderMask & Renderer::UI_EDGES && m_meshEdgeBuffer == nullptr)
          m_meshEdgeBuffer = m_meshBuffer->CreateEdgeMeshBuffer(m_mesh.m_indices, m_mesh.m_vertices);
       if (renderMask & Renderer::UI_EDGES)
-         m_renderer->m_renderDevice->DrawMesh(m_renderer->m_renderDevice->m_basicShader, false, Vertex3Ds(), 10000.f, m_meshEdgeBuffer, RenderDevice::LINELIST, 0, m_meshEdgeBuffer->m_ib->m_count);
+         m_renderer->m_renderDevice->DrawMesh(m_renderer->m_renderDevice->m_basicShader, false, Vertex3Ds(0.f, 0.f, 0.f), 10000.f, m_meshEdgeBuffer, RenderDevice::LINELIST, 0, m_meshEdgeBuffer->m_ib->m_count);
       m_renderer->UpdateBasicShaderMatrix();
       return;
    }

--- a/src/ui/live/LiveUI.cpp
+++ b/src/ui/live/LiveUI.cpp
@@ -503,7 +503,7 @@ void LiveUI::RenderUI()
          {
             m_rd->m_uiShader->SetVector(SHADER_clip_plane, cmd->ClipRect.x, cmd->ClipRect.y, cmd->ClipRect.z, cmd->ClipRect.w);
             m_rd->m_uiShader->SetTexture(SHADER_tex_base_color, cmd->GetTexID());
-            m_rd->DrawMesh(m_rd->m_uiShader, true, Vertex3Ds(), static_cast<float>(depthSort), m_meshBuffers[n], RenderDevice::TRIANGLELIST, cmd->IdxOffset, cmd->ElemCount);
+            m_rd->DrawMesh(m_rd->m_uiShader, true, Vertex3Ds(0.f, 0.f, 0.f), static_cast<float>(depthSort), m_meshBuffers[n], RenderDevice::TRIANGLELIST, cmd->IdxOffset, cmd->ElemCount);
             depthSort--;
          }
       }


### PR DESCRIPTION
Fixes #3685 (Instruction card sometimes renders with a dimmed appearance)

`Vertex3ds()` was being called with an empty default constructor, resulting in uninitialized `x,y,z` values. The uninitialized values were passed down to `DrawMesh`, which used the uninitialized `z` value to offset depth. This explains why some LiveUI elements like images in the Table Rules page randomly draw in the wrong order.

The fix is to pass `(0,0,0)` into `Vertex3ds` so `z` is initialized with a deterministic value.

I found the same bug in `src/parts/primitive.cpp` and fixed it there too, however I didn't test it.

Root cause found by Claude code, reviewed by me.