### PR TITLE
Fix broken tables: subscribe CtrlItemConsumer state sources in pinmame and inspector

### DIFF
--- a/plugins/inspector/InspectorPlugin.cpp
+++ b/plugins/inspector/InspectorPlugin.cpp
@@ -388,6 +388,7 @@ MSGPI_EXPORT void MSGPIAPI InspectorPluginLoad(const uint32_t sessionId, const M
 
    stateSources = std::make_unique<PinballPlugin::Controller::CtrlItemConsumer<StateSrcId>>(
       msgApi, endpointId, CTLPI_STATE_GET_SRC_MSG, CTLPI_STATE_ON_SRC_CHG_MSG, nullptr, nullptr, []() { UpdateTreeCache(); });
+   stateSources->Subscribe();
 
    std::filesystem::path path;
 #if (defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV))) || defined(__ANDROID__)
@@ -414,6 +415,8 @@ MSGPI_EXPORT void MSGPIAPI InspectorPluginUnload()
       webServer.reset();
    }
 
+   if (stateSources)
+      stateSources->Unsubscribe();
    stateSources = nullptr;
 
    msgApi->UnsubscribeMsg(onControllersChangedId, OnSrcChanged, nullptr);

--- a/plugins/pinmame/Controller.cpp
+++ b/plugins/pinmame/Controller.cpp
@@ -44,6 +44,8 @@ Controller::Controller(const MsgPluginAPI* api, unsigned int endpointId, const P
    m_getDmdSrcMsgId = m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_DISPLAY_GET_SRC_MSG);
    m_onDmdChangedMsgId = m_msgApi->GetMsgID(CTLPI_NAMESPACE, CTLPI_DISPLAY_ON_SRC_CHG_MSG);
    m_msgApi->SubscribeMsg(m_endpointId, m_onDmdChangedMsgId, OnDmdSrcChanged, this);
+
+   m_stateSources.Subscribe();
 }
 
 Controller::~Controller()
@@ -51,6 +53,8 @@ Controller::~Controller()
    assert(m_threadLock == std::this_thread::get_id());
 
    Stop();
+
+   m_stateSources.Unsubscribe();
 
    m_msgApi->UnsubscribeMsg(m_onDmdChangedMsgId, OnDmdSrcChanged, this);
    m_msgApi->ReleaseMsgID(m_onDmdChangedMsgId);


### PR DESCRIPTION
## What

Call `Subscribe()`/`Unsubscribe()` on the `CtrlItemConsumer<StateSrcId>` state sources in the pinmame `Controller` and the inspector plugin.

## Why

Commit cd9ace2 ("Plugin: cleanup CtrlConsumer lifecycle") changed `CtrlItemConsumer` so subscription is explicit. Before, the constructor called `SubscribeMsg` and the list populated on construction. After, the list stays empty until `Subscribe()` runs, and `Unsubscribe()` must run before destruction.

That commit migrated the 12 files it touched, but two consumers were never in the diff and kept the old assumption:

- `plugins/pinmame/Controller.cpp` — its `m_stateSources` feeds lamps, GI, solenoids, and switches. With no `Subscribe()` call, the list stayed empty, so lamp reads returned nothing and switch input never registered. This is what made every table look broken: inserts stayed dark and the start key did nothing.
- `plugins/inspector/InspectorPlugin.cpp` — same missing subscription. Dev-only, so no user-facing symptom, but the consumer never populated and its unload freed the pointer without unsubscribing.

## How

- pinmame: `Subscribe()` at the end of the constructor, `Unsubscribe()` at the start of the destructor. The new destructor asserts `!m_subscribed`, so the unsubscribe is also required for a clean teardown.
- inspector: `Subscribe()` after construction, `Unsubscribe()` before resetting the pointer on unload.

## Testing

Built and linked `PinMAMEPlugin` and `InspectorPlugin` on macOS. Confirmed on real tables that inserts light up again and the start key works.