### PR TITLE
Guard live UI access in flipper collisions

### DIFF
--- a/src/physics/hitflipper.cpp
+++ b/src/physics/hitflipper.cpp
@@ -884,7 +884,8 @@ void HitFlipper::Collide(const CollisionEvent& coll)
       else return;
 #endif
    }
-   g_pplayer->m_liveUI->m_ballControl.SetDraggedBall(pball->m_pBall); // Ball control most recently collided with flipper
+   if (g_pplayer->m_liveUI)
+      g_pplayer->m_liveUI->m_ballControl.SetDraggedBall(pball->m_pBall); // Ball control most recently collided with flipper
 
 #ifdef C_DISP_GAIN 
    // correct displacements, mostly from low velocity blindness, an alternative to true acceleration processing


### PR DESCRIPTION
## Summary

- Guard the flipper collision ball-control UI update when running without a live UI.
- Match the null-check pattern already used by nearby ball-control call sites.

## Root Cause

`HitFlipper::Collide` updated `g_pplayer->m_liveUI->m_ballControl` unconditionally. In headless player modes, `m_liveUI` can be null, so a valid ball/flipper collision can dereference a null live UI pointer and crash the process.

## Validation

- Reproduced the crash in a Linux/aarch64 BGFX headless stepping workflow before this change.
- Verified the deterministic replay completed after this change.
- Ran additional headless reset-region validation over flipper-contact starts without crashes.

No flipper collision physics are changed; this only guards a UI bookkeeping update.
