### PR TITLE
Rumble on flipper/ball contact, scaled by impact speed

### DIFF
--- a/src/core/Settings_properties.inl
+++ b/src/core/Settings_properties.inl
@@ -202,6 +202,7 @@ PropInt(Player, NumberOfTimesToShowTouchMessage, "NumberOfTimesToShowTouchMessag
 PropBool(Player, Mirror, "Mirror"s, "Mirror the table (left <-> right)"s, false);
 PropEnum(Player, CacheMode, "Cache Mode"s, "Use cache to limit stutters and speedup loading"s, int, 1, "Disabled"s, "Preload Textures"s);
 PropEnum(Player, RumbleMode, "RumbleMode"s, "Use rumble motor(s) in attached input devices"s, int, 3, "Off"s, "Table only (N/A yet)"s, "Generic only (N/A yet)"s, "Table with generic fallback"s);
+PropFloat(Player, RumbleFlipperContact, "Flipper Contact Rumble"s, "Strength of the rumble played when a ball hits a flipper, scaled by the impact speed (0 disables it)"s, 0.f, 3.f, 1.f);
 PropInt(Player, MinPhysLoopTime, "MinPhysLoopTime"s, ""s, 0, 1000, 0); // Legacy lag reduction hack (e.g. if script execution or physics takes very long, comes at the price of "slower" gameplay). Not supported by BGFX variant (due to its multithreaded loop)
 PropIntUnbounded(Player, PhysicsMaxLoops, "Physics Max Loops"s,
    "Maximum number of physics iteration above which physics engine just skip to stay playable.\nThis is somewhat hacky, override table setup, and may cause gameplay issues. This should not be used anymore."s,

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -68,6 +68,7 @@ InputManager::InputManager(Player* player)
    addTouchRegion(RECT { 70, 90, 100, 100 }, GetLaunchBallActionId());
 
    m_rumbleMode = g_app->m_settings.GetPlayer_RumbleMode();
+   m_rumbleFlipperContact = g_app->m_settings.GetPlayer_RumbleFlipperContact();
 
    // Load settings
    LoadDevicesFromSettings();
@@ -1134,6 +1135,18 @@ void InputManager::PlayRumble(const float lowFrequencySpeed, const float highFre
       };
       VPinballLib::VPinballLib::SendEvent(VPINBALL_EVENT_RUMBLE, &rumbleData);
    #endif
+}
+
+void InputManager::PlayFlipperContactRumble(const float normalImpactSpeed)
+{
+   if (m_rumbleFlipperContact <= 0.f)
+      return;
+
+   // A relative normal velocity of roughly 17 units corresponds to a hard hit. Both motors are
+   // driven, since short pulses on the high frequency motor alone are barely noticeable on many
+   // gamepads.
+   const float impact = clamp(fabsf(normalImpactSpeed) * 0.06f, 0.05f, 1.f);
+   PlayRumble(impact * 0.8f * m_rumbleFlipperContact, impact * m_rumbleFlipperContact, 120);
 }
 
 void InputManager::Autostart(const uint32_t initialDelayMs, const uint32_t retryDelayMs)

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -151,6 +151,11 @@ public:
    // Speed: 0..1
    void PlayRumble(const float lowFrequencySpeed, const float highFrequencySpeed, const int ms_duration);
 
+   // Rumble on flipper/ball contact, scaled by the relative normal velocity of the impact
+   void PlayFlipperContactRumble(const float normalImpactSpeed);
+   float GetFlipperContactRumbleStrength() const { return m_rumbleFlipperContact; }
+   void SetFlipperContactRumbleStrength(const float strength) { m_rumbleFlipperContact = strength; }
+
    int m_leftFlipperLastChangePollDelay = 0;
 
    // Used to add/remove the OpenXR input handler
@@ -257,6 +262,7 @@ private:
    int m_autoStartDirectStateSlot = -1;
 
    int m_rumbleMode = 0; // 0=Off, 1=Table only, 2=Generic only, 3=Table with generic as fallback
+   float m_rumbleFlipperContact = 1.f; // Strength of the rumble played on flipper/ball contact, 0 disables it
 
 #ifdef _WIN32
    HHOOK m_hKeyboardHook = nullptr;

--- a/src/physics/hitflipper.cpp
+++ b/src/physics/hitflipper.cpp
@@ -998,6 +998,7 @@ void HitFlipper::Collide(const CollisionEvent& coll)
          m_flipperMover.m_pflipper->FireGroupEvent(DISPID_HitEvents_Hit); // simple hit event
       else
          m_flipperMover.m_pflipper->FireVoidEventParm(DISPID_FlipperEvents_Collide, flipperHit); // collision velocity (normal to face)
+      g_pplayer->m_pininput.PlayFlipperContactRumble(bnv);
    }
 
    m_last_hittime = g_pplayer->m_time_msec; // keep resetting until idle for 250 milliseconds

--- a/src/ui/live/ingameui/InputSettingsPage.cpp
+++ b/src/ui/live/ingameui/InputSettingsPage.cpp
@@ -44,6 +44,10 @@ void InputSettingsPage::BuildPage()
       Settings::m_propPlayer_RumbleMode, //
       [this]() { return m_player->m_pininput.IsRumbleFeedbackEnabled() ? 3 : 0; }, //
       [this](int, int v) { m_player->m_pininput.EnableRumbleFeedback(v == 3); }));
+   AddItem(std::make_unique<InGameUIItem>( //
+      Settings::m_propPlayer_RumbleFlipperContact, 1.f, "%3.2f"s, //
+      [this]() { return m_player->m_pininput.GetFlipperContactRumbleStrength(); }, //
+      [this](float, float v) { m_player->m_pininput.SetFlipperContactRumbleStrength(v); }));
    // FIXME deprecated, just remove
    // TODO this property is directly persisted. It does not follow the overall UI design: App/Table/Live state => Implement live state (will also enable table override)
    AddItem(std::make_unique<InGameUIItem>( //


### PR DESCRIPTION
First slice of the generic rumble work discussed in #3874, kept deliberately
small as suggested there.

**What it does:** plays a rumble pulse when a ball collides with a flipper,
scaled by the relative normal velocity of the impact (`bnv` in
`HitFlipper::Collide`). A soft catch barely registers, a hard slap kicks.
This complements the existing fixed-strength calls for bumpers, slingshots
and the plunger, and goes through the existing `PlayRumble()`, so it obeys
`RumbleMode` like they do.

**Changes** (+25 lines, no deletions):
- `Settings_properties.inl`: new `Player/RumbleFlipperContact` float
  (0..3, default 1, 0 disables), right below `RumbleMode`
- `InputManager`: cached member read in the constructor,
  `PlayFlipperContactRumble()` next to `PlayRumble()`, inline accessors
  for the live UI
- `hitflipper.cpp`: one call inside the existing hit-event gate (real hit, 250 ms
  idle), so a ball held on a raised flipper stays silent
- `InputSettingsPage`: slider below the RumbleMode entry, following the
  existing PropId item pattern (framework handles persistence)

**Scaling:** ~17 velocity units map to full strength; both motors are driven
because short high-frequency-only pulses are barely noticeable on many pads.
Values come from several weeks of by-hand testing across a large table
collection on a 10.8.0 fork of this.

**Testing:** built and played on Windows x64 (BGFX). Verified: no rumble with
RumbleMode=Off, strength 0 disables it, slider takes effect immediately,
setting persists across restarts, holding a ball on a raised flipper is silent.

If this shape fits, drain/nudge and the remaining events from #3874 would
follow as equally small PRs.

**Disclosure**, consistent with the linked issue: built with AI assistance
under my direction; tested by hand.



