### PR TITLE
Fix BX_CONFIG_DEBUG for build types other than Debug and Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,8 +226,7 @@ if(PLATFORM STREQUAL "windows")
       )
       target_compile_definitions(vpinball PRIVATE
          ENABLE_BGFX
-         $<$<CONFIG:Debug>:BX_CONFIG_DEBUG=1>
-         $<$<CONFIG:Release>:BX_CONFIG_DEBUG=0>
+         $<IF:$<CONFIG:Debug>,BX_CONFIG_DEBUG=1,BX_CONFIG_DEBUG=0>
       )
    elseif(RENDERER STREQUAL "GL")
       target_sources(vpinball PRIVATE
@@ -561,8 +560,7 @@ elseif(PLATFORM STREQUAL "macos")
       target_compile_definitions(vpinball PRIVATE
          ENABLE_BGFX
 
-         $<$<CONFIG:Debug>:BX_CONFIG_DEBUG=1>
-         $<$<CONFIG:Release>:BX_CONFIG_DEBUG=0>
+         $<IF:$<CONFIG:Debug>,BX_CONFIG_DEBUG=1,BX_CONFIG_DEBUG=0>
       )
    else()
       target_compile_definitions(vpinball PRIVATE
@@ -682,8 +680,7 @@ elseif(PLATFORM STREQUAL "linux")
       target_compile_definitions(vpinball PRIVATE
          ENABLE_BGFX
 
-         $<$<CONFIG:Debug>:BX_CONFIG_DEBUG=1>
-         $<$<CONFIG:Release>:BX_CONFIG_DEBUG=0>
+         $<IF:$<CONFIG:Debug>,BX_CONFIG_DEBUG=1,BX_CONFIG_DEBUG=0>
       )
    else()
       target_compile_definitions(vpinball PRIVATE
@@ -829,8 +826,7 @@ elseif(PLATFORM STREQUAL "ios" OR PLATFORM STREQUAL "ios-simulator" OR PLATFORM 
 
       ENABLE_BGFX
       $<$<BOOL:${ENABLE_XR}>:ENABLE_XR>
-      $<$<CONFIG:Debug>:BX_CONFIG_DEBUG=1>
-      $<$<CONFIG:Release>:BX_CONFIG_DEBUG=0>
+      $<IF:$<CONFIG:Debug>,BX_CONFIG_DEBUG=1,BX_CONFIG_DEBUG=0>
    )
 
    target_compile_options(vpinball PUBLIC


### PR DESCRIPTION
`BX_CONFIG_DEBUG` was set by a pair of generator expressions, one for `Debug` and one for
`Release`. Any other configuration matches neither, so the define is absent and
`third-party/include/bx/config.h` stops the build with:

```
error "BX_CONFIG_DEBUG must be defined in build script!"
```

That makes `-DCMAKE_BUILD_TYPE=RelWithDebInfo` and `MinSizeRel` fail outright on macos, linux,
ios and android. The windows-mingw target already used the single-expression form and was
unaffected, so this just makes the other four match it.

Checked on macos by reading the define out of `flags.make` for each build type:

| build type | before | after |
| --- | --- | --- |
| Debug | `BX_CONFIG_DEBUG=1` | `BX_CONFIG_DEBUG=1` |
| Release | `BX_CONFIG_DEBUG=0` | `BX_CONFIG_DEBUG=0` |
| RelWithDebInfo | absent, build fails | `BX_CONFIG_DEBUG=0` |
| MinSizeRel | absent, build fails | `BX_CONFIG_DEBUG=0` |

`Debug` and `Release` are unchanged.

Found while trying to build `RelWithDebInfo` to run a sanitizer against optimised code, which
is also the case it is most useful for.

Written with AI assistance; I verified the behaviour above myself.