### PR TITLE
Fix texture cache key collisions that bound the wrong sampler

### DIFF
--- a/src/renderer/Texture.cpp
+++ b/src/renderer/Texture.cpp
@@ -9,6 +9,14 @@
 #include "utils/BiffReader.h"
 #include "utils/lzwreader.h"
 
+#include <atomic>
+
+static uint64_t NextLiveHash()
+{
+   static std::atomic<uint64_t> s_counter { 1 };
+   return s_counter.fetch_add(1, std::memory_order_relaxed);
+}
+
 #ifndef __STANDALONE__
 #include "FreeImage.h"
 #else
@@ -57,7 +65,7 @@ BaseTexture::BaseTexture(const unsigned int w, const unsigned int h, const Forma
    , m_format(format)
    , m_width(w)
    , m_height(h)
-   , m_liveHash(((size_t)this) ^ usec() ^ ((uint64_t)w << 16) ^ ((uint64_t)h << 32) ^ format)
+   , m_liveHash(NextLiveHash())
    , m_data(reinterpret_cast<uint8_t*>(SDL_aligned_alloc(16, w * h * GetPixelSize(format))))
 {
 }
@@ -105,7 +113,7 @@ std::shared_ptr<BaseTexture> BaseTexture::CreateFromData(const void* data, const
 
    if (data == nullptr || size == 0)
       return nullptr;
-   
+
    // Try to load using fast JPG path via stbi if no texture resize must be triggered
    if (maxTexDimension == 0 && !resizeOnLowMem)
    {
@@ -158,12 +166,12 @@ std::shared_ptr<BaseTexture> BaseTexture::CreateFromData(const void* data, const
       FreeImage_CloseMemory(dataHandle);
       tex = dib ? BaseTexture::CreateFromFreeImage(dib, isImageData, maxTexDimension, resizeOnLowMem) : nullptr;
    }
-   
+
    #ifdef __OPENGLES__
    if (tex && (tex->m_format == SRGB || tex->m_format == RGB_FP16 || tex->m_format == RGB_FP32))
       tex = tex->NewWithAlpha();
    #endif
-   
+
    return tex;
 }
 
@@ -674,7 +682,7 @@ std::shared_ptr<BaseTexture> BaseTexture::Convert(Format format) const
          default: break;
       }
       break;
-   
+
    case RGB_FP32:
       switch (format)
       {
@@ -906,7 +914,7 @@ Texture::Texture(string name, PinBinary* ppb, unsigned int width, unsigned int h
    , m_width(width)
    , m_height(height)
    , m_ppb(ppb)
-   , m_liveHash(((size_t)this) ^ ((uint64_t)ppb) ^ usec() ^ ((uint64_t)width << 16) ^ ((uint64_t)height << 32))
+   , m_liveHash(NextLiveHash())
 {
    assert(m_ppb != nullptr);
    assert(m_width > 0);
@@ -948,7 +956,7 @@ Texture* Texture::CreateFromObjectReader(IObjectReader& reader, PinTable* const 
             // The 'BITS' field is deprecated and only used in pre 10.8.1 files which were all BIFF streams so we can safely cast here
             BiffReader& br = (BiffReader&)reader;
 
-            // FIXME Assert until the old path based on IStorage is removed (still pending removal in undo & copy/paste), but this is already 
+            // FIXME Assert until the old path based on IStorage is removed (still pending removal in undo & copy/paste), but this is already
             // legacy deprecated and largely unused feature, moreover bmp are not supposed to enter this codeblock (no undo or copy/paste)
             assert(br.m_stream != nullptr);
 


### PR DESCRIPTION
## What

`TextureManager` caches GPU samplers in a map keyed by `ITexManCacheable::GetLiveHash()`.
That key was built as:

    m_liveHash = (size_t)this ^ (uint64_t)ppb ^ usec() ^ (w << 16) ^ (h << 32)

For two textures of the same width and height, the `w`/`h` terms cancel, leaving only
`this ^ ppb ^ usec()` to tell them apart. When those coincide, the second texture to load
finds the first's cache entry and gets the first's sampler, so it renders the wrong image.

Because the key depends on `usec()` and on addresses (ASLR), which pair collides varies
from launch to launch, so the wrong texture appears intermittently rather than every run.

This replaces the key with a process-wide monotonic counter: unique per texture, never
reused, stable for the object's lifetime.

## How it showed up

On "Alien Star (Gottlieb 1984)" a flipper rendered a plain, flat texture that varied
from launch to launch. Instrumenting `LoadTexture` to flag when an incoming texture hits
a cache entry owned by a different object caught it live: `Gottflip_greyL` and
`leaf_switch` (both 1024x1024) hashed to the same key, and the left flipper bound
`leaf_switch`'s sampler.

Across runs, the correlation was exact:

| run | flippers | collisions |
|-----|----------|------------|
| 1-3 | correct  | 0          |
| 4   | wrong    | 86 (Gottflip_greyL <-> leaf_switch) |

The failure is a per-run chance, not always on, which is why it looks intermittent.

## Why now

The `usec()` term was added to stop a freed texture's address from aliasing a stale
cache entry (commit e039477, "Fix texture creation/deletion leading to bad cache
management"). It only works if two textures are constructed far enough apart in time.
They are not: measuring construction timestamps on one load of this table, 39% of
textures were built within 1us of the previous one. Same-size textures built in the same
microsecond window have both their `usec()` and `w`/`h` terms cancel, so they collide.
This happens on both the parallel local-disk path and the coordinated sequential
network path (8 real key collisions in one network load, 3 in one local load).

## Why a monotonic counter

- Unique among live objects, so two textures never share a cache entry.
- Never reused after an object is freed, so a recycled address cannot alias a dead
  texture's entry. This is the hazard `usec()` was masking, and the reason a raw
  `this` pointer would not be safe here (several paths free a texture without calling
  `UnloadTexture`, e.g. `PinTable::RemoveImage` and `ImportImage`).
- One relaxed atomic increment at construction. The map still holds `uint64_t` keys and
  hashes them internally, so lookup cost is unchanged and every key is now collision-free.

## Testing

Rebuilt and ran the table repeatedly, local and over the network: 0 collisions on every
run, flippers render correctly. Reverting the change reproduces the wrong texture.

## Screenshots

<img width="864" height="542" alt="image" src="https://github.com/user-attachments/assets/3886178c-7b4f-4f35-a658-60bf0a53b2aa" />

<img width="864" height="542" alt="image" src="https://github.com/user-attachments/assets/d0897297-85b0-46a4-a44e-926965c64f60" />

<img width="864" height="542" alt="image" src="https://github.com/user-attachments/assets/b51d11ec-42ca-466f-b1c4-e92041787b67" />
