### PR TITLE
Fix two data races found with ThreadSanitizer

### DIFF
--- a/plugins/plugins/MsgPluginManager.cpp
+++ b/plugins/plugins/MsgPluginManager.cpp
@@ -266,8 +266,15 @@ void MsgPluginManager::RunOnMainThread(const uint32_t endpointId, const double d
 #endif
       // FIXME block cleanly until processed
       lock.unlock();
-      while (!pm.m_timers.empty())
+      for (;;)
+      {
+         {
+            const std::lock_guard waitLock(pm.m_timerListMutex);
+            if (pm.m_timers.empty())
+               break;
+         }
          std::this_thread::sleep_for(std::chrono::nanoseconds(100));
+      }
    }
    else
    {
@@ -313,8 +320,6 @@ void MsgPluginManager::FlushPendingCallbacks(const uint32_t endpointId)
 void MsgPluginManager::ProcessAsyncCallbacks()
 {
    AssertAPIThread();
-   if (m_timers.empty())
-      return;
    std::list<TimerEntry> timers;
    const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
    {

--- a/src/utils/wintimer.h
+++ b/src/utils/wintimer.h
@@ -5,6 +5,7 @@
 #ifdef __STANDALONE__
 #include <climits>
 #endif
+#include <atomic>
 #include <thread>
 #include <iomanip>
 
@@ -155,9 +156,12 @@ public:
       }
 
       // Processed asynchronously here since input events are from game logic thread while present events are from rendering thread
-      if ((m_processInputTimeStampOnPrepare != 0) && (m_lastPresentedTimeStamp > m_processInputTimeStampOnPrepare))
+      // Loaded once: OnPresented may store between the two uses, and a larger second read would
+      // make the subtraction below underflow.
+      const uint64_t lastPresented = m_lastPresentedTimeStamp.load(std::memory_order_relaxed);
+      if ((m_processInputTimeStampOnPrepare != 0) && (lastPresented > m_processInputTimeStampOnPrepare))
       {
-         unsigned int elapsed = static_cast<unsigned int>(m_lastPresentedTimeStamp - m_processInputTimeStampOnPrepare);
+         unsigned int elapsed = static_cast<unsigned int>(lastPresented - m_processInputTimeStampOnPrepare);
          m_profileData[m_presentedIndex][PROFILE_INPUT_TO_PRESENT] = elapsed;
          m_profileMinData[PROFILE_INPUT_TO_PRESENT] = min(m_profileMinData[PROFILE_INPUT_TO_PRESENT], elapsed);
          m_profileMaxData[PROFILE_INPUT_TO_PRESENT] = max(m_profileMaxData[PROFILE_INPUT_TO_PRESENT], elapsed);
@@ -465,7 +469,7 @@ public:
 
    void OnPresented(uint64_t when) // May be called from any thread
    {
-      m_lastPresentedTimeStamp = when;
+      m_lastPresentedTimeStamp.store(when, std::memory_order_relaxed);
    }
 
    void SetThreadLock()
@@ -510,7 +514,7 @@ private:
    unsigned int m_presentedIndex = 0;
    unsigned int m_presentedCount = 0;
    uint64_t m_processInputTimeStampOnPrepare = 0;
-   uint64_t m_lastPresentedTimeStamp = 0;
+   std::atomic<uint64_t> m_lastPresentedTimeStamp { 0 }; // Written by the presenting thread, read by the profiler's own thread
 
    // Raw data
    unsigned int m_profileData[N_SAMPLES][PROFILE_COUNT];


### PR DESCRIPTION
Two small thread-safety fixes found with ThreadSanitizer. AI-assisted, but verified by
measurement rather than by inspection: I ran TSan on unmodified master, fixed these two, and
re-ran to confirm both reports are gone and nothing new appeared. Not opened as a draft since
the diff is 16 lines and demonstrably works, but happy to convert it if you would rather.

Both were found while working on #3814 and #3817, and neither is related to those. This is
against plain `master`.

## `MsgPluginManager: read the timer list under its mutex`

`ProcessAsyncCallbacks` early-returned on `m_timers.empty()` **before** taking
`m_timerListMutex`, while `RunOnMainThread` inserts into that list from plugin threads while
holding it. TSan showed the two accesses holding different mutexes, which is what gave it away.

This is the one I would not argue is harmless. Everywhere else TSan complains in this codebase
it is a torn scalar, and an aligned 4 or 8 byte access is atomic in practice on the hardware
people run. Here the unlocked read walks `std::list` internals while another thread relinks
them, so there is no width argument to fall back on.

Removed rather than moved inside the lock, because the check was only ever avoiding the lock.
The loop below it does nothing on an empty list and the erase pass is already guarded by
`if (!timers.empty())`, so behaviour is unchanged.

That does cost one uncontended lock per call on the previously-empty path, and this is called
per frame from `UpdateGameLogic`. Uncontended `std::mutex` lock and unlock is tens of
nanoseconds, so at 1000 FPS it is a few microseconds per second. If you would rather keep a
lock-free fast path I can add an atomic count instead, but I did not want to add machinery
without being asked.

The same function has a second unlocked read of `m_timers`, the
`while (!pm.m_timers.empty())` spin in `RunOnMainThread`'s synchronous path. That is the other
half of the same race, so fixing only one would have left it reported. Its `// FIXME block
cleanly until processed` still stands, since it is still a spin, just no longer undefined.

## `FrameProfiler: make the cross-thread present timestamp atomic`

`OnPresented` is already commented "May be called from any thread" and wrote a plain
`uint64_t m_lastPresentedTimeStamp` that `NewFrame` reads on the profiler's own thread. Now
`std::atomic<uint64_t>` with relaxed ordering, which is the same shape as the progress-counter
fix in #3814.

While doing it I noticed `NewFrame` read that field twice, once to compare and once to
subtract. If a store landed between the two, and the second read were larger, the `unsigned`
subtraction underflowed and `PROFILE_INPUT_TO_PRESENT` recorded a garbage value near
`UINT_MAX`, which also poisons the min, max and total accumulators for that counter. It now
loads once into a local. That is a latent bug fixed alongside the race rather than a
consequence of it.

## Verification

TSan build, Release plus `-g`, macos arm64 BGFX, full Fish Tales load then ~15s of play.

| | master | with these fixes |
| --- | --- | --- |
| `ProcessAsyncCallbacks` / `RunOnMainThread` on `m_timers` | 10 reports | **0** |
| `NewFrame` reading `m_lastPresentedTimeStamp` | 1 report | **0** |
| total warnings | 83 | 64 |

I would not read much into 83 against 64. Eleven of the difference is these two races and the
rest is run-to-run variance, since TSan only reports what it happens to observe. The claim I
am making is the two specific rows, each of which went to zero, checked by confirming no
report names the changed lines any more.

Also builds clean in the normal Release configuration, not just under TSan.

## Not fixed here, and why

The same run shows about 60 other races on master. The largest cluster is `FrameProfiler`
again, but from a different cause: `InitFPS()` calls `Reset()` on the render thread's profiler
from the main thread, which memsets a 333 KB object while the render thread writes it. It is
not only a startup ordering issue either, since `PerfUI`, `HomePage` and `ExitSplashPage` all
call `InitFPS()`, so toggling the perf overlay in a running game re-triggers it.

I left that alone deliberately. `InitFPS` has four callers, two of them live UI, and the
consequence is wrong statistics rather than anything a player would notice, so the fix wants a
maintainer's view on intent rather than my guess.

Same for the ball position and velocity reads in `hitball.cpp`, where the render thread
extrapolates toward the predicted display time by design. That looks intentional and
"fixing" it could cost frame time for no visible gain.

Happy to open an issue with the full triage of the rest if that is useful.
