### PR TITLE
Audio: gather existing sources after subscribing to OnAudioSrcChanged

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -777,7 +777,7 @@ Player::Player(PinTable *const table, const PlayMode playMode)
    m_getAudioSrcMsgId = msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_AUDIO_GET_SRC_MSG);
    msgApi->SubscribeMsg(m_pluginAPI.GetVPXEndPointId(), m_onAudioUpdatedMsgId, OnAudioUpdated, this);
    msgApi->SubscribeMsg(m_pluginAPI.GetVPXEndPointId(), m_onAudioSrcChangedMsgId, OnAudioSrcChanged, this);
-
+   OnAudioSrcChanged(m_onAudioSrcChangedMsgId, this, nullptr);
    m_getAuxRendererId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_MSG_GET_AUX_RENDERER);
    m_onAuxRendererChgId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_EVT_AUX_RENDERER_CHG);
    msgApi->SubscribeMsg(m_pluginAPI.GetVPXEndPointId(), m_onAuxRendererChgId, OnAuxRendererChanged, this);


### PR DESCRIPTION
## AI-Generated Fix

This is an AI-generated fix (using Claude), offered as a starting point to help design the final solution — not as a finished, reviewed contribution.

## Issue

Since commit d1cf55576d ("Plugin: Refactor controller sound API"), WMP plugin music is silent. Tables that use `WMPlayer.OCX` for background music (e.g. American Graffiti) produce no audio output despite files loading successfully.

## Root Cause

The refactored audio pipeline requires plugin audio sources to be registered in `m_audioLanes` (populated by `OnAudioSrcChanged`) before `OnAudioUpdated` can route their audio buffers to the SDL device. However, the Player subscribes to `OnAudioSrcChanged` **after** the VBS script has already run and created WMP instances (which broadcast their source registration during construction). The Player misses this broadcast, so `m_audioLanes` is never populated with WMP sources. When audio buffers arrive later via `OnAudioUpdated`, the lane lookup fails and audio is silently dropped.

The previous code didn't have this issue because `OnAudioUpdated` had a lazy fallback (`if (m_activeAudioSourceId == 0) UpdateActiveAudioSource()`) that queried sources on-demand.

## Fix

Add an initial `OnAudioSrcChanged` call immediately after subscribing. This gathers all already-registered audio sources into `m_audioLanes`, matching the pattern already used for `OnAuxRendererChanged` on the very next line.

## Testing

Tested with American Graffiti (Original 2024) table which uses multiple WMP instances for music and sound effects. Music plays correctly after the fix."