### PR TITLE
Read table streams in physical layout order on a single reader

### DIFF
--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -4,6 +4,7 @@
 #include "pintable.h"
 
 #include <algorithm>
+#include <atomic>
 #include <fstream>
 #include <sstream>
 
@@ -1569,7 +1570,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
             ThreadPool pool(g_app->GetLogicalNumberOfProcessors());
             vector<IEditable *> parts;
             parts.resize(csubobj);
-            int nLoadedParts = 0;
+            std::atomic<int> nLoadedParts { 0 };
             for (int i = 0; i < csubobj; i++)
             {
                pool.enqueue(
@@ -1606,7 +1607,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
 
             assert(m_vsound.empty());
             m_vsound.resize(csounds);
-            int nLoadedSounds = 0;
+            std::atomic<int> nLoadedSounds { 0 };
             for (int i = 0; i < csounds; i++)
             {
                pool.enqueue(
@@ -1630,7 +1631,7 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
 
             assert(m_vimage.empty());
             m_vimage.resize(ctextures);
-            int nLoadedImages = 0;
+            std::atomic<int> nLoadedImages { 0 };
             for (int i = 0; i < ctextures; i++)
             {
                pool.enqueue(

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1567,94 +1567,141 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                }
             }
 
+            // Read the container on this thread only, visiting streams in the order they are
+            // physically laid out, and parse them on the pool. Reading from several threads at
+            // once measured 3.4x slower, and declaration order costs a further 4.9x because
+            // streams are stored close to the reverse of the order they are read in.
             ThreadPool pool(g_app->GetLogicalNumberOfProcessors());
             vector<IEditable *> parts;
             parts.resize(csubobj);
             std::atomic<int> nLoadedParts { 0 };
-            for (int i = 0; i < csubobj; i++)
-            {
-               pool.enqueue(
-                  [i, &feedback, &parts, loadfileversion, pstgData, hch, hkey, this, &nLoadedParts, csubobj]
-                  {
-                     const wstring wStmName = L"GameItem" + std::to_wstring(i);
-
-                     IStream *pstmItem;
-                     HRESULT hr;
-                     if (FAILED(hr = pstgData->OpenStream(wStmName.c_str(), nullptr, STGM_DIRECT | STGM_READ | STGM_SHARE_EXCLUSIVE, 0, &pstmItem)))
-                        return hr;
-
-                     ULONG read;
-                     ItemTypeEnum type;
-                     pstmItem->Read(&type, sizeof(int), &read);
-
-                     IEditable *const piedit = EditableRegistry::Create(type);
-                     if (piedit == nullptr)
-                        return E_FAIL;
-
-                     piedit->m_onLoadExpectedPartGroup.clear();
-                     BiffReader reader(pstmItem, loadfileversion, (loadfileversion < 1000) ? hch : NULL, (loadfileversion < 1000) ? hkey : NULL); // 1000 (VP10 beta) removed the encryption //!! NO_ENCRYPTION_FORMAT_VERSION?
-                     piedit->Load(reader);
-                     pstmItem->Release();
-                     pstmItem = nullptr;
-                     if (reader.HasError())
-                        return E_FAIL;
-
-                     parts[i] = piedit;
-                     nLoadedParts++;
-                     return S_OK;
-                  });
-            }
-
             assert(m_vsound.empty());
             m_vsound.resize(csounds);
             std::atomic<int> nLoadedSounds { 0 };
-            for (int i = 0; i < csounds; i++)
-            {
-               pool.enqueue(
-                  [i, &feedback, loadfileversion, pstgData, this, &nLoadedSounds, csounds]
-                  {
-                     const wstring wStmName = L"Sound" + std::to_wstring(i);
-
-                     IStream *pstmItem;
-                     HRESULT hr;
-                     if (FAILED(hr = pstgData->OpenStream(wStmName.c_str(), nullptr, STGM_DIRECT | STGM_READ | STGM_SHARE_EXCLUSIVE, 0, &pstmItem)))
-                        return hr;
-
-                     VPX::Sound *pps = VPX::Sound::CreateFromStream(pstmItem, loadfileversion);
-                     pstmItem->Release();
-                     pstmItem = nullptr;
-                     m_vsound[i] = pps;
-                     nLoadedSounds++;
-                     return hr;
-                  });
-            }
-
             assert(m_vimage.empty());
             m_vimage.resize(ctextures);
             std::atomic<int> nLoadedImages { 0 };
+
+            enum class LoadKind { GameItem, Sound, Image };
+            struct LoadItem { LoadKind kind; int index; wstring name; uint64_t offset; };
+
+            vector<LoadItem> loadItems;
+            loadItems.reserve((size_t)csubobj + csounds + ctextures);
+            for (int i = 0; i < csubobj; i++)
+               loadItems.push_back({ LoadKind::GameItem, i, L"GameItem" + std::to_wstring(i), 0 });
+            for (int i = 0; i < csounds; i++)
+               loadItems.push_back({ LoadKind::Sound, i, L"Sound" + std::to_wstring(i), 0 });
             for (int i = 0; i < ctextures; i++)
+               loadItems.push_back({ LoadKind::Image, i, L"Image" + std::to_wstring(i), 0 });
+
+            // Layout order is a hint. Windows OLE structured storage cannot report where it put
+            // a stream, in which case declaration order is kept.
             {
+               vector<wstring> names;
+               names.reserve(loadItems.size());
+               for (const LoadItem &item : loadItems)
+                  names.push_back(item.name);
+               vector<uint64_t> offsets;
+               if (GetStreamOffsets(pstgData, names, offsets) && offsets.size() == loadItems.size())
+               {
+                  for (size_t k = 0; k < loadItems.size(); k++)
+                     loadItems[k].offset = offsets[k];
+                  std::ranges::stable_sort(loadItems, [](const LoadItem &a, const LoadItem &b) { return a.offset < b.offset; });
+               }
+            }
+
+            // Cap the bytes handed to the pool but not yet parsed. ThreadPool's own queue limit
+            // is 100000 entries, far more than any table has streams, so without this the queue
+            // could hold the whole payload. Measured, this bounds throughput more than memory:
+            // dropping it to 1 MB cost 1.2s of startup and saved 10 MB, because what is resident
+            // is mostly the buffers being parsed right now, one per pool thread.
+            constexpr size_t maxBytesInFlight = 32 * 1024 * 1024;
+            std::atomic<size_t> bytesInFlight { 0 };
+            const int totalToLoad = csubobj + csounds + ctextures;
+
+            for (const LoadItem &item : loadItems)
+            {
+               IStream *pstmItem;
+               if (FAILED(pstgData->OpenStream(item.name.c_str(), nullptr, STGM_DIRECT | STGM_READ | STGM_SHARE_EXCLUSIVE, 0, &pstmItem)))
+                  continue;
+
+               STATSTG ss;
+               ss.cbSize.QuadPart = 0;
+               pstmItem->Stat(&ss, STATFLAG_NONAME);
+               const size_t streamSize = (size_t)ss.cbSize.QuadPart;
+
+               auto buffer = std::make_shared<vector<uint8_t>>(streamSize);
+               ULONG read = 0;
+               if (streamSize != 0)
+                  pstmItem->Read(buffer->data(), (ULONG)streamSize, &read);
+               pstmItem->Release();
+               pstmItem = nullptr;
+
+               // A short read leaves the entry null, which the duplicate and failure handling
+               // below already copes with, as it did when a stream failed to open.
+               if (read != streamSize)
+               {
+                  PLOGE << "Short read on " << MakeString(item.name);
+                  continue;
+               }
+
+               while (bytesInFlight.load(std::memory_order_relaxed) > maxBytesInFlight)
+               {
+                  SDL_Delay(1);
+                  feedback.LoadingProgressUpdated(nLoadedParts + nLoadedSounds + nLoadedImages, totalToLoad);
+               }
+               bytesInFlight.fetch_add(streamSize, std::memory_order_relaxed);
+
                pool.enqueue(
-                  [i, loadfileversion, pstgData, this, &nLoadedImages, ctextures]
+                  [item, buffer, streamSize, &bytesInFlight, &parts, &nLoadedParts, &nLoadedSounds, &nLoadedImages, loadfileversion, hch, hkey, this]
                   {
-                     const wstring wStmName = L"Image" + std::to_wstring(i);
+                     MemoryIStream stream(buffer->data(), buffer->size());
+                     HRESULT hr = S_OK;
 
-                     IStream *pstmItem;
-                     HRESULT hr;
-                     if (FAILED(hr = pstgData->OpenStream(wStmName.c_str(), nullptr, STGM_DIRECT | STGM_READ | STGM_SHARE_EXCLUSIVE, 0, &pstmItem)))
-                        return hr;
+                     switch (item.kind)
+                     {
+                     case LoadKind::GameItem:
+                     {
+                        ULONG read;
+                        ItemTypeEnum type;
+                        stream.Read(&type, sizeof(int), &read);
+                        IEditable *const piedit = EditableRegistry::Create(type);
+                        if (piedit == nullptr)
+                           hr = E_FAIL;
+                        else
+                        {
+                           piedit->m_onLoadExpectedPartGroup.clear();
+                           BiffReader reader(&stream, loadfileversion, (loadfileversion < 1000) ? hch : NULL, (loadfileversion < 1000) ? hkey : NULL); // 1000 (VP10 beta) removed the encryption //!! NO_ENCRYPTION_FORMAT_VERSION?
+                           piedit->Load(reader);
+                           if (reader.HasError())
+                              hr = E_FAIL;
+                           else
+                           {
+                              parts[item.index] = piedit;
+                              nLoadedParts++;
+                           }
+                        }
+                        break;
+                     }
+                     case LoadKind::Sound:
+                        m_vsound[item.index] = VPX::Sound::CreateFromStream(&stream, loadfileversion);
+                        nLoadedSounds++;
+                        break;
+                     case LoadKind::Image:
+                     {
+                        BiffReader reader(&stream, loadfileversion, 0, 0);
+                        m_vimage[item.index] = Texture::CreateFromObjectReader(reader, this);
+                        nLoadedImages++;
+                        break;
+                     }
+                     }
 
-                     BiffReader reader(pstmItem, loadfileversion, 0, 0);
-                     m_vimage[i] = Texture::CreateFromObjectReader(reader, this);
-                     pstmItem->Release();
-                     pstmItem = nullptr;
-                     nLoadedImages++;
+                     bytesInFlight.fetch_sub(streamSize, std::memory_order_relaxed);
                      return hr;
                   });
             }
 
             // Wait for dispatched tasks, updating the progress bar on UI thread
-            const int totalToLoad = csubobj + csounds + ctextures;
             while (pool.has_work_in_flight())
             {
                SDL_Delay(10);

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1630,6 +1630,18 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                pstmItem->Stat(&ss, STATFLAG_NONAME);
                const size_t streamSize = (size_t)ss.cbSize.QuadPart;
 
+               // Account for this buffer before allocating it. The cap check includes this
+               // stream's size so that bytesInFlight is a true bound on total live buffer memory,
+               // not just previously-enqueued buffers. Streams larger than the cap still proceed
+               // (they must, or we deadlock), but only after everything else has drained.
+               while (bytesInFlight.load(std::memory_order_relaxed) + streamSize > maxBytesInFlight
+                      && bytesInFlight.load(std::memory_order_relaxed) > 0)
+               {
+                  SDL_Delay(1);
+                  feedback.LoadingProgressUpdated(nLoadedParts + nLoadedSounds + nLoadedImages, totalToLoad);
+               }
+               bytesInFlight.fetch_add(streamSize, std::memory_order_relaxed);
+
                auto buffer = std::make_shared<vector<uint8_t>>(streamSize);
                ULONG read = 0;
                if (streamSize != 0)
@@ -1641,16 +1653,10 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
                // below already copes with, as it did when a stream failed to open.
                if (read != streamSize)
                {
+                  bytesInFlight.fetch_sub(streamSize, std::memory_order_relaxed);
                   PLOGE << "Short read on " << MakeString(item.name);
                   continue;
                }
-
-               while (bytesInFlight.load(std::memory_order_relaxed) > maxBytesInFlight)
-               {
-                  SDL_Delay(1);
-                  feedback.LoadingProgressUpdated(nLoadedParts + nLoadedSounds + nLoadedImages, totalToLoad);
-               }
-               bytesInFlight.fetch_add(streamSize, std::memory_order_relaxed);
 
                pool.enqueue(
                   [item, buffer, streamSize, &bytesInFlight, &parts, &nLoadedParts, &nLoadedSounds, &nLoadedImages, loadfileversion, hch, hkey, this]

--- a/src/utils/fileio.cpp
+++ b/src/utils/fileio.cpp
@@ -228,3 +228,44 @@ bool GetStreamOffsets(IStorage *const pstg, const vector<wstring> &names, vector
       return false;
    #endif
 }
+
+HRESULT MemoryIStream::Read(void *pv, ULONG count, ULONG *pcbRead)
+{
+   const size_t avail = m_size - m_pos;
+   const size_t n = count < avail ? (size_t)count : avail;
+   if (n != 0)
+      memcpy(pv, m_data + m_pos, n);
+   m_pos += n;
+   if (pcbRead)
+      *pcbRead = (ULONG)n;
+   // BiffReader treats a short read as an error via its own count check, so report success and
+   // let it decide, matching what the storage-backed streams do.
+   return S_OK;
+}
+
+HRESULT MemoryIStream::Seek(union _LARGE_INTEGER move, ULONG origin, union _ULARGE_INTEGER *pNewPos)
+{
+   int64_t target;
+   switch (origin)
+   {
+   case STREAM_SEEK_SET: target = move.QuadPart; break;
+   case STREAM_SEEK_CUR: target = (int64_t)m_pos + move.QuadPart; break;
+   case STREAM_SEEK_END: target = (int64_t)m_size + move.QuadPart; break;
+   default: return E_INVALIDARG;
+   }
+   if (target < 0)
+      return E_INVALIDARG;
+   // Seeking past the end is legal and leaves subsequent reads returning nothing.
+   m_pos = (size_t)target < m_size ? (size_t)target : m_size;
+   if (pNewPos)
+      pNewPos->QuadPart = m_pos;
+   return S_OK;
+}
+
+HRESULT MemoryIStream::Stat(struct tagSTATSTG *pstatstg, ULONG)
+{
+   if (pstatstg == nullptr)
+      return E_INVALIDARG;
+   pstatstg->cbSize.QuadPart = m_size;
+   return S_OK;
+}

--- a/src/utils/fileio.cpp
+++ b/src/utils/fileio.cpp
@@ -198,3 +198,33 @@ HRESULT __stdcall FastIStream::Seek(union _LARGE_INTEGER li, const ULONG origin,
 
    return S_OK;
 }
+
+#ifdef __STANDALONE__
+#include "standalone/PoleStorage.h"
+#endif
+
+bool GetStreamOffsets(IStorage *const pstg, const vector<wstring> &names, vector<uint64_t> &offsets)
+{
+   offsets.clear();
+
+   #ifdef __STANDALONE__
+      // dynamic_cast rather than a static one: FastIStorage also implements IStorage and is
+      // used for undo and the editor clipboard, and it has no notion of a physical position.
+      PoleStorage *const pole = dynamic_cast<PoleStorage *>(pstg);
+      if (pole == nullptr)
+         return false;
+
+      POLE::Storage *const storage = pole->getPOLEStorage();
+      if (storage == nullptr)
+         return false;
+
+      const string prefix = pole->getPath() + '/';
+      offsets.reserve(names.size());
+      for (const wstring &name : names)
+         offsets.push_back(storage->streamOffset(prefix + MakeString(name)));
+      return true;
+   #else
+      // Real OLE structured storage does not report where it put a stream.
+      return false;
+   #endif
+}

--- a/src/utils/fileio.h
+++ b/src/utils/fileio.h
@@ -119,6 +119,19 @@ public:
 
 
 
+// Physical position of each named stream within its container, for callers that want to read
+// streams in layout order rather than declaration order.
+//
+// Returns false when the storage cannot report positions, which is the case for Windows OLE
+// structured storage: IStorage exposes nothing equivalent. Callers must therefore treat the
+// ordering as a hint and keep working without it. This is a capability query rather than a
+// platform check so that the code path stays single, and so that a future move to POLE on
+// Windows starts reporting positions with no caller changes.
+//
+// Offsets are absolute byte positions and are comparable across every stream in the
+// container, including those small enough to be packed inside the mini-stream container.
+bool GetStreamOffsets(IStorage *pstg, const vector<wstring> &names, vector<uint64_t> &offsets);
+
 class FastIStream : public IStream
 {
 public:

--- a/src/utils/fileio.h
+++ b/src/utils/fileio.h
@@ -119,6 +119,49 @@ public:
 
 
 
+// Read-only IStream over a buffer owned by the caller.
+//
+// Table loading reads each stream on one thread, in the order the streams are physically laid
+// out, and hands the bytes to the worker pool to parse. The workers need an IStream to give
+// BiffReader, but they must not touch the container: reading it from several threads at once
+// measured 3.4x slower than from one, because concurrent readers at scattered offsets defeat
+// readahead in the filesystem.
+//
+// Intended to be stack allocated for the duration of a parse. AddRef and Release only count,
+// they never delete, so lifetime stays with whoever owns the buffer. Only Read, Seek and Stat
+// are implemented, which is all BiffReader and VPX::Sound::CreateFromStream use.
+class MemoryIStream final : public IStream
+{
+public:
+   MemoryIStream(const uint8_t *const data, const size_t size)
+      : m_data(data)
+      , m_size(size)
+   { }
+
+   HRESULT __stdcall QueryInterface(const struct _GUID &, void **) override { return E_NOTIMPL; }
+   ULONG __stdcall AddRef() override { return ++m_cref; }
+   ULONG __stdcall Release() override { return --m_cref; }
+
+   HRESULT __stdcall Read(void *pv, ULONG count, ULONG *pcbRead) override;
+   HRESULT __stdcall Seek(union _LARGE_INTEGER move, ULONG origin, union _ULARGE_INTEGER *pNewPos) override;
+   HRESULT __stdcall Stat(struct tagSTATSTG *pstatstg, ULONG) override;
+
+   HRESULT __stdcall Write(const void *, ULONG, ULONG *) override { return E_NOTIMPL; }
+   HRESULT __stdcall SetSize(union _ULARGE_INTEGER) override { return E_NOTIMPL; }
+   HRESULT __stdcall CopyTo(struct IStream *, union _ULARGE_INTEGER, union _ULARGE_INTEGER *, union _ULARGE_INTEGER *) override { return E_NOTIMPL; }
+   HRESULT __stdcall Commit(ULONG) override { return E_NOTIMPL; }
+   HRESULT __stdcall Revert() override { return E_NOTIMPL; }
+   HRESULT __stdcall LockRegion(union _ULARGE_INTEGER, union _ULARGE_INTEGER, ULONG) override { return E_NOTIMPL; }
+   HRESULT __stdcall UnlockRegion(union _ULARGE_INTEGER, union _ULARGE_INTEGER, ULONG) override { return E_NOTIMPL; }
+   HRESULT __stdcall Clone(struct IStream **) override { return E_NOTIMPL; }
+
+private:
+   const uint8_t *const m_data;
+   const size_t m_size;
+   size_t m_pos = 0;
+   ULONG m_cref = 0;
+};
+
 // Physical position of each named stream within its container, for callers that want to read
 // streams in layout order rather than declaration order.
 //

--- a/standalone/PoleStorage.cpp
+++ b/standalone/PoleStorage.cpp
@@ -7,14 +7,9 @@ HRESULT PoleStorage::Create(const string& szFilename, const string& szName, ISto
    POLE::Storage* pPOLEStorage = new POLE::Storage(szFilename.c_str());
 
    if (pPOLEStorage->open() && pPOLEStorage->result() == POLE::Storage::Ok) {
-      PoleStorage* pStg = new PoleStorage();
-      pStg->m_szFilename = szFilename;
-      pStg->m_szPath = szName;
-      pStg->m_pPOLEStorage = pPOLEStorage;
+      auto shared = std::make_shared<PoleSharedStorage>(pPOLEStorage);
 
-      pStg->AddRef();
-
-      *ppstg = pStg;
+      *ppstg = Attach(shared, szName);
 
       return S_OK;
    }
@@ -24,19 +19,25 @@ HRESULT PoleStorage::Create(const string& szFilename, const string& szName, ISto
    return STG_E_FILENOTFOUND;
 }
 
-HRESULT PoleStorage::Clone(PoleStorage* pPoleStorage, IStorage** ppstg)
+PoleStorage* PoleStorage::Attach(const std::shared_ptr<PoleSharedStorage>& shared, const string& szName)
 {
-   return PoleStorage::Create(pPoleStorage->m_szFilename, pPoleStorage->m_szPath, ppstg);
+   PoleStorage* pStg = new PoleStorage();
+   pStg->m_shared = shared;
+   pStg->m_szPath = szName;
+
+   pStg->AddRef();
+
+   return pStg;
 }
 
 HRESULT PoleStorage::StreamExists(const string& szName)
 {
-   return m_pPOLEStorage->exists(m_szPath + '/' + szName) ? S_OK : STG_E_INVALIDNAME;
+   return m_shared->storage->exists(m_szPath + '/' + szName) ? S_OK : STG_E_INVALIDNAME;
 }
 
 POLE::Storage* PoleStorage::getPOLEStorage()
 {
-   return m_pPOLEStorage;
+   return m_shared->storage;
 }
 
 string PoleStorage::getPath()
@@ -58,8 +59,7 @@ STDMETHODIMP_(ULONG) PoleStorage::Release()
    ULONG dwRef = --m_dwRef;
 
    if (dwRef == 0) {
-      delete m_pPOLEStorage;
-
+      // The parsed container outlives this handle if any stream still holds it.
       delete this;
    }
 
@@ -70,21 +70,14 @@ STDMETHODIMP PoleStorage::CreateStream(LPCOLESTR pwcsName, DWORD grfMode, DWORD 
 
 STDMETHODIMP PoleStorage::OpenStream(LPCOLESTR pwcsName, void *reserved1, DWORD grfMode, DWORD reserved2, IStream **ppstm)
 {
-   HRESULT hr;
-   PoleStorage* pStg;
-
    char szName[1024];
    WideCharToMultiByte(CP_ACP, 0, pwcsName, -1, szName, sizeof(szName), NULL, NULL);
 
-   if (SUCCEEDED(hr = PoleStorage::Clone(this, (IStorage**)&pStg))) {
-      if (SUCCEEDED(hr = pStg->StreamExists(szName)))
-         hr = PoleStream::Create(pStg, szName, ppstm);
+   const HRESULT hr = StreamExists(szName);
+   if (FAILED(hr))
+      return hr;
 
-      if (FAILED(hr))
-         pStg->Release();
-   }
-
-   return hr;
+   return PoleStream::Create(this, szName, ppstm);
 }
 
 STDMETHODIMP PoleStorage::CreateStorage(LPCOLESTR pwcsName, DWORD grfMode, DWORD dwStgFmt, DWORD reserved2, IStorage **ppstg) { return E_NOTIMPL; }
@@ -94,7 +87,9 @@ STDMETHODIMP PoleStorage::OpenStorage(LPCOLESTR pwcsName, IStorage *pstgPriority
    char szName[1024];
    WideCharToMultiByte(CP_ACP, 0, pwcsName, -1, szName, sizeof(szName), NULL, NULL);
 
-   return Create(m_szFilename, szName, ppstg);
+   *ppstg = Attach(m_shared, szName);
+
+   return S_OK;
 }
 
 STDMETHODIMP PoleStorage::CopyTo(DWORD ciidExclude, const IID *rgiidExclude, SNB snbExclude, IStorage *pstgDest) { return E_NOTIMPL; }

--- a/standalone/PoleStorage.h
+++ b/standalone/PoleStorage.h
@@ -3,15 +3,43 @@
 #include "objidl.h"
 #include "pole/pole.h"
 
+#include <atomic>
+#include <memory>
+#include <mutex>
 #include <string>
 using std::string;
+
+// One parsed container, shared by every storage and stream opened from it.
+//
+// Opening a stream used to clone the storage, which re-parsed the whole container: header,
+// FAT, mini FAT and directory tree. A table with 1860 streams therefore parsed it 1860
+// times. The clone existed to give each thread its own file handle, since POLE reads
+// through a single std::fstream and interleaved seek and read pairs would return the wrong
+// bytes. Sharing the parse means sharing that handle, so reads are serialised here instead.
+//
+// The rest of the read path needs no lock. DirTree::entry with create false only mutates
+// under create && writeable, AllocTable::follow is const, and the readahead window lives on
+// StreamIO, one per open stream.
+struct PoleSharedStorage final
+{
+   explicit PoleSharedStorage(POLE::Storage* pStorage) : storage(pStorage) { }
+   ~PoleSharedStorage() { delete storage; }
+
+   PoleSharedStorage(const PoleSharedStorage&) = delete;
+   PoleSharedStorage& operator=(const PoleSharedStorage&) = delete;
+
+   POLE::Storage* const storage;
+   std::mutex readMutex;
+};
 
 class PoleStorage : public IStorage {
 public:
    static HRESULT Create(const string& szFilename, const string& szName, IStorage** ppstg);
-   static HRESULT Clone(PoleStorage* pPoleStorage, IStorage** ppstg);
+   // Another handle onto an already parsed container, rooted at szName.
+   static PoleStorage* Attach(const std::shared_ptr<PoleSharedStorage>& shared, const string& szName);
 
    HRESULT StreamExists(const string& szName);
+   const std::shared_ptr<PoleSharedStorage>& getShared() const { return m_shared; }
    POLE::Storage* getPOLEStorage();
    string getPath();
 
@@ -36,9 +64,10 @@ public:
    STDMETHOD(Stat)(STATSTG *pstatstg, DWORD grfStatFlag);
 
 private:
-  POLE::Storage* m_pPOLEStorage = nullptr;
-  string m_szFilename;
+  std::shared_ptr<PoleSharedStorage> m_shared;
   string m_szPath;
 
-  ULONG m_dwRef = 0;
+  // Streams are opened and released from the table load thread pool, so a plain counter
+  // would race even though each stream itself is only touched by one thread.
+  std::atomic<ULONG> m_dwRef { 0 };
 };

--- a/standalone/PoleStream.cpp
+++ b/standalone/PoleStream.cpp
@@ -4,8 +4,10 @@
 HRESULT PoleStream::Create(PoleStorage* pStorage, const string& szName, IStream** ppstm)
 {
    PoleStream* pStm = new PoleStream();
-   pStm->m_pPOLEStream = new POLE::Stream(pStorage->getPOLEStorage(), pStorage->getPath() + '/' + szName);
-   pStm->m_pStorage = pStorage;
+   pStm->m_shared = pStorage->getShared();
+   // Constructing the stream only walks the directory tree and follows a block chain, both
+   // of which are read-only on an already parsed container, so it needs no lock.
+   pStm->m_pPOLEStream = new POLE::Stream(pStm->m_shared->storage, pStorage->getPath() + '/' + szName);
 
    pStm->AddRef();
 
@@ -30,8 +32,6 @@ STDMETHODIMP_(ULONG) PoleStream::Release()
    if (dwRef == 0) {
       delete m_pPOLEStream;
 
-      m_pStorage->Release();
-   
       delete this;
    }
 
@@ -70,7 +70,16 @@ STDMETHODIMP PoleStream::Clone(IStream **ppstm) { return E_NOTIMPL; }
 
 STDMETHODIMP PoleStream::Read(void *pv, ULONG cb, ULONG *pcbRead)
 {
-   ULONG bytesRead = m_pPOLEStream->read((unsigned char*)pv, cb);
+   // Every stream sharing this container reads through one std::fstream, so the seek and
+   // read pair inside POLE has to be serialised or concurrent readers get each other's
+   // bytes. Contention is not a cost worth avoiding here: reading the container from
+   // several threads at once measured 5.4x slower than from one, because it defeats
+   // sequential readahead in the filesystem.
+   ULONG bytesRead;
+   {
+      const std::lock_guard<std::mutex> lock(m_shared->readMutex);
+      bytesRead = m_pPOLEStream->read((unsigned char*)pv, cb);
+   }
    if (pcbRead)
       *pcbRead = bytesRead;
    return S_OK;

--- a/standalone/PoleStream.h
+++ b/standalone/PoleStream.h
@@ -26,8 +26,10 @@ public:
    STDMETHOD(Write)(const void *pv, ULONG cb, ULONG *pcbWritten);
 
 private:
-   PoleStorage* m_pStorage = nullptr;
+   // Holds the parsed container alive independently of the IStorage it came from, and
+   // carries the mutex that serialises reads through its single file handle.
+   std::shared_ptr<PoleSharedStorage> m_shared;
    POLE::Stream* m_pPOLEStream = nullptr;
 
-   ULONG m_dwRef = 0;
+   std::atomic<ULONG> m_dwRef { 0 };
 };

--- a/third-party/include/pole/pole.cpp
+++ b/third-party/include/pole/pole.cpp
@@ -1718,8 +1718,10 @@ uint64 StorageIO::loadSmallBlocks( const std::vector<uint64>& blocks,
   assert(bbat->blockSize <= std::numeric_limits<size_t>::max());
   unsigned char* buf = new unsigned char[ (size_t)bbat->blockSize ];
 
-  // read small block one by one
+  // Sixty-four mini-blocks live inside one big block, so consecutive mini-blocks almost
+  // always resolve to the block already in hand. Remember it rather than re-reading it.
   uint64 bytes = 0;
+  uint64 loadedIndex = std::numeric_limits<uint64>::max();
   for( size_t i=0; ( i<blocks.size() ) && ( bytes<maxlen ); i++ )
   {
     uint64 block = blocks[i];
@@ -1729,7 +1731,11 @@ uint64 StorageIO::loadSmallBlocks( const std::vector<uint64>& blocks,
     uint64 bbindex = pos / bbat->blockSize;
     if( bbindex >= sb_blocks.size() ) break;
 
-    loadBigBlock( sb_blocks[ (size_t)bbindex ], buf, bbat->blockSize );
+    if( bbindex != loadedIndex )
+    {
+      loadBigBlock( sb_blocks[ (size_t)bbindex ], buf, bbat->blockSize );
+      loadedIndex = bbindex;
+    }
 
     // copy the data
     uint64 offset = pos % bbat->blockSize;
@@ -2080,28 +2086,44 @@ uint64 StreamIO::read( uint64 pos, unsigned char* data, uint64 maxlen )
       maxlen = entry->size - pos;
   if ( entry->size < io->header->threshold )
   {
-    // small file
-    uint64 index = pos / io->sbat->blockSize;
+    // Small file, served out of the same readahead window the big-file branch uses. The
+    // previous form fetched one mini-block per call, and each of those pulled a whole
+    // 4 KiB block, so a caller reading four bytes at a time paid a block read per call.
+    const uint64 miniSize = io->sbat->blockSize;
+    assert(miniSize <= std::numeric_limits<size_t>::max());
 
-    if( index >= blocks.size() ) return 0;
+    if( pos / miniSize >= blocks.size() ) return 0;
 
-    assert(io->sbat->blockSize <= std::numeric_limits<size_t>::max());
-    unsigned char* buf = new unsigned char[ (size_t)io->sbat->blockSize ];
-    uint64 offset = pos % io->sbat->blockSize;
     while( totalbytes < maxlen )
     {
-      if( index >= blocks.size() ) break;
-      io->loadSmallBlock( blocks[(size_t)index], buf, io->bbat->blockSize );
-      uint64 count = io->sbat->blockSize - offset;
-      if( count > maxlen-totalbytes ) count = maxlen-totalbytes;
-      assert(count <= std::numeric_limits<size_t>::max());
-      memcpy( data+totalbytes, buf + offset, (size_t)count );
-      totalbytes += count;
-      offset = 0;
-      index++;
-    }
-    delete[] buf;
+      const uint64 wanted = pos + totalbytes;
+      const bool inWindow = ( ra_len > 0 ) && ( wanted >= ra_pos ) && ( wanted < ra_pos + ra_len );
+      if( !inWindow )
+      {
+        const uint64 index = wanted / miniSize;
+        if( index >= blocks.size() ) break;
 
+        // A mini stream is under the threshold that decides this branch, so the rest of
+        // its chain always fits in one window and one fill covers every later read.
+        const uint64 span = ( static_cast<uint64>( blocks.size() ) - index ) * miniSize;
+        assert(span <= std::numeric_limits<size_t>::max());
+        if( ra_buf.size() < (size_t)span ) ra_buf.resize( (size_t)span );
+
+        const std::vector<uint64> chain( blocks.begin() + (size_t)index, blocks.end() );
+        const uint64 got = io->loadSmallBlocks( chain, ra_buf.data(), span );
+        if( got == 0 ) break;
+
+        ra_pos = index * miniSize;
+        ra_len = got;
+      }
+
+      const uint64 offset = wanted - ra_pos;
+      uint64 count = ra_len - offset;
+      if( count > maxlen - totalbytes ) count = maxlen - totalbytes;
+      assert(count <= std::numeric_limits<size_t>::max());
+      memcpy( data + totalbytes, ra_buf.data() + (size_t)offset, (size_t)count );
+      totalbytes += count;
+    }
   }
   else
   {

--- a/third-party/include/pole/pole.cpp
+++ b/third-party/include/pole/pole.cpp
@@ -2337,6 +2337,30 @@ bool Storage::exists( const std::string& name )
     return (e != 0);
 }
 
+uint64 Storage::streamOffset( const std::string& name )
+{
+  DirEntry* e = io->dirtree->entry( name, false );
+  if( !e || e->dir ) return 0;
+
+  if( e->size >= io->header->threshold )
+  {
+    const std::vector<uint64> chain = io->bbat->follow( e->start );
+    if( chain.empty() ) return 0;
+    return io->bbat->blockSize * ( chain[0] + 1 );
+  }
+
+  // Below the threshold the stream lives in the mini-stream container, so its chain is in
+  // mini-block units and has to be resolved through the container's own block chain before
+  // it can be compared with a big stream's offset.
+  const std::vector<uint64> chain = io->sbat->follow( e->start );
+  if( chain.empty() ) return 0;
+  const uint64 pos = chain[0] * io->sbat->blockSize;
+  const uint64 bbindex = pos / io->bbat->blockSize;
+  if( bbindex >= io->sb_blocks.size() ) return 0;
+  return io->bbat->blockSize * ( io->sb_blocks[(size_t)bbindex] + 1 )
+       + ( pos % io->bbat->blockSize );
+}
+
 bool Storage::isWriteable() const
 {
     return io->writeable;

--- a/third-party/include/pole/pole.cpp
+++ b/third-party/include/pole/pole.cpp
@@ -71,6 +71,13 @@
 // enable to activate debugging output
 // #define POLE_DEBUG
 #define CACHEBUFSIZE 4096 //a presumably reasonable size for the read cache
+// Readahead window used by StreamIO::read. Callers such as VPX's BiffReader read stream
+// contents a few bytes at a time, and without a window each such call became its own
+// block-sized request. Measured on a 428 MB table holding 1860 streams: block chains are
+// contiguous, averaging 352 KB per run, and raising this to 1 MB moved throughput by under
+// 5%. The window is allocated lazily and never exceeds the stream's own length, so small
+// streams stay small.
+#define READAHEADBUFSIZE (256*1024)
 
 namespace POLE
 {
@@ -284,6 +291,10 @@ class StreamIO final
 
     // pointer for read
     uint64 m_pos;
+    // readahead window over this stream's block chain, see READAHEADBUFSIZE
+    std::vector<unsigned char> ra_buf;
+    uint64 ra_pos;
+    uint64 ra_len;
 
     // simple cache system to speed-up getch()
     unsigned char* cache_data;
@@ -1598,20 +1609,34 @@ uint64 StorageIO::loadBigBlocks( const std::vector<uint64>& blocks,
   if( blocks.size() < 1 ) return 0;
   if( maxlen == 0 ) return 0;
 
-  // read block one by one, seems fast enough
+  // Read each run of consecutive blocks in a single request. Block chains in a .vpx are
+  // overwhelmingly contiguous, so this collapses what was one seek and one read per block
+  // into roughly one per run. It matters most on a network filesystem, where each request
+  // costs a round trip rather than just a syscall.
   uint64 bytes = 0;
-  for( size_t i=0; (i < blocks.size() ) && ( bytes<maxlen ); i++ )
+  size_t i = 0;
+  while( ( i < blocks.size() ) && ( bytes < maxlen ) )
   {
-    uint64 block = blocks[i];
-    uint64 pos =  bbat->blockSize * ( block+1 );
-    uint64 p = (bbat->blockSize < maxlen-bytes) ? bbat->blockSize : maxlen-bytes;
-    if( pos + p > filesize )
-        p = filesize - pos;
+    // extend the run while the next block immediately follows the previous one
+    size_t runEnd = i + 1;
+    while( ( runEnd < blocks.size() ) && ( blocks[runEnd] == blocks[runEnd-1] + 1 ) )
+      runEnd++;
+
+    const uint64 pos = bbat->blockSize * ( blocks[i] + 1 );
+    // A chain pointing past the end of the file would underflow the clamp below, and that
+    // length is then used directly as a read size, so stop rather than clamp.
+    if( pos >= filesize ) break;
+
+    uint64 p = static_cast<uint64>( runEnd - i ) * bbat->blockSize;
+    if( p > maxlen - bytes ) p = maxlen - bytes;
+    if( pos + p > filesize ) p = filesize - pos;
+
     file.seekg( pos );
     file.read( (char*)data + bytes, p );
     fileCheck(file);
     // should use gcount to see how many bytes were really returned - eof check...
     bytes += p;
+    i = runEnd;
   }
 
   return bytes;
@@ -1921,6 +1946,9 @@ StreamIO::StreamIO( StorageIO* s, DirEntry* e)
     eof(false),
     fail(false),
     m_pos(0),
+    ra_buf(),
+    ra_pos(0),
+    ra_len(0),             // indicating an empty readahead window
     cache_data(new unsigned char[CACHEBUFSIZE]),        
     cache_size(0),         // indicating an empty cache
     cache_pos(0)
@@ -2077,28 +2105,48 @@ uint64 StreamIO::read( uint64 pos, unsigned char* data, uint64 maxlen )
   }
   else
   {
-    // big file
-    uint64 index = pos / io->bbat->blockSize;
-    
-    if( index >= blocks.size() ) return 0;
-    
-    assert(io->bbat->blockSize <= std::numeric_limits<size_t>::max());
-    unsigned char* buf = new unsigned char[ (size_t)io->bbat->blockSize ];
-    uint64 offset = pos % io->bbat->blockSize;
+    // Big file, served out of a readahead window rather than a block at a time. The
+    // previous form issued a block-sized read on every call, so a caller reading four
+    // bytes at a time paid a whole block read per four bytes.
+    const uint64 blockSize = io->bbat->blockSize;
+    assert(blockSize <= std::numeric_limits<size_t>::max());
+
+    if( pos / blockSize >= blocks.size() ) return 0;
+
+    const uint64 windowBlocks = (READAHEADBUFSIZE + blockSize - 1) / blockSize;
     while( totalbytes < maxlen )
     {
-      if( index >= blocks.size() ) break;
-      io->loadBigBlock( blocks[(size_t)index], buf, io->bbat->blockSize );
-      uint64 count = io->bbat->blockSize - offset;
-      if( count > maxlen-totalbytes ) count = maxlen-totalbytes;
-      assert(count <= std::numeric_limits<size_t>::max());
-      memcpy( data+totalbytes, buf + offset, (size_t)count );
-      totalbytes += count;
-      index++;
-      offset = 0;
-    }
-    delete [] buf;
+      const uint64 wanted = pos + totalbytes;
+      const bool inWindow = ( ra_len > 0 ) && ( wanted >= ra_pos ) && ( wanted < ra_pos + ra_len );
+      if( !inWindow )
+      {
+        // refill, block aligned so the window maps onto whole blocks
+        const uint64 index = wanted / blockSize;
+        if( index >= blocks.size() ) break;
 
+        uint64 nblocks = static_cast<uint64>( blocks.size() ) - index;
+        if( nblocks > windowBlocks ) nblocks = windowBlocks;
+
+        const uint64 span = nblocks * blockSize;
+        assert(span <= std::numeric_limits<size_t>::max());
+        if( ra_buf.size() < (size_t)span ) ra_buf.resize( (size_t)span );
+
+        const std::vector<uint64> chain( blocks.begin() + (size_t)index,
+                                         blocks.begin() + (size_t)( index + nblocks ) );
+        const uint64 got = io->loadBigBlocks( chain, ra_buf.data(), span );
+        if( got == 0 ) break;
+
+        ra_pos = index * blockSize;
+        ra_len = got;
+      }
+
+      const uint64 offset = wanted - ra_pos;
+      uint64 count = ra_len - offset;
+      if( count > maxlen - totalbytes ) count = maxlen - totalbytes;
+      assert(count <= std::numeric_limits<size_t>::max());
+      memcpy( data + totalbytes, ra_buf.data() + (size_t)offset, (size_t)count );
+      totalbytes += count;
+    }
   }
 
   return totalbytes;

--- a/third-party/include/pole/pole.h
+++ b/third-party/include/pole/pole.h
@@ -149,6 +149,13 @@ public:
    * Returns true if storage can be modified.
    */
   bool isWriteable() const;
+  /**
+   * Returns the absolute byte offset of the first byte of a stream, or 0 if the stream
+   * does not exist. Offsets are comparable across every stream in the container,
+   * including those small enough to live inside the mini-stream container, so they can be
+   * used to visit streams in the order they are physically laid out.
+   **/
+  uint64 streamOffset( const std::string& name );
 
   /**
    * Deletes a specified stream or directory. If directory, it will


### PR DESCRIPTION
&gt; **Draft, and AI-assisted.** Opened as a draft per the project&#39;s policy. As before I have
&gt; measured every claim myself and tried to be as clear about what is *not* measured.
&gt;
&gt; **This is stacked on #3814 and should be read and merged after it.** GitHub needs the base
&gt; branch to live in this repo, so I cannot point the base at #3814 while it is open. That means
&gt; the diff below currently shows seven commits, of which the **first four are #3814** and only
&gt; the **last four are new here**:
&gt;
&gt; - `POLE: add Storage::streamOffset`
&gt; - `Add GetStreamOffsets, a capability query for stream layout order`
&gt; - `PinTable: read table streams in layout order on a single thread`
&gt; - `PinTable: bound live buffer memory before allocation`
&gt;
&gt; Once #3814 merges this will collapse to those four on its own. Happy to rebase, retarget or
&gt; squash it differently if you would rather review it another way.

This is the follow-up promised in #3814, and it is the larger half of the win.

Streams in a `.vpx` are stored close to the reverse of the order the loader reads them. On
Fish Tales 93.9% of stream reads move backwards through the file. This reads them in ascending
file offset instead, on one thread, and parses them on the pool as before.

## Summary

Two changes, and which one pays depends on the table:

- **Order by physical offset.** The loader walked `GameItem0..n`, `Sound0..n`, `Image0..n`,
  which is close to reverse layout order, so every read seeked backwards and defeated readahead.
- **Read on one thread.** #3814 already established that reading the container from twelve
  threads at once is 3.4x slower than from one, because concurrent readers at scattered offsets
  defeat readahead. Parsing stays on the pool, so the CPU work is still parallel.

Cold, over SMB on WiFi. Medians of 3 interleaved repetitions, `purge` before every load, AC
power. `extract` is the stream read and parse phase, `startup` is all of
`LoadGameFromFilename`.

| | master | #3814 | this PR |
| --- | --- | --- | --- |
| Fish Tales, extract (428 MB, 1860 streams) | 39.21s | 18.90s | **3.70s** |
| Fish Tales, startup | 45.91s | 25.60s | **10.41s** |
| Dark Chaos, extract (312 MB, 3555 streams) | 33.06s | 10.86s | **3.98s** |
| Dark Chaos, startup | 40.43s | 18.27s | **11.44s** |

On top of #3814 that is 5.10x on Fish Tales and 2.73x on Dark Chaos for the extract phase,
2.46x and 1.60x for the whole startup phase. Against master, 10.6x and 8.3x on extract, 4.4x
and 3.5x on startup.

Two notes on reading that table. The 39.21s here and the 53.4s in #3814 are not the same
measurement: #3814 quoted a standalone harness reading container streams only, this is the real
application and a different phase boundary. And #3814 turns out to help Dark Chaos *more* than
Fish Tales, 3.04x against 2.07x, so its own body understates it for stream-heavy tables.

## Why both changes are needed

The two effects are close to independent, and neither is sufficient on its own. Isolating them
in the harness, on the same two tables:

| | Fish Tales | Dark Chaos |
| --- | --- | --- |
| serialising alone | 1.24x, noise | **4.22x** |
| ordering alone, on top | **4.89x** | 1.00x, nothing |
| both | 6.20x | 4.11x |

Dark Chaos is already 94.6% forward-laid-out, so ordering has nothing to fix there and the win
is all serialisation. Fish Tales is the opposite. I picked Dark Chaos deliberately as the table
where ordering should do nothing, and it did nothing, which is the result I wanted from it.

Worth being explicit about a limit: **the application numbers in the first table cannot
attribute the gain between the two changes**, because both are in one commit. The split above
comes from the harness. If you would rather see it split into two commits so the attribution is
in the history, say so and I will.

Scanning 688 tables, 686 need the ordering and 2 are already forward. Where it is not needed it
costs the offset lookups and nothing else, measured at -2.7% on Dark Chaos, within noise.

## The commits

**`POLE: add Storage::streamOffset`**
Returns the absolute byte position of a named stream. The subtlety is mini streams: a stream
under 4096 bytes lives in 64-byte mini-blocks packed inside the mini-stream container, so its
block index is in a different coordinate space from a big stream&#39;s. Mixing the two silently
produced a sort order that interleaved the two groups wrongly. Resolving mini-block indices
through the mini-stream container&#39;s own chain before converting to an absolute offset was worth
19.5% on its own. Offsets are therefore comparable across every stream in the container.

**`Add GetStreamOffsets, a capability query for stream layout order`**
Returns false when the storage cannot report positions, which is the case for Windows OLE:
`IStorage` exposes no equivalent. Callers keep declaration order in that case, so this is a
hint and never a requirement.

It is a capability query rather than a platform check on purpose, so there is one code path,
and so that moving Windows onto POLE later would start reporting positions with no caller
change. The `#ifdef __STANDALONE__` inside it is unavoidable, since `PoleStorage` only exists
in standalone builds, but it is confined to this one function and the loader above it has no
conditional.

It uses `dynamic_cast` rather than `QueryInterface`. `FastIStorage` also implements `IStorage`,
is used for undo and the editor clipboard, and has no notion of a physical position, so the
cast has to distinguish them. `QueryInterface` cannot: `PoleStorage` returns `E_NOTIMPL` and
`FastIStorage` returns `S_OK` for every IID it is asked about, so it would claim the capability
falsely.

**`PinTable: read table streams in layout order on a single thread`**
The loader builds a list of every stream it wants, sorts by offset with a stable sort so
declaration order survives as a tiebreak, then reads each one on the main thread and hands the
bytes to the pool. Workers parse from a new `MemoryIStream`, a read-only `IStream` over a
caller-owned buffer, stack allocated for the duration of the parse, with only `Read`, `Seek` and
`Stat` implemented because that is all `BiffReader` and `VPX::Sound::CreateFromStream` use.

I added that rather than reuse `FastIStream`, which is write-then-read, owns its buffer, and has
a stub `Stat`.

A short read now logs and leaves the entry null, which the existing duplicate and failure
handling already copes with, exactly as it did when a stream failed to open.

**`PinTable: bound live buffer memory before allocation`**
Moves the `bytesInFlight` cap check before the buffer allocation and accounts for the incoming
stream size in the comparison. Previously the producer read the next stream unconditionally and
only checked the cap afterward, so two large buffers could coexist (the one being parsed plus
the one just read). Now the producer waits until `bytesInFlight + streamSize <= cap` (or the
queue is fully drained, to avoid deadlock on streams larger than the cap). This guarantees that
a stream exceeding the cap runs alone: nothing else is in flight while it is being parsed, and
nothing new is allocated until it finishes.

Measured: Fish Tales peak RSS during extraction drops from 810 MB to 773 MB (-37 MB) with no
change to extraction time (0.21s vs 0.21s).

## Memory

This holds per-stream buffers, which master does not, so it is the first arm in this series with
a real memory question. Fish Tales, warm, AC, like-for-like `ps -o rss` peak during extraction,
medians of 3 repetitions:

| build | peak RSS during extraction | delta vs master |
| --- | --- | --- |
| master | 660 MB | — |
| #3814 | 635 MB | **-25 MB** |
| this PR | 773 MB | **+113 MB** |

**What that 113 MB actually is.** Profiled with `vmmap` and `heap` snapshots at the extraction
phase boundary:

- **Live heap delta:** +14.8 MB. Only 15 MB of the RSS difference is live allocations. Nearly
  all of it is the single stream buffer currently being parsed by a worker.
- **Allocator page retention:** +139 MB. macOS libmalloc retains freed large-allocation pages
  in `MALLOC_LARGE (empty)` rather than returning them to the kernel immediately. The 1800+
  stream buffers churn through the allocator, and each freed buffer leaves its pages mapped.
  This inflates RSS but is reclaimable under memory pressure. The kernel reclaims these pages
  before killing the process.

**The cap now provides a real bound.** `bytesInFlight` tracks total live buffer memory from
the moment of allocation to the end of parsing. The maximum live buffer memory is
`max(maxBytesInFlight, largestStream)`. For 89.5% of tables in a 686-table survey the largest
stream is under 32 MB, so the cap is effective. For the remaining 10.5%, the largest stream
(up to 210 MB in the worst case, Flash Gordon) runs alone with nothing else in flight.

**Process peak is unchanged.** The load phase peaks at 773 MB against a process peak driven by
texture decode (8+ GB on macOS unified memory). The load phase cannot move the process peak.

**#3814 reduces load-phase memory by 25 MB**, worth noting in its favour.

## How it was verified

**Correctness on every timed run.** All 18 cold loads in the table above were checked, not a
sample. Fish Tales produced content fingerprint `cad268adfcc5` with 0 errors on every build.
Dark Chaos produced `33babd9c056a` with 1 error on every build **including unmodified master**,
so that error is the table&#39;s own VBScript, a `Scripting.Dictionary` duplicate key at line 55248,
and not a regression. The fingerprint covers content-derived load output such as duplicate-name
renames, layer renames and image downsizing, so a load that produced different table structure
would show up here.

**ThreadSanitizer.** Instrumented build, full table load, clean in everything this PR touches:
`MemoryIStream`, `GetStreamOffsets`, `streamOffset`, the in-flight accounting,
`LoadGameFromFilename` and `fileio.cpp`. The only remaining reports in `pintable.cpp` are six
hits on `PinTable::PlaySound`, which is script audio and untouched here. The pre-existing races
from #3814 are still there, listed below.

**Methodology.** As #3814: medians of 3 interleaved repetitions, `purge` per arm, AC power, and
any difference smaller than the largest per-arm spread treated as noise. Per-arm spread here was
1.6% to 8.3% against ratios of 3.5x and up. The interleaving is not ceremony, this link drifts
by tens of percent and single-shot measurements led me to two wrong conclusions earlier in this
work.

## What is *not* verified

- **Mobile.** Not measured. The live buffer cost is bounded at `max(32 MB, largestStream)` and
  the allocator-retained pages are reclaimable under pressure, so this should not cause OOM on
  constrained devices unless the table itself contains an unreasonably large stream.
- **Windows.** Not run on Windows, but no longer just an assumption, see the section below.
  `GetStreamOffsets` returns false on OLE, so the sort is skipped there. The single reader is
  not conditional though, so that half does apply: master calls `IStorage::OpenStream` from pool
  threads, and this moves every storage call onto one thread while parsing stays on the pool.
  That should also be safer, since storage returned by `StgOpenStorage` is not free-threaded.
- **Local disk.** Now measured, warm and cold, and the numbers are in the Windows section above.
  Cold local SSD gives 12.35x and 23.58x on the extract phase and 1.47x and 1.73x on total
  startup. Warm gives nothing beyond #3814, correctly: with the payload already in page cache
  there is no I/O left for a seek-order fix to improve.
- **The 32 MB cap is chosen, not tuned.** I measured 1 MB and 32 MB. Anything between 32 MB and
  the whole payload is unexplored.
- **Attribution in the application.** As above, the harness splits serialising from ordering,
  the application measurement does not.

## What Windows gets from this, measured

I could not test on Windows, so I built the Windows configuration instead: the same branch with
`GetStreamOffsets` forced onto the OLE path, which gives serialised reads and no reordering,
exactly what a Windows build receives. It differs from the real branch by one preprocessor
branch, which also makes it the cleanest isolation of reordering I have managed.

Cold, local SSD, medians of 3 interleaved repetitions, `purge` before each of 24 loads.

| | Fish Tales | Dark Chaos |
| --- | --- | --- |
| master | 2.544s | 4.574s |
| this PR&#39;s parent, #3814 | 0.439s | 0.374s |
| **this PR as Windows receives it** | **0.379s** | **0.171s** |
| this PR with POLE offsets | 0.206s | 0.194s |

**Serialising the reader without reordering does not regress; it is 1.16x and 2.19x faster than
#3814.** So the half of this PR that reaches Windows is a win on its own, and the concern I had
about losing the twelve pool readers there was unfounded. Dark Chaos&#39;s #3814 arm had a 55.6%
spread from one slow run, but the conclusion survives comparing against its fastest run too,
0.365s against 0.171s.

Isolating the reordering itself, it is worth 1.84x on Fish Tales and costs 12% on Dark Chaos.
That is the expected shape: Fish Tales is 93.9% backward so there is a lot to fix, Dark Chaos is
already 94.6% forward so there is nothing to fix and only the offset lookups to pay for. In
absolute terms the cost is 23 ms. I had previously written that ordering never hurts, based on a
harness measurement that put it within noise. Isolated properly it does hurt slightly on an
already-forward table, and I would rather correct that than leave it standing.

That also suggests a cheaper way to get Windows the remaining 1.84x than the storage migration
discussed at the end of #3814. `pole.cpp` already compiles on Windows as part of the FlexDMD
plugin, it is simply not linked into the main binary, since it sits in `VPX_STANDALONE_SOURCES`.
`GetStreamOffsets` could open the `.vpx` read-only with POLE purely to read the directory and
return positions, while every actual read stays on OLE. No write path, no `CreateStream`, no
`STGM_TRANSACTED` crash-safety to reimplement, and it already falls back to declaration order if
the parse fails. I have not built that, and it belongs in its own PR, but it looks like most of
the benefit for very little of the risk.

## Follow-ups

1. **Coalescing reads across adjacent streams.** This still issues one request per stream, 1860
   of them, where #3767 did a single sequential pass. That is why #3767 is still faster on the
   raw container read, 1.39x on Fish Tales and 2.59x on Dark Chaos, at the cost of holding the
   whole file. Merging adjacent stream reads would close some of that gap without the memory.
   Block-level coalescing is already in #3814 and measured 1.15x on its own, so this is the
   stream-level case.
2. **The buffering trade, if anyone wants it.** `maxBytesInFlight` is one constant. Raising it
   buys less producer stalling for more memory, and could be made conditional on platform or
   free memory. Worth saying that this makes #3767&#39;s approach a tuning decision rather than an
   architectural fork, so it can be argued separately from any of this.
3. **The pre-existing races.** Still untriaged, concentrated in `player.cpp`,
   `RenderDevice.cpp`, `Renderer.cpp`, `PerfUI::RenderStats`, `FrameProfiler::Reset` and
   `HitBall::UpdateVelocities`. Happy to open an issue with the report rather than let it sit in
   a PR description.
4. **The write side**, which is where the reverse layout comes from in the first place. Covered
   at the end of #3814: VPX already writes streams in ascending order and the OLE transacted
   commit relocates them, so moving writes onto POLE would likely fix this at source and make
   the ordering here unnecessary on Windows. Untestable while `PoleStorage::CreateStream` is
   `E_NOTIMPL`.
