### PR TITLE
Fix use-after-destroy in VNI and Serum colorizer teardown

### DIFF
--- a/plugins/serum/serum.cpp
+++ b/plugins/serum/serum.cpp
@@ -50,11 +50,11 @@ public:
    SerumColorizer(const std::filesystem::path& serumPath, const string& currentGameId, uint32_t controllerEndpointId)
       : m_pSerum(Serum_Load(serumPath.string().c_str(), currentGameId.c_str(), FLAG_REQUEST_32P_FRAMES | FLAG_REQUEST_64P_FRAMES))
       , m_controllerEndpointId(controllerEndpointId)
+      , m_colorizedDmd(msgApi, endpointId, CTLPI_DISPLAY_GET_SRC_MSG, CTLPI_DISPLAY_ON_SRC_CHG_MSG)
+      , m_colorizedframeId(std_rand())
       , m_dmdSource(
            msgApi, endpointId, CTLPI_DISPLAY_GET_SRC_MSG, CTLPI_DISPLAY_ON_SRC_CHG_MSG, [this](std::vector<DisplaySrcId>& items) { FilterDmdSource(items); },
            [this]() { StopColorizeThread(); }, [this]() { StartColorizeThread(); })
-      , m_colorizedDmd(msgApi, endpointId, CTLPI_DISPLAY_GET_SRC_MSG, CTLPI_DISPLAY_ON_SRC_CHG_MSG)
-      , m_colorizedframeId(std_rand())
    {
       if (m_pSerum)
       {
@@ -298,7 +298,6 @@ private:
    Serum_Frame_Struc* const m_pSerum;
    const uint32_t m_controllerEndpointId;
 
-   CtrlItemConsumer<DisplaySrcId> m_dmdSource;
    CtrlItemProvider<DisplaySrcId> m_colorizedDmd;
 
    bool m_isRunning = false;
@@ -310,6 +309,8 @@ private:
    unsigned int m_advertisedWidth64 = 0;
 
    unsigned int m_colorizedframeId = 0;
+
+   CtrlItemConsumer<DisplaySrcId> m_dmdSource;
 };
 
 static void OnControllerChanged()

--- a/plugins/vni/vni.cpp
+++ b/plugins/vni/vni.cpp
@@ -42,12 +42,12 @@ public:
       : m_controllerEndpointId(controllerEndpointId)
       , m_palPath(palPath)
       , m_vniPath(vniPath)
+      , m_colorizedDmd(msgApi, endpointId, CTLPI_DISPLAY_GET_SRC_MSG, CTLPI_DISPLAY_ON_SRC_CHG_MSG)
+      , m_onConsoleDataId(msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_EVT_ON_CONSOLE_DATA))
+      , m_colorizedframeId(std_rand())
       , m_dmdSource(
            msgApi, endpointId, CTLPI_DISPLAY_GET_SRC_MSG, CTLPI_DISPLAY_ON_SRC_CHG_MSG, [this](std::vector<DisplaySrcId>& items) { FilterDmdSource(items); },
            [this]() { StopColorizeThread(); }, [this]() { StartColorizeThread(); })
-      , m_colorizedDmd(msgApi, endpointId, CTLPI_DISPLAY_GET_SRC_MSG, CTLPI_DISPLAY_ON_SRC_CHG_MSG)
-      , m_colorizedframeId(std_rand())
-      , m_onConsoleDataId(msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_EVT_ON_CONSOLE_DATA))
    {
          msgApi->SubscribeMsg(endpointId, m_onConsoleDataId, OnConsoleDataStatic, this);
          m_dmdSource.SelectItems(true);
@@ -267,7 +267,6 @@ private:
    const std::filesystem::path m_palPath;
    const std::filesystem::path m_vniPath;
 
-   CtrlItemConsumer<DisplaySrcId> m_dmdSource;
    CtrlItemProvider<DisplaySrcId> m_colorizedDmd;
 
    std::atomic_bool m_isRunning { false };
@@ -285,6 +284,8 @@ private:
    unsigned int m_advertisedWidth = 0;
    unsigned int m_advertisedHeight = 0;
    unsigned int m_colorizedframeId = 0;
+
+   CtrlItemConsumer<DisplaySrcId> m_dmdSource;
 };
 
 static void OnControllersChanged()
@@ -410,6 +411,7 @@ MSGPI_EXPORT void MSGPIAPI VNIPluginLoad(const uint32_t sessionId, const MsgPlug
 
 MSGPI_EXPORT void MSGPIAPI VNIPluginUnload()
 {
+   colorizer = nullptr;
    controllers = nullptr;
    msgApi = nullptr;
 }


### PR DESCRIPTION
Fixes the macOS SIGABRT on exit reported in #3849, seen after playing a table with a VNI-colorized DMD (e.g. Fish Tales).

## The bug

`VNIColorizer` declares its members in this order:

```cpp
CtrlItemConsumer<DisplaySrcId> m_dmdSource;     // declared first, so destroyed last
CtrlItemProvider<DisplaySrcId> m_colorizedDmd;  // declared second, so destroyed first
...
std::thread m_colorizeThread;
std::vector<uint8_t> m_colorFrame;
```

`m_dmdSource`'s destructor fires its `onItemsAboutToChange` callback, which is `StopColorizeThread()`. That callback joins `m_colorizeThread` and touches `m_colorizedDmd` and the frame state. Because members are destroyed in reverse declaration order, `m_dmdSource` is destroyed last, after everything its callback reads is already gone. The callback then touches freed members, and the throw escapes the `noexcept` destructor, so the runtime calls `std::terminate()`.

The crash shows up two ways: at process `exit()` via `__cxa_finalize` destroying the file-scope statics (the stack in #3849), and during `Player::~Player()` when the table exit script broadcasts a controller change that resets the colorizer. Same defect, both paths end in `~CtrlItemConsumer<DisplaySrcId>` calling `std::terminate()`.

Same class of bug as #3849's `ResURIResolver` fix (98c424c), where consumers were destroyed after the caches their callbacks clear.

## The fix

Move `m_dmdSource` to be the last member in both `VNIColorizer` and `SerumColorizer`, so it is destroyed first while everything its teardown touches is still alive. Init lists reordered to match.

`VNIPluginUnload` also now resets `colorizer` before `controllers` before nulling `msgApi`, so the members that call back into the message API are torn down in order while the API is alive. `SerumPluginUnload` already did this.

Serum has the identical member-order bug, so it gets the same reorder.

## Testing

Built `VNIPlugin` and `SerumPlugin`. Local testing on macOS (arm64, BGFX) no longer reproduces the VNI exit crash.

## Not covered

If the app quits without running `UnloadPlugins()`, the statics are still destroyed at `__cxa_finalize` against a dead `msgApi`. That path did not reproduce for me here, so I left it alone. Closing it fully would mean either running `UnloadPlugins()` on the quit path or making `~CtrlItemConsumer` skip its API calls when the API is gone, which touches the shared template used by every plugin.