### PR TITLE
B2S: Add B2SPath INI setting for global backglass file search

### DIFF
--- a/plugins/b2s/B2SPlugin.cpp
+++ b/plugins/b2s/B2SPlugin.cpp
@@ -10,6 +10,10 @@ namespace B2S {
    
 LPI_IMPLEMENT_CPP // Implement shared log support
 
+MSGPI_STRING_VAL_SETTING(b2sPathProp, "B2SPath", "B2S Path", "Folder that contains directb2s backglass files (fallback search path)", true, "", 1024);
+
+const char* B2SGetGlobalPath() { return b2sPathProp_Get(); }
+
 ///////////////////////////////////////////////////////////////////////////////
 // B2S plugin
 // - implement rendering of directb2s backglass and score view
@@ -252,6 +256,7 @@ MSGPI_EXPORT void MSGPIAPI B2SPluginLoad(const uint32_t sessionId, const MsgPlug
 
    B2SRenderer::RegisterSettings(msgApi, endpointId);
    B2SDMDOverlay::RegisterSettings(msgApi, endpointId);
+   msgApi->RegisterSetting(endpointId, &b2sPathProp);
 
    nServer = 0;
    auto classLambda = [](ScriptClassDef* scd) { scriptApi->RegisterScriptClass(scd); };

--- a/plugins/b2s/B2SServer.cpp
+++ b/plugins/b2s/B2SServer.cpp
@@ -33,7 +33,10 @@ B2SServer::B2SServer(const MsgPluginAPI* const msgApi, unsigned int endpointId, 
 
    // Search for an exact match (same file name with .directb2s extension)
    const std::filesystem::path tablePath(tableInfo.path);
+   LOGI("B2S: Searching for directb2s for table: " + tablePath.string());
+   LOGI("B2S: table parent: " + tablePath.parent_path().string() + ", filename: " + tablePath.filename().string());
    std::filesystem::path b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / tablePath.filename().replace_extension(".directb2s"));
+   LOGI("B2S: Local search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
 
    // Search for a file matching the template 'foldername.directb2s' for file layout where tables are located in a folder with their companion files (b2s, pup, flex, music, ...)
    if (b2sFilename.empty())
@@ -41,17 +44,22 @@ B2SServer::B2SServer(const MsgPluginAPI* const msgApi, unsigned int endpointId, 
       std::filesystem::path folderName = tablePath.parent_path().filename();
       folderName += ".directb2s"sv;
       b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / folderName);
+      LOGI("B2S: Folder-name search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
    }
 
    // Fallback: search in the global B2S path setting (for Android SAF workaround)
    if (b2sFilename.empty())
    {
        const std::string b2sBasePath = B2SGetGlobalPath();
+       LOGI("B2S: B2SPath fallback value: '" + b2sBasePath + "'");
       if (!b2sBasePath.empty())
       {
          const std::filesystem::path b2sPath(b2sBasePath);
          const std::filesystem::path b2sFile = tablePath.filename().replace_extension(".directb2s");
-         b2sFilename = find_case_insensitive_file_path(b2sPath / b2sFile);
+         const std::filesystem::path searchPath = b2sPath / b2sFile;
+         LOGI("B2S: Searching B2SPath: " + searchPath.string());
+         b2sFilename = find_case_insensitive_file_path(searchPath);
+         LOGI("B2S: B2SPath search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
       }
    }
 

--- a/plugins/b2s/B2SServer.cpp
+++ b/plugins/b2s/B2SServer.cpp
@@ -7,6 +7,8 @@
 namespace B2S
 {
 
+extern const char* B2SGetGlobalPath();
+
 B2SServer* B2SServer::m_singleton = nullptr;
 
 B2SServer::B2SServer(const MsgPluginAPI* const msgApi, unsigned int endpointId, const VPXPluginAPI* const vpxApi, ScriptClassDef* serverClassDef)
@@ -39,6 +41,18 @@ B2SServer::B2SServer(const MsgPluginAPI* const msgApi, unsigned int endpointId, 
       std::filesystem::path folderName = tablePath.parent_path().filename();
       folderName += ".directb2s"sv;
       b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / folderName);
+   }
+
+   // Fallback: search in the global B2S path setting (for Android SAF workaround)
+   if (b2sFilename.empty())
+   {
+       const std::string b2sBasePath = B2SGetGlobalPath();
+      if (!b2sBasePath.empty())
+      {
+         const std::filesystem::path b2sPath(b2sBasePath);
+         const std::filesystem::path b2sFile = tablePath.filename().replace_extension(".directb2s");
+         b2sFilename = find_case_insensitive_file_path(b2sPath / b2sFile);
+      }
    }
 
    if (!b2sFilename.empty())

--- a/plugins/b2s/B2SServer.cpp
+++ b/plugins/b2s/B2SServer.cpp
@@ -33,10 +33,7 @@ B2SServer::B2SServer(const MsgPluginAPI* const msgApi, unsigned int endpointId, 
 
    // Search for an exact match (same file name with .directb2s extension)
    const std::filesystem::path tablePath(tableInfo.path);
-   LOGI("B2S: Searching for directb2s for table: " + tablePath.string());
-   LOGI("B2S: table parent: " + tablePath.parent_path().string() + ", filename: " + tablePath.filename().string());
    std::filesystem::path b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / tablePath.filename().replace_extension(".directb2s"));
-   LOGI("B2S: Local search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
 
    // Search for a file matching the template 'foldername.directb2s' for file layout where tables are located in a folder with their companion files (b2s, pup, flex, music, ...)
    if (b2sFilename.empty())
@@ -44,22 +41,46 @@ B2SServer::B2SServer(const MsgPluginAPI* const msgApi, unsigned int endpointId, 
       std::filesystem::path folderName = tablePath.parent_path().filename();
       folderName += ".directb2s"sv;
       b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / folderName);
-      LOGI("B2S: Folder-name search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
    }
 
    // Fallback: search in the global B2S path setting (for Android SAF workaround)
+   // Uses direct std::filesystem::exists() + directory_iterator instead of
+   // find_case_insensitive_file_path because the recursive parent traversal breaks on Android
    if (b2sFilename.empty())
    {
-       const std::string b2sBasePath = B2SGetGlobalPath();
-       LOGI("B2S: B2SPath fallback value: '" + b2sBasePath + "'");
+      const std::string b2sBasePath = B2SGetGlobalPath();
       if (!b2sBasePath.empty())
       {
          const std::filesystem::path b2sPath(b2sBasePath);
          const std::filesystem::path b2sFile = tablePath.filename().replace_extension(".directb2s");
+
+         // Try exact path first
          const std::filesystem::path searchPath = b2sPath / b2sFile;
-         LOGI("B2S: Searching B2SPath: " + searchPath.string());
-         b2sFilename = find_case_insensitive_file_path(searchPath);
-         LOGI("B2S: B2SPath search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
+         std::error_code ec;
+         if (std::filesystem::exists(searchPath, ec))
+         {
+            b2sFilename = searchPath;
+         }
+         else
+         {
+            // Try case-insensitive directory scan (only the target directory, not recursive parent)
+            for (const auto& entry : std::filesystem::directory_iterator(b2sPath, ec))
+            {
+               if (!ec && entry.path().extension() == ".directb2s")
+               {
+                  const std::string entryStem = entry.path().stem().string();
+                  const std::string tableStem = b2sFile.stem().string();
+                  // Case-insensitive comparison
+                  if (entryStem.size() == tableStem.size() &&
+                      std::equal(entryStem.begin(), entryStem.end(), tableStem.begin(),
+                         [](char a, char b) { return std::tolower(a) == std::tolower(b); }))
+                  {
+                     b2sFilename = entry.path();
+                     break;
+                  }
+               }
+            }
+         }
       }
    }
 

--- a/plugins/b2slegacy/B2SLegacyPlugin.cpp
+++ b/plugins/b2slegacy/B2SLegacyPlugin.cpp
@@ -13,6 +13,10 @@ namespace B2SLegacy {
 
 LPI_IMPLEMENT_CPP // Implement shared log support
 
+MSGPI_STRING_VAL_SETTING(b2sPathProp, "B2SPath", "B2S Path", "Folder that contains directb2s backglass files (fallback search path)", true, "", 1024);
+
+const char* B2SLegacyGetGlobalPath() { return b2sPathProp_Get(); }
+
 static MsgPluginAPI* msgApi = nullptr;
 static VPXPluginAPI* vpxApi = nullptr;
 static ScriptablePluginAPI* scriptApi = nullptr;
@@ -215,6 +219,7 @@ MSGPI_EXPORT void MSGPIAPI B2SLegacyPluginLoad(const uint32_t sessionId, MsgPlug
    msgApi->BroadcastMsg(endpointId, getScriptApiId, &scriptApi);
 
    DMDOverlay::RegisterSettings(msgApi, endpointId);
+   msgApi->RegisterSetting(endpointId, &b2sPathProp);
 
    nServer = 0;
    auto classLambda = [](ScriptClassDef* scd) { scriptApi->RegisterScriptClass(scd); };

--- a/plugins/b2slegacy/forms/FormBackglass.cpp
+++ b/plugins/b2slegacy/forms/FormBackglass.cpp
@@ -329,26 +329,33 @@ const SDL_FRect& FormBackglass::GetScaleFactor() const
 void FormBackglass::LoadB2SData()
 {
    const std::filesystem::path tablePath(m_pB2SData->GetTableFileName());
+   LOGI("B2SLegacy: Searching for directb2s for table: " + tablePath.string());
+   LOGI("B2SLegacy: table parent: " + tablePath.parent_path().string() + ", filename: " + tablePath.filename().string());
    std::filesystem::path b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / tablePath.filename().replace_extension(".directb2s"));
+   LOGI("B2SLegacy: Local search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
 
    // Fallback: search in the global B2S path setting (for Android SAF workaround)
    if (b2sFilename.empty())
    {
       const std::string b2sBasePath = B2SLegacyGetGlobalPath();
+      LOGI("B2SLegacy: B2SPath fallback value: '" + b2sBasePath + "'");
       if (!b2sBasePath.empty())
       {
          const std::filesystem::path b2sPath(b2sBasePath);
          const std::filesystem::path b2sFile = tablePath.filename().replace_extension(".directb2s");
-         b2sFilename = find_case_insensitive_file_path(b2sPath / b2sFile);
+         const std::filesystem::path searchPath = b2sPath / b2sFile;
+         LOGI("B2SLegacy: Searching B2SPath: " + searchPath.string());
+         b2sFilename = find_case_insensitive_file_path(searchPath);
+         LOGI("B2SLegacy: B2SPath search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
       }
    }
 
    if (b2sFilename.empty()) {
-      LOGD("No directb2s file found"s);
+      LOGI("B2SLegacy: No directb2s file found for: " + tablePath.filename().string());
       throw std::exception();
    }
 
-   LOGI("directb2s file found at: " + b2sFilename.string());
+   LOGI("B2SLegacy: directb2s file found at: " + b2sFilename.string());
 
    m_pB2SData->SetBackglassFileName(b2sFilename.string());
 

--- a/plugins/b2slegacy/forms/FormBackglass.cpp
+++ b/plugins/b2slegacy/forms/FormBackglass.cpp
@@ -329,33 +329,55 @@ const SDL_FRect& FormBackglass::GetScaleFactor() const
 void FormBackglass::LoadB2SData()
 {
    const std::filesystem::path tablePath(m_pB2SData->GetTableFileName());
-   LOGI("B2SLegacy: Searching for directb2s for table: " + tablePath.string());
-   LOGI("B2SLegacy: table parent: " + tablePath.parent_path().string() + ", filename: " + tablePath.filename().string());
    std::filesystem::path b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / tablePath.filename().replace_extension(".directb2s"));
-   LOGI("B2SLegacy: Local search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
 
    // Fallback: search in the global B2S path setting (for Android SAF workaround)
+   // Uses direct std::filesystem::exists() instead of find_case_insensitive_file_path
+   // because the recursive parent traversal breaks on Android SAF directories
    if (b2sFilename.empty())
    {
       const std::string b2sBasePath = B2SLegacyGetGlobalPath();
-      LOGI("B2SLegacy: B2SPath fallback value: '" + b2sBasePath + "'");
       if (!b2sBasePath.empty())
       {
          const std::filesystem::path b2sPath(b2sBasePath);
          const std::filesystem::path b2sFile = tablePath.filename().replace_extension(".directb2s");
+
+         // Try exact path first
          const std::filesystem::path searchPath = b2sPath / b2sFile;
-         LOGI("B2SLegacy: Searching B2SPath: " + searchPath.string());
-         b2sFilename = find_case_insensitive_file_path(searchPath);
-         LOGI("B2SLegacy: B2SPath search result: " + (b2sFilename.empty() ? "EMPTY" : b2sFilename.string()));
+         std::error_code ec;
+         if (std::filesystem::exists(searchPath, ec))
+         {
+            b2sFilename = searchPath;
+         }
+         else
+         {
+            // Try case-insensitive directory scan (only the target directory, not recursive parent)
+            for (const auto& entry : std::filesystem::directory_iterator(b2sPath, ec))
+            {
+               if (!ec && entry.path().extension() == ".directb2s")
+               {
+                  const std::string entryStem = entry.path().stem().string();
+                  const std::string tableStem = b2sFile.stem().string();
+                  // Case-insensitive comparison
+                  if (entryStem.size() == tableStem.size() &&
+                      std::equal(entryStem.begin(), entryStem.end(), tableStem.begin(),
+                         [](char a, char b) { return std::tolower(a) == std::tolower(b); }))
+                  {
+                     b2sFilename = entry.path();
+                     break;
+                  }
+               }
+            }
+         }
       }
    }
 
    if (b2sFilename.empty()) {
-      LOGI("B2SLegacy: No directb2s file found for: " + tablePath.filename().string());
+      LOGD("No directb2s file found"s);
       throw std::exception();
    }
 
-   LOGI("B2SLegacy: directb2s file found at: " + b2sFilename.string());
+   LOGI("directb2s file found at: " + b2sFilename.string());
 
    m_pB2SData->SetBackglassFileName(b2sFilename.string());
 

--- a/plugins/b2slegacy/forms/FormBackglass.cpp
+++ b/plugins/b2slegacy/forms/FormBackglass.cpp
@@ -26,6 +26,8 @@
 
 namespace B2SLegacy {
 
+extern const char* B2SLegacyGetGlobalPath();
+
 FormBackglass::FormBackglass(VPXPluginAPI* vpxApi, MsgPluginAPI* msgApi,uint32_t endpointId, B2SData* pB2SData)
    : Form(vpxApi, msgApi, endpointId, pB2SData, "Backglass"s),
      m_pB2SSettings(pB2SData->GetB2SSettings())
@@ -327,7 +329,20 @@ const SDL_FRect& FormBackglass::GetScaleFactor() const
 void FormBackglass::LoadB2SData()
 {
    const std::filesystem::path tablePath(m_pB2SData->GetTableFileName());
-   const std::filesystem::path b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / tablePath.filename().replace_extension(".directb2s"));
+   std::filesystem::path b2sFilename = find_case_insensitive_file_path(tablePath.parent_path() / tablePath.filename().replace_extension(".directb2s"));
+
+   // Fallback: search in the global B2S path setting (for Android SAF workaround)
+   if (b2sFilename.empty())
+   {
+      const std::string b2sBasePath = B2SLegacyGetGlobalPath();
+      if (!b2sBasePath.empty())
+      {
+         const std::filesystem::path b2sPath(b2sBasePath);
+         const std::filesystem::path b2sFile = tablePath.filename().replace_extension(".directb2s");
+         b2sFilename = find_case_insensitive_file_path(b2sPath / b2sFile);
+      }
+   }
+
    if (b2sFilename.empty()) {
       LOGD("No directb2s file found"s);
       throw std::exception();


### PR DESCRIPTION
Adds a configurable B2SPath setting that provides a fallback search path for .directb2s files.