### PR TITLE
docs: add pinmame cfg directory

### DIFF
--- a/docs/FileLayout.md
+++ b/docs/FileLayout.md
@@ -87,13 +87,17 @@ Table Name (Manufacturer Year)/              <= We created a dedicated folder to
 ├── music/                                   <= Folder from which music are loaded when script use the PlayMusic command
 │   ├── Multiball Theme.ogg
 │   └── ...
-├── pinmame/                                 <= PinMAME plugin will look here for rom, nvram, and alias files
+├── pinmame/                                 <= PinMAME plugin will look here for rom, nvram, config, and alias files
 │   ├── roms/
 │   │   ├── xxx.zip
 │   │   └── yyy.zip
 │   ├── nvram/
 │   │   ├── xxx.nv
 │   │   └── yyy.nv
+│   ├── cfg/
+│   │   ├── default.cfg
+│   │   ├── xxx.cfg
+│   │   └── yyy.cfg
 │   └── alias.txt
 ├── pupvideos/                               <= PinUp player plugin will look here for pinup videos
 │   └── xxx/


### PR DESCRIPTION
Standalone does not have a UI for changing things like per audio channel volumes or dipswitch settings. However, these *can* be changed in pinmame / xpinmame and the `.cfg` files created as a result can be used by libpinmame in VPX. I've documented the process for doing so on this wiki page: https://github.com/dekay/vpinball-wiki/wiki/Linux#using-pinmame-to-set-individual-channel-volumes-and-dipswitch-settings