### PR TITLE
B2S: Fix stuck bulbs

### DIFF
--- a/plugins/b2s/B2SRenderer.cpp
+++ b/plugins/b2s/B2SRenderer.cpp
@@ -174,7 +174,10 @@ void B2SRenderer::RenderBulbs(VPXRenderContext2D* ctx, const B2SServer* server, 
    {
       if (bulb->m_b2sId >= 0 && server)
       {
-         bulb->m_brightness = server->GetLampState(bulb->m_b2sId);
+         const float state = server->GetLampState(bulb->m_b2sId);
+         bulb->m_brightness = (bulb->m_b2sValue > 0) ? 
+            ((static_cast<int>(state) == bulb->m_b2sValue) ? 1.f : 0.f) :
+            state;
       }
       else
       {


### PR DESCRIPTION
Fixes #3756

`B2SValue` is parsed but never used, resulting in various lamps stuck in the ON position.

This PR matches legacy B2S behavior: read lamp `B2SValue`, compare to the lamp currently being rendered, and light the lamp if the values match.

For reference, this was tested on Spirit of 76, which has the following Ball In Play lamps

```
Bulb ID=5  B2SID=32  B2SIDType=7  B2SValue=1
Bulb ID=6  B2SID=32  B2SIDType=7  B2SValue=2
Bulb ID=7  B2SID=32  B2SIDType=7  B2SValue=3
Bulb ID=8  B2SID=32  B2SIDType=7  B2SValue=4
Bulb ID=9  B2SID=32  B2SIDType=7  B2SValue=5
```