### PR TITLE
Throttle standalone progress log to at most once per second

### DIFF
--- a/src/ui/win/ProgressDialog.cpp
+++ b/src/ui/win/ProgressDialog.cpp
@@ -50,8 +50,15 @@ void ProgressDialog::SetProgress(const string &text, const float value)
 #else
    if (value >= 0.f && m_progress != value)
    {
-      PLOGI.printf("%s %d%%", text.c_str(), (int)value);
+      const auto now = std::chrono::steady_clock::now();
+      if (now - m_lastLogTick >= std::chrono::seconds(1) || text != m_lastLogText)
+      {
+         PLOGI.printf("%s %d%%", text.c_str(), (int)value);
+         m_lastLogTick = now;
+         m_lastLogText = text;
+      }
    }
 #endif
-   m_progress = value;
+   if (value >= 0.f)
+      m_progress = value;
 }

--- a/src/ui/win/ProgressDialog.h
+++ b/src/ui/win/ProgressDialog.h
@@ -3,8 +3,9 @@
 #ifndef __STANDALONE__
 #include <wxx_controls.h>
 #include <wxx_dialog.h>
+#else
+#include <chrono>
 #endif
-
 
 class ProgressDialog final : public CDialog
 {
@@ -23,5 +24,8 @@ private:
 #ifndef __STANDALONE__
    CProgressBar m_progressBar;
    CStatic m_progressName;
+#else
+   std::chrono::steady_clock::time_point m_lastLogTick;
+   std::string m_lastLogText;
 #endif
 };


### PR DESCRIPTION
The __STANDALONE__ path in ProgressDialog::SetProgress logged on every single texture load (~1500 lines for Blood Machines). Throttle to one log line per second, with immediate logging on phase changes.

Also fix m_progress being unconditionally set to -1 on text-only calls (value=-1), which caused subsequent GetProgress() to return -1 and produced bogus percentage values (e.g. 'Starting Game Scripts... 4%' instead of the correct 90%).

* [vpinball-before-fix.log](https://github.com/user-attachments/files/30866453/vpinball-before-fix.log)
* [vpinball-after-fix.log](https://github.com/user-attachments/files/30866454/vpinball-after-fix.log)
