### PR TITLE
Nudge: fix spurious tilt on first nudge with an event-driven accelerometer

### DIFF
--- a/src/physics/cabinet/CabinetNudgeSensor.cpp
+++ b/src/physics/cabinet/CabinetNudgeSensor.cpp
@@ -163,6 +163,11 @@ void CabinetNudgeSensor::UpdateAxisSensor(SyncedSensor& sensor, MotionKalmanAxis
       alignedTimestampNS = m_timeNs;
    }
 
+   // An event-driven sensor sends nothing while at rest, so its first sample is motion, not bias.
+   // Seed with zero bias in that case rather than let it be taken for the sensor's zero offset.
+   if (!axis.IsInitialized() && fabsf(sensor.m_sensor.GetValue()) >= restThresold)
+      axis.Reset(alignedTimestampNS);
+
    if (sensor.m_sensor.GetType() == SensorMapping::Type::Velocity)
    {
       axis.UpdateVelocity(alignedTimestampNS, axisGain * sensor.m_sensor.GetValue());


### PR DESCRIPTION
Small fix that constrains the Kalman filter's initial state. Two lines.

## What I hit

On my cabinet (Pinscape KL25Z on the nudge X/Y axes), the **first** nudge after a table starts sends the tilt bob straight to maximum and usually trips a tilt. A few seconds later it settles and every nudge afterwards is fine. Once per table load, every table. I'd been shaking the cabinet a little before starting a game to get past it.

Introduced by 724ec2c53 (nudge & plunger sensor rewrite), which added `MotionKalmanAxis` and its bias state.

## Reproduce

Cabinet with an accelerometer reaching VPX through the SDL joystick path (`Mapping.NudgeN.AccX/AccY`, Cabinet Sensor type).

1. Start a table.
2. Leave the cabinet alone ~10 seconds. Bob sits still, correctly.
3. One firm nudge → bob goes to the tilt limit.
4. Wait ~5 seconds, nudge again the same way → normal.

## Cause and change

**Cause**

- `MotionKalmanAxis::UpdateAcceleration` files its first-ever sample entirely into the acceleration bias — *"Practical idle-start assumption: first measured acceleration is bias-dominated"*.
- That assumes the sensor streams continuously at rest. SDL only emits a joystick event when an axis value *changes*, so a still cabinet emits nothing and the first sample VPX sees is the player's nudge.
- Stored as bias, it's then subtracted from every later sample until `m_biasMeanReversionTimeS` (~5s) drains it — long enough to push the plumb past the tilt threshold.

**Change**

- If the filter is still uninitialised **and** the sample is above the existing rest threshold — motion, not a resting offset — initialise with zero bias and let it take the normal measurement path.
- Sensors that do report at rest are untouched: their first sample falls below the rest threshold, so the current idle-start assumption still applies.

**Evidence** (1ms instrumentation of `CabinetNudgeSensor` and `PlumbHandler`)

- 8.5s of idle produced exactly one non-zero sample; Kalman state stayed `(0,0)` throughout.
- First sample `-14.956 m/s²` filed as bias. Next sample `6.137` → `6.137 - (-14.956) = 21.09`, against an observed `kalX` of `20.864`.
- Peak filter output `20.864` vs peak measurement `14.956` — **40% above the largest measurement it ever received**, which shouldn't be possible for an acceleration estimator fed acceleration.
- With the change: zero tilted samples, peak bob angle 2.276° against the 4.0° threshold, and the first nudge peaks within 2% of the average of later nudges.

## Disclosure

Per CONTRIBUTING.md: **this fix was generated with AI assistance, so I'm opening it as a draft** — a starting point for the final solution rather than a finished, reviewed contribution.

I hit the bug and did the testing on real hardware — reproduction, 1ms captures and before/after measurements are all from my cabinet, on Windows x64 / BGFX with Black Pyramid and the Nudge Test and Calibration table. The root-cause analysis and the patch came from Claude working through the code with me.
