### PR TITLE
Fix use-after-destroy in ResURIResolver destructor

### DIFF
--- a/plugins/plugins/ResURIResolver.cpp
+++ b/plugins/plugins/ResURIResolver.cpp
@@ -50,10 +50,6 @@ ResURIResolver::ResURIResolver(const MsgPluginAPI &msgAPI, unsigned int endpoint
 
 ResURIResolver::~ResURIResolver()
 {
-   // The consumers invoke their on-change callbacks from their destructor, and
-   // those callbacks clear the caches below. Members are destroyed in reverse
-   // declaration order, which would destroy each cache before its consumer,
-   // so release the consumers explicitly while the caches are still alive.
    m_displaySources.reset();
    m_segSources.reset();
    m_stateSources.reset();

--- a/plugins/plugins/ResURIResolver.cpp
+++ b/plugins/plugins/ResURIResolver.cpp
@@ -48,7 +48,16 @@ ResURIResolver::ResURIResolver(const MsgPluginAPI &msgAPI, unsigned int endpoint
    }
 }
 
-ResURIResolver::~ResURIResolver() { }
+ResURIResolver::~ResURIResolver()
+{
+   // The consumers invoke their on-change callbacks from their destructor, and
+   // those callbacks clear the caches below. Members are destroyed in reverse
+   // declaration order, which would destroy each cache before its consumer,
+   // so release the consumers explicitly while the caches are still alive.
+   m_displaySources.reset();
+   m_segSources.reset();
+   m_stateSources.reset();
+}
 
 string ResURIResolver::trim_string(const string &str)
 {


### PR DESCRIPTION
Exiting a table aborted with `free(): invalid pointer` from `ScoreView::~ScoreView` -> `ResURIResolver::~ResURIResolver`.

`ResURIResolver` owns three `CtrlItemConsumer` members whose on-change callbacks (registered in the constructor) clear the resolver's cache maps. `~CtrlItemConsumer` invokes that callback. The consumers are declared before the caches they clear, so with the default reverse destruction order each cache was destroyed first and the callback then ran `clear()` on an already destroyed map.

The destructor now releases the consumers explicitly while the caches are still alive. This affects every plugin that owns a `ResURIResolver` (ScoreView, B2S, B2SLegacy); ScoreView was simply the first to be torn down on `OnGameEnd`.

Backtrace before the fix:
```
#6  std::_Function_handler<void (), PinballPlugin::ResURIResolver::ResURIResolver(...)::{lambda()#1}>::_M_invoke
#7  PinballPlugin::ResURIResolver::~ResURIResolver()
#8  ScoreView::ScoreView::~ScoreView()
#9  ScoreView::OnGameEnd(unsigned int, void*, void*)
#10 MsgPI::MsgPluginManager::BroadcastMsg(unsigned int, unsigned int, void*)
#11 VPXPluginAPIImpl::OnGameEnd()
#12 Player::~Player()
```