### PR TITLE
VR: fix DMD not appearing in backglass

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -3155,11 +3155,17 @@ void Renderer::DrawMatrixDisplay(VPXRenderContext2D* ctx, VPXDisplayRenderStyle 
    const float vy1 = 1.f - srcY / ctx->srcHeight;
    const float vx2 = (srcX + srcW) / ctx->srcWidth;
    const float vy2 = 1.f - (srcY + srcH) / ctx->srcHeight;
-   const Vertex3D_NoTex2 vertices[4] = { //
+   Vertex3D_NoTex2 vertices[4] = { //
       { vx2, vy1, 0.f, 0.f, 0.f, 1.f, 1.f, 1.f }, // 
       { vx1, vy1, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f }, //
       { vx2, vy2, 0.f, 0.f, 0.f, 1.f, 1.f, 0.f },  //
       { vx1, vy2, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f } };
+#if defined(ENABLE_BGFX)
+   if (!ctx->is2D)
+      // The DMD shader is camera-relative and takes world-space vertices,
+      // so apply the model transform on the CPU
+      g_pplayer->m_renderer->GetMVP().GetModel().TransformPositions(vertices, vertices, 4);
+#endif
    rdl->DrawTexturedQuad(rdl->m_DMDShader, vertices, true, g_pplayer->m_renderer->m_ancillaryRenderSetup.depthbias);
 }
 
@@ -3191,11 +3197,17 @@ void Renderer::DrawSegmentDisplay(VPXRenderContext2D* ctx, VPXSegDisplayRenderSt
    const float vy1 = 1.f - srcY / ctx->srcHeight;
    const float vx2 = (srcX + srcW) / ctx->srcWidth;
    const float vy2 = 1.f - (srcY + srcH) / ctx->srcHeight;
-   const Vertex3D_NoTex2 vertices[4] = { // 
+   Vertex3D_NoTex2 vertices[4] = { //
       { vx2, vy1, 0.f, 0.f, 0.f, 1.f, 1.f, 1.f }, //
       { vx1, vy1, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f }, //
       { vx2, vy2, 0.f, 0.f, 0.f, 1.f, 1.f, 0.f }, //
       { vx1, vy2, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f } };
+#if defined(ENABLE_BGFX)
+   if (!ctx->is2D)
+      // The DMD shader is camera-relative and takes world-space vertices,
+      // so apply the model transform on the CPU
+      g_pplayer->m_renderer->GetMVP().GetModel().TransformPositions(vertices, vertices, 4);
+#endif
    rdl->DrawTexturedQuad(rdl->m_DMDShader, vertices, true, g_pplayer->m_renderer->m_ancillaryRenderSetup.depthbias);
 }
 


### PR DESCRIPTION
Disclaimer: Based on my own basic knowledge of 3D transforms supplemented by Claude / Codex

Fixes #3698

`Renderer::DrawMatrixDisplay` passed local normalized vertex coordinates to `DrawTexturedQuad`. This worked in the 2d case because the shader was set up with a matrix that maps normalized coordinates directly to window coordinates.

It also worked in VR in the pre-BGFX era because the legacy DMD shader (`src\shaders\hlsl_glsl\DMDShader.hlsl`) applied the backglass model transform itself: `mul(vPosition, matWorldViewProj);`

But in the era of BGFX the DMD shader (`src\shaders\bgfx\vs_dmd.sc`) does not apply any model transform. It expects vertices in world coordinates. So when `Renderer::DrawMatrixDisplay` passes local normalized coordinates to the new BGFX shader and we're running in VR mode, no backglass model transform is applied and the DMD incorrectly renders somewhere near the world (0,0,0) origin instead of on the backglass.

Appears to be a regression since it appears to have worked before BGFX. Note: limited to tables that don't have their own built in backglass/dmd and the user has selected `PlayerVR.AddBackglass`

The fix is to pre-transform vertices into world space inside of `DrawMatrixDisplay`, gated on VR mode and `ENABLE_BGFX`. `DrawSegmentDisplay` follows the same pattern so I fixed it there too. 