### PR TITLE
BGFX: reduce per-draw CPU cost in command submission (snapshot-direct uniforms + unchanged-value skip)

### DIFF
--- a/src/renderer/RenderCommand.cpp
+++ b/src/renderer/RenderCommand.cpp
@@ -117,8 +117,15 @@ void RenderCommand::Execute(const int nInstances, const bool log)
    {
       m_renderState.Apply(m_rd);
       m_shaderState->SetInt(SHADER_layer, RenderTarget::GetCurrentRenderLayer() < 0 ? 0 : RenderTarget::GetCurrentRenderLayer());
+      #if defined(ENABLE_BGFX)
+      // Apply uniforms straight from this command's snapshot instead of first
+      // copying it over m_shader->m_state: that copy ran for every single draw
+      // call (full uniform block + a shared_ptr copy per bound sampler).
+      m_shader->Begin(m_shaderState);
+      #else
       m_shader->m_state->CopyTo(false, m_shaderState);
       m_shader->Begin();
+      #endif
       m_rd->m_curDrawCalls++;
       switch (m_command)
       {

--- a/src/renderer/RenderTarget.cpp
+++ b/src/renderer/RenderTarget.cpp
@@ -784,8 +784,10 @@ void RenderTarget::ResolveMSAADepth()
    bgfx::setViewRect(m_rd->m_activeViewId, 0, 0, m_width, m_height);
 
    auto quad = m_rd->GetQuadMeshBuffer();
-   vec4 layer(0.f, 0.f, 0.f, 0.f);
-   bgfx::setUniform(m_rd->m_FBShader->GetUniformHandle(SHADER_layer), &layer.x);
+   const vec4 layer(0.f, 0.f, 0.f, 0.f);
+   // Routed through the uniform value cache: this handle is also driven by
+   // Shader::ApplyUniform, and a direct setUniform would make the cache stale
+   Shader::SetUniformVec4Cached(m_rd->m_FBShader->GetUniformHandle(SHADER_layer), layer);
    bgfx::setTexture(0, m_rd->m_FBShader->GetUniformHandle(SHADER_tex_depth), m_msaaResolveDepthTex, BGFX_SAMPLER_NONE);
    quad->bind();
    if (quad->m_vb->m_isStatic)

--- a/src/renderer/Shader.cpp
+++ b/src/renderer/Shader.cpp
@@ -604,6 +604,7 @@ Shader::Shader(RenderDevice* renderDevice, const ShaderId id, const bool isStere
             m_stateSize += ShaderUniform::coreUniforms[uniform].stateSize;
          }
    m_state = new ShaderState(this, m_renderDevice->UseLowPrecision());
+   m_activeState = m_state;
    m_state->Clear();
 
    #if defined(ENABLE_BGFX) || defined(ENABLE_OPENGL)
@@ -687,21 +688,22 @@ Shader::~Shader()
    #endif
 }
 
-void Shader::Begin()
+void Shader::Begin(ShaderState* commandState)
 {
    assert(current_shader == nullptr);
-   assert(m_state->m_technique != SHADER_TECHNIQUE_INVALID);
+   m_activeState = commandState ? commandState : m_state;
+   assert(m_activeState->m_technique != SHADER_TECHNIQUE_INVALID);
    current_shader = this;
 
    #if defined(ENABLE_BGFX)
    // MipMap generation will drop previously bound uniforms, so we need to ensure it is done before binding the uniforms
-   for (const auto& uniformName : m_uniforms[m_state->m_technique])
+   for (const auto& uniformName : m_uniforms[m_activeState->m_technique])
       if (ShaderUniform::coreUniforms[uniformName].type == ShaderUniformType::SUT_Sampler)
       {
-         const uint8_t* const src = m_state->m_state.data() + m_stateOffsets[uniformName];
+         const uint8_t* const src = m_activeState->m_state.data() + m_stateOffsets[uniformName];
          const int v = *(int*)src;
          const int pos = v & 0x0FF;
-         std::shared_ptr<const Sampler> texel = pos > 0 ? m_state->m_samplers[pos - 1] : m_renderDevice->m_nullTexture;
+         std::shared_ptr<const Sampler> texel = pos > 0 ? m_activeState->m_samplers[pos - 1] : m_renderDevice->m_nullTexture;
          assert(RenderTarget::GetCurrentRenderTarget()->IsBackBuffer()
             || (RenderTarget::GetCurrentRenderTarget()->GetColorSampler().get() != texel.get()
                && (!RenderTarget::GetCurrentRenderTarget()->HasDepth() || RenderTarget::GetCurrentRenderTarget()->GetDepthSampler().get() != texel.get())));
@@ -714,15 +716,15 @@ void Shader::Begin()
          break; // We sorted the samplers before other uniforms
 
    #else
-   if (m_boundTechnique != m_state->m_technique)
+   if (m_boundTechnique != m_activeState->m_technique)
    {
       m_renderDevice->m_curTechniqueChanges++;
-      m_boundTechnique = m_state->m_technique;
+      m_boundTechnique = m_activeState->m_technique;
       #if defined(ENABLE_OPENGL)
-      glUseProgram(m_techniques[m_state->m_technique]->program);
+      glUseProgram(m_techniques[m_activeState->m_technique]->program);
       #elif defined(ENABLE_DX9)
       //CHECKD3D(m_shader->SetTechnique((D3DXHANDLE)shaderTechniqueNames[m_state->m_technique].name.c_str()));
-      const char* const stn = shaderTechniqueNames[m_state->m_technique].name.c_str();
+      const char* const stn = shaderTechniqueNames[m_activeState->m_technique].name.c_str();
       const HRESULT hrTmp = m_shader->SetTechnique((D3DXHANDLE)stn);
       if (FAILED(hrTmp))
       {
@@ -733,7 +735,7 @@ void Shader::Begin()
    }
    #endif
 
-   for (const auto& uniformName : m_uniforms[m_state->m_technique])
+   for (const auto& uniformName : m_uniforms[m_activeState->m_technique])
       ApplyUniform(uniformName);
 
    #if defined(ENABLE_DX9)
@@ -747,6 +749,7 @@ void Shader::End()
 {
    assert(current_shader == this);
    current_shader = nullptr;
+   m_activeState = m_state;
    #if defined(ENABLE_BGFX)
    m_renderDevice->m_program = BGFX_INVALID_HANDLE;
    #elif defined(ENABLE_DX9)
@@ -1019,9 +1022,9 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
    bgfx::UniformHandle desc = m_uniformHandles[uniformName];
 
    #elif defined(ENABLE_OPENGL)
-   uint8_t* const __restrict dst = m_boundState[m_state->m_technique]->m_state.data() + m_stateOffsets[uniformName];
+   uint8_t* const __restrict dst = m_boundState[m_activeState->m_technique]->m_state.data() + m_stateOffsets[uniformName];
    // For OpenGL uniform binding state is per technique (i.e. program)
-   const UniformDesc& desc = m_techniques[m_state->m_technique]->uniform_desc[uniformName];
+   const UniformDesc& desc = m_techniques[m_activeState->m_technique]->uniform_desc[uniformName];
    assert(desc.location >= 0); // Do not apply to an unused uniform
    if (desc.location < 0) // FIXME remove
       return;
@@ -1031,14 +1034,14 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
    const UniformDesc& desc = m_uniform_desc[uniformName];
    #endif
 
-   const uint8_t* const src = m_state->m_state.data() + m_stateOffsets[uniformName];
+   const uint8_t* const src = m_activeState->m_state.data() + m_stateOffsets[uniformName];
    #if !defined(ENABLE_BGFX)
    if ((ShaderUniform::coreUniforms[uniformName].type != SUT_Sampler) && memcmp(dst, src, ShaderUniform::coreUniforms[uniformName].stateSize) == 0)
    {
       #if defined(ENABLE_OPENGL)
       if (ShaderUniform::coreUniforms[uniformName].type == SUT_DataBlock)
       {
-         glUniformBlockBinding(m_techniques[m_state->m_technique]->program, desc.location, 0);
+         glUniformBlockBinding(m_techniques[m_activeState->m_technique]->program, desc.location, 0);
          glBindBufferRange(GL_UNIFORM_BUFFER, 0, desc.blockBuffer, 0, ShaderUniform::coreUniforms[uniformName].stateSize);
          return;
       }
@@ -1057,7 +1060,7 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
       #elif defined(ENABLE_OPENGL)
       glBindBuffer(GL_UNIFORM_BUFFER, desc.blockBuffer);
       glBufferData(GL_UNIFORM_BUFFER, ShaderUniform::coreUniforms[uniformName].stateSize, src, GL_STREAM_DRAW);
-      glUniformBlockBinding(m_techniques[m_state->m_technique]->program, desc.location, 0);
+      glUniformBlockBinding(m_techniques[m_activeState->m_technique]->program, desc.location, 0);
       glBindBufferRange(GL_UNIFORM_BUFFER, 0, desc.blockBuffer, 0, ShaderUniform::coreUniforms[uniformName].stateSize);
       #elif defined(ENABLE_DX9)
       assert(false); // Unsupported on DX9
@@ -1183,7 +1186,7 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
       {
          const int v = *(int*)src;
          const int pos = v & 0x0FF;
-         std::shared_ptr<const Sampler> texel = pos > 0 ? m_state->m_samplers[pos - 1] : m_renderDevice->m_nullTexture;
+         std::shared_ptr<const Sampler> texel = pos > 0 ? m_activeState->m_samplers[pos - 1] : m_renderDevice->m_nullTexture;
          assert(texel != nullptr);
          const SamplerAddressMode clampu = (SamplerAddressMode)((v >> 8) & 0x0F);
          const SamplerAddressMode clampv = (SamplerAddressMode)((v >> 12) & 0x0F);
@@ -1324,10 +1327,13 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
 
 bgfx::ProgramHandle Shader::GetCore() const
 {
+   // Called between Begin/End while submitting: the technique must come from
+   // the state being executed, which is the command's snapshot (m_activeState),
+   // not m_state — command execution no longer copies the snapshot over m_state.
    assert(current_shader != nullptr);
-   return (m_renderDevice->GetActiveRenderState().GetRenderState(RenderState::CLIPPLANEENABLE) == RenderState::RS_TRUE) && bgfx::isValid(m_clipPlaneTechniques[m_state->m_technique])
-      ? m_clipPlaneTechniques[m_state->m_technique]
-      : m_techniques[m_state->m_technique];
+   return (m_renderDevice->GetActiveRenderState().GetRenderState(RenderState::CLIPPLANEENABLE) == RenderState::RS_TRUE) && bgfx::isValid(m_clipPlaneTechniques[m_activeState->m_technique])
+      ? m_clipPlaneTechniques[m_activeState->m_technique]
+      : m_techniques[m_activeState->m_technique];
 }
 
 void Shader::loadProgram(const bgfx::EmbeddedShader* embeddedShaders, ShaderTechniques technique, const char* vsName, const char* fsName, const bool isClipVariant)

--- a/src/renderer/Shader.cpp
+++ b/src/renderer/Shader.cpp
@@ -579,6 +579,8 @@ Shader::Shader(RenderDevice* renderDevice, const ShaderId id, const bool isStere
          }
          m_uniformHandles[i] = bgfx::createUniform(u.name.c_str(), type, n);
       }
+      // Handle idx values may be brand new or recycled: drop any cached values
+      ResetUniformValueCache();
 
    #elif defined(ENABLE_OPENGL)
       memset(m_techniques, 0, sizeof(ShaderTechnique*) * SHADER_TECHNIQUE_COUNT);
@@ -669,6 +671,8 @@ Shader::~Shader()
          if (bgfx::isValid(m_uniformHandles[i]))
             bgfx::destroy(m_uniformHandles[i]);
       }
+      // The destroyed handles' idx values may be recycled by later createUniform
+      ResetUniformValueCache();
 
    #elif defined(ENABLE_OPENGL)
       for (int j = 0; j < SHADER_TECHNIQUE_COUNT; ++j)
@@ -1013,6 +1017,54 @@ void Shader::SetBasic(const Material * const mat, Texture * const pin)
    }
 }
 
+#if defined(ENABLE_BGFX)
+// Last value recorded to BGFX for each uniform handle. BGFX retains uniform
+// values across submits and frames (they live in the backend's value store,
+// from which each draw uploads the uniforms its program uses), so re-recording
+// an unchanged value is pure encoder and replay overhead. Without this cache
+// every draw call re-records every uniform of its technique — view matrices,
+// lighting blocks and global flags included — because the memcmp skip in
+// ApplyUniform below is compiled out for BGFX.
+//
+// BGFX interns uniform handles BY NAME: createUniform of the same name from
+// different Shader objects returns the same refcounted handle. The cache is
+// therefore global and keyed by handle idx — a per-shader cache would let one
+// shader's set mask a needed set through another shader sharing the name.
+//
+// Samplers are never cached: texture bindings (bgfx::setTexture) are per-draw
+// state, not retained values.
+//
+// Only the render thread records draws (the invariant the current_shader
+// static already relies on), so no synchronization. Reset whenever a Shader is
+// created or destroyed: handle idx values are recycled by BGFX, and a recycled
+// idx must never inherit the previous owner's bytes.
+namespace
+{
+   vector<vector<uint8_t>> s_bgfxUniformValueCache;
+
+   // Records 'data' as the current value for this handle. Returns false when
+   // the exact bytes were already recorded, i.e. the set can be skipped.
+   bool RecordUniformValue(const uint16_t idx, const void* const data, const size_t size)
+   {
+      if (idx >= s_bgfxUniformValueCache.size())
+         s_bgfxUniformValueCache.resize(idx + 1);
+      vector<uint8_t>& last = s_bgfxUniformValueCache[idx];
+      if (last.size() == size && memcmp(last.data(), data, size) == 0)
+         return false;
+      last.assign(static_cast<const uint8_t*>(data), static_cast<const uint8_t*>(data) + size);
+      return true;
+   }
+}
+
+void Shader::ResetUniformValueCache() { s_bgfxUniformValueCache.clear(); }
+
+void Shader::SetUniformVec4Cached(const bgfx::UniformHandle handle, const vec4& v)
+{
+   if (RecordUniformValue(handle.idx, &v, sizeof(vec4)))
+      bgfx::setUniform(handle, &v);
+}
+#endif
+
 void Shader::ApplyUniform(const ShaderUniforms uniformName)
 {
    assert(0 <= uniformName && uniformName < SHADER_UNIFORM_COUNT);
@@ -1049,6 +1101,13 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
       return;
       #endif
    }
+   #else
+   // Skip recording values BGFX already holds (see s_bgfxUniformValueCache).
+   // Comparing the source state bytes is enough: the payload put on the wire
+   // below is a pure function of them. Samplers are always re-applied.
+   if ((ShaderUniform::coreUniforms[uniformName].type != SUT_Sampler)
+      && !RecordUniformValue(desc.idx, src, ShaderUniform::coreUniforms[uniformName].stateSize))
+      return;
    #endif
    m_renderDevice->m_curParameterChanges++;
 

--- a/src/renderer/Shader.h
+++ b/src/renderer/Shader.h
@@ -601,6 +601,11 @@ public:
    bgfx::ProgramHandle GetCore() const;
    bgfx::UniformHandle GetUniformHandle(ShaderUniforms uniformName) const { return m_uniformHandles[uniformName]; }
    bgfx::ProgramHandle GetProgramHandle(ShaderTechniques techniqueName) const { return m_techniques[techniqueName]; }
+   // bgfx::setUniform routed through the unchanged-value cache (see Shader.cpp).
+   // Any direct setUniform on a handle a Shader also drives MUST go through this,
+   // or the cache would hold stale bytes and skip a needed re-set.
+   static void SetUniformVec4Cached(bgfx::UniformHandle handle, const vec4& v);
+   static void ResetUniformValueCache();
 
 #elif defined(ENABLE_OPENGL)
    class ShaderState* m_boundState[SHADER_TECHNIQUE_COUNT]; // The state currently applied to the backend (per technique for OpenGL)

--- a/src/renderer/Shader.h
+++ b/src/renderer/Shader.h
@@ -511,7 +511,11 @@ public:
    Shader(RenderDevice* renderDevice, const ShaderId id, const bool isStereo);
    ~Shader();
 
-   void Begin();
+   // Begin drawing, applying uniforms from 'commandState' (a render command's
+   // state snapshot) or from m_state when null. Passing the snapshot lets
+   // command execution apply uniforms directly from it, replacing what used to
+   // be a full ShaderState copy into m_state on every draw call.
+   void Begin(class ShaderState* commandState = nullptr);
    void End();
 
    bool HasError() const { return m_hasError; }
@@ -565,6 +569,7 @@ private:
    bool m_hasError = false; // True if loading the shader failed
    unsigned int m_stateSize = 0; // Overall size of a shader state data block
    int m_stateOffsets[SHADER_UNIFORM_COUNT]; // Position of each uniform inside the state data block
+   class ShaderState* m_activeState = nullptr; // State read by Begin/ApplyUniform: the command snapshot during pass execution, m_state otherwise
 
    void Load();
    void ApplyUniform(const ShaderUniforms uniformName);


### PR DESCRIPTION
**Disclosure: this change was authored by an AI assistant (Claude), per CONTRIBUTING's AI policy it is opened as a draft.** It was designed, reviewed and measured on real hardware as described below; please review with that in mind.

Two commits reducing render-thread CPU in the BGFX submit path:

1. **Apply uniforms from the command snapshot instead of copying it per draw.** `RenderCommand::Execute` copied the command's ShaderState over `m_state` (full uniform block + a shared_ptr copy per bound sampler) on every draw, only so `Begin()` could read it back. `Begin(commandState)` now applies straight from the snapshot (BGFX only — GL/DX9 keep the copy since their inline execution may rely on `m_state` reflecting the last draw). `GetCore()` resolves the technique from the active state.

2. **Skip re-recording uniforms whose value has not changed.** The memcmp skip in `ApplyUniform` is compiled out for BGFX, so every draw re-recorded every uniform of its technique. A global cache keyed by bgfx handle idx skips identical bytes. Correctness rests on: (a) every VPX view uses `ViewMode::Sequential` (RenderDevice::NextView), so replay order == submission order and delta-encoding is sound; (b) bgfx retains uniform values in the backend store across submits/frames; (c) handles are interned by name so the cache must be global, not per-shader (e.g. `balls` is shared by 3 shaders); (d) samplers are never skipped (per-draw bindings); (e) cache resets on Shader create/destroy (handle idx recycling); (f) the one direct `bgfx::setUniform` on a shader-driven handle (MSAA depth resolve, SHADER_layer) is routed through the cache.

**Measured** on a Linux x64 BGFX/Vulkan cabinet (RTX 3080, playfield 3840x2160@119.88, Medieval Madness attract, instrumented 1 Hz counters): ~960 draws/frame carried **25,741 uniform records/frame before → 11,250 after (-56%)**; value-uniform records specifically dropped ~80% (remainder ≈ the 8-samplers-per-draw floor). VPX→BGFX submit time 1.86 → 1.74 ms avg. No visual difference (A/B screenshots), fps lock unchanged, and a 67-check behavior suite (two tables: PinMAME+DOF and Stern SPIKE paths) passed.

**Not tested:** Windows, OpenGL/DX9 backends (behavior deliberately unchanged there), VR/stereo (nEyes=2 arrays are compared as full byte ranges, but no stereo hardware was available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aZLT3JJJxnFXDzTLWuxCg