### PR TITLE
Log script errors reported by plugins instead of dropping them

### DIFF
--- a/plugins/pinmame/Controller.cpp
+++ b/plugins/pinmame/Controller.cpp
@@ -137,7 +137,7 @@ void Controller::SetGameName(const string& name)
    }
    else if (status == PINMAME_STATUS_GAME_NOT_FOUND)
    {
-      PSC_FAIL("Game name not found.");
+      PSC_FAIL("Game name not found: '%s'.", name.c_str());
    }
    else if (status == PINMAME_STATUS_CONFIG_NOT_SET)
    {

--- a/src/core/VPXPluginAPIImpl.cpp
+++ b/src/core/VPXPluginAPIImpl.cpp
@@ -337,7 +337,10 @@ bool VPXPluginAPIImpl::IsScriptContributor(const unsigned int endpointId) const 
 void MSGPIAPI VPXPluginAPIImpl::OnScriptError(unsigned int type, const char* message)
 {
    VPXPluginAPIImpl& pi = g_pplayer->m_pluginAPI;
-   // FIXME implement in DynamicDispatch
+   static const char* typeNames[] = { "Failure", "Invalid argument", "Null pointer", "Not implemented" };
+   const char* typeName = type < std::size(typeNames) ? typeNames[type] : "Unknown error";
+   PLOGE << "Script error reported by plugin (" << typeName << "): " << (message ? message : "");
+   // FIXME implement in DynamicDispatch (raise an actual script error instead of just logging)
 }
 
 ScriptClassDef* MSGPIAPI VPXPluginAPIImpl::GetClassDef(const char* typeName)


### PR DESCRIPTION
`VPXPluginAPIImpl::OnScriptError` was an empty stub, so any `PSC_FAIL` raised by a scriptable plugin vanished without a trace: no log line and no script error. A table with an unresolvable PinMAME game name (typo, missing alias entry) loads and renders normally but sits with a silently dead controller, which makes this very painful to diagnose.

This logs the reported error (with its type) until proper script error propagation into the script engine is implemented (existing FIXME), and includes the offending name in the PinMAME game-not-found message since that is half the diagnosis.

Example, previously invisible:
```
ERROR [VPXPluginAPIImpl::OnScriptError@342] Script error reported by plugin (Failure): Game name not found: 'grease'.
```