### PR TITLE
docs: add a 10.8.1 configuration guide

### DIFF
--- a/docs/10.8.1/README.md
+++ b/docs/10.8.1/README.md
@@ -1,0 +1,41 @@
+# VPinballX 10.8.1 — configuration
+
+🇬🇧 [English](#-english) | 🇫🇷 [Français](#-français)
+
+---
+
+## 🇬🇧 English
+
+- **[Input, nudge and tilt](input_eng.md)** — sensor mappings, unit scales, the
+  three nudge modes, the plumb.
+- **[View and cabinet fitting](view_eng.md)** — the Window projection, autofit,
+  glass heights.
+- **[Windows and displays](window_eng.md)** — the four outputs, their shared
+  schema, physical screen dimensions.
+- **[Rendering](rendering_eng.md)** — frame pacing, anti-aliasing, reflections,
+  stereo.
+- **[Audio](audio_eng.md)** — devices, speaker modes, the per-source gain.
+- **[Plugins](plugins_eng.md)** — one section per plugin, and where their keys
+  really come from.
+- **[VR](vr_eng.md)** — OpenXR, cabinet placement, the preview window.
+- **[Removed settings](removed_eng.md)** — what 10.8 had, what replaced it.
+
+---
+
+## 🇫🇷 Français
+
+- **[Entrées, nudge et tilt](input_fra.md)** — mappings de capteurs, échelles
+  d'unité, les trois modes de nudge, le pendule de tilt.
+- **[Vue et ajustement cabinet](view_fra.md)** — la projection Window,
+  l'ajustement automatique, les hauteurs de vitre.
+- **[Fenêtres et écrans](window_fra.md)** — les quatre sorties, leur schéma
+  commun, les dimensions physiques de l'écran.
+- **[Rendu](rendering_fra.md)** — frame pacing, anticrénelage, réflexions,
+  stéréo.
+- **[Audio](audio_fra.md)** — périphériques, modes d'enceintes, le gain par
+  source.
+- **[Plugins](plugins_fra.md)** — une section par plugin, et d'où viennent
+  vraiment leurs clés.
+- **[VR](vr_fra.md)** — OpenXR, placement du cabinet, fenêtre d'aperçu.
+- **[Réglages supprimés](removed_fra.md)** — ce qu'avait la 10.8, ce qui l'a
+  remplacé.

--- a/docs/10.8.1/README.md
+++ b/docs/10.8.1/README.md
@@ -17,6 +17,8 @@
 - **[Audio](audio_eng.md)** — devices, speaker modes, the per-source gain.
 - **[Plugins](plugins_eng.md)** — one section per plugin, and where their keys
   really come from.
+- **[Files and folders](files_eng.md)** — the layout deduced from the ini, the
+  user folder, the search order.
 - **[VR](vr_eng.md)** — OpenXR, cabinet placement, the preview window.
 - **[Removed settings](removed_eng.md)** — what 10.8 had, what replaced it.
 
@@ -36,6 +38,8 @@
   source.
 - **[Plugins](plugins_fra.md)** — une section par plugin, et d'où viennent
   vraiment leurs clés.
+- **[Fichiers et dossiers](files_fra.md)** — la disposition déduite de l'ini, le
+  dossier user, l'ordre de recherche.
 - **[VR](vr_fra.md)** — OpenXR, placement du cabinet, fenêtre d'aperçu.
 - **[Réglages supprimés](removed_fra.md)** — ce qu'avait la 10.8, ce qui l'a
   remplacé.

--- a/docs/10.8.1/audio_eng.md
+++ b/docs/10.8.1/audio_eng.md
@@ -1,0 +1,93 @@
+# Audio in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](audio_fra.md)
+
+Two devices, one output mode, and — since July 2026 — a gain per audio source,
+which is the setting most people have been missing without knowing it existed.
+
+## Devices and volumes
+
+VPX splits sound in two, and the split is physical rather than musical:
+
+| Key | Section | Range | Meaning |
+|---|---|---|---|
+| `SoundDevice` | `[Player]` | device name | playfield speakers — mechanical sounds |
+| `SoundDeviceBG` | `[Player]` | device name | backglass speakers — music and voice |
+| `SoundVolume` | `[Player]` | 0–100 | playfield volume |
+| `MusicVolume` | `[Player]` | 0–100 | backglass volume |
+
+`Sound3D` then decides how playfield sound is spread over the speakers:
+
+| Value | Configuration |
+|---|---|
+| `0` | 2 front channels |
+| `1` | 2 rear channels |
+| `2` | up to 6 channels, rear at the lockbar |
+| `3` | up to 6 channels, front at the lockbar |
+| `4` | 6 ch side & rear at the lockbar, legacy mixing |
+| `5` | 6 ch side & rear at the lockbar, new mixing |
+
+Modes 4 and 5 are the surround feedback (SSF) configurations; the difference
+between them is the mixing, not the wiring.
+
+## A gain per source
+
+This is the part worth knowing. Since
+[`479fa43ab`](https://github.com/vpinball/vpinball/commit/479fa43ab), every audio
+**source** gets its own persisted gain, registered at player creation in
+`src/core/player.cpp`:
+
+```cpp
+const string propId = std::format("AudioSource.{}.Gain", endpointId);
+Settings::GetRegistry().Register(std::make_unique<VPX::Properties::FloatPropertyDef>(
+   "Player"s, propId, std::format("{} Gain", endpointName),
+   std::format("Volume gain applied to audio from '{}'.", endpointName),
+   true, 0.f, 2.f, 0.f, 1.f));
+```
+
+So the ini grows one key per source that has ever been seen:
+
+```ini
+[Player]
+AudioSource.<endpointId>.Gain = 1.000000
+```
+
+Range `0`–`2`, neutral at `1`, shown as 0–200 % in **F12 → Audio**. The endpoint
+id comes from the plugin message bus, so the sources are whatever is actually
+producing sound: PinMAME, AltSound, PUP packs, the table's own samples.
+
+```mermaid
+flowchart LR
+    PM[PinMAME] -->|AudioSource.pinmame.Gain| MIX
+    AS[AltSound] -->|AudioSource.altsound.Gain| MIX
+    PUP[PUP pack] -->|AudioSource.pup.Gain| MIX
+    TBL[Table samples] -->|AudioSource.….Gain| MIX
+    MIX[Mixer] --> PF["Playfield<br/>SoundDevice · SoundVolume · Sound3D"]
+    MIX --> BG["Backglass<br/>SoundDeviceBG · MusicVolume"]
+```
+
+**Why it matters.** Before this, a PUP pack mixed far louder than the ROM left
+only one lever, the master volume, which moved everything together. Per-source
+gain is what lets one source be brought down without flattening the rest — the
+missing piece for balancing a cabinet, and the natural place to hang any
+loudness normalisation.
+
+The levels are persisted, so they survive a restart, and they can be overridden
+per table like any other property.
+
+## What changed around it
+
+| Commit | Change |
+|---|---|
+| [`f805245e2`](https://github.com/vpinball/vpinball/commit/f805245e2) | wmp and altsound moved from a custom mixer to miniaudio's `ma_engine` |
+| [`d1cf55576`](https://github.com/vpinball/vpinball/commit/d1cf55576) | the plugin controller sound API was refactored |
+| [`3a2307d58`](https://github.com/vpinball/vpinball/commit/3a2307d58) | the audio enable/disable setting was removed — a source is silenced with a gain of 0 |
+| [`9629bdea3`](https://github.com/vpinball/vpinball/commit/9629bdea3) | PinMAME honours `Controller.Game.Settings("sound")` |
+| [`361dc0e02`](https://github.com/vpinball/vpinball/commit/361dc0e02) | PinMAME no longer broadcasts audio at a 0 sample rate |
+| [`69795f154`](https://github.com/vpinball/vpinball/commit/69795f154) | sources discovered at player creation, so their gains exist before the first sound |
+
+## Source
+
+- `src/core/Settings_properties.inl` — devices, volumes, `Sound3D`
+- `src/core/player.cpp` — audio source discovery and per-source gain registration
+- `src/ui/live/ingameui/AudioSettingsPage.cpp` — the F12 page

--- a/docs/10.8.1/audio_fra.md
+++ b/docs/10.8.1/audio_fra.md
@@ -1,0 +1,94 @@
+# Audio en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](audio_eng.md) · 🇫🇷 Français
+
+Deux périphériques, un mode de sortie, et — depuis juillet 2026 — un gain par
+source audio, le réglage que beaucoup cherchaient sans savoir qu'il existait.
+
+## Périphériques et volumes
+
+VPX sépare le son en deux, et cette séparation est physique plus que musicale :
+
+| Clé | Section | Plage | Rôle |
+|---|---|---|---|
+| `SoundDevice` | `[Player]` | nom de périphérique | enceintes du plateau — sons mécaniques |
+| `SoundDeviceBG` | `[Player]` | nom de périphérique | enceintes du backglass — musique et voix |
+| `SoundVolume` | `[Player]` | 0–100 | volume du plateau |
+| `MusicVolume` | `[Player]` | 0–100 | volume du backglass |
+
+`Sound3D` décide ensuite comment le son du plateau se répartit sur les enceintes :
+
+| Valeur | Configuration |
+|---|---|
+| `0` | 2 canaux avant |
+| `1` | 2 canaux arrière |
+| `2` | jusqu'à 6 canaux, arrière au lockbar |
+| `3` | jusqu'à 6 canaux, avant au lockbar |
+| `4` | 6 canaux côté & arrière au lockbar, mixage historique |
+| `5` | 6 canaux côté & arrière au lockbar, nouveau mixage |
+
+Les modes 4 et 5 sont les configurations de retour surround (SSF) ; ce qui les
+distingue est le mixage, pas le câblage.
+
+## Un gain par source
+
+C'est la partie à connaître. Depuis
+[`479fa43ab`](https://github.com/vpinball/vpinball/commit/479fa43ab), chaque
+**source** audio reçoit son propre gain persistant, enregistré à la création du
+joueur dans `src/core/player.cpp` :
+
+```cpp
+const string propId = std::format("AudioSource.{}.Gain", endpointId);
+Settings::GetRegistry().Register(std::make_unique<VPX::Properties::FloatPropertyDef>(
+   "Player"s, propId, std::format("{} Gain", endpointName),
+   std::format("Volume gain applied to audio from '{}'.", endpointName),
+   true, 0.f, 2.f, 0.f, 1.f));
+```
+
+L'ini se garnit donc d'une clé par source déjà rencontrée :
+
+```ini
+[Player]
+AudioSource.<endpointId>.Gain = 1.000000
+```
+
+Plage `0`–`2`, neutre à `1`, affichée de 0 à 200 % dans **F12 → Audio**.
+L'identifiant de source vient du bus de messages des plugins : les sources sont
+donc ce qui produit réellement du son — PinMAME, AltSound, les packs PUP, les
+échantillons propres à la table.
+
+```mermaid
+flowchart LR
+    PM[PinMAME] -->|AudioSource.pinmame.Gain| MIX
+    AS[AltSound] -->|AudioSource.altsound.Gain| MIX
+    PUP[Pack PUP] -->|AudioSource.pup.Gain| MIX
+    TBL[Échantillons de table] -->|AudioSource.….Gain| MIX
+    MIX[Mixeur] --> PF["Plateau<br/>SoundDevice · SoundVolume · Sound3D"]
+    MIX --> BG["Backglass<br/>SoundDeviceBG · MusicVolume"]
+```
+
+**Pourquoi c'est important.** Auparavant, un pack PUP mixé bien plus fort que la
+ROM ne laissait qu'un seul levier, le volume général, qui déplaçait tout
+ensemble. Le gain par source est ce qui permet de baisser une source sans
+écraser les autres — la pièce manquante pour équilibrer un cabinet, et l'endroit
+naturel où accrocher une normalisation de niveau sonore.
+
+Les niveaux sont persistés, donc ils survivent à un redémarrage, et ils peuvent
+être surchargés par table comme n'importe quelle autre propriété.
+
+## Ce qui a changé autour
+
+| Commit | Changement |
+|---|---|
+| [`f805245e2`](https://github.com/vpinball/vpinball/commit/f805245e2) | wmp et altsound passent d'un mixeur maison au `ma_engine` de miniaudio |
+| [`d1cf55576`](https://github.com/vpinball/vpinball/commit/d1cf55576) | l'API son du contrôleur de plugin a été refondue |
+| [`3a2307d58`](https://github.com/vpinball/vpinball/commit/3a2307d58) | le réglage d'activation/désactivation de l'audio a disparu — une source se coupe avec un gain à 0 |
+| [`9629bdea3`](https://github.com/vpinball/vpinball/commit/9629bdea3) | PinMAME respecte `Controller.Game.Settings("sound")` |
+| [`361dc0e02`](https://github.com/vpinball/vpinball/commit/361dc0e02) | PinMAME ne diffuse plus d'audio à une fréquence d'échantillonnage nulle |
+| [`69795f154`](https://github.com/vpinball/vpinball/commit/69795f154) | les sources sont découvertes dès la création du joueur, leurs gains existent donc avant le premier son |
+
+## Sources
+
+- `src/core/Settings_properties.inl` — périphériques, volumes, `Sound3D`
+- `src/core/player.cpp` — découverte des sources et enregistrement du gain par source
+- `src/ui/live/ingameui/AudioSettingsPage.cpp` — la page F12

--- a/docs/10.8.1/files_eng.md
+++ b/docs/10.8.1/files_eng.md
@@ -1,0 +1,82 @@
+# Files and folders in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](files_fra.md)
+
+Where VPX reads and writes is decided by `FileLocator`, and the rule that
+surprises people is that **the file layout is not a setting**. It is deduced at
+every start from where `VPinballX.ini` is found.
+
+## The two layouts
+
+`FileLocator::UpdateFileLayoutMode` looks for the ini in two places, in this
+order:
+
+| Ini found in | Layout | Consequence |
+|---|---|---|
+| the preference folder | `AppPrefData` (default) | settings and log in the preference folder, per-table files next to the `.vpx` |
+| next to the executable | `AppOnly` (legacy) | everything together in the application folder |
+| neither | `AppPrefData` | a fresh preference folder is created |
+
+The order matters: an ini sitting in the preference folder **wins**. Dropping a
+copy next to the executable changes nothing on its own — to go back to the
+single-folder layout the preference copy has to be gone, not just duplicated.
+
+`AppOnly` is the pre-10.8 behaviour, from a time when an application could write
+anywhere. It still works, and it needs write access to the install folder.
+
+## Where each thing lives
+
+The preference folder is `SDL_GetPrefPath(nullptr, "VPinballX")` followed by a
+`major.minor` subfolder — so `~/.local/share/VPinballX/10.8/` on Linux,
+`%AppData%\VPinballX\10.8\` on Windows. Settings are grouped per minor version
+on purpose: minor revisions are not allowed to require a user setup change.
+
+| Content | `AppPrefData` | `AppOnly` |
+|---|---|---|
+| `VPinballX.ini` | preference folder | application folder |
+| `vpinball.log` | preference folder | preference folder |
+| `assets/`, `scripts/`, `plugins/`, `docs/`, `shaders-x.y.z/` | application folder, read only | idem |
+| `user/` — highscores, per-table saved data | next to the `.vpx` | shared, in the application folder |
+| `music/` — used by `PlayMusic()` | next to the `.vpx` | application folder |
+| `cache/` — decoded textures | `cache/<table title>/` next to the `.vpx` | preference folder |
+| `autosave/` | next to the `.vpx` | application folder |
+
+Table files landing next to the table, rather than in one shared pile, is what
+the modern layout buys: it works best when each table has its own folder, and
+it survives moving a table around.
+
+## The user folder
+
+There is nothing to create by hand. VPX creates `user/` the first time a table
+actually writes into it — a highscore, a saved table option — and logs a line
+when it does. An empty install simply has no `user/` folder yet, which is
+normal and not a sign of a broken setup.
+
+Coming from an older install, an existing shared `user/` folder is still
+usable: it is on the read path if you drop it either next to the binary or in
+the preference folder.
+
+## Where scripts are searched
+
+`FileLocator::SearchScript` walks these, in order, and takes the first hit
+(case-insensitively):
+
+1. the table's own folder, then `<table>/user`, then `<table>/scripts`
+2. the application folder, then its `user`, `scripts` and `tables` subfolders
+3. the preference folder, then its `user` and `scripts` subfolders
+
+## Migration on first start
+
+When the preference folder for this `major.minor` does not exist yet, VPX
+builds it rather than starting empty. It looks, in order, for:
+
+1. the preference folder of a previous version — scanning down from the current
+   one to 10.0, then the un-versioned `VPinballX` folder used before the
+   `major.minor` layout — and copies its whole content recursively;
+2. failing that, a `VPinballX.ini` sitting next to the executable, which it
+   copies in;
+3. failing that, on Windows only, the pre-10.8 registry settings.
+
+One exception: if an ini next to the executable already declares the current
+`major.minor` in its `[Version]` section, VPX creates the preference folder and
+stops there, leaving the legacy layout alone.

--- a/docs/10.8.1/files_fra.md
+++ b/docs/10.8.1/files_fra.md
@@ -1,0 +1,88 @@
+# Fichiers et dossiers en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](files_eng.md) · 🇫🇷 Français
+
+L'endroit où VPX lit et écrit est décidé par `FileLocator`, et la règle qui
+surprend est que **la disposition des fichiers n'est pas un réglage**. Elle est
+déduite à chaque démarrage de l'endroit où se trouve `VPinballX.ini`.
+
+## Les deux dispositions
+
+`FileLocator::UpdateFileLayoutMode` cherche l'ini à deux endroits, dans cet
+ordre :
+
+| Ini trouvé dans | Disposition | Conséquence |
+|---|---|---|
+| le dossier de préférences | `AppPrefData` (défaut) | réglages et journal dans le dossier de préférences, fichiers par table à côté du `.vpx` |
+| à côté de l'exécutable | `AppOnly` (héritée) | tout ensemble dans le dossier de l'application |
+| ni l'un ni l'autre | `AppPrefData` | un dossier de préférences neuf est créé |
+
+L'ordre compte : un ini présent dans le dossier de préférences **l'emporte**.
+Poser une copie à côté de l'exécutable ne change donc rien à lui seul — pour
+revenir à la disposition en un seul dossier, il faut que la copie du dossier de
+préférences ait disparu, pas seulement qu'elle soit doublée.
+
+`AppOnly` est le comportement d'avant la 10.8, hérité d'une époque où une
+application pouvait écrire n'importe où. Il fonctionne toujours, et il exige un
+accès en écriture au dossier d'installation.
+
+## Où va quoi
+
+Le dossier de préférences est `SDL_GetPrefPath(nullptr, "VPinballX")` suivi
+d'un sous-dossier `majeure.mineure` — soit `~/.local/share/VPinballX/10.8/` sous
+Linux, `%AppData%\VPinballX\10.8\` sous Windows. Le regroupement par version
+mineure est volontaire : une révision mineure n'a pas le droit d'exiger une
+reconfiguration.
+
+| Contenu | `AppPrefData` | `AppOnly` |
+|---|---|---|
+| `VPinballX.ini` | dossier de préférences | dossier de l'application |
+| `vpinball.log` | dossier de préférences | dossier de préférences |
+| `assets/`, `scripts/`, `plugins/`, `docs/`, `shaders-x.y.z/` | dossier d'installation, lecture seule | idem |
+| `user/` — scores, données sauvegardées par table | à côté du `.vpx` | partagé, dans le dossier de l'application |
+| `music/` — utilisé par `PlayMusic()` | à côté du `.vpx` | dossier de l'application |
+| `cache/` — textures décodées | `cache/<titre de la table>/` à côté du `.vpx` | dossier de préférences |
+| `autosave/` | à côté du `.vpx` | dossier de l'application |
+
+Que les fichiers d'une table atterrissent à côté d'elle plutôt que dans un tas
+commun est justement ce qu'apporte la disposition moderne : elle donne son
+meilleur quand chaque table a son propre dossier, et elle survit au
+déplacement d'une table.
+
+## Le dossier `user`
+
+Il n'y a rien à créer à la main. VPX crée `user/` la première fois qu'une table
+y écrit vraiment — un score, une option de table enregistrée — et le signale
+dans le journal. Une installation neuve n'a donc simplement pas encore de
+dossier `user/`, ce qui est normal et ne signale pas une installation cassée.
+
+En venant d'une installation plus ancienne, un dossier `user/` partagé reste
+utilisable : il est sur le chemin de lecture qu'on le pose à côté du binaire ou
+dans le dossier de préférences.
+
+## Où les scripts sont cherchés
+
+`FileLocator::SearchScript` parcourt ces emplacements dans l'ordre et prend le
+premier trouvé (sans tenir compte de la casse) :
+
+1. le dossier de la table, puis `<table>/user`, puis `<table>/scripts` ;
+2. le dossier de l'application, puis ses sous-dossiers `user`, `scripts` et
+   `tables` ;
+3. le dossier de préférences, puis ses sous-dossiers `user` et `scripts`.
+
+## La migration au premier démarrage
+
+Quand le dossier de préférences de cette `majeure.mineure` n'existe pas encore,
+VPX le construit plutôt que de démarrer à vide. Il cherche, dans l'ordre :
+
+1. le dossier de préférences d'une version précédente — en descendant de la
+   version courante jusqu'à la 10.0, puis le dossier `VPinballX` sans version
+   utilisé avant la disposition `majeure.mineure` — et en copie tout le contenu
+   récursivement ;
+2. à défaut, un `VPinballX.ini` posé à côté de l'exécutable, qu'il recopie ;
+3. à défaut, sous Windows uniquement, les réglages en base de registre d'avant
+   la 10.8.
+
+Une exception : si un ini situé à côté de l'exécutable déclare déjà la
+`majeure.mineure` courante dans sa section `[Version]`, VPX crée le dossier de
+préférences et s'arrête là, laissant la disposition héritée intacte.

--- a/docs/10.8.1/input_eng.md
+++ b/docs/10.8.1/input_eng.md
@@ -90,6 +90,43 @@ Sensitivity is a separate field: `Mapping.NudgeN.Strength`, `0`–`2` around a
 neutral `1`. Driving sensitivity through `scale` lies to the engine about what
 the sensor is, and makes a 4 g or 8 g board impossible to describe.
 
+## Which of the four scales actually matter
+
+A cabinet can map four axes: plunger position and velocity, nudge acceleration
+and velocity. They are not equal — only two of them need a scale that means
+something physically.
+
+| Mapping | Needed? | Scale |
+|---|---|---|
+| `Plunger0.Position` | **required** for the plunger to do anything | leave at `1.0` — it is a normalised 0…1 travel, not a physical unit |
+| `Plunger0.Velocity` | optional | **must convert to m/s** (`12.5` on Pinscape) |
+| `Nudge0.AccX` / `AccY` | the physical reference | **must convert to m/s²** (`19.6133` for a ±2 g board) |
+| `Nudge0.VelX` / `VelY` | optional | calibrated automatically — see below |
+
+Without a position mapping, `PlungerSensor::StepOneMillisecond` returns
+immediately and the whole plunger sensor does nothing. Position is the one that
+cannot be skipped, and the one whose scale should be left alone; invert its sign
+only if the axis reads backwards.
+
+Plunger velocity is optional, but when it is mapped `GetHitVelocity` returns
+**its value directly** as the impact speed — hence a scale that has to be a
+real m/s conversion. Unmapped, VPX derives the speed from the position
+estimator instead, which is what a board without a velocity channel gets.
+
+Nudge velocity behaves differently again. When acceleration *and* velocity are
+mapped on the same axis, `CabinetNudgeSensor::UpdateAxis` pushes both into the
+same Kalman filter and lets `MotionGainCalibratorAxis` work out the gain
+between the two channels on its own, taking the acceleration as the reference —
+the velocity is fed as `1 / gain`. Until that calibration reaches a confidence
+of 0.5, the velocity channel is simply **ignored** and only the acceleration is
+used. Its scale therefore does not need to be accurate; the calibration absorbs
+it. The exception is mapping velocity *without* acceleration on that axis: it is
+then used with a gain of 1 and its scale does matter (m/s).
+
+Practical summary for an ini: fix the scale on `Plunger0.Velocity` and
+`Nudge0.AccX/AccY`, leave `Plunger0.Position` and `Nudge0.VelX/VelY` as they
+come.
+
 ## The three nudge modes
 
 `Mapping.NudgeN.Type` selects how a reading becomes cabinet motion:

--- a/docs/10.8.1/input_eng.md
+++ b/docs/10.8.1/input_eng.md
@@ -1,0 +1,176 @@
+# Input and nudge in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](input_fra.md)
+
+10.8.1 replaced the plunger and nudge input handling. The old
+`Mapping.PlungerPos` / `Mapping.NudgeX1` keys are gone and are no longer read.
+What follows is the schema that replaced them, and the chain a reading travels
+through before it reaches the ball.
+
+## Devices
+
+Every device is declared in `[Input]`:
+
+```ini
+Devices = SDLJoy_PSC0041701862884E45J009
+Device.SDLJoy_PSC0041701862884E45J009.Type =
+Device.SDLJoy_PSC0041701862884E45J009.Name =
+Device.SDLJoy_PSC0041701862884E45J009.NoAutoLayout = 1
+```
+
+`NoAutoLayout = 1` stops VPX proposing its default layout for that device. This
+matters more than it looks: the default mappings — including their unit scales —
+are only ever installed by `ApplyDefaultDeviceMapping`, which runs when a device
+is auto-detected **and** the layout prompt is accepted. A config that already
+holds mappings, or that sets `NoAutoLayout`, keeps whatever it has.
+
+## Sensor mappings
+
+Sensors are counted, then mapped:
+
+```ini
+PlungerSensorCount = 1
+Mapping.Plunger0.Position = <device>;514;P;0.000000;1.000000;1.000000
+Mapping.Plunger0.Velocity = <device>;517;V;0.000000;12.500000;1.000000
+
+NudgeSensorCount = 1
+Mapping.Nudge0.AccX = <device>;512;A;0.030000;9.806650;1.000000
+Mapping.Nudge0.AccY = <device>;513;A;0.030000;9.806650;1.000000
+Mapping.Nudge0.Type = 1
+Mapping.Nudge0.Strength = 1.000000
+```
+
+Each mapping line has six fields:
+
+```
+device ; axis ; type ; deadZone ; scale ; limit
+```
+
+| Field | Meaning |
+|---|---|
+| `device` | the device id declared above |
+| `axis` | SDL axis number |
+| `type` | `P` position, `V` velocity, `A` acceleration |
+| `deadZone` | fraction of the axis range nulled around rest, `0`–`0.3` |
+| `scale` | **unit conversion** — see below |
+| `limit` | clamp applied to the normalized value |
+
+They are applied in that order, in `SensorMapping::UpdateValue`:
+
+1. the raw SDL value is normalized to −1…+1 (÷ 32768);
+2. the dead zone is removed and the remainder rescaled — `(v − dz) / (1 − dz)`,
+   so clearing the dead zone starts from zero rather than jumping;
+3. the value is clamped to ±`limit`;
+4. it is multiplied by `scale`.
+
+The dead zone therefore bites **before** the scale, on the raw axis fraction.
+The same 3 % swallows 0.29 m/s² on a 1 g board and 2.4 m/s² on an 8 g one.
+
+## The scale is a unit, not a sensitivity
+
+`scale` converts the normalized axis value into the unit the physics engine
+expects: **m/s² for accelerations, m/s for velocities, per-unit/s for the
+plunger** (one unit being the plunger's travel length). Left at the default of
+1.0, a full-scale reading reaches the engine as 1 m/s² instead of 1 g, and the
+plunger impulse comes out two orders of magnitude short — the `/100` in
+`HitPlunger::HitTest` is meant to be absorbed by this scale.
+
+These are the values the in-game sensor setup page offers as presets:
+
+| Sensor | Scale | Meaning |
+|---|---|---|
+| Accelerometer, ±1 g | `9.80665` | full deflection = 1 g |
+| Accelerometer, ±2 g | `19.61330` | |
+| Accelerometer, ±4 g | `39.22660` | |
+| Accelerometer, ±8 g | `78.45320` | |
+| Pinscape plunger velocity | `12.5` | per-unit/s over the plunger frame |
+| Pinscape nudge velocity | `4096 / (20 × 1000)` | board reports mm/s ×20 over ±4096 |
+
+Sensitivity is a separate field: `Mapping.NudgeN.Strength`, `0`–`2` around a
+neutral `1`. Driving sensitivity through `scale` lies to the engine about what
+the sensor is, and makes a 4 g or 8 g board impossible to describe.
+
+## The three nudge modes
+
+`Mapping.NudgeN.Type` selects how a reading becomes cabinet motion:
+
+**0 — Game Controller.** For a gamepad or VR stick. Reads how far and how fast
+the stick is pushed to infer a nudge. Nothing to do with an accelerometer.
+
+**1 — Intent Sensor.** For cabinets with an accelerometer board. It does not
+pass your acceleration through: `NudgeIntentHandler` detects peaks, discards the
+cabinet's own ringing (a smaller peak within 300 ms of a stronger one), and above
+a threshold injects a calibrated 25 ms half-cosine impulse whose amplitude is the
+peak. Below that threshold **nothing at all** reaches the ball. Designed for
+boards that are noisy, biased or slow.
+
+**2 — Cabinet Sensor.** For a fast, clean, low-latency sensor. The measurement
+drives the cabinet directly, smoothed by a 4 ms EMA and rescaled from the real
+cabinet's mass (`Mapping.NudgeN.CabWeight`, kg) to the simulated 113 kg. No
+threshold, so small shakes count — and so does sensor noise.
+
+The intent threshold is **1 m/s², hardcoded** in
+`NudgeIntentHandler::EvaluateImpulse`, and it is compared *after* `Strength` is
+applied. Raising Strength therefore makes nudges both stronger and easier to
+recognise. It is not exposed in any UI.
+
+## The full chain
+
+For an accelerometer, in order:
+
+```
+raw axis → dead zone → limit → scale (m/s²)
+  → Kalman estimator (always, both modes)
+  → × Strength
+  → mode: intent threshold + impulse   |   EMA + cabinet weight
+  → damped cabinet oscillator (113 kg; 9.3 Hz ζ0.052 X, 5.8 Hz ζ0.055 Y)
+  → plumb pendulum (100 mm rod, 1 kHz)
+  → tilt when the rod passes PlumbThresholdAngle
+```
+
+The Kalman estimator (`MotionKalmanAxis`) is not a smoother — its job is bias
+removal, so a board mounted a degree off level does not read as a permanent
+shove. One consequence is worth knowing: **it takes its very first sample as
+bias**. A sensor that starts moving before it has ever been still is read as
+offset, not motion.
+
+## Tilt
+
+Two keys in `[Player]`:
+
+| Key | Range | Default | Meaning |
+|---|---|---|---|
+| `PlumbThresholdAngle` | 0.15–4 ° | 1.0 | rod angle that trips the tilt |
+| `PlumbDamping` | 0–2 | 1.0 | 0 swings forever, 2 settles twice as fast as life |
+
+VPX does not compare acceleration to a threshold. It simulates a bob on a 100 mm
+rod, driven by gravity plus the cabinet's acceleration, integrated every
+millisecond, and tilts when the rod's angle passes the threshold. A short violent
+knock can leave it unmoved while three rhythmic taps trip it — which no
+instantaneous threshold can express.
+
+The shove a threshold needs is not obvious, and depends on the mode. Simulating
+the chain above with a 100 ms push, at Strength 1.0, gives the acceleration the
+sensor must see:
+
+| Threshold | Intent | Cabinet |
+|---|---|---|
+| 0.15° | 1.0 m/s² | 0.5 m/s² |
+| 1.00° (default) | 6.7 m/s² | 3.5 m/s² |
+| 2.08° | 14.0 m/s² | 7.4 m/s² |
+| 4.00° | 27.2 m/s² | 14.5 m/s² |
+
+Two things follow. Intent needs roughly twice the shove of Cabinet for the same
+angle, because only the peak of your knock survives the 25 ms impulse. And on a
+±1 g board — full scale 9.81 m/s² — anything past about 1.4° in Intent mode is
+**unreachable**: the sensor saturates before the pendulum gets there, so the top
+two thirds of the slider do nothing.
+
+## Source
+
+- `src/input/SensorMapping.h` — the six fields, the processing order, the unit scales
+- `src/input/InputManager.cpp` — device declaration, `ApplyDefaultDeviceMapping`
+- `src/physics/cabinet/NudgeIntentHandler.cpp` — peak detection, impulse, threshold
+- `src/physics/cabinet/CabinetNudgeSensor.cpp` — the cabinet-sensor path
+- `src/physics/cabinet/MotionKalmanAxis.h` — the estimator and its bias assumption
+- `src/physics/cabinet/PlumbHandler.cpp` — the pendulum

--- a/docs/10.8.1/input_fra.md
+++ b/docs/10.8.1/input_fra.md
@@ -1,0 +1,182 @@
+# Entrées et nudge en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](input_eng.md) · 🇫🇷 Français
+
+La 10.8.1 a remplacé la gestion des entrées du plongeur et du nudge. Les
+anciennes clés `Mapping.PlungerPos` / `Mapping.NudgeX1` ont disparu et ne sont
+plus lues. Voici le schéma qui leur a succédé, et le chemin que parcourt une
+mesure avant d'atteindre la bille.
+
+## Périphériques
+
+Chaque périphérique est déclaré dans `[Input]` :
+
+```ini
+Devices = SDLJoy_PSC0041701862884E45J009
+Device.SDLJoy_PSC0041701862884E45J009.Type =
+Device.SDLJoy_PSC0041701862884E45J009.Name =
+Device.SDLJoy_PSC0041701862884E45J009.NoAutoLayout = 1
+```
+
+`NoAutoLayout = 1` empêche VPX de proposer sa disposition par défaut pour ce
+périphérique. Ce détail compte plus qu'il n'y paraît : les mappings par défaut —
+et donc leurs échelles d'unité — ne sont installés que par
+`ApplyDefaultDeviceMapping`, qui ne s'exécute que si un périphérique est
+auto-détecté **et** que la proposition de disposition est acceptée. Une
+configuration qui contient déjà des mappings, ou qui pose `NoAutoLayout`,
+conserve ce qu'elle a.
+
+## Mappings de capteurs
+
+Les capteurs sont comptés, puis mappés :
+
+```ini
+PlungerSensorCount = 1
+Mapping.Plunger0.Position = <device>;514;P;0.000000;1.000000;1.000000
+Mapping.Plunger0.Velocity = <device>;517;V;0.000000;12.500000;1.000000
+
+NudgeSensorCount = 1
+Mapping.Nudge0.AccX = <device>;512;A;0.030000;9.806650;1.000000
+Mapping.Nudge0.AccY = <device>;513;A;0.030000;9.806650;1.000000
+Mapping.Nudge0.Type = 1
+Mapping.Nudge0.Strength = 1.000000
+```
+
+Chaque ligne comporte six champs :
+
+```
+device ; axe ; type ; deadZone ; scale ; limit
+```
+
+| Champ | Signification |
+|---|---|
+| `device` | l'identifiant déclaré plus haut |
+| `axe` | numéro d'axe SDL |
+| `type` | `P` position, `V` vitesse, `A` accélération |
+| `deadZone` | fraction de la course annulée autour du repos, `0`–`0.3` |
+| `scale` | **conversion d'unité** — voir plus bas |
+| `limit` | écrêtage appliqué à la valeur normalisée |
+
+Ils s'appliquent dans cet ordre, dans `SensorMapping::UpdateValue` :
+
+1. la valeur SDL brute est normalisée entre −1 et +1 (÷ 32768) ;
+2. la zone morte est retirée et le reste remis à l'échelle — `(v − dz) / (1 − dz)`,
+   pour que le franchissement de la zone morte reparte de zéro au lieu de sauter ;
+3. la valeur est écrêtée à ±`limit` ;
+4. elle est multipliée par `scale`.
+
+La zone morte mord donc **avant** l'échelle, sur la fraction d'axe brute. Les
+mêmes 3 % avalent 0,29 m/s² sur une carte 1 g et 2,4 m/s² sur une carte 8 g.
+
+## L'échelle est une unité, pas une sensibilité
+
+`scale` convertit la valeur d'axe normalisée dans l'unité qu'attend le moteur
+physique : **m/s² pour les accélérations, m/s pour les vitesses, unités/s pour le
+plongeur** (l'unité étant la course du plongeur). Laissée à 1.0, une mesure à
+fond d'échelle arrive au moteur comme 1 m/s² au lieu de 1 g, et l'impulsion du
+plongeur ressort deux ordres de grandeur trop bas — le `/100` de
+`HitPlunger::HitTest` est censé être absorbé par cette échelle.
+
+Ce sont les valeurs que la page de configuration des capteurs propose en
+préréglages :
+
+| Capteur | Échelle | Sens |
+|---|---|---|
+| Accéléromètre ±1 g | `9.80665` | pleine déviation = 1 g |
+| Accéléromètre ±2 g | `19.61330` | |
+| Accéléromètre ±4 g | `39.22660` | |
+| Accéléromètre ±8 g | `78.45320` | |
+| Vitesse plongeur Pinscape | `12.5` | unités/s sur la course du plongeur |
+| Vitesse nudge Pinscape | `4096 / (20 × 1000)` | la carte rapporte des mm/s ×20 sur ±4096 |
+
+La sensibilité est un champ distinct : `Mapping.NudgeN.Strength`, de `0` à `2`
+autour d'un `1` neutre. Piloter la sensibilité par `scale` revient à mentir au
+moteur sur la nature du capteur, et rend une carte 4 g ou 8 g indescriptible.
+
+## Les trois modes de nudge
+
+`Mapping.NudgeN.Type` choisit comment une mesure devient un mouvement de cabinet :
+
+**0 — Manette de jeu.** Pour un gamepad ou un stick VR. Lit l'amplitude et la
+vitesse de poussée du stick pour en déduire un nudge. Sans rapport avec un
+accéléromètre.
+
+**1 — Capteur d'intention.** Pour les cabinets équipés d'une carte
+accéléromètre. Votre accélération n'est pas transmise telle quelle :
+`NudgeIntentHandler` détecte les pics, écarte les oscillations propres du
+cabinet (un pic plus faible survenant dans les 300 ms après un plus fort), et
+au-delà d'un seuil injecte une impulsion calibrée de 25 ms en demi-cosinus dont
+l'amplitude est celle du pic. En dessous de ce seuil, **rien du tout** n'atteint
+la bille. Conçu pour les cartes bruitées, biaisées ou lentes.
+
+**2 — Capteur de cabinet.** Pour un capteur rapide, propre et à faible latence.
+La mesure pilote directement le cabinet, lissée par une EMA de 4 ms et ramenée de
+la masse réelle du cabinet (`Mapping.NudgeN.CabWeight`, en kg) aux 113 kg
+simulés. Aucun seuil : les petites secousses comptent, le bruit du capteur aussi.
+
+Le seuil d'intention vaut **1 m/s², codé en dur** dans
+`NudgeIntentHandler::EvaluateImpulse`, et il est comparé *après* application de
+`Strength`. Monter Strength rend donc les nudges à la fois plus forts et plus
+faciles à reconnaître. Ce seuil n'est exposé dans aucune interface.
+
+## La chaîne complète
+
+Pour un accéléromètre, dans l'ordre :
+
+```
+axe brut → zone morte → limit → scale (m/s²)
+  → estimateur de Kalman (toujours, dans les deux modes)
+  → × Strength
+  → mode : seuil d'intention + impulsion   |   EMA + poids du cabinet
+  → oscillateur amorti du cabinet (113 kg ; 9,3 Hz ζ0,052 en X, 5,8 Hz ζ0,055 en Y)
+  → pendule (tige de 100 mm, 1 kHz)
+  → tilt lorsque la tige dépasse PlumbThresholdAngle
+```
+
+L'estimateur de Kalman (`MotionKalmanAxis`) n'est pas un lisseur : son rôle est
+de retirer le biais, pour qu'une carte montée à un degré près ne se lise pas
+comme une poussée permanente. Une conséquence mérite d'être connue : **il prend
+son tout premier échantillon pour du biais**. Un capteur qui bouge avant d'avoir
+jamais été au repos est lu comme un décalage, pas comme un mouvement.
+
+## Tilt
+
+Deux clés dans `[Player]` :
+
+| Clé | Plage | Défaut | Sens |
+|---|---|---|---|
+| `PlumbThresholdAngle` | 0,15–4 ° | 1,0 | angle de tige qui déclenche le tilt |
+| `PlumbDamping` | 0–2 | 1,0 | 0 oscille sans fin, 2 se stabilise deux fois plus vite que la réalité |
+
+VPX ne compare pas une accélération à un seuil. Il simule une masse au bout
+d'une tige de 100 mm, entraînée par la gravité et l'accélération du cabinet,
+intégrée toutes les millisecondes, et déclenche le tilt quand l'angle de la tige
+dépasse le seuil. Un coup bref et violent peut la laisser immobile là où trois
+tapes rythmées la font partir — ce qu'aucun seuil instantané ne sait exprimer.
+
+La secousse qu'exige un seuil n'a rien d'évident, et dépend du mode. En simulant
+la chaîne ci-dessus avec une poussée de 100 ms, à Strength 1.0, voici
+l'accélération que le capteur doit voir :
+
+| Seuil | Intention | Cabinet |
+|---|---|---|
+| 0,15° | 1,0 m/s² | 0,5 m/s² |
+| 1,00° (défaut) | 6,7 m/s² | 3,5 m/s² |
+| 2,08° | 14,0 m/s² | 7,4 m/s² |
+| 4,00° | 27,2 m/s² | 14,5 m/s² |
+
+Deux conséquences. Le mode intention exige environ deux fois la secousse du mode
+cabinet pour le même angle, puisque seul le pic de votre coup survit à
+l'impulsion de 25 ms. Et sur une carte ±1 g — pleine échelle 9,81 m/s² — tout ce
+qui dépasse environ 1,4° en mode intention est **hors d'atteinte** : le capteur
+sature avant que le pendule n'y parvienne, si bien que les deux tiers hauts du
+curseur ne font rien.
+
+## Sources
+
+- `src/input/SensorMapping.h` — les six champs, l'ordre de traitement, les échelles
+- `src/input/InputManager.cpp` — déclaration des périphériques, `ApplyDefaultDeviceMapping`
+- `src/physics/cabinet/NudgeIntentHandler.cpp` — détection de pic, impulsion, seuil
+- `src/physics/cabinet/CabinetNudgeSensor.cpp` — le chemin du capteur de cabinet
+- `src/physics/cabinet/MotionKalmanAxis.h` — l'estimateur et son hypothèse de biais
+- `src/physics/cabinet/PlumbHandler.cpp` — le pendule

--- a/docs/10.8.1/input_fra.md
+++ b/docs/10.8.1/input_fra.md
@@ -93,6 +93,45 @@ La sensibilité est un champ distinct : `Mapping.NudgeN.Strength`, de `0` à `2`
 autour d'un `1` neutre. Piloter la sensibilité par `scale` revient à mentir au
 moteur sur la nature du capteur, et rend une carte 4 g ou 8 g indescriptible.
 
+## Laquelle des quatre échelles compte vraiment
+
+Un cabinet peut mapper quatre axes : position et vitesse du plongeur,
+accélération et vitesse du nudge. Ils ne se valent pas — deux seulement ont
+besoin d'une échelle qui veut dire quelque chose physiquement.
+
+| Mapping | Nécessaire ? | Échelle |
+|---|---|---|
+| `Plunger0.Position` | **obligatoire** pour que le plongeur fasse quoi que ce soit | à laisser à `1.0` — c'est une course normalisée 0…1, pas une unité physique |
+| `Plunger0.Velocity` | facultatif | **doit convertir en m/s** (`12.5` sur Pinscape) |
+| `Nudge0.AccX` / `AccY` | la référence physique | **doit convertir en m/s²** (`19.6133` pour une carte ±2 g) |
+| `Nudge0.VelX` / `VelY` | facultatif | calibrée automatiquement — voir plus bas |
+
+Sans mapping de position, `PlungerSensor::StepOneMillisecond` sort
+immédiatement et tout le capteur de plongeur reste inerte. La position est
+celle qu'on ne peut pas omettre, et celle dont l'échelle doit être laissée
+telle quelle ; on n'inverse son signe que si l'axe se lit à l'envers.
+
+La vitesse du plongeur est facultative, mais lorsqu'elle est mappée
+`GetHitVelocity` renvoie **sa valeur directement** comme vitesse d'impact —
+d'où une échelle qui doit être une vraie conversion en m/s. Non mappée, VPX
+déduit la vitesse de l'estimateur de position, ce qu'obtient toute carte sans
+canal de vitesse.
+
+La vitesse du nudge se comporte encore autrement. Quand l'accélération *et* la
+vitesse sont mappées sur le même axe, `CabinetNudgeSensor::UpdateAxis` pousse
+les deux dans le même filtre de Kalman et laisse `MotionGainCalibratorAxis`
+déterminer seul le gain entre les deux canaux, en prenant l'accélération pour
+référence — la vitesse est injectée à `1 / gain`. Tant que cette calibration
+n'atteint pas une confiance de 0,5, le canal de vitesse est purement
+**ignoré** et seule l'accélération est utilisée. Son échelle n'a donc pas
+besoin d'être exacte : la calibration l'absorbe. L'exception est de mapper la
+vitesse *sans* accélération sur cet axe : elle est alors utilisée avec un gain
+de 1 et son échelle compte pleinement (m/s).
+
+En résumé pour un ini : corriger l'échelle de `Plunger0.Velocity` et de
+`Nudge0.AccX/AccY`, laisser `Plunger0.Position` et `Nudge0.VelX/VelY` telles
+qu'elles viennent.
+
 ## Les trois modes de nudge
 
 `Mapping.NudgeN.Type` choisit comment une mesure devient un mouvement de cabinet :

--- a/docs/10.8.1/plugins_eng.md
+++ b/docs/10.8.1/plugins_eng.md
@@ -1,0 +1,99 @@
+# Plugins in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](plugins_fra.md)
+
+PinMAME, B2S, PUP, DOF, FlexDMD, AltSound, Serum and the score view are no
+longer parts of VPX. They are plugins, each owning its settings — which is why
+old keys like `PUPCapture` or `B2SWindows` vanished from `[Player]`, see
+[Removed](removed_eng.md#external-windows).
+
+## One section per plugin
+
+Every plugin gets its own ini section, `[Plugin.<Name>]`, and always has at least
+an `Enable` key:
+
+```ini
+[Plugin.PinMAME]
+; Enable: Enable PinMAME plugin [Default: 1]
+Enable =
+Sound =
+Cheat =
+PinMAMEPath =
+```
+
+The ten `Enable` keys are declared in `src/core/Settings_properties.inl`:
+
+| Section | Plugin | Enabled by default |
+|---|---|---|
+| `[Plugin.PinMAME]` | ROM emulation | standalone builds only |
+| `[Plugin.B2SLegacy]` | legacy backglass | standalone builds only |
+| `[Plugin.ScoreView]` | score view / DMD rendering | standalone builds only |
+| `[Plugin.PUP]` | PinUP Player | standalone builds only |
+| `[Plugin.FlexDMD]` | FlexDMD | standalone builds only |
+| `[Plugin.Serum]` | Serum colourisation | standalone builds only |
+| `[Plugin.WMP]` | media playback | standalone builds only |
+| `[Plugin.AltSound]` | alternative sound packs | off |
+| `[Plugin.VNI]` | VNI colourisation | off |
+| `[Plugin.DMDUtil]` | external DMD devices | off |
+
+`g_isStandalone` is what decides the default: the standalone builds — the ones
+cabinets run — turn most of them on, a plain desktop build does not.
+
+## Where the other keys come from
+
+Only `Enable` is declared by VPX. Everything else in a plugin's section is
+declared **by the plugin itself**, at load time, through the message API:
+
+```cpp
+MSGPI_BOOL_VAL_SETTING(enableSoundProp, "Sound", "Enable Sound", "Enable sound emulation", true, true);
+MSGPI_STRING_VAL_SETTING(pinMAMEPathProp, "PinMAMEPath", "PinMAME Path",
+                         "Folder that contains PinMAME subfolders (roms, nvram, ...)", true, "", 1024);
+MSGPI_BOOL_VAL_SETTING(cheatProp, "Cheat", "Cheat Mode", "", true, false);
+
+msgApi->RegisterSetting(endpointId, &enableSoundProp);
+msgApi->RegisterSetting(endpointId, &pinMAMEPathProp);
+msgApi->RegisterSetting(endpointId, &cheatProp);
+```
+
+Two consequences follow, and they explain most of the confusion around plugin
+configuration.
+
+**A disabled plugin declares nothing.** Its keys do not appear in the ini and do
+not show up in the F12 UI, because the code that registers them never runs. An
+empty-looking section is not a broken install; it is a plugin that has not been
+loaded yet.
+
+**The authoritative list is the plugin's source**, not `Settings_properties.inl`.
+Looking for `Sound` or `Cheat` in VPX's property file finds nothing — they live
+in `plugins/pinmame/PinMAMEPlugin.cpp`.
+
+```mermaid
+flowchart TD
+    VPX[VPX core] -->|declares| EN["Plugin.&lt;Name&gt;.Enable"]
+    EN -->|if enabled| LOAD[Plugin loaded]
+    LOAD -->|RegisterSetting| KEYS["its own keys<br/>in the same section"]
+    KEYS --> UI[F12 → Plugins]
+    KEYS --> INI[VPinballX.ini]
+    EN -.->|if disabled| NONE[no other key exists]
+```
+
+## PinMAME
+
+`[Plugin.PinMAME]`, from `plugins/pinmame/PinMAMEPlugin.cpp`:
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `Enable` | bool | on (standalone) | load the plugin |
+| `Sound` | bool | on | sound emulation |
+| `Cheat` | bool | off | cheat mode |
+| `PinMAMEPath` | string | empty | folder holding the `roms`, `nvram`… subfolders |
+
+It also publishes an audio source named `PinMAME`, targeted at the backglass,
+which is what gives it an entry in the per-source gains — see
+[Audio](audio_eng.md#a-gain-per-source).
+
+## Source
+
+- `src/core/Settings_properties.inl` — the ten `Enable` keys and their defaults
+- `plugins/<name>/` — each plugin's own settings, registered via `RegisterSetting`
+- `plugins/README.md` — the plugin API itself

--- a/docs/10.8.1/plugins_fra.md
+++ b/docs/10.8.1/plugins_fra.md
@@ -1,0 +1,100 @@
+# Plugins en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](plugins_eng.md) · 🇫🇷 Français
+
+PinMAME, B2S, PUP, DOF, FlexDMD, AltSound, Serum et le score view ne font plus
+partie de VPX. Ce sont des plugins, chacun propriétaire de ses réglages — d'où
+la disparition d'anciennes clés comme `PUPCapture` ou `B2SWindows` de la section
+`[Player]`, voir [Supprimés](removed_fra.md#fenêtres-externes).
+
+## Une section par plugin
+
+Chaque plugin dispose de sa propre section d'ini, `[Plugin.<Nom>]`, et possède
+toujours au moins une clé `Enable` :
+
+```ini
+[Plugin.PinMAME]
+; Enable: Enable PinMAME plugin [Default: 1]
+Enable =
+Sound =
+Cheat =
+PinMAMEPath =
+```
+
+Les dix clés `Enable` sont déclarées dans `src/core/Settings_properties.inl` :
+
+| Section | Plugin | Actif par défaut |
+|---|---|---|
+| `[Plugin.PinMAME]` | émulation des ROM | builds standalone seulement |
+| `[Plugin.B2SLegacy]` | backglass historique | builds standalone seulement |
+| `[Plugin.ScoreView]` | rendu du score view / DMD | builds standalone seulement |
+| `[Plugin.PUP]` | PinUP Player | builds standalone seulement |
+| `[Plugin.FlexDMD]` | FlexDMD | builds standalone seulement |
+| `[Plugin.Serum]` | colorisation Serum | builds standalone seulement |
+| `[Plugin.WMP]` | lecture de médias | builds standalone seulement |
+| `[Plugin.AltSound]` | packs sonores alternatifs | non |
+| `[Plugin.VNI]` | colorisation VNI | non |
+| `[Plugin.DMDUtil]` | afficheurs DMD externes | non |
+
+C'est `g_isStandalone` qui décide du défaut : les builds standalone — celles que
+font tourner les cabinets — en activent la plupart, une build desktop ordinaire
+non.
+
+## D'où viennent les autres clés
+
+VPX ne déclare que `Enable`. Tout le reste d'une section de plugin est déclaré
+**par le plugin lui-même**, à son chargement, via l'API de messages :
+
+```cpp
+MSGPI_BOOL_VAL_SETTING(enableSoundProp, "Sound", "Enable Sound", "Enable sound emulation", true, true);
+MSGPI_STRING_VAL_SETTING(pinMAMEPathProp, "PinMAMEPath", "PinMAME Path",
+                         "Folder that contains PinMAME subfolders (roms, nvram, ...)", true, "", 1024);
+MSGPI_BOOL_VAL_SETTING(cheatProp, "Cheat", "Cheat Mode", "", true, false);
+
+msgApi->RegisterSetting(endpointId, &enableSoundProp);
+msgApi->RegisterSetting(endpointId, &pinMAMEPathProp);
+msgApi->RegisterSetting(endpointId, &cheatProp);
+```
+
+Deux conséquences en découlent, et elles expliquent l'essentiel de la confusion
+autour de la configuration des plugins.
+
+**Un plugin désactivé ne déclare rien.** Ses clés n'apparaissent ni dans l'ini ni
+dans l'interface F12, puisque le code qui les enregistre ne s'exécute jamais. Une
+section qui paraît vide n'est pas une installation cassée : c'est un plugin qui
+n'a pas encore été chargé.
+
+**La liste qui fait foi est le code du plugin**, pas `Settings_properties.inl`.
+Chercher `Sound` ou `Cheat` dans le fichier de propriétés de VPX ne donne rien :
+ils vivent dans `plugins/pinmame/PinMAMEPlugin.cpp`.
+
+```mermaid
+flowchart TD
+    VPX[Cœur VPX] -->|déclare| EN["Plugin.&lt;Nom&gt;.Enable"]
+    EN -->|si activé| LOAD[Plugin chargé]
+    LOAD -->|RegisterSetting| KEYS["ses propres clés<br/>dans la même section"]
+    KEYS --> UI[F12 → Plugins]
+    KEYS --> INI[VPinballX.ini]
+    EN -.->|si désactivé| NONE[aucune autre clé n'existe]
+```
+
+## PinMAME
+
+`[Plugin.PinMAME]`, d'après `plugins/pinmame/PinMAMEPlugin.cpp` :
+
+| Clé | Type | Défaut | Rôle |
+|---|---|---|---|
+| `Enable` | booléen | actif (standalone) | charger le plugin |
+| `Sound` | booléen | actif | émulation du son |
+| `Cheat` | booléen | inactif | mode triche |
+| `PinMAMEPath` | chaîne | vide | dossier contenant les sous-dossiers `roms`, `nvram`… |
+
+Il publie également une source audio nommée `PinMAME`, dirigée vers le
+backglass, ce qui lui donne une entrée dans les gains par source — voir
+[Audio](audio_fra.md#un-gain-par-source).
+
+## Sources
+
+- `src/core/Settings_properties.inl` — les dix clés `Enable` et leurs défauts
+- `plugins/<nom>/` — les réglages propres à chaque plugin, enregistrés via `RegisterSetting`
+- `plugins/README.md` — l'API de plugin elle-même

--- a/docs/10.8.1/removed_eng.md
+++ b/docs/10.8.1/removed_eng.md
@@ -1,0 +1,86 @@
+# Settings removed in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](removed_fra.md)
+
+Settings that existed in 10.8 and no longer do. VPX ignores them silently, so an
+`ini` carried over from 10.8 keeps lines that look meaningful and do nothing.
+
+Each entry gives what the setting did, the commit that removed it, and what
+replaced it — or the fact that nothing did, which is the part worth knowing
+before migrating a configuration.
+
+## Input
+
+The input system was rewritten twice: once in March 2025
+([`954ceb8d2`](https://github.com/vpinball/vpinball/commit/954ceb8d2)) and again
+in October
+([`f6252e874`](https://github.com/vpinball/vpinball/commit/f6252e874)). Axes are
+no longer named settings; they are fields of a sensor mapping — see
+[Input](input_eng.md#sensor-mappings).
+
+| Removed | Was | Replaced by |
+|---|---|---|
+| `LRAxis`, `UDAxis` | accelerometer axis numbers | the axis field of `Mapping.NudgeN.AccX` / `AccY` |
+| `LRAxisFlip`, `UDAxisFlip` | axis inversion | a negative `scale` in the mapping |
+| `PlungerAxis`, `PlungerSpeedAxis` | plunger axis numbers | `Mapping.Plunger0.Position` / `.Velocity` |
+| `ReversePlungerAxis` | plunger inversion | a negative `scale` in the mapping |
+| `AccelVelocityInput` | "the board sends velocity, not acceleration" | the mapping's type field: `V` instead of `A` |
+| `EnableNudgeFilter` | anti-noise filter on the raw signal | the dead zone field, plus the Kalman estimator VPX now always applies |
+| `PlungerFilter` | never implemented | nothing ([`5b690a030`](https://github.com/vpinball/vpinball/commit/5b690a030)) |
+| `InputApi` | which input backend to use | nothing — SDL only |
+| `EnableMouseInPlayer` | allow mouse input in game | nothing |
+| `DisableESC`, `EscapeKey` | disable or remap the escape key | a normal action mapping, remappable in **F12 → Input** |
+| `Joy*Key` (all of them) | one setting per joystick button | `Mapping.<Action>` with a device id and a button number |
+
+## Tilt and nudge
+
+Legacy tilt was removed in November 2025
+([`89527dd2b`](https://github.com/vpinball/vpinball/commit/89527dd2b)); the
+commit notes it had been disabled for years. The plumb simulation replaced it —
+see [Input](input_eng.md#tilt).
+
+| Removed | Was | Replaced by |
+|---|---|---|
+| `TiltAmount`, `TiltTriggerTime` | legacy tilt sensitivity and window | `PlumbThresholdAngle` |
+| `JoltAmount`, `JoltTriggerTime` | legacy jolt detection | nothing — the plumb covers it |
+| `PlumbInertia` | plumb inertia | `PlumbDamping`, which is a damping factor rather than an inertia |
+| `EnableLegacyNudge`, `LegacyNudgeStrength` | VP9 nudge model | `KeyboardNudgeMode` (which still offers the VP9 model) and `KeyboardNudgeStrength` |
+
+## Rendering
+
+| Removed | Was | Replaced by | Commit |
+|---|---|---|---|
+| `Stereo3DFake`, `Stereo3DMaxSeparation`, `Stereo3DOffset`, `Stereo3DYAxis`, `Stereo3DZPD` | fake stereo, a 2D approximation | nothing — real stereo only, via `Stereo3D` | [`7c456c07a`](https://github.com/vpinball/vpinball/commit/7c456c07a) |
+| `Anaglyph` | anaglyph as a separate mode | a `Stereo3D` mode, with its calibration in F12 | [`7c456c07a`](https://github.com/vpinball/vpinball/commit/7c456c07a) |
+| `ScaleFX`, `ScaleFXDMD` | ScaleFX upscaler | nothing | [`8d018bbec`](https://github.com/vpinball/vpinball/commit/8d018bbec) |
+| `AdaptiveVSync`, `EnableLegacyMaximumPreRenderedFrames`, `MaxPrerenderedFrames` | frame pacing knobs inherited from DX9 | `SyncMode` (four values, including frame pacing) and `MaxFramerate` | [`0f556f09b`](https://github.com/vpinball/vpinball/commit/0f556f09b) |
+| `DisableDWM` | disable the Windows compositor | nothing | [`9cad8a131`](https://github.com/vpinball/vpinball/commit/9cad8a131) |
+| `BWRendering` | black and white rendering | nothing | [`da11f5481`](https://github.com/vpinball/vpinball/commit/da11f5481) |
+
+## External windows
+
+Backglass, DMD and PUP windows were owned by the standalone build, each with its
+own position and size settings. They became plugins and rendered surfaces
+([`779f7be15`](https://github.com/vpinball/vpinball/commit/779f7be15),
+[`25ec2f640`](https://github.com/vpinball/vpinball/commit/25ec2f640),
+[`6f0e23fe0`](https://github.com/vpinball/vpinball/commit/6f0e23fe0)).
+
+| Removed | Replaced by |
+|---|---|
+| `B2SBackglassX/Y/Width/Height/Rotation` | the `[Backglass]` window section |
+| `B2SDMDX/Y/Width/Height/Rotation/FlipY` | the `[ScoreView]` window section |
+| `B2SWindows`, `B2SPlugins`, `B2SDualMode`, `B2SHide*` | `[Plugin.B2SLegacy]` |
+| `PUPWindows`, `PUPCapture`, `PUPPlugin` | `[Plugin.PUP]` |
+| `DOFPlugin` | `[Plugin.DOF]` |
+| `DMDServer`, `DMDServerAddr`, `DMDServerPort` | the DMDUtil plugin's own settings |
+| `AltColor`, `AltSound` | `[Plugin.AltColor]`, `[Plugin.AltSound]` |
+
+## A note on the November 2025 migration
+
+A series of commits titled *Migrate … props* moved every setting to a property
+registry. Names mostly survived, but some moved section, and defaults were
+re-declared in one place — `src/core/Settings_properties.inl`, which is now the
+authoritative list of what exists.
+
+A setting missing from that file does not exist, whatever an old ini or an old
+guide says.

--- a/docs/10.8.1/removed_fra.md
+++ b/docs/10.8.1/removed_fra.md
@@ -1,0 +1,89 @@
+# Réglages supprimés en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](removed_eng.md) · 🇫🇷 Français
+
+Les réglages qui existaient en 10.8 et n'existent plus. VPX les ignore
+silencieusement : un `ini` repris de la 10.8 conserve donc des lignes qui ont
+l'air de vouloir dire quelque chose et ne font rien.
+
+Chaque entrée indique ce que faisait le réglage, le commit qui l'a supprimé, et
+ce qui l'a remplacé — ou le fait que rien ne l'a remplacé, ce qui est justement
+ce qu'il faut savoir avant de migrer une configuration.
+
+## Entrées
+
+Le système d'entrée a été réécrit deux fois : en mars 2025
+([`954ceb8d2`](https://github.com/vpinball/vpinball/commit/954ceb8d2)) puis en
+octobre
+([`f6252e874`](https://github.com/vpinball/vpinball/commit/f6252e874)). Les axes
+ne sont plus des réglages nommés : ce sont des champs d'un mapping de capteur —
+voir [Entrées](input_fra.md#mappings-de-capteurs).
+
+| Supprimé | Rôle | Remplacé par |
+|---|---|---|
+| `LRAxis`, `UDAxis` | numéros d'axe de l'accéléromètre | le champ axe de `Mapping.NudgeN.AccX` / `AccY` |
+| `LRAxisFlip`, `UDAxisFlip` | inversion d'axe | un `scale` négatif dans le mapping |
+| `PlungerAxis`, `PlungerSpeedAxis` | numéros d'axe du plongeur | `Mapping.Plunger0.Position` / `.Velocity` |
+| `ReversePlungerAxis` | inversion du plongeur | un `scale` négatif dans le mapping |
+| `AccelVelocityInput` | « la carte envoie une vitesse, pas une accélération » | le champ type du mapping : `V` au lieu de `A` |
+| `EnableNudgeFilter` | filtre anti-bruit sur le signal brut | le champ de zone morte, plus l'estimateur de Kalman que VPX applique désormais toujours |
+| `PlungerFilter` | jamais implémenté | rien ([`5b690a030`](https://github.com/vpinball/vpinball/commit/5b690a030)) |
+| `InputApi` | choix du backend d'entrée | rien — SDL uniquement |
+| `EnableMouseInPlayer` | autoriser la souris en jeu | rien |
+| `DisableESC`, `EscapeKey` | désactiver ou remapper la touche Échap | un mapping d'action ordinaire, remappable dans **F12 → Input** |
+| `Joy*Key` (tous) | un réglage par bouton de joystick | `Mapping.<Action>` avec un identifiant de périphérique et un numéro de bouton |
+
+## Tilt et nudge
+
+Le tilt historique a été supprimé en novembre 2025
+([`89527dd2b`](https://github.com/vpinball/vpinball/commit/89527dd2b)) ; le
+commit précise qu'il était désactivé depuis des années. La simulation du pendule
+l'a remplacé — voir [Entrées](input_fra.md#tilt).
+
+| Supprimé | Rôle | Remplacé par |
+|---|---|---|
+| `TiltAmount`, `TiltTriggerTime` | sensibilité et fenêtre du tilt historique | `PlumbThresholdAngle` |
+| `JoltAmount`, `JoltTriggerTime` | détection de secousse historique | rien — le pendule couvre le cas |
+| `PlumbInertia` | inertie du pendule | `PlumbDamping`, qui est un facteur d'amortissement et non une inertie |
+| `EnableLegacyNudge`, `LegacyNudgeStrength` | modèle de nudge VP9 | `KeyboardNudgeMode` (qui propose toujours le modèle VP9) et `KeyboardNudgeStrength` |
+
+## Rendu
+
+| Supprimé | Rôle | Remplacé par | Commit |
+|---|---|---|---|
+| `Stereo3DFake`, `Stereo3DMaxSeparation`, `Stereo3DOffset`, `Stereo3DYAxis`, `Stereo3DZPD` | fausse stéréo, une approximation 2D | rien — stéréo réelle uniquement, via `Stereo3D` | [`7c456c07a`](https://github.com/vpinball/vpinball/commit/7c456c07a) |
+| `Anaglyph` | anaglyphe comme mode séparé | un mode de `Stereo3D`, avec sa calibration dans F12 | [`7c456c07a`](https://github.com/vpinball/vpinball/commit/7c456c07a) |
+| `ScaleFX`, `ScaleFXDMD` | agrandisseur ScaleFX | rien | [`8d018bbec`](https://github.com/vpinball/vpinball/commit/8d018bbec) |
+| `AdaptiveVSync`, `EnableLegacyMaximumPreRenderedFrames`, `MaxPrerenderedFrames` | réglages de cadence hérités de DX9 | `SyncMode` (quatre valeurs, dont le frame pacing) et `MaxFramerate` | [`0f556f09b`](https://github.com/vpinball/vpinball/commit/0f556f09b) |
+| `DisableDWM` | désactiver le compositeur Windows | rien | [`9cad8a131`](https://github.com/vpinball/vpinball/commit/9cad8a131) |
+| `BWRendering` | rendu en noir et blanc | rien | [`da11f5481`](https://github.com/vpinball/vpinball/commit/da11f5481) |
+
+## Fenêtres externes
+
+Le backglass, le DMD et les fenêtres PUP appartenaient à la build standalone,
+chacun avec ses propres réglages de position et de taille. Ils sont devenus des
+plugins et des surfaces de rendu
+([`779f7be15`](https://github.com/vpinball/vpinball/commit/779f7be15),
+[`25ec2f640`](https://github.com/vpinball/vpinball/commit/25ec2f640),
+[`6f0e23fe0`](https://github.com/vpinball/vpinball/commit/6f0e23fe0)).
+
+| Supprimé | Remplacé par |
+|---|---|
+| `B2SBackglassX/Y/Width/Height/Rotation` | la section de fenêtre `[Backglass]` |
+| `B2SDMDX/Y/Width/Height/Rotation/FlipY` | la section de fenêtre `[ScoreView]` |
+| `B2SWindows`, `B2SPlugins`, `B2SDualMode`, `B2SHide*` | `[Plugin.B2SLegacy]` |
+| `PUPWindows`, `PUPCapture`, `PUPPlugin` | `[Plugin.PUP]` |
+| `DOFPlugin` | `[Plugin.DOF]` |
+| `DMDServer`, `DMDServerAddr`, `DMDServerPort` | les réglages propres au plugin DMDUtil |
+| `AltColor`, `AltSound` | `[Plugin.AltColor]`, `[Plugin.AltSound]` |
+
+## À propos de la migration de novembre 2025
+
+Une série de commits intitulés *Migrate … props* a déplacé chaque réglage vers un
+registre de propriétés. Les noms ont pour l'essentiel survécu, mais certains ont
+changé de section, et les valeurs par défaut ont été redéclarées en un seul
+endroit — `src/core/Settings_properties.inl`, qui fait désormais autorité sur ce
+qui existe.
+
+Un réglage absent de ce fichier n'existe pas, quoi qu'en disent un ancien ini ou
+un ancien guide.

--- a/docs/10.8.1/rendering_eng.md
+++ b/docs/10.8.1/rendering_eng.md
@@ -1,0 +1,79 @@
+# Rendering in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](rendering_fra.md)
+
+All of these live in `[Player]`. The frame pacing work
+([`3da46f1ef`](https://github.com/vpinball/vpinball/commit/3da46f1ef)) replaced
+the DX9-era latency knobs — see [Removed](removed_eng.md#rendering).
+
+## Synchronisation
+
+`SyncMode` is the setting that decides how the picture is paced, and its default
+changed: **frame pacing is now the default**, not vertical sync.
+
+| Value | Mode | Trade-off |
+|---|---|---|
+| `0` | No sync | tearing, lowest latency |
+| `1` | Vertical sync | no tearing, high visual latency |
+| `2` | Adaptive sync | vsync except for late frames, still high latency |
+| `3` | **Frame pacing** (default) | paces rendering to cut latency; can stutter on an underpowered machine |
+
+`MaxFramerate` limits the rate, and its two special values are worth knowing:
+
+| Value | Effect |
+|---|---|
+| `-1` (default) | limit to the display's refresh rate |
+| `0` | no limit at all |
+| any other | limit to that value — steadier framerate, less heat |
+
+Note the inversion: `0` does **not** mean "no cap", it means "no cap at all",
+while `-1` is the sensible default. Reading it as a plain number gets it
+backwards.
+
+## Anti-aliasing
+
+Three independent stages, which stack:
+
+| Key | Values | Meaning |
+|---|---|---|
+| `AAFactor` | 0.5–2.0, default 1.0 | supersampling — renders at that multiple of the resolution, then downsamples. 2.0 means four times the pixels |
+| `MSAASamples` | `0` disabled, `1` 4×, `2` 6×, `3` 8× | geometry aliasing only, costs GPU memory |
+| `FXAA` | `0` disabled … `7` | post-process: Fast/Standard/Quality FXAA, Fast NFAA, Standard DLAA, Quality SMAA, Quality FAAA |
+
+`AAFactor` is brute force and by far the most expensive: 200 % is twice the
+resolution in each direction, so four times the work. MSAA is cheaper but only
+touches geometry edges. FXAA is nearly free and blurs a little.
+
+`Sharpen` (`0` disabled, `1` CAS, `2` Bilateral CAS) exists mostly to counter
+that blur.
+
+## Reflections and textures
+
+| Key | Values | Meaning |
+|---|---|---|
+| `PFReflection` | `0`–`5`, default `5` | Disable / Balls Only / Static Only / Static & Balls / Static & Unsynced Dynamic / **Dynamic** |
+| `SSRefl` | bool | screen-space reflections |
+| `MaxTexDimension` | 512–16384, default 16384 (1536 on mobile) | images above this are scaled down on load |
+
+`PFReflection` at `2` (Static Only) is the one with no runtime cost, except in
+VR. `5` is the default and the best looking.
+
+## Stereo
+
+`Stereo3D` selects the mode, and the fake modes are gone
+([`7c456c07a`](https://github.com/vpinball/vpinball/commit/7c456c07a)) — what
+remains is real stereo: Top/Bottom, interlaced variants, side-by-side, anaglyph.
+`Stereo3DEnabled` toggles it, and the eye separation, brightness, saturation,
+defocus and per-eye contrast tune it.
+
+## The one cosmetic setting worth knowing
+
+`BallAntiStretch` ("Unstretch Ball", default **off**) compensates the render
+stretch that makes a fast ball look egg-shaped. It changes nothing about
+physics — but on a cabinet playfield it is usually wanted, and it is off unless
+asked for.
+
+## Source
+
+- `src/core/Settings_properties.inl` — every key above, with its range and default
+- `src/renderer/Renderer.cpp` — where the post-process chain is assembled

--- a/docs/10.8.1/rendering_eng.md
+++ b/docs/10.8.1/rendering_eng.md
@@ -26,9 +26,39 @@ changed: **frame pacing is now the default**, not vertical sync.
 | `0` | no limit at all |
 | any other | limit to that value — steadier framerate, less heat |
 
-Note the inversion: `0` does **not** mean "no cap", it means "no cap at all",
-while `-1` is the sensible default. Reading it as a plain number gets it
-backwards.
+Note the inversion: `-1` is the sensible default and `0` removes the cap
+entirely — reading these as plain numbers gets it backwards.
+
+Whatever you ask for, **as soon as `SyncMode` is not `0` the value is clamped to
+the display**, in `Player::Init`: above the refresh rate it is brought back down
+to it, below it it is rounded to an integer division of it (60 → 30 → 20, never
+under 24 FPS). So `SyncMode = 3` with `MaxFramerate = 240` on a 144 Hz screen
+runs at 144, not 240.
+
+### Variable refresh rate (G-Sync, FreeSync)
+
+That clamp is exactly what a VRR panel does not want, since the whole point of
+VRR is that the display follows the game rather than the reverse. But turning
+synchronisation off is not automatically the right answer either, because frame
+pacing is not vertical sync: mode `3` runs a different game loop
+(`FramePacingGameLoop`) that aims to have the frame ready just in time for the
+vblank, keeping physics and input stepping meanwhile. It cooperates with a
+variable refresh rate rather than fighting it.
+
+Two setups make sense:
+
+- `SyncMode = 3` with `MaxFramerate` set to the display's refresh rate. The
+  clamp then becomes a no-op, since you are asking for exactly what the screen
+  does, and you keep the low-latency pacing. Start here.
+- `SyncMode = 0` with `MaxFramerate` set by hand, which frees VPX from the
+  clamp and lets the monitor pace the game. Capping a couple of Hz below the top
+  of the VRR window so as never to leave it is general VRR practice rather than
+  anything specific to VPX.
+
+Modes `1` and `2` are the ones to avoid on a VRR screen: both impose a fixed
+cadence, along with the visual latency that comes with it. VR is a separate
+case — sync is forced off there and pacing is left to the runtime, see
+[VR](vr_eng.md).
 
 ## Anti-aliasing
 

--- a/docs/10.8.1/rendering_fra.md
+++ b/docs/10.8.1/rendering_fra.md
@@ -1,0 +1,82 @@
+# Rendu en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](rendering_eng.md) · 🇫🇷 Français
+
+Tous ces réglages vivent dans `[Player]`. Le travail sur le frame pacing
+([`3da46f1ef`](https://github.com/vpinball/vpinball/commit/3da46f1ef)) a remplacé
+les réglages de latence hérités de DX9 — voir
+[Supprimés](removed_fra.md#rendu).
+
+## Synchronisation
+
+`SyncMode` décide de la cadence de l'image, et son défaut a changé : **le frame
+pacing est désormais le mode par défaut**, plus la synchronisation verticale.
+
+| Valeur | Mode | Compromis |
+|---|---|---|
+| `0` | Aucune | déchirure, latence minimale |
+| `1` | Synchro verticale | pas de déchirure, forte latence visuelle |
+| `2` | Synchro adaptative | vsync sauf pour les images en retard, latence encore élevée |
+| `3` | **Frame pacing** (défaut) | cadence le rendu pour réduire la latence ; peut saccader sur une machine trop juste |
+
+`MaxFramerate` limite la cadence, et ses deux valeurs spéciales méritent d'être
+connues :
+
+| Valeur | Effet |
+|---|---|
+| `-1` (défaut) | limiter à la fréquence de rafraîchissement de l'écran |
+| `0` | aucune limite |
+| toute autre | limiter à cette valeur — cadence plus stable, moins de chaleur |
+
+Notez l'inversion : `0` ne veut pas dire « pas de bridage raisonnable », il veut
+dire « aucune limite du tout », tandis que `-1` est le défaut sensé. Lire ces
+valeurs comme de simples nombres conduit à l'inverse de l'intention.
+
+## Anticrénelage
+
+Trois étages indépendants, qui se cumulent :
+
+| Clé | Valeurs | Rôle |
+|---|---|---|
+| `AAFactor` | 0,5–2,0, défaut 1,0 | suréchantillonnage — rend à ce multiple de la résolution puis réduit. 2,0 = quatre fois plus de pixels |
+| `MSAASamples` | `0` désactivé, `1` 4×, `2` 6×, `3` 8× | crénelage géométrique seulement, coûte de la mémoire GPU |
+| `FXAA` | `0` désactivé … `7` | post-traitement : FXAA rapide/standard/qualité, NFAA rapide, DLAA standard, SMAA qualité, FAAA qualité |
+
+`AAFactor` est la force brute, et de loin le plus coûteux : 200 % double la
+résolution dans chaque direction, soit quatre fois le travail. Le MSAA est moins
+cher mais ne touche que les arêtes géométriques. Le FXAA est presque gratuit et
+adoucit un peu l'image.
+
+`Sharpen` (`0` désactivé, `1` CAS, `2` CAS bilatéral) existe surtout pour
+contrer cet adoucissement.
+
+## Réflexions et textures
+
+| Clé | Valeurs | Rôle |
+|---|---|---|
+| `PFReflection` | `0`–`5`, défaut `5` | Désactivé / Billes seules / Statique seul / Statique & billes / Statique & dynamique non synchronisé / **Dynamique** |
+| `SSRefl` | booléen | réflexions en espace écran |
+| `MaxTexDimension` | 512–16384, défaut 16384 (1536 sur mobile) | les images plus grandes sont réduites au chargement |
+
+`PFReflection` à `2` (statique seul) est le seul sans coût à l'exécution, sauf en
+VR. `5` est le défaut et le plus beau.
+
+## Stéréo
+
+`Stereo3D` choisit le mode, et les modes factices ont disparu
+([`7c456c07a`](https://github.com/vpinball/vpinball/commit/7c456c07a)) — il ne
+reste que la vraie stéréo : haut/bas, variantes entrelacées, côte à côte,
+anaglyphe. `Stereo3DEnabled` l'active, et l'écartement des yeux, la luminosité,
+la saturation, le flou et le contraste par œil l'ajustent.
+
+## Le réglage cosmétique à connaître
+
+`BallAntiStretch` (« Unstretch Ball », défaut **inactif**) compense l'étirement
+de rendu qui donne à une bille rapide une allure d'œuf. Il ne change rien à la
+physique — mais sur un plateau de cabinet, on le veut généralement, et il reste
+inactif tant qu'on ne le demande pas.
+
+## Sources
+
+- `src/core/Settings_properties.inl` — toutes les clés ci-dessus, avec plages et défauts
+- `src/renderer/Renderer.cpp` — assemblage de la chaîne de post-traitement

--- a/docs/10.8.1/rendering_fra.md
+++ b/docs/10.8.1/rendering_fra.md
@@ -28,9 +28,39 @@ connues :
 | `0` | aucune limite |
 | toute autre | limiter à cette valeur — cadence plus stable, moins de chaleur |
 
-Notez l'inversion : `0` ne veut pas dire « pas de bridage raisonnable », il veut
-dire « aucune limite du tout », tandis que `-1` est le défaut sensé. Lire ces
-valeurs comme de simples nombres conduit à l'inverse de l'intention.
+Notez l'inversion : `-1` est le défaut sensé et `0` supprime toute limite —
+lire ces valeurs comme de simples nombres conduit à l'inverse de l'intention.
+
+Quoi qu'on demande, **dès que `SyncMode` n'est pas `0` la valeur est ramenée à
+l'écran**, dans `Player::Init` : au-dessus de la fréquence de rafraîchissement
+elle y est rabattue, en dessous elle est arrondie à une division entière de
+celle-ci (60 → 30 → 20, jamais sous 24 FPS). Ainsi `SyncMode = 3` avec
+`MaxFramerate = 240` sur un écran 144 Hz tourne à 144, pas à 240.
+
+### Fréquence de rafraîchissement variable (G-Sync, FreeSync)
+
+Ce rabattement est précisément ce dont un écran VRR ne veut pas, puisque tout
+l'intérêt du VRR est que l'écran suive le jeu et non l'inverse. Mais couper la
+synchronisation n'est pas pour autant la bonne réponse, car le frame pacing
+n'est pas de la synchronisation verticale : le mode `3` exécute une boucle de
+jeu différente (`FramePacingGameLoop`) qui vise à livrer l'image juste à temps
+pour le vblank, en continuant d'avancer la physique et les entrées entre-temps.
+Il coopère avec une fréquence variable au lieu de la contrarier.
+
+Deux configurations se tiennent :
+
+- `SyncMode = 3` avec `MaxFramerate` réglé sur la fréquence de l'écran. Le
+  rabattement devient alors sans effet, puisqu'on demande exactement ce que
+  l'écran fait, et on garde la cadence à faible latence. À essayer en premier.
+- `SyncMode = 0` avec `MaxFramerate` fixé à la main, ce qui libère VPX du
+  rabattement et laisse le moniteur cadencer le jeu. Plafonner deux ou trois Hz
+  sous le haut de la plage VRR pour ne jamais en sortir relève de la pratique
+  VRR générale, pas d'une particularité de VPX.
+
+Les modes `1` et `2` sont ceux à éviter sur un écran VRR : tous deux imposent
+une cadence fixe, avec la latence visuelle qui va avec. La VR est un cas à
+part — la synchronisation y est forcée à l'arrêt et la cadence laissée au
+runtime, voir [VR](vr_fra.md).
 
 ## Anticrénelage
 

--- a/docs/10.8.1/view_eng.md
+++ b/docs/10.8.1/view_eng.md
@@ -1,0 +1,120 @@
+# View and cabinet fitting in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](view_fra.md)
+
+10.8.1 adds automatic view fitting for cabinets, and with it a dependency most
+tables have never had to satisfy: the height of the glass.
+
+## Three projections
+
+`ViewLayoutMode` decides how the scene is projected. It is set per view mode and
+per table, and reachable in game through **F12 → Point of View**:
+
+| Mode | What it does |
+|---|---|
+| `0` Legacy | pre-10.8 rendering — a fit over bounding vertices, skewed by a layback angle. Visually incorrect stretches by design. |
+| `1` Camera | classic perspective, viewer placed relative to the bottom centre of the table. The desktop mode. |
+| `2` Window | oblique reprojection, viewer placed relative to the bottom centre of **the screen**. Designed for cabinets. |
+
+Window is the one that treats your screen as the physical glass of the cabinet,
+with the viewer positioned relative to it in real units. That is also why head
+tracking only works there: moving your eye has to produce an asymmetric frustum,
+which needs a screen that exists in the model.
+
+The keys are `TableOverride.ViewCabMode`, `ViewDTMode` and `ViewFSSMode` — one
+per view mode (Cabinet, Desktop, FSS), stored as a per-table override rather
+than in the application settings.
+
+## Automatic fitting
+
+`Player.CabinetAutofitMode` applies to the Cabinet view:
+
+| Value | Name | Effect |
+|---|---|---|
+| `0` | Manual | nothing is computed; the table's own point of view is used |
+| `1` | Fit Table | uniform scale, fitted on table width |
+| `2` | Fit Screen | non-uniform stretch, table fills the screen |
+
+The difference is two lines of `ViewSetup::SetWindowAutofit`:
+
+```cpp
+mSceneScaleX = (screenHeight / table->GetTableWidth()) * (table->GetHeight() / screenWidth);
+mSceneScaleY = allowNonUniformStretch ? 1.f : mSceneScaleX;
+```
+
+**Fit Table** keeps proportions — Y is scaled like X — at the cost of not showing
+everything: part of the apron, or of the top of the table, falls outside the
+frame. `Player.CabinetAutofitPos` (0–20 %, default 5 %) then decides where the
+resting flipper bats sit on screen, so the same reference point holds from table
+to table.
+
+**Fit Screen** cuts nothing but stretches one axis against the other. On a
+head-tracked cabinet this is the wrong choice: parallax depends on rendered
+geometry matching real geometry, and a stretched scene answers a horizontal head
+movement differently from a vertical one.
+
+Selecting either mode forces `mMode = VLM_WINDOW`, so autofit and the Window
+projection come together.
+
+## What autofit needs from the table
+
+Two things, and only one of them is under the table's control.
+
+**The screen's physical dimensions**, `Player.ScreenWidth` and
+`Player.ScreenHeight`, in centimetres. Autofit refuses to run without them:
+
+```
+Screen dimensions must be defined before using automatic point of view
+```
+
+These are the dimensions of the visible playfield area, not the panel's diagonal.
+Get them wrong and every table is misframed identically.
+
+**The glass heights**, `m_glassBottomHeight` and `m_glassTopHeight`, which become
+the projection volume:
+
+```cpp
+Vertex2D glass = table->EvaluateGlassHeight();
+if (table->m_glassTopHeight != table->m_glassBottomHeight) { /* the table declares it */ }
+else { glassNotification("Missing glass position guessed to be {..}cm / {..}cm"); }
+mWindowBottomZOfs = bottomHeight;
+mWindowTopZOfs    = topHeight;
+```
+
+A flat glass was the old default, so a table that never set these is detected by
+its glass being horizontal, and VPX **guesses** both heights by analysing element
+bounds. When the table does declare them, VPX uses its values but compares them
+to its own estimate and warns if they differ by more than an inch:
+
+```
+Glass height was evaluated to X cm / Y cm
+It differs from the defined glass position Z cm / W cm
+```
+
+Those two notifications are the first thing to read when a table sits badly in
+Window mode. They say whether the frame rests on declared geometry or on a guess.
+
+## Why tables sit badly
+
+Window mode exercises geometry that Camera and Legacy never did. A table can look
+perfect on a desktop and still show, on a cabinet:
+
+- **apron or cabinet walls drawn where they should not be** — geometry that was
+  only ever seen from a viewpoint that hid it;
+- **elements displaced in proportion to their height** above the playfield, which
+  is the signature of a wrong projection volume rather than of misplaced parts:
+  a painted insert cannot move, a ramp 10 cm up moves the most;
+- **a frame that cuts too much or too little**, when the glass heights were
+  guessed rather than declared.
+
+None of this is visible without a cabinet running Window mode, which is why it
+went unnoticed: the people who could fix the tables are the least likely to meet
+the problem.
+
+## Source
+
+- `src/renderer/ViewSetup.h` — `ViewLayoutMode`, the three projections
+- `src/renderer/ViewSetup.cpp` — `SetWindowAutofit`, glass heights, scene scales
+- `src/core/player.cpp` — `SetCabinetAutoFitMode`, `SetCabinetAutoFitPos`
+- `src/ui/live/ingameui/PointOfViewSettingsPage.cpp` — the F12 page
+- `src/core/Settings_properties.inl` — `CabinetAutofitMode`, `CabinetAutofitPos`, `BGSet`

--- a/docs/10.8.1/view_fra.md
+++ b/docs/10.8.1/view_fra.md
@@ -1,0 +1,126 @@
+# Vue et ajustement cabinet en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](view_eng.md) · 🇫🇷 Français
+
+La 10.8.1 ajoute l'ajustement automatique de la vue pour les cabinets, et avec
+lui une dépendance que la plupart des tables n'ont jamais eu à satisfaire : la
+hauteur de la vitre.
+
+## Trois projections
+
+`ViewLayoutMode` décide de la façon dont la scène est projetée. Il se règle par
+mode de vue et par table, et se trouve en jeu dans **F12 → Point of View** :
+
+| Mode | Effet |
+|---|---|
+| `0` Legacy | rendu d'avant la 10.8 — un cadrage sur des sommets englobants, biaisé par un angle de *layback*. Des déformations visuellement fausses, par construction. |
+| `1` Camera | perspective classique, spectateur placé par rapport au bas-centre de la table. Le mode desktop. |
+| `2` Window | reprojection oblique, spectateur placé par rapport au bas-centre de **l'écran**. Conçu pour les cabinets. |
+
+Window est celui qui traite votre écran comme la vitre physique du cabinet, avec
+le spectateur positionné par rapport à elle en unités réelles. C'est aussi
+pourquoi le head tracking n'y fonctionne que là : déplacer l'œil doit produire un
+frustum asymétrique, ce qui suppose un écran existant dans le modèle.
+
+Les clés sont `TableOverride.ViewCabMode`, `ViewDTMode` et `ViewFSSMode` — une
+par mode de vue (Cabinet, Desktop, FSS), enregistrées comme surcharge par table
+plutôt que dans les réglages de l'application.
+
+## Ajustement automatique
+
+`Player.CabinetAutofitMode` s'applique à la vue Cabinet :
+
+| Valeur | Nom | Effet |
+|---|---|---|
+| `0` | Manual | rien n'est calculé ; le point de vue propre à la table est utilisé |
+| `1` | Fit Table | échelle uniforme, calée sur la largeur de la table |
+| `2` | Fit Screen | étirement non uniforme, la table remplit l'écran |
+
+La différence tient en deux lignes de `ViewSetup::SetWindowAutofit` :
+
+```cpp
+mSceneScaleX = (screenHeight / table->GetTableWidth()) * (table->GetHeight() / screenWidth);
+mSceneScaleY = allowNonUniformStretch ? 1.f : mSceneScaleX;
+```
+
+**Fit Table** conserve les proportions — Y est mis à l'échelle comme X — au prix
+de ne pas tout montrer : une partie du tablier, ou du haut de la table, sort du
+cadre. `Player.CabinetAutofitPos` (0–20 %, défaut 5 %) décide alors de la
+position à l'écran des palettes au repos, afin que le même point de référence
+vaille d'une table à l'autre.
+
+**Fit Screen** ne coupe rien mais étire un axe par rapport à l'autre. Sur un
+cabinet avec head tracking, c'est le mauvais choix : la parallaxe suppose que la
+géométrie rendue corresponde à la géométrie réelle, et une scène étirée répond
+différemment à un mouvement de tête horizontal et vertical.
+
+Choisir l'un ou l'autre mode force `mMode = VLM_WINDOW` : l'ajustement
+automatique et la projection Window vont donc ensemble.
+
+## Ce que l'ajustement attend de la table
+
+Deux choses, dont une seule dépend de la table.
+
+**Les dimensions physiques de l'écran**, `Player.ScreenWidth` et
+`Player.ScreenHeight`, en centimètres. L'ajustement refuse de s'exécuter sans
+elles :
+
+```
+Screen dimensions must be defined before using automatic point of view
+```
+
+Ce sont les dimensions de la zone visible du plateau, pas la diagonale de la
+dalle. Fausses, elles décadrent toutes les tables de la même façon.
+
+**Les hauteurs de vitre**, `m_glassBottomHeight` et `m_glassTopHeight`, qui
+deviennent le volume de projection :
+
+```cpp
+Vertex2D glass = table->EvaluateGlassHeight();
+if (table->m_glassTopHeight != table->m_glassBottomHeight) { /* la table les déclare */ }
+else { glassNotification("Missing glass position guessed to be {..}cm / {..}cm"); }
+mWindowBottomZOfs = bottomHeight;
+mWindowTopZOfs    = topHeight;
+```
+
+Une vitre horizontale était l'ancien réglage par défaut : une table qui ne les a
+jamais définies se reconnaît donc à sa vitre plate, et VPX **devine** les deux
+hauteurs en analysant les bornes des éléments. Lorsque la table les déclare, VPX
+utilise ses valeurs mais les compare à sa propre estimation et prévient si
+l'écart dépasse un pouce :
+
+```
+Glass height was evaluated to X cm / Y cm
+It differs from the defined glass position Z cm / W cm
+```
+
+Ces deux notifications sont la première chose à lire quand une table tombe mal en
+mode Window. Elles disent si le cadrage repose sur une géométrie déclarée ou sur
+une supposition.
+
+## Pourquoi des tables tombent mal
+
+Le mode Window met à l'épreuve une géométrie que Camera et Legacy n'ont jamais
+sollicitée. Une table peut être parfaite en desktop et présenter, sur un
+cabinet :
+
+- **un tablier ou des parois de cabinet dessinés là où ils ne devraient pas
+  l'être** — une géométrie qui n'avait jamais été vue que d'un point de vue qui
+  la masquait ;
+- **des éléments décalés proportionnellement à leur hauteur** au-dessus du
+  plateau, ce qui signe un volume de projection faux plutôt que des pièces mal
+  placées : un insert peint ne peut pas bouger, une rampe à 10 cm bouge le plus ;
+- **un cadrage qui coupe trop ou pas assez**, lorsque les hauteurs de vitre ont
+  été devinées au lieu d'être déclarées.
+
+Rien de tout cela n'est visible sans un cabinet en mode Window, et c'est
+précisément pourquoi c'est passé inaperçu : ceux qui pourraient corriger les
+tables sont ceux qui ont le moins de chances de croiser le problème.
+
+## Sources
+
+- `src/renderer/ViewSetup.h` — `ViewLayoutMode`, les trois projections
+- `src/renderer/ViewSetup.cpp` — `SetWindowAutofit`, hauteurs de vitre, échelles de scène
+- `src/core/player.cpp` — `SetCabinetAutoFitMode`, `SetCabinetAutoFitPos`
+- `src/ui/live/ingameui/PointOfViewSettingsPage.cpp` — la page F12
+- `src/core/Settings_properties.inl` — `CabinetAutofitMode`, `CabinetAutofitPos`, `BGSet`

--- a/docs/10.8.1/vr_eng.md
+++ b/docs/10.8.1/vr_eng.md
@@ -1,0 +1,56 @@
+# VR in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](vr_fra.md)
+
+OpenVR was removed in June 2026
+([`6524789e3`](https://github.com/vpinball/vpinball/commit/6524789e3)); VR now
+runs on OpenXR only. Settings live in `[PlayerVR]`, and the VR options that were
+in the Win32 dialogs moved into the in-game UI
+([`be980d774`](https://github.com/vpinball/vpinball/commit/be980d774)).
+
+## Turning it on
+
+| Key | Values | Default | Meaning |
+|---|---|---|---|
+| `AskToTurnOn` | `0` Enabled, `1` Autodetect, `2` Disabled | `0` on VR-capable builds, `2` elsewhere | whether VR is used |
+
+## Placing the cabinet
+
+These are the settings that make a VR cabinet feel right, and they are all
+per-table overridable:
+
+| Key | Range | Default | Meaning |
+|---|---|---|---|
+| `Orientation` | −180…180 ° | 0 | rotation of the view |
+| `TableX`, `TableY`, `TableZ` | −100…100 | 0 | position offsets |
+| `LockFeetToGround` | bool | on | keeps the cabinet's feet on the floor rather than letting it float |
+| `AddBackglass` | bool | off | adds a default backglass display to the scene |
+
+`LockFeetToGround` is the one that changes the impression most: without it the
+cabinet can appear to hover, which reads as wrong even when the height is right.
+
+## Controller-based centring
+
+Rather than nudging offsets by hand, the view can be centred by pointing the
+controllers at the real cabinet. Two settings calibrate that:
+
+| Key | Range | Default | Meaning |
+|---|---|---|---|
+| `ControllerCabYOffset` | −150…50 | 0 | Y offset applied when centring with the controllers |
+| `ControllerLockbarScale` | 0.5–2.0 | 1.0 | lockbar size ratio used by that centring |
+
+## The preview window
+
+VR draws a flat preview on the desktop, and it is a window like any other — same
+eleven keys as the outputs in [Windows](window_eng.md#four-outputs-one-schema),
+prefixed `Preview`: `PreviewDisplay`, `PreviewFullScreen`, `PreviewWndX/Y`,
+`PreviewWidth/Height`, `PreviewFSWidth/FSHeight`, `PreviewRefreshRate`,
+`PreviewColorDepth`.
+
+`ShrinkPreview` (default off) reduces it, which costs less than rendering it full
+size.
+
+## Source
+
+- `src/core/Settings_properties.inl` — the `[PlayerVR]` block
+- `src/ui/live/ingameui/` — the VR pages, since the Win32 dialogs went away

--- a/docs/10.8.1/vr_fra.md
+++ b/docs/10.8.1/vr_fra.md
@@ -1,0 +1,58 @@
+# VR en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](vr_eng.md) · 🇫🇷 Français
+
+OpenVR a été supprimé en juin 2026
+([`6524789e3`](https://github.com/vpinball/vpinball/commit/6524789e3)) : la VR
+repose désormais sur OpenXR seul. Les réglages vivent dans `[PlayerVR]`, et les
+options VR qui se trouvaient dans les boîtes de dialogue Win32 sont passées dans
+l'interface en jeu
+([`be980d774`](https://github.com/vpinball/vpinball/commit/be980d774)).
+
+## Activation
+
+| Clé | Valeurs | Défaut | Rôle |
+|---|---|---|---|
+| `AskToTurnOn` | `0` activé, `1` détection auto, `2` désactivé | `0` sur les builds compatibles VR, `2` ailleurs | utiliser ou non la VR |
+
+## Placer le cabinet
+
+Ce sont les réglages qui font qu'un cabinet VR paraît juste, et ils sont tous
+surchargeables par table :
+
+| Clé | Plage | Défaut | Rôle |
+|---|---|---|---|
+| `Orientation` | −180…180 ° | 0 | rotation de la vue |
+| `TableX`, `TableY`, `TableZ` | −100…100 | 0 | décalages de position |
+| `LockFeetToGround` | booléen | actif | garde les pieds du cabinet au sol au lieu de le laisser flotter |
+| `AddBackglass` | booléen | inactif | ajoute un backglass par défaut à la scène |
+
+`LockFeetToGround` est celui qui change le plus l'impression : sans lui, le
+cabinet semble léviter, ce qui paraît faux même quand la hauteur est bonne.
+
+## Centrage par les manettes
+
+Plutôt que d'ajuster les décalages à la main, la vue peut être centrée en
+pointant les manettes vers le cabinet réel. Deux réglages calibrent ce
+mécanisme :
+
+| Clé | Plage | Défaut | Rôle |
+|---|---|---|---|
+| `ControllerCabYOffset` | −150…50 | 0 | décalage en Y appliqué lors du centrage aux manettes |
+| `ControllerLockbarScale` | 0,5–2,0 | 1,0 | rapport de taille du lockbar utilisé par ce centrage |
+
+## La fenêtre d'aperçu
+
+La VR dessine un aperçu plat sur le bureau, et c'est une fenêtre comme une autre
+— les mêmes onze clés que les sorties décrites dans
+[Fenêtres](window_fra.md#quatre-sorties-un-seul-schéma), préfixées `Preview` :
+`PreviewDisplay`, `PreviewFullScreen`, `PreviewWndX/Y`, `PreviewWidth/Height`,
+`PreviewFSWidth/FSHeight`, `PreviewRefreshRate`, `PreviewColorDepth`.
+
+`ShrinkPreview` (inactif par défaut) le réduit, ce qui coûte moins cher que de le
+rendre en taille réelle.
+
+## Sources
+
+- `src/core/Settings_properties.inl` — le bloc `[PlayerVR]`
+- `src/ui/live/ingameui/` — les pages VR, depuis la disparition des dialogues Win32

--- a/docs/10.8.1/window_eng.md
+++ b/docs/10.8.1/window_eng.md
@@ -1,0 +1,118 @@
+# Windows and displays in 10.8.1
+
+[← Index](README.md#-english) · 🇬🇧 English · [🇫🇷 Français](window_fra.md)
+
+The window setup was rewritten in November 2025
+([`ab19a7e4f`](https://github.com/vpinball/vpinball/commit/ab19a7e4f)) and moved
+to the property registry
+([`bd8c77206`](https://github.com/vpinball/vpinball/commit/bd8c77206)). Four
+outputs now share one identical set of settings, where the standalone build used
+to carry its own per-window keys — see [Removed](removed_eng.md#external-windows)
+for the ones that went.
+
+## Four outputs, one schema
+
+| Output | Section | Prefix |
+|---|---|---|
+| Playfield | `[Player]` | `Playfield` |
+| Backglass | `[Backglass]` | `Backglass` |
+| Score view (DMD) | `[ScoreView]` | `ScoreView` |
+| Topper | `[Topper]` | `Topper` |
+
+Every output takes the same eleven keys, prefixed by its own name:
+
+```ini
+[Backglass]
+BackglassOutput      = 1     ; 0 disabled, 1 window, 2 embedded in the playfield
+BackglassDisplay     =       ; display name, as VPX enumerates it
+BackglassFullScreen  = 0     ; 0 windowed, 1 borderless fullscreen
+BackglassWndX        = 0     ; windowed position on that display
+BackglassWndY        = 0
+BackglassWidth       = 1920  ; windowed size
+BackglassHeight      = 1080
+BackglassFSWidth     = 1920  ; fullscreen size — a separate pair
+BackglassFSHeight    = 1080
+BackglassRefreshRate = 0     ; fullscreen only, 0 = let the driver choose
+BackglassColorDepth  = 32    ; fullscreen only
+```
+
+Three points are easy to get wrong.
+
+**Windowed and fullscreen sizes are separate keys.** `Width`/`Height` apply in
+windowed mode, `FSWidth`/`FSHeight` in fullscreen. Setting the first pair and
+switching to fullscreen changes nothing visible, which reads as the setting being
+ignored.
+
+**`RefreshRate` and `ColorDepth` only apply in fullscreen.** They describe a
+display mode, not a window.
+
+**Under BGFX there is no exclusive fullscreen.** `FullScreen` offers two values,
+windowed and borderless fullscreen; the third value, real fullscreen, only exists
+in non-BGFX builds. On a cabinet, borderless fullscreen is the one that behaves.
+
+## Output modes
+
+`<Prefix>Output` selects what the output is, from `Window::OutputMode` in
+`src/renderer/Window.h`:
+
+| Value | Name | Meaning |
+|---|---|---|
+| `0` | `OM_DISABLED` | the output does not exist |
+| `1` | `OM_WINDOW` | a native window of its own — the cabinet case |
+| `2` | `OM_EMBEDDED` | drawn inside the playfield window |
+
+Mode `2` is what lets a single-screen setup show a backglass or a score view
+without a second display: the surface is composited into the playfield window
+rather than given a window of its own.
+
+```mermaid
+flowchart LR
+    T[Table] --> PF[Playfield window]
+    T --> BG{BackglassOutput}
+    T --> SV{ScoreViewOutput}
+    BG -->|1 window| BGW[Own window<br/>on BackglassDisplay]
+    BG -->|2 embedded| PF
+    BG -->|0 disabled| X[not rendered]
+    SV -->|1 window| SVW[Own window<br/>on ScoreViewDisplay]
+    SV -->|2 embedded| PF
+    SV -->|0 disabled| X
+```
+
+## Naming the display
+
+`<Prefix>Display` holds a display **name**, not an index. VPX enumerates
+displays through SDL, and the name it reports depends on the video driver in
+use: the same panel can appear as `Iiyama North America 42"` under Wayland,
+`DP-1 42"` under XWayland and `PL4380UH 42"` under a real Xorg session.
+
+A name written under one driver therefore does not resolve under another, and the
+window falls back to the primary display. This is not a bug in the ini; it is
+what happens when the identity of a screen comes from the driver.
+
+## Physical dimensions
+
+Two settings in `[Player]` describe the playfield screen in the real world,
+in centimetres, and have nothing to do with pixels:
+
+| Key | Range | Default | Meaning |
+|---|---|---|---|
+| `ScreenWidth` | 5–200 cm | 95.89 | width of the **visible** playfield area |
+| `ScreenHeight` | 5–200 cm | 53.94 | height of that area |
+| `ScreenInclination` | −30…30 ° | 0 | the screen's angle, 0 being horizontal |
+
+The property's own description says **width > height**: these are given in
+landscape orientation, even when the screen is mounted portrait in the cabinet —
+which is how it is mounted on every cabinet. Swapping them because the panel
+stands upright is the single easiest way to misframe every table at once. They
+are the visible area, not the panel diagonal.
+
+They were introduced with the window/POV work
+([`cfdb53635`](https://github.com/vpinball/vpinball/commit/cfdb53635)) and are
+required by cabinet autofit, which refuses to run without them — see
+[View](view_eng.md#what-autofit-needs-from-the-table).
+
+## Source
+
+- `src/core/Settings_properties.inl` — the eleven keys, per output, with ranges and defaults
+- `src/renderer/Window.h` — `OutputMode`, and what a window actually is
+- `src/renderer/Window.cpp` — display enumeration and mode selection

--- a/docs/10.8.1/window_fra.md
+++ b/docs/10.8.1/window_fra.md
@@ -1,0 +1,119 @@
+# Fenêtres et écrans en 10.8.1
+
+[← Index](README.md#-français) · [🇬🇧 English](window_eng.md) · 🇫🇷 Français
+
+La configuration des fenêtres a été réécrite en novembre 2025
+([`ab19a7e4f`](https://github.com/vpinball/vpinball/commit/ab19a7e4f)) puis
+migrée vers le registre de propriétés
+([`bd8c77206`](https://github.com/vpinball/vpinball/commit/bd8c77206)). Quatre
+sorties partagent désormais un jeu de réglages identique, là où la build
+standalone portait ses propres clés par fenêtre — voir
+[Supprimés](removed_fra.md#fenêtres-externes) pour celles qui ont disparu.
+
+## Quatre sorties, un seul schéma
+
+| Sortie | Section | Préfixe |
+|---|---|---|
+| Plateau | `[Player]` | `Playfield` |
+| Backglass | `[Backglass]` | `Backglass` |
+| Score view (DMD) | `[ScoreView]` | `ScoreView` |
+| Topper | `[Topper]` | `Topper` |
+
+Chaque sortie prend les mêmes onze clés, préfixées par son nom :
+
+```ini
+[Backglass]
+BackglassOutput      = 1     ; 0 désactivé, 1 fenêtre, 2 intégré au plateau
+BackglassDisplay     =       ; nom de l'écran, tel que VPX l'énumère
+BackglassFullScreen  = 0     ; 0 fenêtré, 1 plein écran sans bordure
+BackglassWndX        = 0     ; position en mode fenêtré, sur cet écran
+BackglassWndY        = 0
+BackglassWidth       = 1920  ; taille en mode fenêtré
+BackglassHeight      = 1080
+BackglassFSWidth     = 1920  ; taille en plein écran — un couple distinct
+BackglassFSHeight    = 1080
+BackglassRefreshRate = 0     ; plein écran seulement, 0 = laisser le pilote choisir
+BackglassColorDepth  = 32    ; plein écran seulement
+```
+
+Trois points se trompent facilement.
+
+**Les tailles fenêtrée et plein écran sont des clés distinctes.**
+`Width`/`Height` s'appliquent en mode fenêtré, `FSWidth`/`FSHeight` en plein
+écran. Régler le premier couple puis passer en plein écran ne change rien de
+visible, ce qui se lit comme un réglage ignoré.
+
+**`RefreshRate` et `ColorDepth` ne valent qu'en plein écran.** Ils décrivent un
+mode d'affichage, pas une fenêtre.
+
+**Sous BGFX, il n'y a pas de plein écran exclusif.** `FullScreen` ne propose que
+deux valeurs, fenêtré et plein écran sans bordure ; la troisième, le vrai plein
+écran, n'existe que dans les builds non-BGFX. Sur un cabinet, c'est le plein
+écran sans bordure qui se comporte correctement.
+
+## Modes de sortie
+
+`<Préfixe>Output` choisit ce qu'est la sortie, d'après `Window::OutputMode` dans
+`src/renderer/Window.h` :
+
+| Valeur | Nom | Sens |
+|---|---|---|
+| `0` | `OM_DISABLED` | la sortie n'existe pas |
+| `1` | `OM_WINDOW` | une fenêtre native à elle — le cas du cabinet |
+| `2` | `OM_EMBEDDED` | dessinée à l'intérieur de la fenêtre du plateau |
+
+Le mode `2` est ce qui permet à une installation mono-écran d'afficher un
+backglass ou un score view sans second écran : la surface est composée dans la
+fenêtre du plateau au lieu de recevoir une fenêtre propre.
+
+```mermaid
+flowchart LR
+    T[Table] --> PF[Fenêtre plateau]
+    T --> BG{BackglassOutput}
+    T --> SV{ScoreViewOutput}
+    BG -->|1 fenêtre| BGW[Fenêtre propre<br/>sur BackglassDisplay]
+    BG -->|2 intégré| PF
+    BG -->|0 désactivé| X[non rendu]
+    SV -->|1 fenêtre| SVW[Fenêtre propre<br/>sur ScoreViewDisplay]
+    SV -->|2 intégré| PF
+    SV -->|0 désactivé| X
+```
+
+## Nommer l'écran
+
+`<Préfixe>Display` contient un **nom** d'écran, pas un indice. VPX énumère les
+écrans via SDL, et le nom rapporté dépend du pilote vidéo utilisé : la même dalle
+peut apparaître comme `Iiyama North America 42"` sous Wayland, `DP-1 42"` sous
+XWayland et `PL4380UH 42"` sous une vraie session Xorg.
+
+Un nom écrit sous un pilote ne se résout donc pas sous un autre, et la fenêtre
+retombe sur l'écran principal. Ce n'est pas un défaut de l'ini : c'est ce qui
+arrive quand l'identité d'un écran vient du pilote.
+
+## Dimensions physiques
+
+Trois réglages de `[Player]` décrivent l'écran du plateau dans le monde réel, en
+centimètres, et n'ont rien à voir avec les pixels :
+
+| Clé | Plage | Défaut | Sens |
+|---|---|---|---|
+| `ScreenWidth` | 5–200 cm | 95,89 | largeur de la zone **visible** du plateau |
+| `ScreenHeight` | 5–200 cm | 53,94 | hauteur de cette zone |
+| `ScreenInclination` | −30…30 ° | 0 | inclinaison de l'écran, 0 étant l'horizontale |
+
+La description de la propriété précise **width > height** : ces valeurs se
+donnent en orientation paysage, même quand l'écran est monté en portrait dans le
+cabinet — c'est-à-dire dans tous les cabinets. Les intervertir sous prétexte que
+la dalle est debout est le moyen le plus simple de décadrer toutes les tables
+d'un coup. Il s'agit de la zone visible, pas de la diagonale de la dalle.
+
+Elles ont été introduites avec le travail sur les fenêtres et le point de vue
+([`cfdb53635`](https://github.com/vpinball/vpinball/commit/cfdb53635)) et sont
+exigées par l'ajustement automatique, qui refuse de s'exécuter sans elles — voir
+[Vue](view_fra.md#ce-que-lajustement-attend-de-la-table).
+
+## Sources
+
+- `src/core/Settings_properties.inl` — les onze clés par sortie, plages et défauts
+- `src/renderer/Window.h` — `OutputMode`, et ce qu'est réellement une fenêtre
+- `src/renderer/Window.cpp` — énumération des écrans et choix du mode


### PR DESCRIPTION
10.8.1 rewrote several subsystems rather than extending them. The settings that replaced the old ones aren't documented anywhere, so cabinet owners are currently reverse-engineering their own `VPinballX.ini` — reading source, or guessing.

The most visible symptom is the plunger: a sensor mapping's `scale` is a unit conversion that defaults to 1.0, so the launch impulse comes out two orders of magnitude short and nothing on screen says why. That's what sent me digging, and #3780 fixes the defaults — but the docs gap remains for anyone with an existing ini.

This adds `docs/10.8.1/`, eight chapters in English and French:

- **input** — the sensor mapping schema and its six fields, the unit scales, the three nudge modes and the hardcoded 1 m/s² intent threshold, the plumb
- **view** — the Window projection, the two autofit modes, the glass heights the frame is built from
- **window** — the four outputs and their shared schema, and the physical screen dimensions autofit needs
- **rendering** — frame pacing now being the default, the three AA stages, reflections, stereo
- **audio** — devices, the six speaker modes, and the per-source gain added in July
- **plugins** — one section per plugin, and why a disabled plugin's keys appear nowhere
- **vr** — OpenXR, cabinet placement, the preview window
- **removed** — what 10.8 had and no longer exists, with what replaced it, or the fact that nothing did

Everything was verified against the code rather than inferred from behaviour, and every chapter lists the files and functions it describes so a reader — or a future maintainer — can check whether it still holds. Where a change alters a way of reasoning rather than just a key, the mechanics are explained: the nudge chain and the tilt thresholds get the most space, since that's where the questions come from.

Two things worth flagging before review.

**Scope**: this covers changes since the 10.8.0 release, not since the CI's `VERSION_START_SHA`, which is the origin of the revision counter and predates 10.8.0 by three years.

**It's a first pass.** It's deliberately short, and it doesn't cover LiveUI, or the internal settings of plugins other than PinMAME. I'm happy to extend, restructure, drop the French, or fold it into the existing `docs/` layout — whatever fits how you'd like the docs to grow. If a section reads wrong, tell me which and I'll fix it against the code.


**AI disclosure**, per CONTRIBUTING.md — I should have put this in from the start, sorry. I wrote this with Claude Code: it read the source to establish each behaviour, and drafted the prose in both languages. I set the scope and the chapter structure, and I checked the content against the code myself. That's also why every chapter ends with the files and functions it describes: the claims are meant to be verifiable rather than taken on trust, by you now and by whoever maintains the docs later. The French is my own language, so I can vouch for that half directly.
