### PR TITLE
Ignore the clangd index cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ VisualPinball.sln
 /*.vcxproj
 /*.vcxproj.filters
 /.build
+
+/.cache/


### PR DESCRIPTION
clangd writes its index to `.cache/clangd` whenever it finds a `compile_commands.json` in the
project root, which the CMake build generates. The directory then shows up as untracked in
every `git status` and has to be scrolled past when reviewing changes.

Root-anchored to match the existing entries nearby, `/.build` and `/*.vcxproj`.

Written with AI assistance.