### PR TITLE
Optimize POLE stream reads for faster table loading

### DIFF
--- a/src/core/Settings_properties.inl
+++ b/src/core/Settings_properties.inl
@@ -4,6 +4,9 @@ PropString(Version, VPinball, "VPX Version"s, "VPX version that saved this file"
 // General Application settings
 PropBool(Editor, EnableLog, "Enable Log"s, "Enable general logging to the vinball.log file"s, true);
 PropBool(Editor, DisableHash, "Disable File Validation"s, "Disable file integrity validation (risky; but slightly faster loading)"s, false);
+PropEnum(Editor, LoadThreadPoolMode, "Table Load Concurrency"s,
+   "Thread pool size used to read and parse table data during load.\nAuto reads with a single thread for network/SMB paths (keeps reads sequential, far faster over the network) and uses multi threaded for local storage.\nSingle Threaded forces one thread; Multi Threaded forces all cores."s,
+   int, 0, "Auto"s, "Single Threaded"s, "Multi Threaded"s);
 
 // Audio settings
 PropInt(Player, MusicVolume, "Backglass Volume"s, "Main volume for music and sound played from the backglass speakers"s, 0, 100, 100);

--- a/src/core/def.cpp
+++ b/src/core/def.cpp
@@ -8,6 +8,12 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include "standalone/PoleStorage.h"
+#if defined(__APPLE__)
+#include <sys/param.h>
+#include <sys/mount.h>
+#elif defined(__linux__) || defined(__ANDROID__)
+#include <sys/vfs.h>
+#endif
 #endif
 
 #include "core/VPApp.h"
@@ -587,6 +593,47 @@ void write_file(const string& filename, const vector<uint8_t>& data, const bool 
    }
    file.write(reinterpret_cast<const char*>(data.data()), data.size());
    file.close();
+}
+
+bool IsNetworkPath(const std::filesystem::path& path)
+{
+#ifndef __STANDALONE__
+   // Windows: a UNC path (\\server\share or //server/share) is always remote. Otherwise ask the
+   // drive type of the path's root.
+   const std::wstring wpath = path.native();
+   if (wpath.size() >= 2 && (wpath[0] == L'\\' || wpath[0] == L'/') && (wpath[1] == L'\\' || wpath[1] == L'/'))
+      return true;
+   const std::filesystem::path root = path.root_path();
+   if (root.empty())
+      return false;
+   return GetDriveTypeW(root.wstring().c_str()) == DRIVE_REMOTE;
+#elif defined(__APPLE__)
+   // macOS/BSD: MNT_LOCAL is set for local filesystems and clear for network mounts.
+   struct statfs buf;
+   if (statfs(path.c_str(), &buf) != 0)
+      return false;
+   return (buf.f_flags & MNT_LOCAL) == 0;
+#elif defined(__linux__) || defined(__ANDROID__)
+   // Linux has no MNT_LOCAL, so match the filesystem magic of known network filesystems.
+   struct statfs buf;
+   if (statfs(path.c_str(), &buf) != 0)
+      return false;
+   switch (static_cast<unsigned long>(buf.f_type))
+   {
+   case 0x6969:     // NFS_SUPER_MAGIC
+   case 0x517B:     // SMB_SUPER_MAGIC (legacy smbfs)
+   case 0xFF534D42: // CIFS_MAGIC_NUMBER
+   case 0xFE534D42: // SMB2_MAGIC_NUMBER
+   case 0x7461636C: // OCFS2
+   case 0x01021997: // V9FS (Plan 9, used by some VM shares)
+      return true;
+   default:
+      return false;
+   }
+#else
+   (void)path;
+   return false;
+#endif
 }
 
 string normalize_path_separators(const string& szPath)

--- a/src/core/def.h
+++ b/src/core/def.h
@@ -911,6 +911,11 @@ vector<uint8_t> read_file(const std::filesystem::path& filename, const bool bina
 void write_file(const string& filename, const vector<uint8_t>& data, const bool binary = true);
 inline bool DirExists(const std::filesystem::path& dirPath) { return std::filesystem::exists(dirPath) && std::filesystem::is_directory(dirPath); }
 inline bool FileExists(const std::filesystem::path& filePath) { return std::filesystem::exists(filePath) && !std::filesystem::is_directory(filePath); }
+// True if the path lives on a network/remote filesystem (SMB, NFS, ...). Best-effort: on any
+// query failure or unknown filesystem it returns false (treated as local). Used to pick a
+// sequential single-threaded read strategy for network shares, where interleaved concurrent
+// reads defeat the client's read-ahead.
+bool IsNetworkPath(const std::filesystem::path& path);
 inline string TitleFromFilename(const std::filesystem::path& filename) { return filename.stem().string(); }
 inline std::filesystem::path PathFromFilename(const std::filesystem::path& filename) { return filename.parent_path(); }
 string normalize_path_separators(const string& szPath);

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -1614,8 +1614,23 @@ HRESULT PinTable::LoadGameFromFilename(const std::filesystem::path &filename, VP
          }
 
          // Dispatch all load tasks & wait, updating the progress bar on UI thread
-         // Tasks are sorted by storage offset to limit read back and get better reading performance
-         ThreadPool pool(g_app->GetLogicalNumberOfProcessors());
+         // Tasks are sorted by storage offset to limit read back and get better reading performance.
+         // Concurrent workers read their own streams, which interleaves requests on the underlying
+         // file. On local storage that is a win (parsing parallelises). Over a network share it is a
+         // loss: interleaved reads defeat the SMB/NFS client read-ahead, and a single reader visiting
+         // streams in offset order is several times faster. So size the pool by where the table lives,
+         // overridable via the Editor/LoadThreadPoolMode setting.
+         const int logicalCores = g_app->GetLogicalNumberOfProcessors();
+         int loadPoolSize;
+         switch (m_settings.GetEditor_LoadThreadPoolMode())
+         {
+         case 1: loadPoolSize = 1; break; // Single Threaded
+         case 2: loadPoolSize = logicalCores; break; // Multi Threaded
+         default: loadPoolSize = IsNetworkPath(m_filename) ? 1 : logicalCores; break; // Auto
+         }
+         PLOGI << "Loading " << loadQueue.size() << " table streams on " << loadPoolSize
+               << (loadPoolSize == 1 ? " thread" : " threads");
+         ThreadPool pool(loadPoolSize);
          std::ranges::sort(loadQueue, [&rootStorage](const LoadTask &a, const LoadTask &b) { return rootStorage.streamOffset(a.name) < rootStorage.streamOffset(b.name); });
          feedback.SetLength(static_cast<unsigned int>(loadQueue.size()));
          for (const LoadTask &task : loadQueue)

--- a/third-party/include/pole/pole.cpp
+++ b/third-party/include/pole/pole.cpp
@@ -72,6 +72,13 @@
 // enable to activate debugging output
 // #define POLE_DEBUG
 #define CACHEBUFSIZE 4096 //a presumably reasonable size for the read cache
+// Readahead window used by StreamIO::read. Callers such as VPX's BiffReader read stream
+// contents a few bytes at a time, and without a window each such call became its own
+// block-sized request. Measured on a 428 MB table holding 1860 streams: block chains are
+// contiguous, averaging 352 KB per run, and raising this to 1 MB moved throughput by under
+// 5%. The window is allocated lazily and never exceeds the stream's own length, so small
+// streams stay small.
+#define READAHEADBUFSIZE (256*1024)
 
 namespace POLE
 {
@@ -287,6 +294,10 @@ class StreamIO final
 
     // pointer for read
     uint64 m_pos;
+    // readahead window over this stream's block chain, see READAHEADBUFSIZE
+    std::vector<unsigned char> ra_buf;
+    uint64 ra_pos;
+    uint64 ra_len;
 
     // simple cache system to speed-up getch()
     unsigned char* cache_data;
@@ -1608,20 +1619,34 @@ uint64 StorageIO::loadBigBlocks( const std::vector<uint64>& blocks,
   if( blocks.size() < 1 ) return 0;
   if( maxlen == 0 ) return 0;
 
-  // read block one by one, seems fast enough
+  // Read each run of consecutive blocks in a single request. Block chains in a .vpx are
+  // overwhelmingly contiguous, so this collapses what was one seek and one read per block
+  // into roughly one per run. It matters most on a network filesystem, where each request
+  // costs a round trip rather than just a syscall.
   uint64 bytes = 0;
-  for( size_t i=0; (i < blocks.size() ) && ( bytes<maxlen ); i++ )
+  size_t i = 0;
+  while( ( i < blocks.size() ) && ( bytes < maxlen ) )
   {
-    uint64 block = blocks[i];
-    uint64 pos =  bbat->blockSize * ( block+1 );
-    uint64 p = (bbat->blockSize < maxlen-bytes) ? bbat->blockSize : maxlen-bytes;
-    if( pos + p > filesize )
-        p = filesize - pos;
+    // extend the run while the next block immediately follows the previous one
+    size_t runEnd = i + 1;
+    while( ( runEnd < blocks.size() ) && ( blocks[runEnd] == blocks[runEnd-1] + 1 ) )
+      runEnd++;
+
+    const uint64 pos = bbat->blockSize * ( blocks[i] + 1 );
+    // A chain pointing past the end of the file would underflow the clamp below, and that
+    // length is then used directly as a read size, so stop rather than clamp.
+    if( pos >= filesize ) break;
+
+    uint64 p = static_cast<uint64>( runEnd - i ) * bbat->blockSize;
+    if( p > maxlen - bytes ) p = maxlen - bytes;
+    if( pos + p > filesize ) p = filesize - pos;
+
     file.seekg( pos );
     file.read( (char*)data + bytes, p );
     fileCheck(file);
     // should use gcount to see how many bytes were really returned - eof check...
     bytes += p;
+    i = runEnd;
   }
 
   return bytes;
@@ -1940,6 +1965,9 @@ StreamIO::StreamIO( StorageIO* s, DirEntry* e)
     eof(false),
     fail(false),
     m_pos(0),
+    ra_buf(),
+    ra_pos(0),
+    ra_len(0),             // indicating an empty readahead window
     cache_data(new unsigned char[CACHEBUFSIZE]),        
     cache_size(0),         // indicating an empty cache
     cache_pos(0)
@@ -2096,28 +2124,48 @@ uint64 StreamIO::read( uint64 pos, unsigned char* data, uint64 maxlen )
   }
   else
   {
-    // big file
-    uint64 index = pos / io->bbat->blockSize;
-    
-    if( index >= blocks.size() ) return 0;
-    
-    assert(io->bbat->blockSize <= std::numeric_limits<size_t>::max());
-    unsigned char* buf = new unsigned char[ (size_t)io->bbat->blockSize ];
-    uint64 offset = pos % io->bbat->blockSize;
+    // Big file, served out of a readahead window rather than a block at a time. The
+    // previous form issued a block-sized read on every call, so a caller reading four
+    // bytes at a time paid a whole block read per four bytes.
+    const uint64 blockSize = io->bbat->blockSize;
+    assert(blockSize <= std::numeric_limits<size_t>::max());
+
+    if( pos / blockSize >= blocks.size() ) return 0;
+
+    const uint64 windowBlocks = (READAHEADBUFSIZE + blockSize - 1) / blockSize;
     while( totalbytes < maxlen )
     {
-      if( index >= blocks.size() ) break;
-      io->loadBigBlock( blocks[(size_t)index], buf, io->bbat->blockSize );
-      uint64 count = io->bbat->blockSize - offset;
-      if( count > maxlen-totalbytes ) count = maxlen-totalbytes;
-      assert(count <= std::numeric_limits<size_t>::max());
-      memcpy( data+totalbytes, buf + offset, (size_t)count );
-      totalbytes += count;
-      index++;
-      offset = 0;
-    }
-    delete [] buf;
+      const uint64 wanted = pos + totalbytes;
+      const bool inWindow = ( ra_len > 0 ) && ( wanted >= ra_pos ) && ( wanted < ra_pos + ra_len );
+      if( !inWindow )
+      {
+        // refill, block aligned so the window maps onto whole blocks
+        const uint64 index = wanted / blockSize;
+        if( index >= blocks.size() ) break;
 
+        uint64 nblocks = static_cast<uint64>( blocks.size() ) - index;
+        if( nblocks > windowBlocks ) nblocks = windowBlocks;
+
+        const uint64 span = nblocks * blockSize;
+        assert(span <= std::numeric_limits<size_t>::max());
+        if( ra_buf.size() < (size_t)span ) ra_buf.resize( (size_t)span );
+
+        const std::vector<uint64> chain( blocks.begin() + (size_t)index,
+                                         blocks.begin() + (size_t)( index + nblocks ) );
+        const uint64 got = io->loadBigBlocks( chain, ra_buf.data(), span );
+        if( got == 0 ) break;
+
+        ra_pos = index * blockSize;
+        ra_len = got;
+      }
+
+      const uint64 offset = wanted - ra_pos;
+      uint64 count = ra_len - offset;
+      if( count > maxlen - totalbytes ) count = maxlen - totalbytes;
+      assert(count <= std::numeric_limits<size_t>::max());
+      memcpy( data + totalbytes, ra_buf.data() + (size_t)offset, (size_t)count );
+      totalbytes += count;
+    }
   }
 
   return totalbytes;

--- a/third-party/include/pole/pole.cpp
+++ b/third-party/include/pole/pole.cpp
@@ -1734,8 +1734,10 @@ uint64 StorageIO::loadSmallBlocks( const std::vector<uint64>& blocks,
   assert(bbat->blockSize <= std::numeric_limits<size_t>::max());
   unsigned char* buf = new unsigned char[ (size_t)bbat->blockSize ];
 
-  // read small block one by one
+  // Sixty-four mini-blocks live inside one big block, so consecutive mini-blocks almost
+  // always resolve to the block already in hand. Remember it rather than re-reading it.
   uint64 bytes = 0;
+  uint64 loadedIndex = std::numeric_limits<uint64>::max();
   for( size_t i=0; ( i<blocks.size() ) && ( bytes<maxlen ); i++ )
   {
     uint64 block = blocks[i];
@@ -1745,7 +1747,11 @@ uint64 StorageIO::loadSmallBlocks( const std::vector<uint64>& blocks,
     uint64 bbindex = pos / bbat->blockSize;
     if( bbindex >= sb_blocks.size() ) break;
 
-    loadBigBlock( sb_blocks[ (size_t)bbindex ], buf, bbat->blockSize );
+    if( bbindex != loadedIndex )
+    {
+      loadBigBlock( sb_blocks[ (size_t)bbindex ], buf, bbat->blockSize );
+      loadedIndex = bbindex;
+    }
 
     // copy the data
     uint64 offset = pos % bbat->blockSize;
@@ -2099,28 +2105,44 @@ uint64 StreamIO::read( uint64 pos, unsigned char* data, uint64 maxlen )
       maxlen = entry->size - pos;
   if ( entry->size < io->header->threshold )
   {
-    // small file
-    uint64 index = pos / io->sbat->blockSize;
+    // Small file, served out of the same readahead window the big-file branch uses. The
+    // previous form fetched one mini-block per call, and each of those pulled a whole
+    // 4 KiB block, so a caller reading four bytes at a time paid a block read per call.
+    const uint64 miniSize = io->sbat->blockSize;
+    assert(miniSize <= std::numeric_limits<size_t>::max());
 
-    if( index >= blocks.size() ) return 0;
+    if( pos / miniSize >= blocks.size() ) return 0;
 
-    assert(io->sbat->blockSize <= std::numeric_limits<size_t>::max());
-    unsigned char* buf = new unsigned char[ (size_t)io->sbat->blockSize ];
-    uint64 offset = pos % io->sbat->blockSize;
     while( totalbytes < maxlen )
     {
-      if( index >= blocks.size() ) break;
-      io->loadSmallBlock( blocks[(size_t)index], buf, io->bbat->blockSize );
-      uint64 count = io->sbat->blockSize - offset;
-      if( count > maxlen-totalbytes ) count = maxlen-totalbytes;
-      assert(count <= std::numeric_limits<size_t>::max());
-      memcpy( data+totalbytes, buf + offset, (size_t)count );
-      totalbytes += count;
-      offset = 0;
-      index++;
-    }
-    delete[] buf;
+      const uint64 wanted = pos + totalbytes;
+      const bool inWindow = ( ra_len > 0 ) && ( wanted >= ra_pos ) && ( wanted < ra_pos + ra_len );
+      if( !inWindow )
+      {
+        const uint64 index = wanted / miniSize;
+        if( index >= blocks.size() ) break;
 
+        // A mini stream is under the threshold that decides this branch, so the rest of
+        // its chain always fits in one window and one fill covers every later read.
+        const uint64 span = ( static_cast<uint64>( blocks.size() ) - index ) * miniSize;
+        assert(span <= std::numeric_limits<size_t>::max());
+        if( ra_buf.size() < (size_t)span ) ra_buf.resize( (size_t)span );
+
+        const std::vector<uint64> chain( blocks.begin() + (size_t)index, blocks.end() );
+        const uint64 got = io->loadSmallBlocks( chain, ra_buf.data(), span );
+        if( got == 0 ) break;
+
+        ra_pos = index * miniSize;
+        ra_len = got;
+      }
+
+      const uint64 offset = wanted - ra_pos;
+      uint64 count = ra_len - offset;
+      if( count > maxlen - totalbytes ) count = maxlen - totalbytes;
+      assert(count <= std::numeric_limits<size_t>::max());
+      memcpy( data + totalbytes, ra_buf.data() + (size_t)offset, (size_t)count );
+      totalbytes += count;
+    }
   }
   else
   {


### PR DESCRIPTION
> Draft, and AI-assisted. Opened as a draft per the project's policy. Every claim here I measured myself, and I have tried to be clear about what is not measured.

Follow-up to #3817. That PR's ordered task list and cross-platform POLE move are merged. This picks up the two POLE read optimizations mentioned there but not taken, plus one more that turns out to matter more than either: sizing the load thread pool by where the table lives.

Cold over SMB, tables load 23-32x faster than current master. Local loading is unchanged. The only added memory is a small per-stream read-ahead buffer (see below), nowhere near the whole-stream buffering that raised memory concerns before.

## Why

Current master reads each stream on a pool worker, so all workers read at once. On local storage that is a win, the disk does not care about interleaving and the parsing runs in parallel. Over a network share it is a big loss. The client's read-ahead only works on a sequential run of requests, and a dozen workers reading a dozen different regions is not sequential. Every interleaved jump stalls the prefetch and costs a round trip.

Two things follow from that, and this PR does both. Make each stream's own reads contiguous, and stop workers reading different streams at the same time when the table is on a network share.

## The commits

**`POLE: coalesce block reads and add a per-stream readahead window`.** `StreamIO::read` did one `seekg` plus one `read` per block, and `BiffReader` reads a handful of bytes at a time, so a single stream turned into hundreds of block-sized requests. This merges physically contiguous blocks into one request (`.vpx` chains are almost always contiguous) and serves `read` from a 256 KB per-stream window, so a run of small reads no longer triggers a block read each time. The window belongs to the `StreamIO`, so it stays safe under the existing read mutex.

**`POLE: stop re-reading the same block for every mini-block`.** Streams under 4096 bytes live in the mini-stream container, and reading each 64-byte mini-block pulled its whole enclosing 4 KB block again. This keeps the last enclosing block so consecutive mini-blocks in it come from one read.

**`PinTable: size the load thread pool by storage type`.** The loader now picks its pool size from where the table lives. One thread for a network or SMB path, all cores for local storage. Streams are still visited in offset order in both cases (already in current master); the only thing this changes is how many threads read at once. On a network share one reader keeps the requests sequential, which is what the read-ahead needs. On local storage all cores parse in parallel with no interleaving penalty. Detection is `IsNetworkPath()` in `def.cpp`: `MNT_LOCAL` on macOS, filesystem magic on Linux, UNC plus `GetDriveType` on Windows, best-effort and treating anything it cannot classify as local. A new `Editor / LoadThreadPoolMode` setting (Auto, Single Threaded, Multi Threaded) overrides it if the guess is ever wrong.

The only memory this adds is the read-ahead windows from the first two commits: 256 KB per stream being read, so at most one per pool thread. Master's approach of buffering whole streams, and the memory concern raised on #3817 and #3767, does not apply here.

## How the design was chosen

The useful part was ruling out the obvious answers. All measured on a real SMB share, purge before every load so every read is cold, medians of 3.

Reads are not starved by request size. A single-threaded sequential read of a 428 MB table is about 3.2s at ~130 MB/s, and that holds whether the read size is 512 bytes or 1 MB. The macOS SMB client prefetches well, so small sequential reads are already fast.

Concurrency does not help the reads. The same file read with 1, 4, and 12 threads gave 133, 102, and 114 MB/s. More readers is flat to worse, one already saturates the link. So dropping POLE's internal read lock to allow concurrent reads would buy nothing, and I ruled it out.

The cost is the seek pattern, not the reads. If 3.2s of reading sits inside a 20s or 137s load, the rest is stalls. Forcing the current pool to a single thread over SMB took one table from ~20s at 12 threads to ~4.4s at 1 thread, near the sequential floor. That points straight at interleaving between concurrent workers as the dominant cost.

So the fix is to read sequentially over the network, not to read in parallel and not to touch the lock. Coalescing makes each stream's reads contiguous. Single-threaded loading keeps the order across streams monotonic. A producer/consumer split, one reader feeding parallel parsers, would gain a little more but brings back per-stream buffering and its memory cost, so I left it out. Adaptive sizing gets most of the win with no added memory.

## Results

Extract phase (`PinTable Data loaded` to `Images, Sounds, Fonts and Parts loaded`), medians of 3, cold, purge before each load. Same machine and method as the #3817 numbers.

Cold, over SMB (WiFi):

| build | Fish Tales | Dark Chaos | Airborne |
| --- | --- | --- | --- |
| master `42ec8999f` (pre-rewrite) | 38.1s | 32.1s | 21.4s |
| master `193928030` (current) | 137.0s | 99.3s | 73.5s |
| this PR | 4.4s | 4.4s | 2.6s |

Warm, local SSD, where adaptive keeps all cores:

| build | Dark Chaos |
| --- | --- |
| master `193928030` | 5.5s |
| this PR | 0.37s |

The local win comes from the two POLE commits alone; they help every transport. The SMB win is those plus the single reader. Content fingerprints and error counts match across builds on all three tables, so what gets loaded is unchanged.

## Testing

macOS arm64 BGFX, tables on both local SSD and a real SMB NAS. Auto-detection checked both ways: SMB paths load on 1 thread, local paths on all cores, both logged. Both override modes checked. The Windows and Linux detection paths are written but not run here; each falls back to local on any failure, so the worst case is today's behavior.
