### PR TITLE
Input: restore unit scales on default sensor mappings

### DIFF
--- a/src/input/OpenPinDevHandler.cpp
+++ b/src/input/OpenPinDevHandler.cpp
@@ -391,11 +391,14 @@ OpenPinDevHandler::OpenPinDevHandler(InputManager &pininput)
                               map.MapAction(ButtonMapping::Create(deviceId, 26), m_inputManager.GetVolumeDownActionId()); // Audio volume down
                               std::unique_ptr<PlungerSensor> plunger = std::make_unique<PlungerSensor>(&m_inputManager);
                               plunger->GetPositionSensor()->SetMapping(SensorMapping::Create(deviceId, 0x200, SensorMapping::Type::Position));
-                              plunger->GetVelocitySensor()->SetMapping(SensorMapping::Create(deviceId, 0x201, SensorMapping::Type::Velocity));
+                              // Velocities are expected in m/s (per-unit/s for the plunger): without the unit scale, the reported
+                              // values are used as is and the plunger impulse ends up two orders of magnitude too low
+                              plunger->GetVelocitySensor()->SetMapping(
+                                 SensorMapping::Create(deviceId, 0x201, SensorMapping::Type::Velocity).WithScale(SensorUnitScale::pinscapePlungerVelocity));
                               map.MapPlunger(std::move(plunger));
                               std::unique_ptr<VPX::Physics::GamepadNudge> nudge = std::make_unique<VPX::Physics::GamepadNudge>(&m_inputManager);
-                              nudge->GetXSensor().SetMapping(SensorMapping::Create(deviceId, 0x204, SensorMapping::Type::Velocity));
-                              nudge->GetYSensor().SetMapping(SensorMapping::Create(deviceId, 0x205, SensorMapping::Type::Velocity));
+                              nudge->GetXSensor().SetMapping(SensorMapping::Create(deviceId, 0x204, SensorMapping::Type::Velocity).WithScale(SensorUnitScale::pinscapeNudgeVelocity));
+                              nudge->GetYSensor().SetMapping(SensorMapping::Create(deviceId, 0x205, SensorMapping::Type::Velocity).WithScale(SensorUnitScale::pinscapeNudgeVelocity));
                               map.MapNudge(std::move(nudge));
                            };
                            m_inputManager.SetDeviceDefaultMapping(deviceId, defaultMapping);

--- a/src/input/SDLInputHandler.h
+++ b/src/input/SDLInputHandler.h
@@ -356,8 +356,9 @@ private:
                plunger->GetPositionSensor()->SetMapping(SensorMapping::Create(deviceId, 0x0202, SensorMapping::Type::Position));
                map.MapPlunger(std::move(plunger));
                std::unique_ptr<VPX::Physics::GamepadNudge> nudge = std::make_unique<VPX::Physics::GamepadNudge>(&m_pininput);
-               nudge->GetXSensor().SetMapping(SensorMapping::Create(deviceId, 0x0200, SensorMapping::Type::Acceleration));
-               nudge->GetYSensor().SetMapping(SensorMapping::Create(deviceId, 0x0201, SensorMapping::Type::Acceleration));
+               // Accelerations are expected in m/s^2: without the unit scale, a full scale reading would be 1m/s^2 instead of 1g
+               nudge->GetXSensor().SetMapping(SensorMapping::Create(deviceId, 0x0200, SensorMapping::Type::Acceleration).WithScale(SensorUnitScale::gravity));
+               nudge->GetYSensor().SetMapping(SensorMapping::Create(deviceId, 0x0201, SensorMapping::Type::Acceleration).WithScale(SensorUnitScale::gravity));
                map.MapNudge(std::move(nudge));
             });
          break;

--- a/src/input/SensorMapping.h
+++ b/src/input/SensorMapping.h
@@ -7,6 +7,22 @@
 #include <complex>
 
 
+// Unit scales for the physics sensors.
+//
+// A sensor mapping's scale converts the acquired (normalized) axis value to the
+// unit the physics engine expects: m/s^2 for accelerations, m/s for velocities,
+// and per-unit/s for the plunger velocity (the 'unit' being the plunger travel
+// length). These are the scales used both by the default device mappings and by
+// the unit presets of the sensor setup page, so that a device set up
+// automatically behaves like one set up by hand.
+namespace SensorUnitScale
+{
+   constexpr float gravity = 9.80665f; // 1g accelerometer range, the usual default of Pinscape boards
+   constexpr float pinscapeNudgeVelocity = 4096.f / (20.f * 1000.f); // Pinscape measures in mm/s, multiplies by 20 and reports over a -4096/4096 range
+   constexpr float pinscapePlungerVelocity = 12.5f; // Per-unit velocity regarding the full plunger frame length (so no direct length unit)
+}
+
+
 class SensorMapping final
 {
 public:

--- a/src/ui/live/ingameui/SensorSetupPage.cpp
+++ b/src/ui/live/ingameui/SensorSetupPage.cpp
@@ -161,7 +161,7 @@ void SensorSetupPageSection::AppendSection(InGameUIPage* page, PhysicsSensor* se
    {
       // Accelerations must be provided to the engine in m/s^2 (acquired value x scale => m/s^2)
       // We propose some default scales, that is to say 1/2/4/8g (which is what Pinscape boards propose)
-      constexpr float g = 9.80665f;
+      constexpr float g = SensorUnitScale::gravity;
       int accUnit = abs(liveScale - g) < 0.01f ? 1 //
          : abs(liveScale - 2.f * g) < 0.01f    ? 2 //
          : abs(liveScale - 4.f * g) < 0.01f    ? 3 //
@@ -193,8 +193,8 @@ void SensorSetupPageSection::AppendSection(InGameUIPage* page, PhysicsSensor* se
    {
       // Velocities must be provided to the engine in m/s (acquired value x scale => m/s)
       // We propose some default scales (derived from Pinscape firmware)
-      constexpr float pinscapeDefaultNudge = 4096.f / (20.f * 1000.f); // Pinscape measure in mm/s then multiply by 20 and send a -4096/4096 range (this scale can be overriden)
-      constexpr float pinscapeDefaultPlunger = 12.5f;
+      constexpr float pinscapeDefaultNudge = SensorUnitScale::pinscapeNudgeVelocity; // Pinscape measure in mm/s then multiply by 20 and send a -4096/4096 range (this scale can be overriden)
+      constexpr float pinscapeDefaultPlunger = SensorUnitScale::pinscapePlungerVelocity;
       int velUnit = fabs(liveScale/pinscapeDefaultNudge - 1.f) < 0.005f   ? 1 //
                   : fabs(liveScale/pinscapeDefaultPlunger - 1.f) < 0.005f ? 2 //
                                                                           : 0;


### PR DESCRIPTION
A sensor mapping's `scale` is a unit conversion: the acquired (normalized) axis value times the scale gives m/s² for accelerations, m/s for velocities, and per-unit/s for the plunger.

The default device mappings were left at the default scale of 1.0, so the raw value reaches the physics engine unconverted:

- nudge acceleration tops out at 1 m/s² full scale instead of 1g;
- the plunger impulse comes out two orders of magnitude too low — the `/100` in `HitPlunger::HitTest` is meant to be absorbed by the unit scale.

The plunger one is easy to see on a cabinet: pulling the plunger all the way back and releasing gets the ball about 3 cm up the shooter lane. The nudge one is quieter, the ball just barely moves.

This uses the very scales the sensor setup page already proposes as unit presets, and moves them next to `SensorMapping` so the defaults and the UI presets cannot drift apart. Devices configured automatically then behave like ones set up by hand.

Tested on a Pinscape KL25Z (plunger + accelerometer) on Linux/SDL3.

---

While tracking this down I ran into something else, which may or may not be intentional.

`NudgeIntentHandler::EvaluateImpulse` compares the segment strength against a hardcoded 1 m/s² threshold, below which no impulse is sent at all. It is applied after `Strength`, so it interacts with it, but it is not exposed anywhere and not mentioned in the sensor setup page.

On a 1g board with `Strength` at its neutral 1.0, that threshold sits at about 10% of the axis. That is a sensible floor and I am not suggesting it is wrong. But combined with the 25 ms impulse replacing the measured knock, reaching the 1° default plumb angle takes roughly 0.7g at the sensor, which is a firm shove. Someone tuning `PlumbThresholdAngle` upwards on a 1g board runs out of sensor range before running out of slider: past ~1.4° nothing can tilt any more.

Would it make sense to expose this threshold, or at least document it next to the sensor type? Happy to open a separate issue if you would rather keep this PR to the scales.
