### PR TITLE
Linux: enable OpenXR compilation for standalone BGFX.

### DIFF
--- a/.github/workflows/vpinball.yml
+++ b/.github/workflows/vpinball.yml
@@ -165,7 +165,7 @@ jobs:
       - if: (matrix.platform == 'linux')
         run: |
           sudo apt-get update
-          sudo apt install cmake nasm bison zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev
+          sudo apt install cmake nasm bison zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev libvulkan-dev
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.context.outputs.checkout_ref }}
@@ -413,7 +413,7 @@ jobs:
     steps:
       - run: |
           sudo apt-get update
-          sudo apt install cmake nasm bison zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libgpiod-dev
+          sudo apt install cmake nasm bison zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libgpiod-dev libvulkan-dev
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.context.outputs.checkout_ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ endif()
 if(PLATFORM STREQUAL "linux")
    option(BUILD_RPI "Build for Raspberry PI" OFF)
    option(BUILD_RK3588 "Build for RK3588" OFF)
+   option(ENABLE_XR "Enable OpenXR support (BGFX only)" ON)
+   message(STATUS "ENABLE_XR: ${ENABLE_XR}")
 endif()
 if(PLATFORM STREQUAL "ios" OR PLATFORM STREQUAL "ios-simulator" OR PLATFORM STREQUAL "android")
    option(ENABLE_XR "Enable OpenXR support" OFF)
@@ -679,6 +681,7 @@ elseif(PLATFORM STREQUAL "linux")
    if(RENDERER STREQUAL "BGFX")
       target_compile_definitions(vpinball PRIVATE
          ENABLE_BGFX
+         $<$<BOOL:${ENABLE_XR}>:ENABLE_XR>
 
          $<IF:$<CONFIG:Debug>,BX_CONFIG_DEBUG=1,BX_CONFIG_DEBUG=0>
       )
@@ -733,6 +736,10 @@ elseif(PLATFORM STREQUAL "linux")
 
    target_link_libraries(vpinball PUBLIC $<IF:$<STREQUAL:${RENDERER},BGFX>,bgfx,glad>)
 
+   if(ENABLE_XR AND RENDERER STREQUAL "BGFX")
+      target_link_libraries(vpinball PUBLIC openxr_loader vulkan)
+   endif()
+
    set(RUNTIME_OUTPUT_NAME "$<IF:$<STREQUAL:${RENDERER},BGFX>,VPinballX_BGFX,VPinballX_GL>")
 
    set_target_properties(vpinball PROPERTIES
@@ -777,6 +784,12 @@ elseif(PLATFORM STREQUAL "linux")
       if(RENDERER STREQUAL "BGFX")
          add_custom_command(TARGET vpinball POST_BUILD
             COMMAND cp -a "${RUNTIME_LIBS_DIR}/libbgfx.so" "$<TARGET_FILE_DIR:vpinball>"
+         )
+      endif()
+      if(ENABLE_XR AND RENDERER STREQUAL "BGFX")
+         add_custom_command(TARGET vpinball POST_BUILD
+            COMMAND cp -a "${RUNTIME_LIBS_DIR}/libopenxr_loader.so" "$<TARGET_FILE_DIR:vpinball>"
+            COMMAND cp -a "${RUNTIME_LIBS_DIR}/libopenxr_loader.so.*" "$<TARGET_FILE_DIR:vpinball>"
          )
       endif()
    endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ endif()
 if(PLATFORM STREQUAL "linux")
    option(BUILD_RPI "Build for Raspberry PI" OFF)
    option(BUILD_RK3588 "Build for RK3588" OFF)
+   option(ENABLE_XR "Enable OpenXR support (BGFX only)" ON)
+   message(STATUS "ENABLE_XR: ${ENABLE_XR}")
 endif()
 if(PLATFORM STREQUAL "ios" OR PLATFORM STREQUAL "ios-simulator" OR PLATFORM STREQUAL "android")
    option(ENABLE_XR "Enable OpenXR support" OFF)
@@ -680,6 +682,7 @@ elseif(PLATFORM STREQUAL "linux")
    if(RENDERER STREQUAL "BGFX")
       target_compile_definitions(vpinball PRIVATE
          ENABLE_BGFX
+         $<$<BOOL:${ENABLE_XR}>:ENABLE_XR>
 
          $<IF:$<CONFIG:Debug>,BX_CONFIG_DEBUG=1,BX_CONFIG_DEBUG=0>
       )
@@ -734,6 +737,10 @@ elseif(PLATFORM STREQUAL "linux")
 
    target_link_libraries(vpinball PUBLIC $<IF:$<STREQUAL:${RENDERER},BGFX>,bgfx,glad>)
 
+   if(ENABLE_XR AND RENDERER STREQUAL "BGFX")
+      target_link_libraries(vpinball PUBLIC openxr_loader vulkan)
+   endif()
+
    set(RUNTIME_OUTPUT_NAME "$<IF:$<STREQUAL:${RENDERER},BGFX>,VPinballX_BGFX,VPinballX_GL>")
 
    set_target_properties(vpinball PROPERTIES
@@ -778,6 +785,12 @@ elseif(PLATFORM STREQUAL "linux")
       if(RENDERER STREQUAL "BGFX")
          add_custom_command(TARGET vpinball POST_BUILD
             COMMAND cp -a "${RUNTIME_LIBS_DIR}/libbgfx.so" "$<TARGET_FILE_DIR:vpinball>"
+         )
+      endif()
+      if(ENABLE_XR AND RENDERER STREQUAL "BGFX")
+         add_custom_command(TARGET vpinball POST_BUILD
+            COMMAND cp -a "${RUNTIME_LIBS_DIR}/libopenxr_loader.so" "$<TARGET_FILE_DIR:vpinball>"
+            COMMAND cp -a "${RUNTIME_LIBS_DIR}/libopenxr_loader.so.*" "$<TARGET_FILE_DIR:vpinball>"
          )
       endif()
    endif()

--- a/make/README.md
+++ b/make/README.md
@@ -120,7 +120,7 @@ build/VPinballX_BGFX.app/Contents/MacOS/VPinballX_BGFX -play src/assets/exampleT
 
 ```
 sudo apt-get update
-sudo apt install git build-essential pkg-config autoconf automake libtool cmake nasm bison curl zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev
+sudo apt install git build-essential pkg-config autoconf automake libtool cmake nasm bison curl zlib1g-dev libdrm-dev libgbm-dev libglu1-mesa-dev libegl-dev libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev libudev-dev libx11-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libxrandr-dev libasound2-dev libpipewire-0.3-dev libvulkan-dev
 platforms/linux-x64/external.sh
 cmake -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build -- -j$(nproc)

--- a/platforms/linux-aarch64/external.sh
+++ b/platforms/linux-aarch64/external.sh
@@ -18,6 +18,7 @@ echo "  LIBDOF_SHA: ${LIBDOF_SHA}"
 echo "  FFMPEG_SHA: ${FFMPEG_SHA}"
 echo "  LIBZIP_SHA: ${LIBZIP_SHA}"
 echo "  LIBWINEVBS_SHA: ${LIBWINEVBS_SHA}"
+echo "  OPENXR_SHA: ${OPENXR_SHA}"
 echo ""
 
 NUM_PROCS=$(nproc)
@@ -157,6 +158,38 @@ if [ "${BGFX_EXPECTED_SHA}" != "${BGFX_FOUND_SHA}" ]; then
    cd ..
 
    echo "$BGFX_EXPECTED_SHA" > cache.txt
+
+   cd ..
+fi
+
+
+#
+# build openxr
+#
+
+OPENXR_EXPECTED_SHA="${OPENXR_SHA}"
+OPENXR_FOUND_SHA="$([ -f openxr/cache.txt ] && cat openxr/cache.txt || echo "")"
+
+if [ "${OPENXR_EXPECTED_SHA}" != "${OPENXR_FOUND_SHA}" ]; then
+   echo "Building OpenXR. Expected: ${OPENXR_EXPECTED_SHA}, Found: ${OPENXR_FOUND_SHA}"
+
+   rm -rf openxr
+   mkdir openxr
+   cd openxr
+
+   curl -sL https://github.com/KhronosGroup/OpenXR-SDK-Source/archive/${OPENXR_SHA}.tar.gz -o OpenXR-SDK-Source-${OPENXR_SHA}.tar.gz
+   tar xzf OpenXR-SDK-Source-${OPENXR_SHA}.tar.gz
+   mv OpenXR-SDK-Source-${OPENXR_SHA} openxr
+   cd openxr
+   cmake \
+      -DBUILD_TESTS=OFF \
+      -DDYNAMIC_LOADER=ON \
+      -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+      -B build
+   cmake --build build -- -j${NUM_PROCS}
+   cd ..
+
+   echo "$OPENXR_EXPECTED_SHA" > cache.txt
 
    cd ..
 fi
@@ -395,6 +428,9 @@ fi
 #
 # copy libraries
 #
+
+cp -a openxr/openxr/build/src/loader/libopenxr_loader.so* ../../../third-party/runtime-libs/linux-aarch64
+cp -r openxr/openxr/include/openxr ../../../third-party/include
 
 cp -a SDL3/SDL/build/libSDL3.{so,so.*} ../../../third-party/runtime-libs/linux-aarch64
 cp -r SDL3/SDL/include/SDL3 ../../../third-party/include/

--- a/platforms/linux-x64/external.sh
+++ b/platforms/linux-x64/external.sh
@@ -18,6 +18,7 @@ echo "  LIBDOF_SHA: ${LIBDOF_SHA}"
 echo "  FFMPEG_SHA: ${FFMPEG_SHA}"
 echo "  LIBZIP_SHA: ${LIBZIP_SHA}"
 echo "  LIBWINEVBS_SHA: ${LIBWINEVBS_SHA}"
+echo "  OPENXR_SHA: ${OPENXR_SHA}"
 echo ""
 
 NUM_PROCS=$(nproc)
@@ -156,6 +157,38 @@ if [ "${BGFX_EXPECTED_SHA}" != "${BGFX_FOUND_SHA}" ]; then
    cd ..
 
    echo "$BGFX_EXPECTED_SHA" > cache.txt
+
+   cd ..
+fi
+
+
+#
+# build openxr
+#
+
+OPENXR_EXPECTED_SHA="${OPENXR_SHA}"
+OPENXR_FOUND_SHA="$([ -f openxr/cache.txt ] && cat openxr/cache.txt || echo "")"
+
+if [ "${OPENXR_EXPECTED_SHA}" != "${OPENXR_FOUND_SHA}" ]; then
+   echo "Building OpenXR. Expected: ${OPENXR_EXPECTED_SHA}, Found: ${OPENXR_FOUND_SHA}"
+
+   rm -rf openxr
+   mkdir openxr
+   cd openxr
+
+   curl -sL https://github.com/KhronosGroup/OpenXR-SDK-Source/archive/${OPENXR_SHA}.tar.gz -o OpenXR-SDK-Source-${OPENXR_SHA}.tar.gz
+   tar xzf OpenXR-SDK-Source-${OPENXR_SHA}.tar.gz
+   mv OpenXR-SDK-Source-${OPENXR_SHA} openxr
+   cd openxr
+   cmake \
+      -DBUILD_TESTS=OFF \
+      -DDYNAMIC_LOADER=ON \
+      -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+      -B build
+   cmake --build build -- -j${NUM_PROCS}
+   cd ..
+
+   echo "$OPENXR_EXPECTED_SHA" > cache.txt
 
    cd ..
 fi
@@ -396,6 +429,9 @@ fi
 #
 # copy libraries
 #
+
+cp -a openxr/openxr/build/src/loader/libopenxr_loader.so* ../../../third-party/runtime-libs/linux-x64
+cp -r openxr/openxr/include/openxr ../../../third-party/include
 
 cp -a SDL3/SDL/build/libSDL3.{so,so.*} ../../../third-party/runtime-libs/linux-x64
 cp -r SDL3/SDL/include/SDL3 ../../../third-party/include/

--- a/src/renderer/VRDevice.cpp
+++ b/src/renderer/VRDevice.cpp
@@ -211,7 +211,7 @@ VRDevice::VRDevice(const Settings& settings)
          #endif
          else
             m_rendererType = bgfx::RendererType::Enum::Direct3D11; // Default to Direct3D 11
-      #elif BX_PLATFORM_ANDROID
+      #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
          m_rendererType = bgfx::RendererType::Enum::Vulkan;
       #else
          #error "Unsupported platform for OpenXR"
@@ -241,7 +241,7 @@ VRDevice::VRDevice(const Settings& settings)
       m_visibilityMaskExtensionSupported = EnableExtensionIfSupported(XR_KHR_VISIBILITY_MASK_EXTENSION_NAME);
       #if BX_PLATFORM_WINDOWS
          m_win32PerfCounterExtensionSupported = EnableExtensionIfSupported(XR_KHR_WIN32_CONVERT_PERFORMANCE_COUNTER_TIME_EXTENSION_NAME);
-      #elif BX_PLATFORM_ANDROID
+      #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
          m_convertTimespecTimeExtensionSupported = EnableExtensionIfSupported(XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME);
       #endif
       m_passthroughExtensionSupported = EnableExtensionIfSupported(XR_FB_PASSTHROUGH_EXTENSION_NAME);
@@ -270,7 +270,7 @@ VRDevice::VRDevice(const Settings& settings)
          OPENXR_CHECK(xrGetInstanceProcAddr(m_xrInstance, "xrConvertTimeToWin32PerformanceCounterKHR", (PFN_xrVoidFunction*)&m_xrConvertTimeToWin32PerformanceCounterKHR),
             "Failed to get xrConvertTimeToWin32PerformanceCounterKHR.");
       }
-      #elif BX_PLATFORM_ANDROID
+      #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
       if (m_convertTimespecTimeExtensionSupported)
       {
          OPENXR_CHECK(
@@ -567,7 +567,7 @@ void VRDevice::SetupHMD()
    PLOGI << "Selected resolution: " << m_eyeWidth << 'x' << m_eyeHeight;
 
    // Create graphics backend early so GetGraphicContext() can provide Vulkan handles to BGFX
-   #if BX_PLATFORM_WINDOWS || BX_PLATFORM_ANDROID
+   #if BX_PLATFORM_WINDOWS || BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
    if (m_rendererType == bgfx::RendererType::Vulkan)
    {
       PLOGI << "Creating Vulkan backend for OpenXR (before BGFX initialization)";
@@ -991,7 +991,7 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
       QueryPerformanceFrequency(&TimerFreq);
       m_predictedDisplayTimestamp += static_cast<float>(displayTime.QuadPart - now.QuadPart) / static_cast<float>(TimerFreq.QuadPart);
    }
-   #elif BX_PLATFORM_ANDROID
+   #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
    if (m_xrConvertTimeToTimespecTimeKHR)
    {
       timespec displayTime;

--- a/src/renderer/VRDevice.cpp
+++ b/src/renderer/VRDevice.cpp
@@ -204,7 +204,7 @@ VRDevice::VRDevice(const Settings& settings)
             m_rendererType = bgfx::RendererType::Enum::Direct3D12;
          else
             m_rendererType = bgfx::RendererType::Enum::Direct3D11; // Default to Direct3D 11
-      #elif BX_PLATFORM_ANDROID
+      #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
          m_rendererType = bgfx::RendererType::Enum::Vulkan;
       #else
          #error "Unsupported platform for OpenXR"
@@ -234,7 +234,7 @@ VRDevice::VRDevice(const Settings& settings)
       m_visibilityMaskExtensionSupported = EnableExtensionIfSupported(XR_KHR_VISIBILITY_MASK_EXTENSION_NAME);
       #if BX_PLATFORM_WINDOWS
          m_win32PerfCounterExtensionSupported = EnableExtensionIfSupported(XR_KHR_WIN32_CONVERT_PERFORMANCE_COUNTER_TIME_EXTENSION_NAME);
-      #elif BX_PLATFORM_ANDROID
+      #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
          m_convertTimespecTimeExtensionSupported = EnableExtensionIfSupported(XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME);
       #endif
       m_passthroughExtensionSupported = EnableExtensionIfSupported(XR_FB_PASSTHROUGH_EXTENSION_NAME);
@@ -263,7 +263,7 @@ VRDevice::VRDevice(const Settings& settings)
          OPENXR_CHECK(xrGetInstanceProcAddr(m_xrInstance, "xrConvertTimeToWin32PerformanceCounterKHR", (PFN_xrVoidFunction*)&m_xrConvertTimeToWin32PerformanceCounterKHR),
             "Failed to get xrConvertTimeToWin32PerformanceCounterKHR.");
       }
-      #elif BX_PLATFORM_ANDROID
+      #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
       if (m_convertTimespecTimeExtensionSupported)
       {
          OPENXR_CHECK(
@@ -560,7 +560,7 @@ void VRDevice::SetupHMD()
    PLOGI << "Selected resolution: " << m_eyeWidth << 'x' << m_eyeHeight;
 
    // Create graphics backend early so GetGraphicContext() can provide Vulkan handles to BGFX
-   #if BX_PLATFORM_WINDOWS || BX_PLATFORM_ANDROID
+   #if BX_PLATFORM_WINDOWS || BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
    if (m_rendererType == bgfx::RendererType::Vulkan)
    {
       PLOGI << "Creating Vulkan backend for OpenXR (before BGFX initialization)";
@@ -984,7 +984,7 @@ void VRDevice::RenderFrame(RenderDevice* rd, const std::function<void(RenderTarg
       QueryPerformanceFrequency(&TimerFreq);
       m_predictedDisplayTimestamp += static_cast<float>(displayTime.QuadPart - now.QuadPart) / static_cast<float>(TimerFreq.QuadPart);
    }
-   #elif BX_PLATFORM_ANDROID
+   #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
    if (m_xrConvertTimeToTimespecTimeKHR)
    {
       timespec displayTime;

--- a/src/renderer/VRDevice.h
+++ b/src/renderer/VRDevice.h
@@ -13,6 +13,15 @@
       #define BX_PLATFORM_ANDROID 1
    #endif
 
+   // libwinevbs / Wine headers define _WIN32 on standalone Linux, so bx/platform.h
+   // incorrectly reports BX_PLATFORM_WINDOWS and we pull in d3d11.h / d3d12.h.
+   #if defined(__STANDALONE__) && defined(__linux__) && !defined(__ANDROID__)
+      #undef BX_PLATFORM_WINDOWS
+      #define BX_PLATFORM_WINDOWS 0
+      #undef BX_PLATFORM_LINUX
+      #define BX_PLATFORM_LINUX 1
+   #endif
+
    #if BX_PLATFORM_WINDOWS
       #define XR_USE_PLATFORM_WIN32
       #define XR_USE_GRAPHICS_API_VULKAN
@@ -26,6 +35,9 @@
       #define XR_USE_PLATFORM_ANDROID
       #define XR_USE_GRAPHICS_API_VULKAN
       //#define XR_USE_GRAPHICS_API_OPENGL_ES
+   #elif BX_PLATFORM_LINUX
+      #define XR_USE_TIMESPEC
+      #define XR_USE_GRAPHICS_API_VULKAN
    #endif
 
 
@@ -276,7 +288,7 @@ private:
    #if BX_PLATFORM_WINDOWS
    bool m_win32PerfCounterExtensionSupported = false;
    PFN_xrConvertTimeToWin32PerformanceCounterKHR m_xrConvertTimeToWin32PerformanceCounterKHR = nullptr;
-   #elif BX_PLATFORM_ANDROID
+   #elif BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX
    bool m_convertTimespecTimeExtensionSupported = false;
    PFN_xrConvertTimeToTimespecTimeKHR m_xrConvertTimeToTimespecTimeKHR = nullptr;
    #endif

--- a/src/renderer/VRDevice.h
+++ b/src/renderer/VRDevice.h
@@ -3,23 +3,13 @@
 #pragma once
 
 #if defined(ENABLE_XR)
-   #include "bx/platform.h"
-
-   #if defined(__ANDROID__) && BX_PLATFORM_WINDOWS
-      // Our setup may lead to this incorrect double definition, so fix it
-      #undef BX_PLATFORM_WINDOWS
-      #define BX_PLATFORM_WINDOWS 0
-      #undef BX_PLATFORM_ANDROID
-      #define BX_PLATFORM_ANDROID 1
+   #ifdef __STANDALONE__
+   #pragma push_macro("_WIN64")
+   #undef _WIN64
    #endif
-
-   // libwinevbs / Wine headers define _WIN32 on standalone Linux, so bx/platform.h
-   // incorrectly reports BX_PLATFORM_WINDOWS and we pull in d3d11.h / d3d12.h.
-   #if defined(__STANDALONE__) && defined(__linux__) && !defined(__ANDROID__)
-      #undef BX_PLATFORM_WINDOWS
-      #define BX_PLATFORM_WINDOWS 0
-      #undef BX_PLATFORM_LINUX
-      #define BX_PLATFORM_LINUX 1
+   #include "bx/platform.h"
+   #ifdef __STANDALONE__
+   #pragma pop_macro("_WIN64")
    #endif
 
    #if BX_PLATFORM_WINDOWS

--- a/src/renderer/XRVulkanBackend.h
+++ b/src/renderer/XRVulkanBackend.h
@@ -12,6 +12,20 @@
 #include <vulkan/vulkan_android.h>
 #endif
 
+#if BX_PLATFORM_LINUX
+// Disabled preview-window path still references these tokens at compile time.
+// Avoid vulkan_wayland.h / vulkan_xlib.h / vulkan_xcb.h (X11 None/Success clashes).
+#ifndef VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME
+#define VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME "VK_KHR_wayland_surface"
+#endif
+#ifndef VK_KHR_XLIB_SURFACE_EXTENSION_NAME
+#define VK_KHR_XLIB_SURFACE_EXTENSION_NAME "VK_KHR_xlib_surface"
+#endif
+#ifndef VK_KHR_XCB_SURFACE_EXTENSION_NAME
+#define VK_KHR_XCB_SURFACE_EXTENSION_NAME "VK_KHR_xcb_surface"
+#endif
+#endif
+
 #include "bx/os.h"
 
 class LibVulkan

--- a/src/renderer/XRVulkanBackend.h
+++ b/src/renderer/XRVulkanBackend.h
@@ -12,20 +12,6 @@
 #include <vulkan/vulkan_android.h>
 #endif
 
-#if BX_PLATFORM_LINUX
-// Disabled preview-window path still references these tokens at compile time.
-// Avoid vulkan_wayland.h / vulkan_xlib.h / vulkan_xcb.h (X11 None/Success clashes).
-#ifndef VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME
-#define VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME "VK_KHR_wayland_surface"
-#endif
-#ifndef VK_KHR_XLIB_SURFACE_EXTENSION_NAME
-#define VK_KHR_XLIB_SURFACE_EXTENSION_NAME "VK_KHR_xlib_surface"
-#endif
-#ifndef VK_KHR_XCB_SURFACE_EXTENSION_NAME
-#define VK_KHR_XCB_SURFACE_EXTENSION_NAME "VK_KHR_xcb_surface"
-#endif
-#endif
-
 #include "bx/os.h"
 
 class LibVulkan
@@ -119,9 +105,9 @@ public:
 #if BX_PLATFORM_ANDROID
          instanceExtensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 #elif BX_PLATFORM_LINUX
-         instanceExtensions.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-         instanceExtensions.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-         instanceExtensions.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+         instanceExtensions.push_back("VK_KHR_wayland_surface");
+         instanceExtensions.push_back("VK_KHR_xlib_surface");
+         instanceExtensions.push_back("VK_KHR_xcb_surface");
 #elif BX_PLATFORM_WINDOWS
          instanceExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif BX_PLATFORM_OSX


### PR DESCRIPTION
Warning : this is AI-based. I was just willing to see what was missing for openxr support on Linux, and I was very pleased to see very little was actually missing.

Build the OpenXR loader in linux-x64/aarch64 external.sh, gate ENABLE_XR on Linux BGFX, and teach VRDevice/XRVulkanBackend about BX_PLATFORM_LINUX.

Wine's basetsd.h / minwindef.h define _WIN64 on 64-bit Unix, which made bx/platform.h report BX_PLATFORM_WINDOWS (and pull in the D3D headers). VRDevice.h now wraps the bx/platform.h include with the same push_macro / undef _WIN64 / pop_macro guard already used in Shader.h and typedefs3D.h, so bx detects Linux and Android on its own and the previous Android override is dropped too. The disabled preview-window path in XRVulkanBackend.h uses the Vulkan WSI extension name literals directly instead of pulling in the xlib / xcb / wayland Vulkan headers.

Testing instructions : 
* run platforms/linux-x64/external.sh
* cmake -DCMAKE_BUILD_TYPE=Release -B build
* cmake --build build -- -j$(nproc)
* ensure your VR runtime is running (if using wivrn like me, make sure the wivrn client is connected)
* export XR_RUNTIME_JSON="$HOME/.config/openxr/1/active_runtime.json"
* run VPinballX_BGFX with a VR-compatible ini file and table
