### PR TITLE
Retract advertised displays before releasing display providers

### DIFF
--- a/plugins/alphadmd/alphadmd.cpp
+++ b/plugins/alphadmd/alphadmd.cpp
@@ -132,7 +132,9 @@ public:
          .GetIdentifyFrame = &GetIdentifyFrame });
    }
 
-   ~AlphaDMDRenderer()
+   ~AlphaDMDRenderer() { Stop(); }
+
+   void Stop()
    {
       StopRenderThread();
       m_dmdProvider.ClearItems();
@@ -631,6 +633,15 @@ static void SetupRenderer()
 
 using namespace AlphaDMD;
 
+static void ReleaseRenderer()
+{
+   if (renderer)
+   {
+      renderer->Stop();
+      renderer = nullptr;
+   }
+}
+
 MSGPI_EXPORT void MSGPIAPI AlphaDMDPluginLoad(const uint32_t sessionId, const MsgPluginAPI* api)
 {
    msgApi = api;
@@ -639,7 +650,7 @@ MSGPI_EXPORT void MSGPIAPI AlphaDMDPluginLoad(const uint32_t sessionId, const Ms
    segSource = std::make_unique<CtrlItemConsumer<SegSrcId>>(
       msgApi, endpointId, CTLPI_SEG_GET_SRC_MSG, CTLPI_SEG_ON_SRC_CHG_MSG,
       [](std::vector<SegSrcId>& items) { SelectSource(items); },
-      []() { renderer = nullptr; },
+      []() { ReleaseRenderer(); },
       []() { SetupRenderer(); });
    segSource->Subscribe();
 }

--- a/plugins/serum/serum.cpp
+++ b/plugins/serum/serum.cpp
@@ -80,6 +80,8 @@ public:
       }
    }
 
+   void Stop() { StopColorizeThread(); }
+
 private:
    void FilterDmdSource(std::vector<DisplaySrcId>& items)
    {
@@ -383,6 +385,15 @@ static void SelectController(std::vector<ControllerDef>& items)
    items.clear();
 }
 
+static void ReleaseColorizer()
+{
+   if (colorizer)
+   {
+      colorizer->Stop();
+      colorizer = nullptr;
+   }
+}
+
 static void OnControllerChanged()
 {
    controllers->With(
@@ -413,7 +424,7 @@ MSGPI_EXPORT void MSGPIAPI SerumPluginLoad(const uint32_t sessionId, const MsgPl
    msgApi->RegisterSetting(endpointId, &serumPathProp);
    onDmdTrigger = msgApi->GetMsgID("Serum", "OnDmdTrigger");
    controllers = std::make_unique<CtrlItemConsumer<ControllerDef>>(
-      msgApi, endpointId, CTLPI_CONTROLLERS_GET_MSG, CTLPI_CONTROLLERS_ON_CHG_MSG, [](std::vector<ControllerDef>& items) { SelectController(items); }, []() { colorizer = nullptr; },
+      msgApi, endpointId, CTLPI_CONTROLLERS_GET_MSG, CTLPI_CONTROLLERS_ON_CHG_MSG, [](std::vector<ControllerDef>& items) { SelectController(items); }, []() { ReleaseColorizer(); },
       []() { OnControllerChanged(); });
    controllers->Subscribe();
 }

--- a/plugins/upscaledmd/UpscaleDMD.cpp
+++ b/plugins/upscaledmd/UpscaleDMD.cpp
@@ -208,7 +208,9 @@ public:
       m_renderThread = std::thread(&DMDUpscaler::RenderThread, this);
    }
 
-   ~DMDUpscaler()
+   ~DMDUpscaler() { Stop(); }
+
+   void Stop()
    {
       {
          std::lock_guard lock(m_mutex);
@@ -217,6 +219,7 @@ public:
       m_updateCondVar.notify_all();
       if (m_renderThread.joinable())
          m_renderThread.join();
+      m_upscaledDmd.ClearItems();
    }
 
 private:
@@ -413,6 +416,15 @@ private:
 
 using namespace UpscaleDMD;
 
+static void ReleaseUpscaler()
+{
+   if (upscaler)
+   {
+      upscaler->Stop();
+      upscaler = nullptr;
+   }
+}
+
 MSGPI_EXPORT void MSGPIAPI UpscaleDMDPluginLoad(const uint32_t sessionId, const MsgPluginAPI* api)
 {
    msgApi = api;
@@ -440,7 +452,7 @@ MSGPI_EXPORT void MSGPIAPI UpscaleDMDPluginLoad(const uint32_t sessionId, const 
          if (displaySource)
             items.push_back(*displaySource);
       },
-      []() { upscaler = nullptr; },
+      []() { ReleaseUpscaler(); },
       []()
       {
          upscalerMode = nextUpscalerMode;

--- a/plugins/vni/vni.cpp
+++ b/plugins/vni/vni.cpp
@@ -61,6 +61,8 @@ public:
       msgApi->ReleaseMsgID(m_onConsoleDataId);
    }
 
+   void Stop() { StopColorizeThread(); }
+
 private:
    void FilterDmdSource(std::vector<DisplaySrcId>& items)
    {
@@ -386,6 +388,15 @@ static void OnControllersChanged()
 
 using namespace Vni;
 
+static void ReleaseColorizer()
+{
+   if (colorizer)
+   {
+      colorizer->Stop();
+      colorizer = nullptr;
+   }
+}
+
 MSGPI_EXPORT void MSGPIAPI VNIPluginLoad(const uint32_t sessionId, const MsgPluginAPI* api)
 {
    msgApi = api;
@@ -406,7 +417,7 @@ MSGPI_EXPORT void MSGPIAPI VNIPluginLoad(const uint32_t sessionId, const MsgPlug
          constexpr std::string_view pinmamePrefix(PMPI_GAMEID_PREFIX); // Keep only controllers exposing a PinMAME compatible game
          std::erase_if(items, [pinmamePrefix](const ControllerDef& controller) { return !string(controller.gameId).starts_with(pinmamePrefix); });
       },
-      []() { colorizer = nullptr; }, []() { OnControllersChanged(); });
+      []() { ReleaseColorizer(); }, []() { OnControllersChanged(); });
    controllers->Subscribe();
 }
 


### PR DESCRIPTION
Exiting a table with Serum active crashed in `GetRenderFrameSerumV1`. Serum, VNI, AlphaDMD and UpscaleDMD release their provider object by resetting a global pointer in the controller change hook; the pointer is nulled before the destructor retracts the advertised displays, so a consumer finishing a frame during that broadcast dereferenced a null provider.

The providers now retract their displays first and are released afterwards, so nothing is advertised past the point where it can be served.