### PR TITLE
Misc updates

### DIFF
--- a/plugins/dof/DOFPlugin.cpp
+++ b/plugins/dof/DOFPlugin.cpp
@@ -248,7 +248,10 @@ MSGPI_EXPORT void MSGPIAPI DOFPluginLoad(const uint32_t sessionId, const MsgPlug
    msgApi->BroadcastMsg(endpointId, getVpxApiId, &vpxApi);
    msgApi->ReleaseMsgID(getVpxApiId);
 
-   b2sPluginEventStream = std::make_unique<B2SPluginEventStream>(msgApi, endpointId, [](char type, int index, int value) { dofThread->PostEvent({ static_cast<uint8_t>(type), index, value }); });
+   b2sPluginEventStream = std::make_unique<B2SPluginEventStream>(msgApi, endpointId, [](char type, int index, int value) {
+      if (DOFEventConsumer* consumer = dofThread.get())
+         consumer->PostEvent({ static_cast<uint8_t>(type), index, value });
+   });
 
    VPXInfo vpxInfo;
    vpxApi->GetVpxInfo(&vpxInfo);

--- a/plugins/plugins/B2SPluginEventStream.cpp
+++ b/plugins/plugins/B2SPluginEventStream.cpp
@@ -19,7 +19,7 @@ B2SPluginEventStream::B2SPluginEventStream(const MsgPluginAPI* msgApi, uint32_t 
    , m_eventHandler(eventHandler)
    , m_onControllersChangedId(msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_CONTROLLERS_ON_CHG_MSG))
    , m_getControllersId(msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_CONTROLLERS_GET_MSG))
-   , m_getSegSrcId(m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_DISPLAY_GET_SRC_MSG))
+   , m_getSegSrcId(m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_SEG_GET_SRC_MSG))
    , m_onSegSrcChangedId(m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_SEG_ON_SRC_CHG_MSG))
    , m_getStateSrcId(m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_STATE_GET_SRC_MSG))
    , m_onStateSrcChangedId(m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_STATE_ON_SRC_CHG_MSG))

--- a/plugins/plugins/B2SPluginEventStream.cpp
+++ b/plugins/plugins/B2SPluginEventStream.cpp
@@ -148,9 +148,12 @@ void B2SPluginEventStream::OnSegSrcChanged(const unsigned int eventId, void* use
       me->m_pmSegSrc.resize(1024);
       GetSegSrcMsg getSrcMsg = { static_cast<unsigned int>(me->m_pmSegSrc.size()), 0, me->m_pmSegSrc.data() };
       me->m_msgApi->SendMsg(me->m_endpointId, me->m_getSegSrcId, me->m_pinmameEndPoint, &getSrcMsg);
-      me->m_pmSegSrc.resize(getSrcMsg.count);
-      me->m_pmLastSegFrame.resize(getSrcMsg.count);
-      me->m_pmLastSegFrameId.resize(getSrcMsg.count);
+      me->m_pmSegSrc.resize(std::min(getSrcMsg.count, static_cast<unsigned int>(me->m_pmSegSrc.size())));
+      me->m_pmLastSegFrameId.resize(me->m_pmSegSrc.size());
+      size_t nElements = 0;
+      for (const auto& segSrc : me->m_pmSegSrc)
+         nElements += segSrc.nElements;
+      me->m_pmLastSegFrame.resize(nElements);
    }
 }
 
@@ -259,7 +262,7 @@ void B2SPluginEventStream::StatePollingThread()
             {
                uint16_t elementState = 0;
                for (int j = 0; j < 16; j++)
-                  if (segFrame.frame[j] > 0.5f)
+                  if (segFrame.frame[i * 16 + j] > 0.5f)
                      elementState |= 1u << j;
                if (elementState != m_pmLastSegFrame[segDisplayIndex])
                {

--- a/src/audio/AudioPlayer.cpp
+++ b/src/audio/AudioPlayer.cpp
@@ -278,9 +278,19 @@ AudioPlayer::AudioPlayer(const string& backglassDevice, const string& playfieldD
          engineConfig.noAutoStart = MA_TRUE;
          m_backglassEngine = std::make_unique<ma_engine>();
          result = ma_engine_init(&engineConfig, m_backglassEngine.get());
-         m_backglassDevice->device.onData = ma_engine_data_callback_internal;
-         m_backglassDevice->device.pUserData = m_backglassEngine.get();
-         ma_engine_start(m_backglassEngine.get());
+         if (result == MA_SUCCESS)
+         {
+            m_backglassDevice->device.onData = ma_engine_data_callback_internal;
+            m_backglassDevice->device.pUserData = m_backglassEngine.get();
+            ma_engine_start(m_backglassEngine.get());
+         }
+         else
+         {
+            PLOGE << "Failed to initialize miniaudio engine for backglass sounds";
+            m_backglassEngine = nullptr;
+            ma_device_uninit(&m_backglassDevice->device);
+            m_backglassDevice = nullptr;
+         }
       }
       else
       {
@@ -312,9 +322,19 @@ AudioPlayer::AudioPlayer(const string& backglassDevice, const string& playfieldD
          engineConfig.noAutoStart = MA_TRUE;
          m_playfieldEngine = std::make_unique<ma_engine>();
          result = ma_engine_init(&engineConfig, m_playfieldEngine.get());
-         m_playfieldDevice->device.onData = ma_engine_data_callback_internal;
-         m_playfieldDevice->device.pUserData = m_playfieldEngine.get();
-         ma_engine_start(m_playfieldEngine.get());
+         if (result == MA_SUCCESS)
+         {
+            m_playfieldDevice->device.onData = ma_engine_data_callback_internal;
+            m_playfieldDevice->device.pUserData = m_playfieldEngine.get();
+            ma_engine_start(m_playfieldEngine.get());
+         }
+         else
+         {
+            PLOGE << "Failed to initialize miniaudio engine for playfield sounds";
+            m_playfieldEngine = nullptr;
+            ma_device_uninit(&m_playfieldDevice->device);
+            m_playfieldDevice = nullptr;
+         }
       }
       else
       {
@@ -508,6 +528,12 @@ SoundSpec AudioPlayer::GetSoundInformations(const Sound* const sound) const
       return specs;
    specs.nChannels = decoder.outputChannels;
    specs.sampleFrequency = decoder.outputSampleRate;
+
+   if (m_backglassEngine == nullptr)
+   {
+      ma_decoder_uninit(&decoder);
+      return specs;
+   }
 
    ma_sound maSound;
    ma_sound_config config = ma_sound_config_init_2(m_backglassEngine.get());

--- a/src/audio/SoundPlayer.cpp
+++ b/src/audio/SoundPlayer.cpp
@@ -220,6 +220,8 @@ SoundPlayer::SoundPlayer(const AudioPlayer* audioPlayer, const string& filename)
       SetThreadName("VPX.SoundPlayer ["s.append(filename).append(1, ']'));
 
       ma_engine* engine = m_audioPlayer->GetEngine(m_outputTarget);
+      if (engine == nullptr)
+         return;
 
       // Add custom node for channel mixing
       m_vpxMixNode = std::make_unique<vpx_node>();
@@ -272,6 +274,8 @@ SoundPlayer::SoundPlayer(const AudioPlayer* audioPlayer, Sound* sound)
       SetThreadName("VPX.SoundPlayer ["s.append(sound->GetName()).append(1, ']'));
 
       ma_engine* engine = m_audioPlayer->GetEngine(m_outputTarget);
+      if (engine == nullptr)
+         return;
 
       // Add custom node for channel mixing
       m_vpxMixNode = std::make_unique<vpx_node>();


### PR DESCRIPTION
Latest builds were crashing on Batocera 42.

Batocera has no gdb, so I pulled the core dumps into an Ubuntu docker container and analyzed them there with gdb and set sysroot pointing at the box's binaries, which gave real stack traces.

4 fixes: 

- The backglass event stream was asking PinMAME for the wrong kind of display list, so it misread the reply and called a garbage pointer, crashing every DMD table at game start.

- The array tracking segment display states was sized for the number of displays instead of the number of digits, so alphanumeric games wrote past the end of it and corrupted memory.

- DOF could receive backglass events before a game was running and tried to use a thread that didn't exist yet, so now it just skips those events.

- If the audio device fails to open, VPX now plays no sound instead of crashing when the table tries to play one.