### PR TITLE
Skip DMD texture re-upload when the source frame is unchanged

### DIFF
--- a/plugins/b2s/B2SDMDOverlay.cpp
+++ b/plugins/b2s/B2SDMDOverlay.cpp
@@ -120,12 +120,20 @@ void B2SDMDOverlay::Render(VPXRenderContext2D* ctx)
    if (m_frame.z == 0 || m_frame.w == 0)
       return;
 
-   switch (dmd.source->frameFormat)
+   // m_dmdTex is shared with the other overlay (scoreview/backglass), but the
+   // gate is per-overlay: each records what IT last uploaded, so neither can
+   // suppress the other's first upload after a change. Worst case is one
+   // redundant upload per content change while both windows are active.
+   if (m_displayUploadGate.NeedsUpload(dmd, m_dmdTex))
    {
-   case CTLPI_DISPLAY_FORMAT_LUM32F: UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_BW32F, dmd.state.frame); break;
-   case CTLPI_DISPLAY_FORMAT_SRGB888: UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB8, dmd.state.frame); break;
-   case CTLPI_DISPLAY_FORMAT_SRGB565: UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB565, dmd.state.frame); break;
-   default: return;
+      switch (dmd.source->frameFormat)
+      {
+      case CTLPI_DISPLAY_FORMAT_LUM32F: UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_BW32F, dmd.state.frame); break;
+      case CTLPI_DISPLAY_FORMAT_SRGB888: UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB8, dmd.state.frame); break;
+      case CTLPI_DISPLAY_FORMAT_SRGB565: UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB565, dmd.state.frame); break;
+      default: return;
+      }
+      m_displayUploadGate.MarkUploaded(dmd, m_dmdTex);
    }
 
    vec4 glassArea(0.f, 0.f, 0.f, 0.f);

--- a/plugins/b2s/B2SDMDOverlay.h
+++ b/plugins/b2s/B2SDMDOverlay.h
@@ -26,6 +26,9 @@ private:
 
    ResURIResolver& m_resURIResolver;
    VPXTexture& m_dmdTex;
+   // Gates the per-frame display pull so unchanged frames are not re-uploaded
+   // into m_dmdTex at render rate. Per-overlay even though m_dmdTex is shared.
+   ResURIResolver::DisplayUploadGate m_displayUploadGate;
 
    ivec4 m_frame;
    bool m_enable = false;

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -130,12 +130,19 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
       }
    }
 
-   switch (dmd.source->frameFormat)
+   // m_dmdTex may be shared with another overlay, but the gate is per-overlay:
+   // each records what IT last uploaded, so neither can suppress the other's
+   // first upload after a change.
+   if (m_displayUploadGate.NeedsUpload(dmd, m_dmdTex))
    {
-   case CTLPI_DISPLAY_FORMAT_LUM32F: m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_BW32F, dmd.state.frame); break;
-   case CTLPI_DISPLAY_FORMAT_SRGB888: m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB8, dmd.state.frame); break;
-   case CTLPI_DISPLAY_FORMAT_SRGB565: m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB565, dmd.state.frame); break;
-   default: return;
+      switch (dmd.source->frameFormat)
+      {
+      case CTLPI_DISPLAY_FORMAT_LUM32F: m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_BW32F, dmd.state.frame); break;
+      case CTLPI_DISPLAY_FORMAT_SRGB888: m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB8, dmd.state.frame); break;
+      case CTLPI_DISPLAY_FORMAT_SRGB565: m_vpxApi->UpdateTexture(&m_dmdTex, dmd.source->width, dmd.source->height, VPXTextureFormat::VPXTEXFMT_sRGB565, dmd.state.frame); break;
+      default: return;
+      }
+      m_displayUploadGate.MarkUploaded(dmd, m_dmdTex);
    }
 
    vec4 glassArea(0.f, 0.f, 0.f, 0.f);

--- a/plugins/b2slegacy/utils/DMDOverlay.h
+++ b/plugins/b2slegacy/utils/DMDOverlay.h
@@ -24,6 +24,9 @@ private:
 
    ResURIResolver& m_resURIResolver;
    VPXTexture& m_dmdTex;
+   // Gates the per-frame display pull so unchanged frames are not re-uploaded
+   // into m_dmdTex at render rate. Per-overlay even though m_dmdTex is shared.
+   ResURIResolver::DisplayUploadGate m_displayUploadGate;
    VPXPluginAPI* m_vpxApi = nullptr;
 
    ivec4 m_frame;

--- a/plugins/plugins/ResURIResolver.h
+++ b/plugins/plugins/ResURIResolver.h
@@ -67,6 +67,62 @@ public:
       DisplayFrame state;
    };
    DisplayState GetDisplayState(const std::string &link);
+
+   // Skip-unchanged gate for consumers that pull a DisplayState once per
+   // rendered frame and copy it into a texture. Sources only advance
+   // DisplayFrame.frameId when the frame content actually changed, so a
+   // consumer that remembers the id it last uploaded can skip the copy (and
+   // the GPU upload behind it) instead of re-uploading a static image at
+   // render rate.
+   //
+   // One gate per consumer-owned target texture. Never share a gate between
+   // two consumers, even when they feed the same texture: the first puller's
+   // upload would suppress the second one's, and whichever window pulls later
+   // goes stale while everything else looks healthy.
+   //
+   // frameId is compared for INEQUALITY, not ordering: id sequences restart
+   // with their source (new table, ROM restart, source swap) and can wrap, so
+   // "different from the id THIS gate last uploaded" is the only safe trigger.
+   //
+   // The target texture pointer and the source identity/geometry are part of
+   // the key so a cached id can never suppress the first upload into a texture
+   // object this gate has not fed yet (still null, recreated, reallocated), an
+   // upload from a different source that happens to reuse an id, or an upload
+   // after the source changed shape under an unchanged id. Callers must call
+   // MarkUploaded AFTER the upload, with the texture pointer as it is AFTER
+   // the call — the upload itself may reallocate the texture.
+   //
+   // Skipping is safe against GPU-side texture lifetime: the last uploaded
+   // frame remains in the consumer's CPU-side texture, which is what the
+   // renderer's texture cache rebuilds from if its GPU copy is evicted or the
+   // device is reset — so a skipped upload can never leave the display blank
+   // or frozen, only identical to the frame already shown.
+   struct DisplayUploadGate
+   {
+      const void *texture = nullptr; // consumer's target texture as of the last upload
+      uint64_t srcId = 0;
+      unsigned int frameId = 0;
+      unsigned int width = 0;
+      unsigned int height = 0;
+      unsigned int frameFormat = 0;
+
+      bool NeedsUpload(const DisplayState &display, const void *targetTexture) const
+      {
+         return targetTexture == nullptr || targetTexture != texture
+            || display.source->id.id != srcId || display.state.frameId != frameId
+            || display.source->width != width || display.source->height != height
+            || display.source->frameFormat != frameFormat;
+      }
+      void MarkUploaded(const DisplayState &display, const void *targetTexture)
+      {
+         texture = targetTexture;
+         srcId = display.source->id.id;
+         frameId = display.state.frameId;
+         width = display.source->width;
+         height = display.source->height;
+         frameFormat = display.source->frameFormat;
+      }
+   };
    void SetDisplayFilter(const std::function<bool(const DisplaySrcId& src)>& filter);
    std::string DumpDisplaySources() const;
    

--- a/plugins/scoreview/ScoreView.cpp
+++ b/plugins/scoreview/ScoreView.cpp
@@ -596,11 +596,15 @@ bool ScoreView::Render(VPXRenderContext2D* ctx)
          if (dmd.state.frame == nullptr)
             continue;
          LoadGlass(visual);
-         m_vpxApi->UpdateTexture(&visual.dmdTex, dmd.source->width, dmd.source->height,
-              dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F  ? VPXTextureFormat::VPXTEXFMT_BW32F
-            : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? VPXTextureFormat::VPXTEXFMT_sRGB565
-                                                                      : VPXTextureFormat::VPXTEXFMT_sRGB8,
-            dmd.state.frame);
+         if (visual.displayUploadGate.NeedsUpload(dmd, visual.dmdTex))
+         {
+            m_vpxApi->UpdateTexture(&visual.dmdTex, dmd.source->width, dmd.source->height,
+                 dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F  ? VPXTextureFormat::VPXTEXFMT_BW32F
+               : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? VPXTextureFormat::VPXTEXFMT_sRGB565
+                                                                         : VPXTextureFormat::VPXTEXFMT_sRGB8,
+               dmd.state.frame);
+            visual.displayUploadGate.MarkUploaded(dmd, visual.dmdTex);
+         }
          vec4 glassArea;
          if (visual.glass == nullptr || visual.glassArea.z == 0.f || visual.glassArea.w == 0.f)
             glassArea = vec4(0.f, 0.f, 1.f, 1.f);

--- a/plugins/scoreview/ScoreView.h
+++ b/plugins/scoreview/ScoreView.h
@@ -110,6 +110,9 @@ private:
       // Live data (not serialized)
       VPXTexture glass;
       VPXTexture dmdTex;
+      // Per-visual on purpose: each visual pulls its source independently, so
+      // each needs its own record of what it last uploaded into its dmdTex.
+      ResURIResolver::DisplayUploadGate displayUploadGate;
       int liveStyle;
    };
    struct Layout

--- a/src/parts/flasher.cpp
+++ b/src/parts/flasher.cpp
@@ -1319,11 +1319,14 @@ void Flasher::Render(const unsigned int renderMask)
                dmd = g_pplayer->m_resURIResolver.GetDisplayState(m_d.m_imageSrcLink);
             if (dmd.state.frame == nullptr)
                dmd = g_pplayer->m_resURIResolver.GetDisplayState("ctrl://default/display"s);
-            if (dmd.state.frame != nullptr)
+            if (dmd.state.frame != nullptr && m_displayUploadGate.NeedsUpload(dmd, m_renderFrame.get()))
+            {
                BaseTexture::Update(m_renderFrame, dmd.source->width, dmd.source->height,
                               dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F  ? BaseTexture::BW_FP32
                             : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? BaseTexture::SRGB565
                                                                                       : BaseTexture::SRGB, dmd.state.frame);
+               m_displayUploadGate.MarkUploaded(dmd, m_renderFrame.get());
+            }
          }
          if (m_renderFrame != nullptr)
          {
@@ -1347,11 +1350,18 @@ void Flasher::Render(const unsigned int renderMask)
       case FlasherData::DISPLAY:
          if (const ResURIResolver::DisplayState display = g_pplayer->m_resURIResolver.GetDisplayState(m_d.m_imageSrcLink); display.state.frame != nullptr)
          {
-            BaseTexture::Update(m_renderFrame, display.source->width, display.source->height,
-               display.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F       ? BaseTexture::BW_FP32
-                  : display.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? BaseTexture::SRGB565
-                                                                                : BaseTexture::SRGB,
-               display.state.frame);
+            // Shares m_displayUploadGate with the DMD case above: only one of
+            // the two runs per frame, and if the render mode is switched at
+            // runtime the gate re-arms through its source-id/texture key.
+            if (m_displayUploadGate.NeedsUpload(display, m_renderFrame.get()))
+            {
+               BaseTexture::Update(m_renderFrame, display.source->width, display.source->height,
+                  display.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F       ? BaseTexture::BW_FP32
+                     : display.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? BaseTexture::SRGB565
+                                                                                   : BaseTexture::SRGB,
+                  display.state.frame);
+               m_displayUploadGate.MarkUploaded(display, m_renderFrame.get());
+            }
             Texture *const glass = m_ptable->GetImage(m_d.m_szImageA);
             if (m_d.m_modulate_vs_add < 1.f)
                m_renderer->m_renderDevice->EnableAlphaBlend(m_d.m_addBlend);

--- a/src/parts/flasher.h
+++ b/src/parts/flasher.h
@@ -5,6 +5,7 @@
 #include "parts/dragpoint.h"
 #include "parts/pintable.h"
 #include "physics/hitable.h"
+#include "plugins/ResURIResolver.h"
 #include "renderer/Renderable.h"
 #include "ui/win/resource.h"
 #include "utils/eventproxy.h"
@@ -203,6 +204,9 @@ private:
    int2 m_dmdSize = int2(0,0);
 
    std::shared_ptr<BaseTexture> m_renderFrame = nullptr;
+   // Gates the per-frame display pull (DMD/DISPLAY render modes) so unchanged
+   // frames are not re-uploaded into m_renderFrame at render rate.
+   ResURIResolver::DisplayUploadGate m_displayUploadGate;
 
    Light *m_lightmap = nullptr;
 

--- a/src/parts/textbox.cpp
+++ b/src/parts/textbox.cpp
@@ -311,11 +311,15 @@ void Textbox::Render(const unsigned int renderMask)
       ResURIResolver::DisplayState dmd = g_pplayer->m_resURIResolver.GetDisplayState("ctrl://default/display"s);
       if (dmd.state.frame == nullptr)
          return;
-      BaseTexture::Update(m_texture, dmd.source->width, dmd.source->height, 
-              dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F  ? BaseTexture::BW_FP32
-            : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? BaseTexture::SRGB565
-                                                                      : BaseTexture::SRGB,
-         dmd.state.frame);
+      if (m_displayUploadGate.NeedsUpload(dmd, m_texture.get()))
+      {
+         BaseTexture::Update(m_texture, dmd.source->width, dmd.source->height,
+                 dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_LUM32F  ? BaseTexture::BW_FP32
+               : dmd.source->frameFormat == CTLPI_DISPLAY_FORMAT_SRGB565 ? BaseTexture::SRGB565
+                                                                         : BaseTexture::SRGB,
+            dmd.state.frame);
+         m_displayUploadGate.MarkUploaded(dmd, m_texture.get());
+      }
       // DMD support for textbox is for backward compatibility only, so only use compatibility style #0
       const vec3 color = m_texture->m_format == BaseTexture::BW_FP32 ? convertColor(m_d.m_fontcolor) : vec3(1.f, 1.f, 1.f);
       m_renderer->SetupDMDRender(0, true, color, m_d.m_intensity_scale, m_texture, 1.f, Renderer::Reinhard, nullptr,
@@ -332,6 +336,12 @@ void Textbox::Render(const unsigned int renderMask)
       if (m_textureDirty)
       {
          m_textureDirty = false;
+         // The rasterizer below writes text pixels straight into m_texture. A
+         // textbox can flip between text and DMD mode at runtime (is_dmd also
+         // matches on the text content), so drop the DMD gate's memory: its
+         // cached frameId now describes pixels that are no longer in the
+         // texture, and keeping it would skip the upload that restores them.
+         m_displayUploadGate = {};
          RECT rect;
          rect.left = (int)min(m_d.m_v1.x, m_d.m_v2.x);
          rect.top = (int)min(m_d.m_v1.y, m_d.m_v2.y);

--- a/src/parts/textbox.h
+++ b/src/parts/textbox.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "parts/pintable.h"
+#include "plugins/ResURIResolver.h"
 #include "renderer/Renderable.h"
 #include "ui/win/resource.h"
 #include "utils/eventproxy.h"
@@ -93,6 +94,12 @@ private:
    Renderer *m_renderer = nullptr;
    bool m_textureDirty = true;
    std::shared_ptr<BaseTexture> m_texture = nullptr;
+   // Gates the per-frame DMD-mode display pull so unchanged frames are not
+   // re-uploaded into m_texture at render rate. Must be reset whenever the
+   // text path rasterizes into m_texture: the DMD gate would otherwise see an
+   // unchanged frameId over a texture whose pixels are now text, and skip the
+   // upload that repairs it.
+   ResURIResolver::DisplayUploadGate m_displayUploadGate;
    IFont *m_pIFontPlay = nullptr; // Our font, scaled to match play window resolution
 
 #ifdef __STANDALONE__


### PR DESCRIPTION
**Disclosure: this change was authored by an AI assistant (Claude), per CONTRIBUTING's AI policy it is opened as a draft.**

Display sources only advance `DisplayFrame.frameId` when content actually changed, but the pull-side consumers (flasher DMD/DISPLAY, textbox DMD, scoreview, both B2S DMD overlays) called `UpdateTexture` once per rendered frame unconditionally — so a DMD changing ~60×/s was re-uploaded at full render rate, and a fully static DMD kept uploading forever.

Adds `ResURIResolver::DisplayUploadGate`: per consumer and per target texture, remember the (source id, frameId, geometry, texture object) last uploaded and skip when unchanged. Design notes: per-consumer (never shared — one puller's upload must not suppress another's), inequality comparison (frameId sequences restart/wrap), target texture pointer recorded AFTER upload (Update may reallocate), and textbox resets its gate when the text rasterizer writes the shared texture. Push-model paths (script DMDPixels), segment displays, and paths already gated on frameId are deliberately untouched; PUP video has no change token and is untouched.

**Measured** on a 120 Hz Linux BGFX/Vulkan cabinet (Medieval Madness, instrumented build): DMD-texture uploads previously ran at ~2.15× rendered-frame rate (4.3× the content change rate); with the gate they track the content change rate, and a static DMD drops to ~0 uploads/s. A 67-check behavior suite over a PinMAME+DOF table and a Stern SPIKE table (different DMD path) passed; DMD rendering verified on both plus B2S overlays.

**Not tested:** Windows, OpenGL/DX9 (code is backend-agnostic pull-side logic), FlexDMD-composited edge cases beyond the two suite tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aZLT3JJJxnFXDzTLWuxCg