### PR TITLE
Player: enumerate existing plugin audio sources after subscribing

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -778,6 +778,10 @@ Player::Player(PinTable *const table, const PlayMode playMode)
    msgApi->SubscribeMsg(m_pluginAPI.GetVPXEndPointId(), m_onAudioUpdatedMsgId, OnAudioUpdated, this);
    msgApi->SubscribeMsg(m_pluginAPI.GetVPXEndPointId(), m_onAudioSrcChangedMsgId, OnAudioSrcChanged, this);
 
+   // Plugins may have announced their audio sources before Player subscribed.
+   // Perform an initial enumeration so audio lanes exist before samples arrive.
+   OnAudioSrcChanged(m_onAudioSrcChangedMsgId, this, nullptr);
+
    m_getAuxRendererId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_MSG_GET_AUX_RENDERER);
    m_onAuxRendererChgId = msgApi->GetMsgID(VPXPI_NAMESPACE, VPXPI_EVT_AUX_RENDERER_CHG);
    msgApi->SubscribeMsg(m_pluginAPI.GetVPXEndPointId(), m_onAuxRendererChgId, OnAuxRendererChanged, this);


### PR DESCRIPTION
## Summary

This fixes a race where plugin audio sources can be registered before `Player`
subscribes to `CTLPI_AUDIO_ON_SRC_CHG_MSG`.

If the initial source announcement is missed, the plugin's audio source is
never enumerated, so subsequent `AudioUpdate` messages are discarded because
no matching audio lane exists.

## Fix

After subscribing to `OnAudioSrcChanged`, perform one initial enumeration:

```cpp
OnAudioSrcChanged(m_onAudioSrcChangedMsgId, this, nullptr);

This discovers plugin audio sources that were already registered before the
subscription while preserving the existing event-driven behavior for later
changes.

Testing
Linux BGFX

Wuthering Waves PuP-Pack
Before: MP3 decoded and PCM broadcast, but no music was audible.
After: audio lane is created and PuP music plays correctly.

This is a minimal four-line change with no impact on the normal
OnAudioSrcChanged event flow.
