### PR TITLE
perf: slurp vpx into memory for network-attached storage

### DIFF
--- a/standalone/PoleStorage.cpp
+++ b/standalone/PoleStorage.cpp
@@ -2,13 +2,36 @@
 #include "PoleStorage.h"
 #include "PoleStream.h"
 
+#include <fstream>
+
 HRESULT PoleStorage::Create(const string& szFilename, const string& szName, IStorage** ppstg)
 {
-   POLE::Storage* pPOLEStorage = new POLE::Storage(szFilename.c_str());
+   // Slurp the entire file into memory for network-friendly access
+   std::ifstream ifs(szFilename, std::ios::binary | std::ios::ate);
+   if (!ifs.good())
+      return STG_E_FILENOTFOUND;
+
+   const auto size = ifs.tellg();
+   if (size <= 0)
+      return STG_E_FILENOTFOUND;
+
+   auto fileData = std::make_shared<std::vector<uint8_t>>(static_cast<size_t>(size));
+   ifs.seekg(0);
+   ifs.read(reinterpret_cast<char*>(fileData->data()), size);
+   if (!ifs.good())
+      return STG_E_FILENOTFOUND;
+   ifs.close();
+
+   return Create(fileData, szName, ppstg);
+}
+
+HRESULT PoleStorage::Create(std::shared_ptr<std::vector<uint8_t>> fileData, const string& szName, IStorage** ppstg)
+{
+   POLE::Storage* pPOLEStorage = new POLE::Storage(fileData->data(), static_cast<POLE::uint64>(fileData->size()));
 
    if (pPOLEStorage->open() && pPOLEStorage->result() == POLE::Storage::Ok) {
       PoleStorage* pStg = new PoleStorage();
-      pStg->m_szFilename = szFilename;
+      pStg->m_fileData = fileData;
       pStg->m_szPath = szName;
       pStg->m_pPOLEStorage = pPOLEStorage;
 
@@ -26,6 +49,8 @@ HRESULT PoleStorage::Create(const string& szFilename, const string& szName, ISto
 
 HRESULT PoleStorage::Clone(PoleStorage* pPoleStorage, IStorage** ppstg)
 {
+   if (pPoleStorage->m_fileData)
+      return PoleStorage::Create(pPoleStorage->m_fileData, pPoleStorage->m_szPath, ppstg);
    return PoleStorage::Create(pPoleStorage->m_szFilename, pPoleStorage->m_szPath, ppstg);
 }
 
@@ -94,6 +119,8 @@ STDMETHODIMP PoleStorage::OpenStorage(LPCOLESTR pwcsName, IStorage *pstgPriority
    char szName[1024];
    WideCharToMultiByte(CP_ACP, 0, pwcsName, -1, szName, sizeof(szName), NULL, NULL);
 
+   if (m_fileData)
+      return Create(m_fileData, szName, ppstg);
    return Create(m_szFilename, szName, ppstg);
 }
 

--- a/standalone/PoleStorage.h
+++ b/standalone/PoleStorage.h
@@ -3,12 +3,15 @@
 #include "objidl.h"
 #include "pole/pole.h"
 
+#include <memory>
 #include <string>
+#include <vector>
 using std::string;
 
 class PoleStorage : public IStorage {
 public:
    static HRESULT Create(const string& szFilename, const string& szName, IStorage** ppstg);
+   static HRESULT Create(std::shared_ptr<std::vector<uint8_t>> fileData, const string& szName, IStorage** ppstg);
    static HRESULT Clone(PoleStorage* pPoleStorage, IStorage** ppstg);
 
    HRESULT StreamExists(const string& szName);
@@ -37,6 +40,7 @@ public:
 
 private:
   POLE::Storage* m_pPOLEStorage = nullptr;
+  std::shared_ptr<std::vector<uint8_t>> m_fileData;
   string m_szFilename;
   string m_szPath;
 

--- a/third-party/include/pole/pole.cpp
+++ b/third-party/include/pole/pole.cpp
@@ -192,6 +192,8 @@ class StorageIO final
     uint64 filesize;   // size of the file
     bool writeable;           // true if the file can be modified
     
+    const unsigned char* fileData;  // pre-loaded file content (nullptr if file-backed)
+
     Header* header;           // storage header 
     DirTree* dirtree;         // directory tree
     AllocTable* bbat;         // allocation table for big blocks
@@ -205,6 +207,7 @@ class StorageIO final
     std::list<Stream*> streams;
 
     StorageIO( Storage* storage, const char* filename );
+    StorageIO( Storage* storage, const unsigned char* data, uint64 size );
     ~StorageIO();
     
     bool open(bool bWriteAccess = false, bool bCreate = false);
@@ -1242,9 +1245,33 @@ StorageIO::StorageIO( Storage* st, const char* fname )
   opened(false),        
   filesize(0),        
   writeable(false),        
+  fileData(nullptr),
   header(new Header()),        
   dirtree(new DirTree(1ull << header->b_shift)),        
   bbat(new AllocTable()),        
+  sbat(new AllocTable()),
+  sb_blocks(),
+  mbat_blocks(),
+  mbat_data(),
+  mbatDirty(),
+  streams()
+{
+  bbat->blockSize = (uint64) 1 << header->b_shift;
+  sbat->blockSize = (uint64) 1 << header->s_shift;
+}
+
+StorageIO::StorageIO( Storage* st, const unsigned char* data, uint64 size )
+: storage(st),
+  filename(),
+  file(),
+  result(Storage::Ok),
+  opened(false),
+  filesize(size),
+  writeable(false),
+  fileData(data),
+  header(new Header()),
+  dirtree(new DirTree(1ull << header->b_shift)),
+  bbat(new AllocTable()),
   sbat(new AllocTable()),
   sb_blocks(),
   mbat_blocks(),
@@ -1294,29 +1321,37 @@ void StorageIO::load(bool bWriteAccess)
   // open the file, check for error
   result = Storage::OpenFailed;
 
+  if( !fileData )
+  {
 #if defined(POLE_USE_UTF16_FILENAMES)
-  if (bWriteAccess)
-      file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in | std::ios::out);
-  else
-      file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in);
+    if (bWriteAccess)
+        file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in | std::ios::out);
+    else
+        file.open(UTF8toUTF16(filename).c_str(), std::ios::binary | std::ios::in);
 #else
-  if (bWriteAccess)
-      file.open(filename.c_str(), std::ios::binary | std::ios::in | std::ios::out);
-  else
-      file.open(filename.c_str(), std::ios::binary | std::ios::in);
+    if (bWriteAccess)
+        file.open(filename.c_str(), std::ios::binary | std::ios::in | std::ios::out);
+    else
+        file.open(filename.c_str(), std::ios::binary | std::ios::in);
 #endif //defined(POLE_USE_UTF16_FILENAMES) && defined(POLE_WIN)
 
-  if( !file.good() ) return;
-  
-  // find size of input file
-  file.seekg(0, std::ios::end );
-  filesize = static_cast<uint64>(file.tellg());
+    if( !file.good() ) return;
+
+    // find size of input file
+    file.seekg(0, std::ios::end );
+    filesize = static_cast<uint64>(file.tellg());
+  }
 
   // load header
   buffer = new unsigned char[512];
-  file.seekg( 0 ); 
-  file.read( (char*)buffer, 512 );
-  fileCheck(file);
+  if( fileData )
+      memcpy( buffer, fileData, 512 );
+  else
+  {
+    file.seekg( 0 ); 
+    file.read( (char*)buffer, 512 );
+    fileCheck(file);
+  }
   header->load( buffer );
   delete[] buffer;
 
@@ -1593,10 +1628,26 @@ uint64 StorageIO::loadBigBlocks( const std::vector<uint64>& blocks,
 {
   // sentinel
   if( !data ) return 0;
+
+  if( fileData )
+  {
+    // Memory-backed mode: copy directly from the buffer
+    uint64 bytes = 0;
+    for( size_t i=0; (i < blocks.size() ) && ( bytes<maxlen ); i++ )
+    {
+      uint64 block = blocks[i];
+      uint64 pos = bbat->blockSize * ( block+1 );
+      uint64 p = (bbat->blockSize < maxlen-bytes) ? bbat->blockSize : maxlen-bytes;
+      if( pos + p > filesize )
+          p = filesize - pos;
+      memcpy( data + bytes, fileData + pos, (size_t)p );
+      bytes += p;
+    }
+    return bytes;
+  }
+
   fileCheck(file);
   if( !file.good() ) return 0;
-  if( blocks.size() < 1 ) return 0;
-  if( maxlen == 0 ) return 0;
 
   // read block one by one, seems fast enough
   uint64 bytes = 0;
@@ -1622,8 +1673,11 @@ uint64 StorageIO::loadBigBlock( uint64 block,
 {
   // sentinel
   if( !data ) return 0;
-  fileCheck(file);
-  if( !file.good() ) return 0;
+  if( !fileData )
+  {
+    fileCheck(file);
+    if( !file.good() ) return 0;
+  }
   
   // wraps call for loadBigBlocks
   std::vector<uint64> blocks;
@@ -2217,6 +2271,11 @@ void StreamIO::updateCache()
 Storage::Storage( const char* filename )
 {
   io = new StorageIO( this, filename );
+}
+
+Storage::Storage( const unsigned char* data, uint64 size )
+{
+  io = new StorageIO( this, data, size );
 }
 
 Storage::~Storage()

--- a/third-party/include/pole/pole.h
+++ b/third-party/include/pole/pole.h
@@ -111,6 +111,12 @@ public:
   Storage( const char* filename );
 
   /**
+   * Constructs a storage backed by pre-loaded memory (read-only).
+   * The caller must keep the data alive for the lifetime of this Storage.
+   **/
+  Storage( const unsigned char* data, uint64 size );
+
+  /**
    * Destroys the storage.
    **/
   ~Storage();


### PR DESCRIPTION
Note: generated with ai assistance and shows massive perf improvements in manual testing.

On standalone builds (macOS, Linux, Windows MinGW) the POLE structured-storage shim re-opens and re-parses the container metadata once per stream, then reads each 4 KiB block via an individual seekg+read with a per-call heap allocation. For a table with 1,858 streams (Fish Tales, 428 MiB) served from a NAS over WiFi, the multi-threaded stream load scatters reads across the file and hits a ~3 ms/block random-access penalty, resulting in a ~40 s load time.

Fix:

Read the entire .vpx sequentially into a shared vector<uint8_t> at open time (~3.3 s at 130 MiB/s over WiFi), then serve all POLE block reads via memcpy from that buffer. The buffer is shared across all PoleStorage clones via shared_ptr, so the 1,858 stream opens share one copy.

Changes:
- pole.h/cpp: Add Storage(const unsigned char*, uint64) constructor and matching StorageIO memory-backed path. loadBigBlocks() uses memcpy when backed by memory.
- standalone/PoleStorage.{h,cpp}: Create(filename) slurps the file then delegates to Create(shared_ptr<vector<uint8_t>>, path). Clone and OpenStorage share the buffer.

Measured on Fish Tales (428 MiB) over WiFi SMB, cold cache:
- ThreadPool phase (stream extraction): 40 s -> 0.1 s
- Total table load: 47 s -> 10 s
- Local SSD (no network): 7.3 s -> 5.3 s (also benefits from eliminating per-block syscall overhead)
- Peak memory: +file size during load (freed when load completes); checking 669 tables the largest is 493 MiB

PTAL @vbousquet 