### PR TITLE
Fix invalid default DMD selection when there are other displays

### DIFF
--- a/plugins/b2s/DMDOverlay.cpp
+++ b/plugins/b2s/DMDOverlay.cpp
@@ -112,7 +112,7 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
    if (!m_enable)
       return;
 
-   PinballPlugin::ResURIResolver::DisplayState dmd = m_resURIResolver.GetDmdDisplayState("ctrl://default/display"s);
+   PinballPlugin::ResURIResolver::DisplayState dmd = m_resURIResolver.GetDisplayState("ctrl://default/display?dmd_only=1"s);
    if (dmd.state.frame == nullptr)
       return;
 

--- a/plugins/b2slegacy/utils/DMDOverlay.cpp
+++ b/plugins/b2slegacy/utils/DMDOverlay.cpp
@@ -112,7 +112,7 @@ void DMDOverlay::Render(VPXRenderContext2D* ctx)
    if (!m_enable)
       return;
 
-   PinballPlugin::ResURIResolver::DisplayState dmd = m_resURIResolver.GetDmdDisplayState("ctrl://default/display"s);
+   PinballPlugin::ResURIResolver::DisplayState dmd = m_resURIResolver.GetDisplayState("ctrl://default/display?dmd_only=1"s);
    if (dmd.state.frame == nullptr)
       return;
 

--- a/plugins/plugins/ResURIResolver.cpp
+++ b/plugins/plugins/ResURIResolver.cpp
@@ -290,21 +290,6 @@ const DisplaySrcId *ResURIResolver::GetDefaultDisplaySource(const std::vector<Di
    return displaySource;
 }
 
-// 'ctrl://default/display' resolves to e.g. a Pinball 2000 set's CRT, that being the only display it has, so every
-// dot matrix element would otherwise draw a 640x480 picture through its DMD related shader(s). Filtered here rather than
-// in GetDefaultDisplaySource() so that URI keeps meaning what it documents, the default DMD *or* display
-ResURIResolver::DisplayState ResURIResolver::GetDmdDisplayState(const string &link)
-{
-   const DisplayState state = GetDisplayState(link);
-   if (state.source != nullptr)
-   {
-      const unsigned int family = state.source->hardware & CTLPI_DISPLAY_HARDWARE_FAMILY_MASK;
-      if ((family == CTLPI_DISPLAY_HARDWARE_CRT_DISPLAY) || (family == CTLPI_DISPLAY_HARDWARE_LCD_DISPLAY))
-         return { };
-   }
-   return state;
-}
-
 ResURIResolver::DisplayState ResURIResolver::GetDisplayState(const string &link)
 {
    return m_displaySources->With(
@@ -320,11 +305,22 @@ ResURIResolver::DisplayState ResURIResolver::GetDisplayState(const string &link)
          }
          else if ((uri.scheme == "ctrl") && (uri.path == "/display"))
          {
+            std::vector<DisplaySrcId> filteredSources;
+            if (auto dmdOnlyPart = uri.query.find("dmd_only"s); dmdOnlyPart != uri.query.end())
+            {
+               std::copy_if(sources.begin(), sources.end(), std::back_inserter(filteredSources), [](const DisplaySrcId &source) {
+                  const unsigned int family = source.hardware & CTLPI_DISPLAY_HARDWARE_FAMILY_MASK;
+                  return (family != CTLPI_DISPLAY_HARDWARE_CRT_DISPLAY) && (family != CTLPI_DISPLAY_HARDWARE_LCD_DISPLAY);
+               });
+            }
+            else
+               filteredSources = sources;
+
             const DisplaySrcId *displaySource = nullptr;
             bool walkDownOverrides = true;
             if (uri.authority.host == "default")
             {
-               displaySource = GetDefaultDisplaySource(sources);
+               displaySource = GetDefaultDisplaySource(filteredSources);
             }
             else
             {
@@ -334,24 +330,24 @@ ResURIResolver::DisplayState ResURIResolver::GetDisplayState(const string &link)
                   int resId = 0;
                   if (auto resIdPart = uri.query.find("id"s); resIdPart != uri.query.end() && try_parse_int(resIdPart->second, resId))
                   {
-                     auto source = std::ranges::find_if(sources, [plugin, resId](const DisplaySrcId &cd) { return cd.id.endpointId == plugin && cd.id.resId == resId; });
-                     if (source != sources.end())
+                     auto source = std::ranges::find_if(filteredSources, [plugin, resId](const DisplaySrcId &cd) { return cd.id.endpointId == plugin && cd.id.resId == resId; });
+                     if (source != filteredSources.end())
                         displaySource = std::to_address(source);
                   }
                   else
                   {
                      // No id: select first source from selected endpoint
-                     auto source = sources.end();
+                     auto source = filteredSources.end();
                      uint32_t bestResId = UINT32_MAX;
-                     for (auto it = sources.begin(); it != sources.end(); ++it)
+                     for (auto it = filteredSources.begin(); it != filteredSources.end(); ++it)
                      {
-                        if (it->id.endpointId == plugin && (source == sources.end() || it->id.resId < bestResId))
+                        if (it->id.endpointId == plugin && (source == filteredSources.end() || it->id.resId < bestResId))
                         {
                            source = it;
                            bestResId = it->id.resId;
                         }
                      }
-                     if (source != sources.end())
+                     if (source != filteredSources.end())
                         displaySource = std::to_address(source);
                   }
                }
@@ -374,7 +370,10 @@ ResURIResolver::DisplayState ResURIResolver::GetDisplayState(const string &link)
             }
 
             if (displaySource != nullptr)
+            {
+               displaySource = std::to_address(std::ranges::find_if(sources, [displaySource](const DisplaySrcId &source) { return source.id.id == displaySource->id.id; }));
                lambda = [displaySource](const string &) { return DisplayState { displaySource, displaySource->GetRenderFrame(displaySource->callContext) }; };
+            }
          }
 
          if (lambda == nullptr)

--- a/plugins/plugins/ResURIResolver.h
+++ b/plugins/plugins/ResURIResolver.h
@@ -47,6 +47,7 @@
 //
 //   examples:
 //   - ctrl://default/display                  => Default DMD or display
+//   - ctrl://default/display?dmd_only         => Default DMD (rejecting LCD or CRT displays)
 //   - ctrl://flexdmd/display                  => FlexDMD first DMD
 //   - ctrl://pinmame/display?x=0&y=0          => Relative luminance of the top left dot of PinMAME's first display [Unimplemented]
 //   - ctrl://pinmame/display?override=no      => Untouched version of PinMAME first display (no colorization or upscaling) [Unimplemented]
@@ -73,9 +74,6 @@ public:
       DisplayFrame state;
    };
    DisplayState GetDisplayState(const std::string &link);
-   // Same, for elements that render dots (DMDs): resolves as above, then reports no frame for a CRT or LCD source.
-   // Anything that can legitimately show a video screen (a flasher in Display mode) keeps using GetDisplayState()
-   DisplayState GetDmdDisplayState(const std::string &link);
    std::string DumpDisplaySources() const;
    static const DisplaySrcId *GetDefaultDisplaySource(const std::vector<DisplaySrcId> &sources);
    

--- a/src/parts/flasher.cpp
+++ b/src/parts/flasher.cpp
@@ -1374,9 +1374,9 @@ void Flasher::Render(const unsigned int renderMask)
             // Display mode below is the intended way to show these
             PinballPlugin::ResURIResolver::DisplayState dmd { nullptr };
             if (!m_d.m_imageSrcLink.empty())
-               dmd = g_pplayer->m_resURIResolver.GetDmdDisplayState(m_d.m_imageSrcLink);
+               dmd = g_pplayer->m_resURIResolver.GetDisplayState(m_d.m_imageSrcLink);
             if (dmd.state.frame == nullptr)
-               dmd = g_pplayer->m_resURIResolver.GetDmdDisplayState("ctrl://default/display"s);
+               dmd = g_pplayer->m_resURIResolver.GetDisplayState("ctrl://default/display?dmd_only=1"s);
             if (dmd.state.frame != nullptr)
                UploadRenderFrame(dmd);
          }

--- a/src/parts/textbox.cpp
+++ b/src/parts/textbox.cpp
@@ -307,7 +307,7 @@ void Textbox::Render(const unsigned int renderMask)
          { vx1, vy1, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f }
       };
 
-      PinballPlugin::ResURIResolver::DisplayState dmd = g_pplayer->m_resURIResolver.GetDmdDisplayState("ctrl://default/display"s);
+      PinballPlugin::ResURIResolver::DisplayState dmd = g_pplayer->m_resURIResolver.GetDisplayState("ctrl://default/display?dmd_only=1"s);
       if (dmd.state.frame == nullptr)
          return;
 


### PR DESCRIPTION
Non DMD were discarded after filtering leading sometime to invalid empty selection