### PR TITLE
liveui: stack widgets below labels on narrow displays (fixes mobile)

### DIFF
--- a/src/ui/live/ingameui/InGameUIPage.cpp
+++ b/src/ui/live/ingameui/InGameUIPage.cpp
@@ -614,8 +614,11 @@ void InGameUIPage::Render(float elapsedS)
       if (item->IsAdjustable())
          maxLabelWidth = max(maxLabelWidth, ImGui::CalcTextSize(item->m_label.c_str()).x);
    maxLabelWidth = min(maxLabelWidth, ImGui::CalcTextSize("Maximum label length before ellipsis").x);
-   const float labelEndScreenX = ImGui::GetCursorScreenPos().x + maxLabelWidth + style.ItemSpacing.x * 2.0f + 30.f;
-   const float itemEndScreenX = ImGui::GetCursorScreenPos().x + ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize("*", nullptr, true).x - itemPadding.x;
+   const float rowStartScreenX = ImGui::GetCursorScreenPos().x;
+   const float labelEndScreenX = rowStartScreenX + maxLabelWidth + style.ItemSpacing.x * 2.0f + 30.f;
+   const float itemEndScreenX = rowStartScreenX + ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize("*", nullptr, true).x - itemPadding.x;
+   const bool stackFields = (itemEndScreenX - labelEndScreenX) < 12.f * ImGui::GetFontSize();
+   const float labelMaxWidth = stackFields ? itemEndScreenX - rowStartScreenX : maxLabelWidth;
    const float closeButtonWidth = ImGui::CalcTextSize(ICON_FK_TIMES, nullptr, true).x + style.FramePadding.x * 2.0f;
    const float circleTextWidth = ImGui::CalcTextSize(ICON_FK_CIRCLE, nullptr, true).x + style.FramePadding.x * 2.0f;
    for (int i = 0; i < (int)m_items.size(); i++)
@@ -634,7 +637,9 @@ void InGameUIPage::Render(float elapsedS)
       if (item->m_type == Back || item->m_type == SaveChanges || item->m_type == ResetToDefaults || item->m_type == ResetToStoredValues)
          continue;
 
-      const float itemHeight = ImGui::GetTextLineHeight() + itemPadding.y * 2.f;
+      const bool isStackedItem = stackFields && item->IsAdjustable() && !(item->m_type == Property && item->m_property->m_type == VPX::Properties::PropertyDef::Type::Bool);
+      const float rowHeight = isStackedItem ? ImGui::GetTextLineHeight() + itemPadding.y + ImGui::GetFrameHeight() : ImGui::GetTextLineHeight();
+      const float itemHeight = rowHeight + itemPadding.y * 2.f;
       const bool isMouseOver = (ImGui::IsWindowHovered()) && (ImGui::GetMousePos().y >= ImGui::GetCursorScreenPos().y - itemPadding.y - 1.f)
          && (ImGui::GetMousePos().y <= ImGui::GetCursorScreenPos().y + itemHeight - itemPadding.y);
       const bool hovered = (m_player->m_liveUI->m_inGameUI.IsFlipperNav() && i == m_selectedItem) || (!m_player->m_liveUI->m_inGameUI.IsFlipperNav() && isMouseOver && item->IsSelectable());
@@ -643,7 +648,7 @@ void InGameUIPage::Render(float elapsedS)
          hoveredItem = item.get();
          ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
          ImGui::GetWindowDrawList()->AddRectFilled(ImGui::GetCursorScreenPos() - itemPadding,
-            ImGui::GetCursorScreenPos() + ImVec2(itemPadding.x, itemPadding.y * 2.f) + ImVec2(itemEndScreenX - ImGui::GetCursorScreenPos().x + itemPadding.x, ImGui::GetTextLineHeight()),
+            ImGui::GetCursorScreenPos() + ImVec2(itemPadding.x, itemPadding.y * 2.f) + ImVec2(itemEndScreenX - ImGui::GetCursorScreenPos().x + itemPadding.x, rowHeight),
             IM_COL32(0, 255, 0, 50));
          if (m_player->m_liveUI->m_inGameUI.IsFlipperNav())
          {
@@ -726,10 +731,11 @@ void InGameUIPage::Render(float elapsedS)
 
       case ActionInputMapping:
       {
-         ImGui::Text("%s", item->m_label.c_str());
+         TextWithEllipsis(item->m_label, labelMaxWidth);
          if (item->m_inputAction->IsMapped())
          {
-            ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
+            if (!stackFields)
+               ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
             if (ImGui::Button(std::format("{}##Item{:d}", ICON_FK_TIMES, i).c_str(), ImVec2(closeButtonWidth, 0)))
             {
                item->m_inputAction->ClearMapping();
@@ -741,9 +747,13 @@ void InGameUIPage::Render(float elapsedS)
             }
             ImGui::SameLine();
          }
-         else
+         else if (!stackFields)
          {
             ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x + closeButtonWidth + style.ItemSpacing.x);
+         }
+         else
+         {
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + closeButtonWidth + style.ItemSpacing.x);
          }
          const string mappingLabel = item->m_inputAction->GetMappingLabel();
          const float mapButtonWidth = itemEndScreenX - ImGui::GetCursorScreenPos().x - circleTextWidth - style.ItemSpacing.x;
@@ -773,8 +783,9 @@ void InGameUIPage::Render(float elapsedS)
          case VPX::Properties::PropertyDef::Type::Float:
          {
             auto prop = dynamic_cast<VPX::Properties::FloatPropertyDef*>(item->m_property.get());
-            ImGui::Text("%s", prop->m_label.c_str());
-            ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
+            TextWithEllipsis(prop->m_label, labelMaxWidth);
+            if (!stackFields)
+               ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
             float v = item->GetFloatValue() * item->m_floatValueDisplayScale;
             ImGui::SetNextItemWidth(itemEndScreenX - ImGui::GetCursorScreenPos().x);
             ImGui::SliderFloat(std::format("##Item{}", i).c_str(), &v, prop->m_min * item->m_floatValueDisplayScale,
@@ -798,8 +809,9 @@ void InGameUIPage::Render(float elapsedS)
          case VPX::Properties::PropertyDef::Type::Int:
          {
             auto prop = dynamic_cast<VPX::Properties::IntPropertyDef*>(item->m_property.get());
-            TextWithEllipsis(prop->m_label, maxLabelWidth);
-            ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
+            TextWithEllipsis(prop->m_label, labelMaxWidth);
+            if (!stackFields)
+               ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
             int v = item->GetIntValue();
             const auto id = Settings::GetRegistry().GetPropertyId(item->m_property->m_groupId, item->m_property->m_propId);
             if (id.has_value() && (((Settings::m_propPlayer_PlayfieldWidth.index == id.value().index) || (Settings::m_propPlayer_PlayfieldHeight.index == id.value().index)) && !m_player->m_liveUI->m_inGameUI.IsFlipperNav()))
@@ -834,8 +846,9 @@ void InGameUIPage::Render(float elapsedS)
          case VPX::Properties::PropertyDef::Type::Enum:
          {
             auto prop = dynamic_cast<VPX::Properties::EnumPropertyDef*>(item->m_property.get());
-            TextWithEllipsis(prop->m_label, maxLabelWidth);
-            ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
+            TextWithEllipsis(prop->m_label, labelMaxWidth);
+            if (!stackFields)
+               ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
             int v = item->GetIntValue() - prop->m_min;
             ImGui::SetNextItemWidth(itemEndScreenX - ImGui::GetCursorScreenPos().x);
             ImGui::Combo(std::format("##Item{}", i).c_str(), &v,
@@ -865,8 +878,11 @@ void InGameUIPage::Render(float elapsedS)
          case VPX::Properties::PropertyDef::Type::Bool:
          {
             auto prop = dynamic_cast<VPX::Properties::BoolPropertyDef*>(item->m_property.get());
-            ImGui::Text("%s", prop->m_label.c_str());
-            ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
+            TextWithEllipsis(prop->m_label, stackFields ? itemEndScreenX - rowStartScreenX - ImGui::GetFrameHeight() * 1.75f - style.ItemSpacing.x : maxLabelWidth);
+            if (stackFields)
+               ImGui::SameLine();
+            else
+               ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
             bool v = item->GetBoolValue();
             RenderToggle(std::format("{}##Item{}", prop->m_label, i), ImVec2(itemEndScreenX - ImGui::GetCursorScreenPos().x, ImGui::GetFrameHeight()), v);
             if (item->IsModified())
@@ -887,8 +903,9 @@ void InGameUIPage::Render(float elapsedS)
          case VPX::Properties::PropertyDef::Type::String:
          {
             auto prop = dynamic_cast<VPX::Properties::StringPropertyDef*>(item->m_property.get());
-            ImGui::Text("%s", prop->m_label.c_str());
-            ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
+            TextWithEllipsis(prop->m_label, labelMaxWidth);
+            if (!stackFields)
+               ImGui::SameLine(labelEndScreenX - ImGui::GetCursorScreenPos().x);
             string v = item->GetStringValue();
             ImGui::SetNextItemWidth(itemEndScreenX - ImGui::GetCursorScreenPos().x);
             ImGui::InputText(std::format("##Item{}", i).c_str(), &v);


### PR DESCRIPTION
This PR will stack LiveUI widgets on smaller displays like phones.

**Before:**
<img width="1320" height="2868" alt="image0" src="https://github.com/user-attachments/assets/f250c314-b84b-4233-9cf0-b56dfe1dd5a6" />


**After:**
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/e1779f5b-8707-4139-b6cd-ab062f9366e4" />
