### PR TITLE
Fix deprecated VR backglass flasher stealing a part name

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1661,6 +1661,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
             };
 
             // Handle failed loading & duplicates
+            vector<Primitive *> deprecatedVRBackglasses;
             if (!parts.empty())
             {
                // Process unnamed parts after named parts
@@ -1692,108 +1693,113 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                      // image named backglassimage. We now have support for external renderer on flasher, so we replace these primitives by flashers.
                      // As this may cause script error if the original table would expect a primitive object and tweak properties not supported by flasher object, 
                      // we keep the original object. This is not perfect as the table script will not tweak this one, but at least, it makes updating table easy.
+                     // Note that the replacement is postponed until all parts have been added, since creating the flasher requires an unused name, which
+                     // can only be evaluated once all part names are known (otherwise it would steal the name of a part that is not yet loaded).
                      if (part->GetItemType() == eItemPrimitive && StrCompareNoCase(((Primitive *)part)->m_d.m_szImage, "backglassimage"s))
-                     {
-                        bool hasBackglassFlasher = false;
-                        for (auto existing : parts)
-                        {
-                           if (existing->GetItemType() == ItemTypeEnum::eItemFlasher)
-                           {
-                              if (Flasher *const exBackglass = (Flasher *)existing;
-                                 exBackglass->m_d.m_renderMode == FlasherData::EXT_RENDER && exBackglass->m_d.m_renderStyle == VPXWindowId::VPXWINDOW_Backglass)
-                              {
-                                 hasBackglassFlasher = true;
-                                 break;
-                              }
-                           }
-                        }
-                        Primitive * const primitive = (Primitive *)part;
-                        if (!hasBackglassFlasher && primitive->m_d.m_use3DMesh)
-                        {
-                           // We need to reduce the primitive to a flasher rectangle. The algorithm is:
-                           // - to find the flasher plane using mesh's faces normals, favoring faces looking toward the player (a backfacing backglass is unlikely)
-                           // - to find the plane position by considering the vertices nearest to the player (to discard back of the primitive if using a box instead of a rect)
-                           // - to evaluate an axis align square in this plane and define a flasher accordingly (a rotated backglass is unlikely)
-                           const Matrix3D& transform = primitive->RecalculateMatrices();
-                           vector<vec3> vertices(primitive->m_mesh.m_vertices.size());
-                           for (size_t i2 = 0; i2 < primitive->m_mesh.m_vertices.size(); i2++)
-                              vertices[i2] = transform * primitive->m_mesh.m_vertices[i2];
-                           vec3 planeNormal(0.f, 0.f, 0.f);
-                           float planeNormalWeight = 0.f;
-                           for (size_t i2 = 0; i2 < primitive->m_mesh.m_indices.size(); i2 += 3)
-                           {
-                              vec3 &a = vertices[primitive->m_mesh.m_indices[i2]];
-                              vec3 &b = vertices[primitive->m_mesh.m_indices[i2 + 1]];
-                              vec3 &c = vertices[primitive->m_mesh.m_indices[i2 + 2]];
-                              vec3 ab(b.x - a.x, b.y - a.y, b.z - a.z);
-                              vec3 ac(c.x - a.x, c.y - a.y, c.z - a.z);
-                              vec3 n = CrossProduct(ac, ab);
-                              n.Normalize();
-                              const float weight = -n.z; //= n.Dot(vec3(0.f, 0.f, -1.f));
-                              if (weight > 0.f)
-                              {
-                                 planeNormal += weight * n;
-                                 planeNormalWeight += weight;
-                              }
-                           }
-
-                           planeNormal.x = 0.f; // to simplify, we align the backglass X axis with the table (after all, backglasses should be facing the player)
-                           if (const float normalLength = planeNormal.Length(); normalLength > 1e-5f)
-                           {
-                              planeNormal /= normalLength;
-
-                              float planeDist = FLT_MAX;
-                              for (const unsigned int idx : primitive->m_mesh.m_indices)
-                                 planeDist = min(planeDist, planeNormal.Dot(vertices[idx]));
-
-                              float minx = FLT_MAX; // min/max along the x axis
-                              float miny = FLT_MAX; // min/max along planeYAxis
-                              float maxx = FLT_MIN;
-                              float maxy = FLT_MIN;
-                              const vec3 planeYAxis(0.f,planeNormal.z,-planeNormal.y); //= CrossProduct(planeNormal, vec3(1.f, 0.f, 0.f));
-                              for (const unsigned int idx : primitive->m_mesh.m_indices)
-                                 if (const float proj = planeNormal.Dot(vertices[idx]); proj < planeDist + 1.f)
-                                 {
-                                    const float px = vertices[idx].x; // since we aligned the x axis, planeXAxis is (1, 0, 0)
-                                    const float py = vertices[idx].Dot(planeYAxis);
-                                    minx = min(minx, px);
-                                    maxx = max(miny, px);
-                                    miny = min(miny, py);
-                                    maxy = max(maxy, py);
-                                 }
-                              const float backglassWidth = maxx - minx;
-                              const float backglassHeight = maxy - miny;
-                              if (backglassWidth > 0.f && backglassHeight > 0.f)
-                              {
-                                 Flasher *const backglass = (Flasher *)EditableRegistry::CreateAndInit(ItemTypeEnum::eItemFlasher, this, 0.f, 0.f);
-                                 if (backglass)
-                                 {
-                                    backglass->m_wzName = GetUniqueName(primitive->GetWName());
-                                    backglass->m_onLoadExpectedPartGroup = primitive->m_onLoadExpectedPartGroup;
-                                    backglass->Scale(backglassWidth / 100.f, backglassHeight / 100.f, Vertex2D {}, true); // We should gather the base flasher size from the object instead of guessing its default value
-                                    vec3 center = planeDist * planeNormal;
-                                    center += (miny + 0.5f * backglassHeight) * planeYAxis;
-                                    center.x += (minx + 0.5f * backglassWidth); // since planeXAxis is (1, 0, 0)
-                                    backglass->Translate(Vertex2D(center.x, center.y));
-                                    backglass->m_d.m_vCenter = Vertex2D(center.x, center.y);
-                                    backglass->m_d.m_height = center.z;
-                                    backglass->m_d.m_rotX = -180.f - RADTOANG(atan2(planeNormal.y, planeNormal.z)); // since planeXAxis is (1, 0, 0)
-                                    backglass->m_d.m_renderMode = FlasherData::EXT_RENDER;
-                                    backglass->m_d.m_renderStyle = VPXWindowId::VPXWINDOW_Backglass;
-                                    backglass->m_d.m_depthBias = primitive->m_d.m_depthBias;
-                                    backglass->m_d.m_isVisible = primitive->m_d.m_visible;
-                                    primitive->m_d.m_visible = false;
-                                    PLOGE << "Primitive '" << primitive->GetName() << "' used as a deprecated VR backglass was hidden and an external renderer flasher named '"
-                                          << backglass->GetName() << "' was added. This may cause script issues.";
-                                    AddPart(backglass);
-                                    backglass->Release();
-                                 }
-                              }
-                           }
-                        }
-                     }
+                        deprecatedVRBackglasses.push_back((Primitive *)part);
 
                      part->Release();
+                  }
+               }
+            }
+
+            // Replace the primitives used as deprecated VR backglasses by an external render flasher (see above)
+            for (Primitive *const primitive : deprecatedVRBackglasses)
+            {
+               bool hasBackglassFlasher = false;
+               for (auto existing : parts)
+               {
+                  if (existing->GetItemType() == ItemTypeEnum::eItemFlasher)
+                  {
+                     if (Flasher *const exBackglass = (Flasher *)existing;
+                        exBackglass->m_d.m_renderMode == FlasherData::EXT_RENDER && exBackglass->m_d.m_renderStyle == VPXWindowId::VPXWINDOW_Backglass)
+                     {
+                        hasBackglassFlasher = true;
+                        break;
+                     }
+                  }
+               }
+               if (!hasBackglassFlasher && primitive->m_d.m_use3DMesh)
+               {
+                  // We need to reduce the primitive to a flasher rectangle. The algorithm is:
+                  // - to find the flasher plane using mesh's faces normals, favoring faces looking toward the player (a backfacing backglass is unlikely)
+                  // - to find the plane position by considering the vertices nearest to the player (to discard back of the primitive if using a box instead of a rect)
+                  // - to evaluate an axis align square in this plane and define a flasher accordingly (a rotated backglass is unlikely)
+                  const Matrix3D& transform = primitive->RecalculateMatrices();
+                  vector<vec3> vertices(primitive->m_mesh.m_vertices.size());
+                  for (size_t i2 = 0; i2 < primitive->m_mesh.m_vertices.size(); i2++)
+                     vertices[i2] = transform * primitive->m_mesh.m_vertices[i2];
+                  vec3 planeNormal(0.f, 0.f, 0.f);
+                  float planeNormalWeight = 0.f;
+                  for (size_t i2 = 0; i2 < primitive->m_mesh.m_indices.size(); i2 += 3)
+                  {
+                     vec3 &a = vertices[primitive->m_mesh.m_indices[i2]];
+                     vec3 &b = vertices[primitive->m_mesh.m_indices[i2 + 1]];
+                     vec3 &c = vertices[primitive->m_mesh.m_indices[i2 + 2]];
+                     vec3 ab(b.x - a.x, b.y - a.y, b.z - a.z);
+                     vec3 ac(c.x - a.x, c.y - a.y, c.z - a.z);
+                     vec3 n = CrossProduct(ac, ab);
+                     n.Normalize();
+                     const float weight = -n.z; //= n.Dot(vec3(0.f, 0.f, -1.f));
+                     if (weight > 0.f)
+                     {
+                        planeNormal += weight * n;
+                        planeNormalWeight += weight;
+                     }
+                  }
+
+                  planeNormal.x = 0.f; // to simplify, we align the backglass X axis with the table (after all, backglasses should be facing the player)
+                  if (const float normalLength = planeNormal.Length(); normalLength > 1e-5f)
+                  {
+                     planeNormal /= normalLength;
+
+                     float planeDist = FLT_MAX;
+                     for (const unsigned int idx : primitive->m_mesh.m_indices)
+                        planeDist = min(planeDist, planeNormal.Dot(vertices[idx]));
+
+                     float minx = FLT_MAX; // min/max along the x axis
+                     float miny = FLT_MAX; // min/max along planeYAxis
+                     float maxx = FLT_MIN;
+                     float maxy = FLT_MIN;
+                     const vec3 planeYAxis(0.f,planeNormal.z,-planeNormal.y); //= CrossProduct(planeNormal, vec3(1.f, 0.f, 0.f));
+                     for (const unsigned int idx : primitive->m_mesh.m_indices)
+                        if (const float proj = planeNormal.Dot(vertices[idx]); proj < planeDist + 1.f)
+                        {
+                           const float px = vertices[idx].x; // since we aligned the x axis, planeXAxis is (1, 0, 0)
+                           const float py = vertices[idx].Dot(planeYAxis);
+                           minx = min(minx, px);
+                           maxx = max(miny, px);
+                           miny = min(miny, py);
+                           maxy = max(maxy, py);
+                        }
+                     const float backglassWidth = maxx - minx;
+                     const float backglassHeight = maxy - miny;
+                     if (backglassWidth > 0.f && backglassHeight > 0.f)
+                     {
+                        Flasher *const backglass = (Flasher *)EditableRegistry::CreateAndInit(ItemTypeEnum::eItemFlasher, this, 0.f, 0.f);
+                        if (backglass)
+                        {
+                           backglass->m_wzName = GetUniqueName(primitive->GetWName());
+                           backglass->m_onLoadExpectedPartGroup = primitive->m_onLoadExpectedPartGroup;
+                           backglass->Scale(backglassWidth / 100.f, backglassHeight / 100.f, Vertex2D {}, true); // We should gather the base flasher size from the object instead of guessing its default value
+                           vec3 center = planeDist * planeNormal;
+                           center += (miny + 0.5f * backglassHeight) * planeYAxis;
+                           center.x += (minx + 0.5f * backglassWidth); // since planeXAxis is (1, 0, 0)
+                           backglass->Translate(Vertex2D(center.x, center.y));
+                           backglass->m_d.m_vCenter = Vertex2D(center.x, center.y);
+                           backglass->m_d.m_height = center.z;
+                           backglass->m_d.m_rotX = -180.f - RADTOANG(atan2(planeNormal.y, planeNormal.z)); // since planeXAxis is (1, 0, 0)
+                           backglass->m_d.m_renderMode = FlasherData::EXT_RENDER;
+                           backglass->m_d.m_renderStyle = VPXWindowId::VPXWINDOW_Backglass;
+                           backglass->m_d.m_depthBias = primitive->m_d.m_depthBias;
+                           backglass->m_d.m_isVisible = primitive->m_d.m_visible;
+                           primitive->m_d.m_visible = false;
+                           PLOGE << "Primitive '" << primitive->GetName() << "' used as a deprecated VR backglass was hidden and an external renderer flasher named '"
+                                 << backglass->GetName() << "' was added. This may cause script issues.";
+                           AddPart(backglass);
+                           backglass->Release();
+                        }
+                     }
                   }
                }
             }


### PR DESCRIPTION
> [!IMPORTANT]
> **This is an AI-generated fix, opened as a draft per [CONTRIBUTING.md → AI-Generated Fixes for Identified Issues](https://github.com/vpinball/vpinball/blob/master/CONTRIBUTING.md#ai-generated-fixes-for-identified-issues).**
>
> I identified the issue and reproduced it, but the code change itself was generated with AI assistance (Claude via Kiro). It is offered as a starting point / possible direction to help design the final solution, not as a finished, human-validated contribution. Please treat it as a reference rather than a review-ready patch. I am happy to iterate on it, or for a maintainer to take it over or reimplement it.

Fixes #3657

## Describe the bug

Loading *Time Machine (Data East 1988)* logs a script runtime error:

```
ERROR [Main] [Player::OnScriptError@1236] Runtime error on line 4870, col 40: Object doesn't support this property or method
```

The failing script line is in the table's own code:

```vb
Sub SetBackglassRefl(Opt)
    Select Case Opt
        Case 0:
            For each xx in BackglassReflections: xx.ReflectionEnabled = False : Next
            ...
        Case 1:
            For each xx in BackglassReflections: xx.ReflectionEnabled = True : Next   ' <-- fails here
            ...
```

### Root cause

`PinTable::LoadGameFromFilename` does two things in the same pass over the loaded parts:

1. Registers each part name via `AddPart` (renaming duplicates), and
2. Runs the deprecated-VR-backglass conversion: a primitive using the `backglassimage` texture is hidden and replaced by an external-render flasher, named with `GetUniqueName(primitive->GetWName())`.

`GetUniqueName` can only see names that are *already registered*. This table has both `PinCab_Backglass` and `PinCab_Backglass001`, and the former is processed first, so `PinCab_Backglass001` still looks free and the generated flasher takes it. When the real primitive is registered moments later it is treated as a duplicate and bumped. Both steps are visible in the log:

```
ERROR [Main] [PinTable::LoadGameFromFilename@1786] Primitive 'PinCab_Backglass' used as a deprecated VR backglass was hidden and an external renderer flasher named 'PinCab_Backglass001' was added. This may cause script issues.
ERROR [Main] [PinTable::LoadGameFromFilename@1686] Duplicate part name found: PinCab_Backglass001 renamed it to PinCab_Backglass001001
```

`Collection::InitPostLoad` resolves collection members by name *after* loading, so the table's `BackglassReflections` collection binds `PinCab_Backglass001` to the flasher instead of to the primitive. Flashers have no `ReflectionEnabled` property, hence error 438.

Credit to @francisdb, who diagnosed this in #3657; this PR implements that analysis.

## To Reproduce

1. Use a table that contains a primitive textured with `backglassimage` (the deprecated VPVR backglass hack) **and** another part whose name is the auto-generated candidate for it, i.e. `<primitiveName>001`. *Time Machine (Data East 1988)* has `PinCab_Backglass` + `PinCab_Backglass001`.
2. Launch the table.
3. Observe in the log: the generated flasher takes `PinCab_Backglass001`, the real primitive is renamed to `PinCab_Backglass001001`, and the script raises error 438 when touching `ReflectionEnabled` on a collection containing `PinCab_Backglass001`.

## Expected behavior

The auto-created flasher should never take a name belonging to a part in the table file. Existing part names must keep resolving to their original objects so table scripts and collections continue to work.

## Technical overview

Single change in `src/parts/pintable.cpp`: collect the candidate primitives during the registration pass, then perform the flasher conversion in a second pass once every part name is registered, so `GetUniqueName` sees the complete registry.

```cpp
vector<Primitive *> deprecatedVRBackglasses;
...
      // in the registration loop
      if (part->GetItemType() == eItemPrimitive && StrCompareNoCase(((Primitive *)part)->m_d.m_szImage, "backglassimage"s))
         deprecatedVRBackglasses.push_back((Primitive *)part);
...
// after the loop
for (Primitive *const primitive : deprecatedVRBackglasses)
{ /* conversion body, unchanged */ }
```

The conversion body itself is unchanged logic. It is only re-indented because it moved out of the loop, which inflates the raw line count; **`git diff -w` shows the real change as 12 added / 6 removed lines**. The parts remain valid in the second pass since `AddPart` takes a reference.

## Testing

* Built `Release_BGFX-x64` on Windows (MSVC), no new warnings or errors.
* Ran *Time Machine (Data East 1988)* before and after the change on the same machine and settings.

Before:

```
ERROR ... flasher named 'PinCab_Backglass001' was added
ERROR ... Duplicate part name found: PinCab_Backglass001 renamed it to PinCab_Backglass001001
ERROR [Main] [Player::OnScriptError@1236] Runtime error on line 4870, col 40: Object doesn't support this property or method
```

After:

```
ERROR ... flasher named 'PinCab_Backglass009' was added
INFO  [Main] [Player::Player@833] Startup done
```

No duplicate-rename, no script error, table starts and plays. The flasher now lands on a genuinely free name and `PinCab_Backglass001` resolves to the real primitive again. Remaining log entries for this table (duplicate sound `WireRamp_Stop`, duplicate image `flasher2`, deprecated PinMAME calls, plugin refcount warnings at shutdown) are pre-existing and unrelated.

Tested only on Windows / BGFX (DX12). Not tested on OpenGL ES or standalone, though the change is in platform-independent table loading code.

## Discussion / risks

* Behaviour is unchanged for tables where the generated name was already free; only the collision case differs.
* The `hasBackglassFlasher` pre-check still iterates the loaded `parts` list, so a table with two `backglassimage` primitives would still produce two flashers, exactly as before. I left that as-is to keep the change to one concern, but a maintainer may prefer checking the live part list instead.
* The generated name is now less predictable (`PinCab_Backglass009` rather than `...001`), since it depends on which names are already taken. That was already true in general, and the name is only reachable from script if a table happens to reference it.
* Broader question for maintainers: the conversion intentionally keeps the original primitive, so a table script tweaking the *primitive* has no effect on the *flasher*. This PR does not address that; it only stops the flasher from hijacking an existing name.

## Additional work (not included)

Two pre-existing bugs I noticed in the same block while reading it, deliberately left out to keep this PR to one change. Happy to open a separate PR:

* `maxx = max(miny, px);` looks like a copy/paste slip and should be `max(maxx, px)`, so the computed backglass width is wrong.
* `maxx` / `maxy` are seeded with `FLT_MIN`, the smallest *positive* float, where `-FLT_MAX` is intended.

Both affect the generated flasher's size/position rather than the name binding, so neither is involved in this issue.

## Versions & Settings

* VPX: `v10.8.1 Beta (Rev. 9999 (unknown), windows BGFX 64bits)`, local `Release_BGFX-x64` build of `master` plus this commit
* Windows 11, BGFX / DX12 backend
