### PR TITLE
Ignore empty display frames in DMDUtil plugin

### DIFF
--- a/plugins/dmdutil/DMDUtilPlugin.cpp
+++ b/plugins/dmdutil/DMDUtilPlugin.cpp
@@ -128,7 +128,9 @@ private:
    void ProcessFrame(const DisplaySrcId& dmdSource)
    {
       const DisplayFrame frame = dmdSource.GetRenderFrame(dmdSource.id);
-      if (m_lastFrameID == frame.frameId)
+      // A source may answer with no frame (for example PinMAME once its emulation
+      // is stopped but before it has retracted its display sources)
+      if (frame.frame == nullptr || m_lastFrameID == frame.frameId)
          return;
       m_lastFrameID = frame.frameId;
 
@@ -185,7 +187,7 @@ private:
 
    std::unique_ptr<DMDUtil::DMD> m_pDmd;
    std::thread m_updateThread;
-   bool m_isRunning = true;
+   std::atomic<bool> m_isRunning { true };
    int m_lastFrameID = 0;
 };
 


### PR DESCRIPTION
Exiting a PinMAME table crashed with a SIGSEGV in the DMDUtil plugin's update thread.

When the emulation stops, PinMAME's display source keeps being advertised for a short while but no longer has a frame to hand out. DMDUtil did not account for that and tried to read a frame that was not there. It now ignores empty frames, like the other display consumers do.

Only visible once #3870 is in, which removed an earlier abort in the same teardown sequence.