### PR TITLE
Log messages re deprecated apis and duplicate assets as warnings

### DIFF
--- a/plugins/pinmame/Controller.h
+++ b/plugins/pinmame/Controller.h
@@ -87,15 +87,15 @@ public:
    int GetRawDmdHeight();
    std::vector<uint8_t> GetRawDmdPixels();
    std::vector<uint32_t> GetRawDmdColoredPixels();
-   bool GetShowPinDMD() const { LOGE("ShowPinDMD is deprecated"s); return false; } // Deprecated as this must not be part of the table script but of the global setup
-   void SetShowPinDMD(bool v) const { LOGE("ShowPinDMD is deprecated"s); } // Deprecated as this must not be part of the table script but of the global setup
-   bool GetShowWinDMD() const { LOGE("ShowWinDMD is deprecated"s); return false; } // Deprecated (could be implemented as exposing or not the DMD, but there is no good use case for this)
-   void SetShowWinDMD(bool v) const { LOGE("ShowWinDMD is deprecated"s); } // Deprecated (could be implemented as exposing or not the DMD, but there is no good use case for this)
+   bool GetShowPinDMD() const { LOGW("ShowPinDMD is deprecated"s); return false; } // Deprecated as this must not be part of the table script but of the global setup
+   void SetShowPinDMD(bool v) const { LOGW("ShowPinDMD is deprecated"s); } // Deprecated as this must not be part of the table script but of the global setup
+   bool GetShowWinDMD() const { LOGW("ShowWinDMD is deprecated"s); return false; } // Deprecated (could be implemented as exposing or not the DMD, but there is no good use case for this)
+   void SetShowWinDMD(bool v) const { LOGW("ShowWinDMD is deprecated"s); } // Deprecated (could be implemented as exposing or not the DMD, but there is no good use case for this)
 
    // Note: we force input handling to be always disabled as it would lead to setup problems and conflicts.
    // All interactions must be performed through the script or plugin API
-   bool GetHandleKeyboard() const { LOGE("GetHandleKeyboard is deprecated"s); return false; }
-   void SetHandleKeyboard(const bool handle) { LOGE("SetHandleKeyboard is deprecated"s); }
+   bool GetHandleKeyboard() const { LOGW("GetHandleKeyboard is deprecated"s); return false; }
+   void SetHandleKeyboard(const bool handle) { LOGW("SetHandleKeyboard is deprecated"s); }
 
    // All these properties/methods are part of the VPinMAME IDL but doesn't seem to be used anywhere (or are deprecated)
    //STDMETHOD(get_DmdWidth)(/*[out, retval]*/ int *pVal);
@@ -131,25 +131,25 @@ public:
    //STDMETHOD(get_AudioDeviceModule)(/*[in]*/ int num, /*[out, retval]*/ BSTR *pVal);
    //STDMETHOD(get_CurrentAudioDevice)(/*[out, retval]*/ int *pVal);
    //STDMETHOD(put_CurrentAudioDevice)(/*[in]*/ int num);
-   bool GetLockDisplay() const { LOGE("LockDisplay is deprecated"s); return false; }
-   void SetLockDisplay(bool v) const { LOGE("LockDisplay is deprecated"s); }
-   bool GetDoubleSize() const { LOGE("DoubleSize is deprecated"s); return false; }
-   void SetDoubleSize(bool v) const { LOGE("DoubleSize is deprecated"s); }
-   bool GetShowFrame() const { LOGE("ShowFrame is deprecated"s); return false; }
-   void SetShowFrame(bool v) const { LOGE("ShowFrame is deprecated"s); }
-   bool GetShowDMDOnly() const { LOGE("ShowDMDOnly is deprecated"s); return false; }
-   void SetShowDMDOnly(bool v) const { LOGE("ShowDMDOnly is deprecated"s); }
-   bool GetShowTitle() const { LOGE("ShowTitle is deprecated"s); return false; }
-   void SetShowTitle(bool v) const { LOGE("ShowTitle is deprecated"s); }
-   int GetFastFrames() const { LOGE("FastFrames is deprecated"s); return 0; }
-   void SetFastFrames(int v) const { LOGE("FastFrames is deprecated"s); }
-   bool GetIgnoreRomCrc() const { LOGE("IgnoreRomCrc is deprecated"s); return false; }
-   void SetIgnoreRomCrc(bool v) const { LOGE("IgnoreRomCrc is deprecated"s); }
-   bool GetCabinetMode() const { LOGE("CabinetMode is deprecated"s); return false; }
-   void SetCabinetMode(bool v) const { LOGE("CabinetMode is deprecated"s); }
-   int GetSoundMode() const { LOGE("SoundMode is deprecated"s); return 0; }
-   void SetSoundMode(int v) const { LOGE("SoundMode is deprecated"s); }
-   void ShowOptsDialog(long hParentWnd = 0L) const { LOGE("ShowOptsDialog is deprecated"s); }
+   bool GetLockDisplay() const { LOGW("LockDisplay is deprecated"s); return false; }
+   void SetLockDisplay(bool v) const { LOGW("LockDisplay is deprecated"s); }
+   bool GetDoubleSize() const { LOGW("DoubleSize is deprecated"s); return false; }
+   void SetDoubleSize(bool v) const { LOGW("DoubleSize is deprecated"s); }
+   bool GetShowFrame() const { LOGW("ShowFrame is deprecated"s); return false; }
+   void SetShowFrame(bool v) const { LOGW("ShowFrame is deprecated"s); }
+   bool GetShowDMDOnly() const { LOGW("ShowDMDOnly is deprecated"s); return false; }
+   void SetShowDMDOnly(bool v) const { LOGW("ShowDMDOnly is deprecated"s); }
+   bool GetShowTitle() const { LOGW("ShowTitle is deprecated"s); return false; }
+   void SetShowTitle(bool v) const { LOGW("ShowTitle is deprecated"s); }
+   int GetFastFrames() const { LOGW("FastFrames is deprecated"s); return 0; }
+   void SetFastFrames(int v) const { LOGW("FastFrames is deprecated"s); }
+   bool GetIgnoreRomCrc() const { LOGW("IgnoreRomCrc is deprecated"s); return false; }
+   void SetIgnoreRomCrc(bool v) const { LOGW("IgnoreRomCrc is deprecated"s); }
+   bool GetCabinetMode() const { LOGW("CabinetMode is deprecated"s); return false; }
+   void SetCabinetMode(bool v) const { LOGW("CabinetMode is deprecated"s); }
+   int GetSoundMode() const { LOGW("SoundMode is deprecated"s); return 0; }
+   void SetSoundMode(int v) const { LOGW("SoundMode is deprecated"s); }
+   void ShowOptsDialog(long hParentWnd = 0L) const { LOGW("ShowOptsDialog is deprecated"s); }
    //STDMETHOD(ShowPathesDialog)(/*[in,defaultvalue(0)]*/ LONG_PTR hParentWnd);
    //STDMETHOD(SetDisplayPosition)(/*[in]*/ int x, /*[in]*/ int y, /*[in]*/ LONG_PTR hParentWindow);
    //STDMETHOD(CheckROMS)(/*[in,defaultvalue(0)]*/ int nShowOptions, /*[in,defaultvalue(0)]*/ LONG_PTR hParentWnd, /*[out, retval]*/ VARIANT_BOOL *pVal);

--- a/plugins/pinmame/GameSettings.h
+++ b/plugins/pinmame/GameSettings.h
@@ -25,8 +25,8 @@ public:
    //ScriptVariant GetValue(const string& name) const { return {}; /* Not yet implemented */ }
    //void PutValue(const string& name, ScriptVariant v) { /* Not yet implemented */ }
 
-   void SetDisplayPosition(float newValX, float newValY, void* hWnd = nullptr) { LOGE("Game.GameSettings.SetDisplayPosition is deprecated (display position is defined in user settings, not through script)."); }
-   void ShowSettingsDlg(void* hParentWnd = nullptr) { LOGE("Game.GameSettings.ShowSettingsDlg is deprecated (settings are managed by the host application, not through script)."); }
+   void SetDisplayPosition(float newValX, float newValY, void* hWnd = nullptr) { LOGW("Game.GameSettings.SetDisplayPosition is deprecated (display position is defined in user settings, not through script)."); }
+   void ShowSettingsDlg(void* hParentWnd = nullptr) { LOGW("Game.GameSettings.ShowSettingsDlg is deprecated (settings are managed by the host application, not through script)."); }
 
 private:
    std::unordered_map<string, int> m_values;

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -132,7 +132,7 @@ PinTable::~PinTable()
 
       for (size_t i = 0; i < m_vimage.size(); i++)
          delete m_vimage[i];
-  
+
       for (size_t i = 0; i < m_vfont.size(); i++)
       {
          m_vfont[i]->UnRegister();
@@ -160,7 +160,7 @@ PinTable::~PinTable()
 }
 
 void PinTable::UpdatePropertyImageList()
-{ 
+{
 #ifndef __STANDALONE__
     // just update the combo boxes in the property dialog
     g_pvp->GetPropertiesDocker()->GetContainProperties()->GetPropertyDialog()->UpdateTabs(m_vmultisel);
@@ -554,7 +554,7 @@ PinTable* PinTable::CopyForPlay()
    AddRef(); // as the live table holds a reference on this
 
    CComObject<PinTable> *dst = live_table;
-   
+
    dst->m_original_table_script = src->m_original_table_script;
    dst->m_external_script_name = src->m_external_script_name;
    dst->m_script_text = src->m_script_text;
@@ -1217,7 +1217,7 @@ void PinTable::Save(IObjectWriter& writer, const bool saveForUndo)
    writer.WriteFloat(FID(BOTM), m_bottom);
 
    writer.WriteBool(FID(EFSS), m_isFSSViewModeEnabled);
-   static constexpr int vsFields[NUM_BG_SETS][19] = { 
+   static constexpr int vsFields[NUM_BG_SETS][19] = {
       { FID(VSM0), FID(ROTA), FID(INCL), FID(LAYB), FID(FOVX), FID(XLTX), FID(XLTY), FID(XLTZ), FID(SCLX), FID(SCLY), FID(SCLZ), FID(HOF0), FID(VOF0), FID(WTX0), FID(WTY0), FID(WTZ0), FID(WBX0), FID(WBY0), FID(WBZ0) },
       { FID(VSM1), FID(ROTF), FID(INCF), FID(LAYF), FID(FOVF), FID(XLFX), FID(XLFY), FID(XLFZ), FID(SCFX), FID(SCFY), FID(SCFZ), FID(HOF1), FID(VOF1), FID(WTX1), FID(WTY1), FID(WTZ1), FID(WBX1), FID(WBY1), FID(WBZ1) },
       { FID(VSM2), FID(ROFS), FID(INFS), FID(LAFS), FID(FOFS), FID(XLXS), FID(XLYS), FID(XLZS), FID(SCXS), FID(SCYS), FID(SCZS), FID(HOF2), FID(VOF2), FID(WTX2), FID(WTY2), FID(WTZ2), FID(WBX2), FID(WBY2), FID(WBZ2) },
@@ -1541,7 +1541,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
             const int ctextures = m_loadTemp[2];
             const int cfonts = m_loadTemp[3];
             const int ccollection = m_loadTemp[4];
-            
+
             PLOGI << "PinTable Data loaded"; // For profiling
 
             feedback.AboutToProcessTable(csubobj + csounds + ctextures + cfonts);
@@ -1592,7 +1592,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
 
                      piedit->m_onLoadExpectedPartGroup.clear();
                      BiffReader reader(pstmItem, loadfileversion, (loadfileversion < 1000) ? hch : NULL, (loadfileversion < 1000) ? hkey : NULL); // 1000 (VP10 beta) removed the encryption //!! NO_ENCRYPTION_FORMAT_VERSION?
-                     piedit->Load(reader); 
+                     piedit->Load(reader);
                      pstmItem->Release();
                      pstmItem = nullptr;
                      if (reader.HasError())
@@ -1683,7 +1683,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                      {
                         const wstring oldName = part->GetIScriptable()->m_wzName;
                         part->GetIScriptable()->m_wzName = GetUniqueName(part->GetIScriptable()->m_wzName);
-                        PLOGE << "Duplicate part name found: " << MakeString(oldName) << " renamed it to " << MakeString(part->GetIScriptable()->m_wzName);
+                        PLOGW << "Duplicate part name found: " << MakeString(oldName) << " renamed it to " << MakeString(part->GetIScriptable()->m_wzName);
                      }
                      AddPart(part);
                      part->Release();
@@ -1817,7 +1817,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                      for (size_t i2 = i + 1; i2 < m_vsound.size(); ++i2)
                         if (sound->GetName() == m_vsound[i2]->GetName())
                         {
-                           PLOGE << "Duplicate sound name found: " << sound->GetName() << ", dropping it!";
+                           PLOGW << "Duplicate sound name found: " << sound->GetName() << ", dropping it!";
                            m_vsound.erase(m_vsound.begin() + i2);
                            --i2;
                         }
@@ -1838,7 +1838,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                      for (size_t i2 = i + 1; i2 < m_vimage.size(); ++i2)
                         if (image->m_name == m_vimage[i2]->m_name)
                         {
-                           PLOGE << "Duplicate image name found: " << image->GetName() << ", dropping it!";
+                           PLOGW << "Duplicate image name found: " << image->GetName() << ", dropping it!";
                            m_vimage.erase(m_vimage.begin() + i2);
                            --i2;
                         }
@@ -1892,7 +1892,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                      // Postpend "layer" to keep alphabetic order of layer
                      if (!layerPostpend && !layerName.ends_with(L"_Layer"))
                      {
-                        layerPostpend = true; 
+                        layerPostpend = true;
                         layerName += L"_Layer";
                      }
                      else
@@ -2095,7 +2095,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                   RenamePart(editable, shortName);
                });
          }
-         
+
          // Since 10.8.1, Flashers are allowed on a 2D backdrop, with advanced rendering capabilities.
          /* This code would replace a DMD textbox by a flasher. It is deactivated since it would break scripting (but does anyone script this ?)
          for (size_t i = 0; i < m_vedit.size(); ++i)
@@ -2188,7 +2188,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
 
    std::filesystem::path tablePath = std::filesystem::path(filename).parent_path();
    std::filesystem::path tableFile = std::filesystem::path(filename).filename();
-   
+
    // Auto-import POV settings, if it exists. This is kept for backward compatibility as POV settings
    // are now normal settings stored with others in app/table ini file. It will be only imported if there is no table ini file
    if (const std::filesystem::path filenameAuto = tablePath / tableFile.replace_extension(".pov"); !FileExists(GetSettingsFileName()) && FileExists(filenameAuto))
@@ -2235,7 +2235,7 @@ void PinTable::LoadScriptOverride(const std::filesystem::path& scriptPath)
       return;
    }
    PLOGI << "Loading script: " << scriptPath.string();
-   
+
    std::streamsize size = file.tellg();
    file.seekg(0, std::ios::beg);
    std::vector<char> buffer((size_t)size);
@@ -2433,7 +2433,7 @@ void PinTable::Load(IObjectReader& reader)
             break;
          case FID(BTST):
             // FIXME Before 10.8, user tweaks were stored in the table file (now moved to a user ini file), we import the legacy settings if there is no user ini file
-            if (const int ballTrailStrength = reader.AsInt(); !hasIni) 
+            if (const int ballTrailStrength = reader.AsInt(); !hasIni)
                m_settings.SetPlayer_BallTrailStrength(dequantizeUnsigned<8>(ballTrailStrength), true);
             break;
          case FID(UAOC): m_enableAO = reader.AsInt() != 0; break; // Before 10.8, 1 would force AO
@@ -3343,7 +3343,7 @@ void PinTable::ImportBackdropPOV(const std::filesystem::path &filename)
 #ifndef __STANDALONE__
       const string& initialDir = m_settings.GetRecentDir_POVDir();
       vector<string> fileNames;
-      if (!m_vpinball->OpenFileDialog(initialDir, fileNames, 
+      if (!m_vpinball->OpenFileDialog(initialDir, fileNames,
          "User settings file (*.ini)\0*.ini\0Old POV file (*.pov)\0*.pov\0Legacy POV file(*.xml)\0*.xml\0",
          "ini", 0, toUserSettings ? "Import POV to user settings"s : "Import POV to table properties"s))
          return;
@@ -3844,7 +3844,7 @@ void PinTable::ClearMultiSel(ISelect* newSel)
       m_vmultisel[i].m_selectstate = SelectState::NotSelected;
 
    //remove the clone of the multi selection in the smart browser class
-   //to sync the clone and the actual multi-selection 
+   //to sync the clone and the actual multi-selection
    //it will be updated again on AddMultiSel() call
    m_vmultisel.clear();
 

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1792,7 +1792,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                               backglass->m_d.m_depthBias = primitive->m_d.m_depthBias;
                               backglass->m_d.m_isVisible = primitive->m_d.m_visible;
                               primitive->m_d.m_visible = false;
-                              PLOGE << "Primitive '" << primitive->GetName() << "' used as a deprecated VR backglass was hidden and an external renderer flasher named '"
+                              PLOGW << "Primitive '" << primitive->GetName() << "' used as a deprecated VR backglass was hidden and an external renderer flasher named '"
                                     << backglass->GetName() << "' was added. This may cause script issues.";
                               AddPart(backglass);
                               backglass->Release();
@@ -6947,20 +6947,20 @@ void PinTable::ShowWhereMaterialUsed(vector<WhereUsedInfo> &vWhereUsed, Material
 
 STDMETHODIMP PinTable::get_ReflectElementsOnPlayfield(VARIANT_BOOL *pVal)
 {
-   PLOGE << "ReflectElementsOnPlayfield is deprecated";
+   PLOGW << "ReflectElementsOnPlayfield is deprecated";
    *pVal = FTOVB(true);
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_ReflectElementsOnPlayfield(VARIANT_BOOL newVal)
 {
-   PLOGE << "ReflectElementsOnPlayfield is deprecated";
+   PLOGW << "ReflectElementsOnPlayfield is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_YieldTime(LONG *pVal)
 {
-   PLOGE << "YieldTime is deprecated";
+   PLOGW << "YieldTime is deprecated";
    *pVal = 0;
    if (!g_pplayer)
       return E_FAIL;
@@ -6969,7 +6969,7 @@ STDMETHODIMP PinTable::get_YieldTime(LONG *pVal)
 
 STDMETHODIMP PinTable::put_YieldTime(LONG newVal)
 {
-   PLOGE << "YieldTime is deprecated";
+   PLOGW << "YieldTime is deprecated";
    if (!g_pplayer)
       return E_FAIL;
    return S_OK;
@@ -6977,138 +6977,138 @@ STDMETHODIMP PinTable::put_YieldTime(LONG newVal)
 
 STDMETHODIMP PinTable::get_TableHeight(float *pVal)
 {
-   PLOGE << "TableHeight is deprecated";
+   PLOGW << "TableHeight is deprecated";
    *pVal = 0.f;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_TableHeight(float newVal)
 {
-   PLOGE << "TableHeight is deprecated";
+   PLOGW << "TableHeight is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_TableAdaptiveVSync(int *pVal)
 {
-   PLOGE << "TableAdaptiveVSync is deprecated";
+   PLOGW << "TableAdaptiveVSync is deprecated";
    *pVal = -1;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_TableAdaptiveVSync(int newVal)
 {
-   PLOGE << "TableAdaptiveVSync is deprecated";
+   PLOGW << "TableAdaptiveVSync is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_GlobalAlphaAcc(VARIANT_BOOL *pVal)
 {
-   PLOGE << "GlobalAlphaAcc is deprecated";
+   PLOGW << "GlobalAlphaAcc is deprecated";
    *pVal = (VARIANT_BOOL)-1;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_GlobalAlphaAcc(VARIANT_BOOL newVal)
 {
-   PLOGE << "GlobalAlphaAcc is deprecated";
+   PLOGW << "GlobalAlphaAcc is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_GlobalDayNight(VARIANT_BOOL *pVal)
 {
-   PLOGE << "GlobalDayNight is deprecated";
+   PLOGW << "GlobalDayNight is deprecated";
    *pVal = (VARIANT_BOOL)0;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_GlobalDayNight(VARIANT_BOOL newVal)
 {
-   PLOGE << "GlobalDayNight is deprecated";
+   PLOGW << "GlobalDayNight is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_GlobalStereo3D(VARIANT_BOOL *pVal)
 {
-   PLOGE << "GlobalStereo3D is deprecated";
+   PLOGW << "GlobalStereo3D is deprecated";
    *pVal = (VARIANT_BOOL)0;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_GlobalStereo3D(VARIANT_BOOL newVal)
 {
-   PLOGE << "GlobalStereo3D is deprecated";
+   PLOGW << "GlobalStereo3D is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_MaxSeparation(float *pVal)
 {
-   PLOGE << "MaxSeparation is deprecated";
+   PLOGW << "MaxSeparation is deprecated";
    *pVal = 0.f;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_MaxSeparation(float newVal)
 {
-   PLOGE << "MaxSeparation is deprecated";
+   PLOGW << "MaxSeparation is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_ZPD(float *pVal)
 {
-   PLOGE << "ZPD is deprecated";
+   PLOGW << "ZPD is deprecated";
    *pVal = 0.f;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_ZPD(float newVal)
 {
-   PLOGE << "ZPD is deprecated";
+   PLOGW << "ZPD is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_Offset(float *pVal)
 {
-   PLOGE << "3D Offset is deprecated";
+   PLOGW << "3D Offset is deprecated";
    *pVal = 0.f;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Offset(float newVal)
 {
-   PLOGE << "3D Offset is deprecated";
+   PLOGW << "3D Offset is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_PlungerFilter(VARIANT_BOOL *pVal)
 {
-   PLOGE << "PlungerFilter is deprecated";
+   PLOGW << "PlungerFilter is deprecated";
    *pVal = (VARIANT_BOOL)0;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_PlungerFilter(VARIANT_BOOL newVal)
 {
-   PLOGE << "PlungerFilter is deprecated";
+   PLOGW << "PlungerFilter is deprecated";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_PlungerNormalize(int *pVal)
 {
-   PLOGE << "PlungerNormalize is deprecated";
+   PLOGW << "PlungerNormalize is deprecated";
    *pVal = 100;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_PlungerNormalize(int newVal)
 {
-   PLOGE << "PlungerNormalize is deprecated";
+   PLOGW << "PlungerNormalize is deprecated";
    return S_OK;
 }
 
 // Changing AA & FXAA is somewhat wrong as it changes the setting for all time, and is not implemented while playing, so this is just a No-Op
 STDMETHODIMP PinTable::get_EnableAntialiasing(UserDefaultOnOff *pVal)
 {
-   PLOGE << "EnableAntialiasing is deprecated";
+   PLOGW << "EnableAntialiasing is deprecated";
    *pVal = UserDefaultOnOff::Default;
    return S_OK;
 }
@@ -7116,14 +7116,14 @@ STDMETHODIMP PinTable::get_EnableAntialiasing(UserDefaultOnOff *pVal)
 // Changing AA & FXAA is somewhat wrong as it changes the setting for all time, and is not implemented while playing, so this is just a No-Op
 STDMETHODIMP PinTable::put_EnableAntialiasing(UserDefaultOnOff newVal)
 {
-   PLOGE << "EnableAntialiasing is deprecated";
+   PLOGW << "EnableAntialiasing is deprecated";
    return S_OK;
 }
 
 // Changing AA & FXAA is somewhat wrong as it changes the setting for all time, and is not implemented while playing, so this is just a No-Op
 STDMETHODIMP PinTable::get_EnableFXAA(FXAASettings *pVal)
 {
-   PLOGE << "EnableFXAA is deprecated";
+   PLOGW << "EnableFXAA is deprecated";
    *pVal = FXAASettings::Defaults;
    return S_OK;
 }
@@ -7131,7 +7131,7 @@ STDMETHODIMP PinTable::get_EnableFXAA(FXAASettings *pVal)
 // Changing AA & FXAA is somewhat wrong as it changes the setting for all time, and is not implemented while playing, so this is just a No-Op
 STDMETHODIMP PinTable::put_EnableFXAA(FXAASettings newVal)
 {
-   PLOGE << "EnableFXAA is deprecated";
+   PLOGW << "EnableFXAA is deprecated";
    return S_OK;
 }
 
@@ -7139,27 +7139,27 @@ STDMETHODIMP PinTable::put_EnableFXAA(FXAASettings newVal)
 
 STDMETHODIMP PinTable::get_BackglassMode(BackglassIndex *pVal)
 {
-   PLOGE << "BackglassMode is deprecated";
+   PLOGW << "BackglassMode is deprecated";
    *pVal = static_cast<BackglassIndex>(static_cast<int>(m_viewMode) + static_cast<int>(DESKTOP));
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_BackglassMode(BackglassIndex pVal)
 {
-   PLOGE << "BackglassMode is deprecated and ignored, this call has no effect";
+   PLOGW << "BackglassMode is deprecated and ignored, this call has no effect";
    return S_OK;
 }
 
 STDMETHODIMP PinTable::get_FieldOfView(float *pVal)
 {
-   PLOGE << "FieldOfView is deprecated";
+   PLOGW << "FieldOfView is deprecated";
    *pVal = mViewSetups[m_viewMode].mFOV;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_FieldOfView(float newVal)
 {
-   PLOGE << "FieldOfView is deprecated";
+   PLOGW << "FieldOfView is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mFOV = newVal;
    STOPUNDO
@@ -7169,14 +7169,14 @@ STDMETHODIMP PinTable::put_FieldOfView(float newVal)
 
 STDMETHODIMP PinTable::get_Inclination(float *pVal)
 {
-   PLOGE << "Inclination is deprecated";
+   PLOGW << "Inclination is deprecated";
    *pVal = mViewSetups[m_viewMode].mLookAt;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Inclination(float newVal)
 {
-   PLOGE << "Inclination is deprecated";
+   PLOGW << "Inclination is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mLookAt = newVal;
    STOPUNDO
@@ -7186,14 +7186,14 @@ STDMETHODIMP PinTable::put_Inclination(float newVal)
 
 STDMETHODIMP PinTable::get_Layback(float *pVal)
 {
-   PLOGE << "Layback is deprecated";
+   PLOGW << "Layback is deprecated";
    *pVal = mViewSetups[m_viewMode].mLayback;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Layback(float newVal)
 {
-   PLOGE << "Layback is deprecated";
+   PLOGW << "Layback is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mLayback = newVal;
    STOPUNDO
@@ -7203,14 +7203,14 @@ STDMETHODIMP PinTable::put_Layback(float newVal)
 
 STDMETHODIMP PinTable::get_Rotation(float *pVal)
 {
-   PLOGE << "Rotation is deprecated";
+   PLOGW << "Rotation is deprecated";
    *pVal = mViewSetups[m_viewMode].mViewportRotation;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Rotation(float newVal)
 {
-   PLOGE << "Rotation is deprecated";
+   PLOGW << "Rotation is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mViewportRotation = newVal;
    STOPUNDO
@@ -7220,14 +7220,14 @@ STDMETHODIMP PinTable::put_Rotation(float newVal)
 
 STDMETHODIMP PinTable::get_Scalex(float *pVal)
 {
-   PLOGE << "Scalex is deprecated";
+   PLOGW << "Scalex is deprecated";
    *pVal = mViewSetups[m_viewMode].mSceneScaleX;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Scalex(float newVal)
 {
-   PLOGE << "Scalex is deprecated";
+   PLOGW << "Scalex is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mSceneScaleX = newVal;
    STOPUNDO
@@ -7237,14 +7237,14 @@ STDMETHODIMP PinTable::put_Scalex(float newVal)
 
 STDMETHODIMP PinTable::get_Scaley(float *pVal)
 {
-   PLOGE << "Scaley is deprecated";
+   PLOGW << "Scaley is deprecated";
    *pVal = mViewSetups[m_viewMode].mSceneScaleY;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Scaley(float newVal)
 {
-   PLOGE << "Scaley is deprecated";
+   PLOGW << "Scaley is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mSceneScaleY = newVal;
    STOPUNDO
@@ -7254,14 +7254,14 @@ STDMETHODIMP PinTable::put_Scaley(float newVal)
 
 STDMETHODIMP PinTable::get_Scalez(float *pVal)
 {
-   PLOGE << "Scalez is deprecated";
+   PLOGW << "Scalez is deprecated";
    *pVal = mViewSetups[m_viewMode].mSceneScaleZ;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Scalez(float newVal)
 {
-   PLOGE << "Scalez is deprecated";
+   PLOGW << "Scalez is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mSceneScaleZ = newVal;
    STOPUNDO
@@ -7271,14 +7271,14 @@ STDMETHODIMP PinTable::put_Scalez(float newVal)
 
 STDMETHODIMP PinTable::get_Xlatex(float *pVal)
 {
-   PLOGE << "Xlatex is deprecated";
+   PLOGW << "Xlatex is deprecated";
    *pVal = mViewSetups[m_viewMode].mViewX;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Xlatex(float newVal)
 {
-   PLOGE << "Xlatex is deprecated";
+   PLOGW << "Xlatex is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mViewX = newVal;
    STOPUNDO
@@ -7288,14 +7288,14 @@ STDMETHODIMP PinTable::put_Xlatex(float newVal)
 
 STDMETHODIMP PinTable::get_Xlatey(float *pVal)
 {
-   PLOGE << "Xlatey is deprecated";
+   PLOGW << "Xlatey is deprecated";
    *pVal = mViewSetups[m_viewMode].mViewY;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Xlatey(float newVal)
 {
-   PLOGE << "Xlatey is deprecated";
+   PLOGW << "Xlatey is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mViewY = newVal;
    STOPUNDO
@@ -7305,14 +7305,14 @@ STDMETHODIMP PinTable::put_Xlatey(float newVal)
 
 STDMETHODIMP PinTable::get_Xlatez(float *pVal)
 {
-   PLOGE << "Xlatez is deprecated";
+   PLOGW << "Xlatez is deprecated";
    *pVal = mViewSetups[m_viewMode].mViewZ;
    return S_OK;
 }
 
 STDMETHODIMP PinTable::put_Xlatez(float newVal)
 {
-   PLOGE << "Xlatez is deprecated";
+   PLOGW << "Xlatez is deprecated";
    STARTUNDO
    mViewSetups[m_viewMode].mViewZ = newVal;
    STOPUNDO


### PR DESCRIPTION
Changes "deprecated" and "duplicate name" log messages from error level to warning level. These messages are triggered by table data (old scripts calling deprecated APIs, tables with duplicate asset names) and are handled gracefully (returns defaults, skips duplicates, renames conflicts), so warning is the appropriate severity.
