### PR TITLE
Timer: fix Defer() scheduling the timer in the past instead of the future

### DIFF
--- a/src/physics/hittimer.cpp
+++ b/src/physics/hittimer.cpp
@@ -20,8 +20,8 @@ void HitTimer::SetInterval(int intervalMs)
 
 void HitTimer::Defer()
 {
-   // Fakes the disabling of the timer, until it will be catched by the cleanup via m_changed_vht
-   m_nextfire = g_pplayer->m_time_msec + 0xFFFFFFFF;
+   // Fake disabling the timer by scheduling it in the far future until m_changed_vht cleans it up
+   m_nextfire = 0xFFFFFFFF;
 }
 
 void HitTimer::Update(const unsigned int simulationTime)


### PR DESCRIPTION
`Defer` was scheduling the timer one second in the past instead of in the far future.

This code may have been mis-copied from 10.8.0:
https://github.com/vpinball/vpinball/blob/7cdbb55bf49c73774d152def3719bb0b95d7c49f/ieditable.cpp#L77
https://github.com/vpinball/vpinball/blob/7cdbb55bf49c73774d152def3719bb0b95d7c49f/src/parts/timer.cpp#L192

I don't think this breaks anything today but it's a bug just waiting to happen.