### PR TITLE
fix: map toggle table options back to declared min/max range

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -6623,7 +6623,10 @@ STDMETHODIMP PinTable::get_Option(BSTR optionName, float minValue, float maxValu
    {
       if ((option.id.type == prop.value().type) && (option.id.index == prop.value().index))
       {
-         *param = option.value;
+         if (Settings::GetRegistry().GetProperty(option.id)->m_type == VPX::Properties::PropertyDef::Type::Bool)
+            *param = minValue + option.value;
+         else
+            *param = option.value;
          return S_OK;
       }
    }
@@ -6636,7 +6639,10 @@ STDMETHODIMP PinTable::put_Option(BSTR optionName, float minValue, float maxValu
    auto prop = RegisterOption(optionName, minValue, maxValue, step, defaultValue, unit, values);
    if (!prop.has_value())
       return E_FAIL;
-   m_settings.Set(prop.value(), val, true);
+   if (Settings::GetRegistry().GetProperty(prop.value())->m_type == VPX::Properties::PropertyDef::Type::Bool)
+      m_settings.Set(prop.value(), val != minValue, true);
+   else
+      m_settings.Set(prop.value(), val, true);
    return S_OK;
 }
 

--- a/src/ui/live/ingameui/TableOptionsPage.cpp
+++ b/src/ui/live/ingameui/TableOptionsPage.cpp
@@ -50,7 +50,7 @@ void TableOptionsPage::BuildPage()
       case VPX::Properties::PropertyDef::Type::Bool:
          AddItem(std::make_unique<InGameUIItem>(
             option.id, //
-            [this, id]() { return GetOption(id)->value != 0.f; }, //
+            [this, id, isReversed]() { return isReversed ? (GetOption(id)->value == 0.f) : (GetOption(id)->value != 0.f); }, //
             [this, id, isReversed](bool v) {
                m_player->m_ptable->SetOptionLiveValue(id, isReversed ? (v ? 0.f : 1.f) : (v ? 1.f : 0.f));
                m_player->m_ptable->FireOptionEvent(PinTable::OptionEventType::Changed);


### PR DESCRIPTION
I was testing RollerGames when I saw:

```
ERROR [PinTable::RegisterOption@6510] Table.Option("FlexDMD"): invalid arguments (minValue=1, maxValue=2, step=1, defaultValue=0); require minValue < maxValue, step > 0, and minValue <= defaultValue <= maxValue
ERROR [Player::OnScriptError@1236] Runtime error on line 5105, col 0: Description unavailable
```

The table does:

```
UseFlexDMD = RollerGames.Option("FlexDMD", 1, 2, 1, UseFlexDMD + 1, 0, Array("OFF", "ON")) - 1
```

When `Table.Option` sees a two-entry `OFF`/`ON` (or `SHOW`/`HIDE`, `TRUE`/`FALSE`) array, it registers the option as a boolean and returns the raw 0/1 — even if the table declared a different range. 

RollerGames asked for 1..2 but got back 0, making `UseFlexDMD` become -1 — and the next time the line runs it passes `defaultValue = 0`, which fails validation.

Now that 3a1f6fe4 logs an error when `Table.Option` rejects bad arguments, this finally shows up in the log — before that the call just returned `E_FAIL` which would cause a script runtime error.