### PR TITLE
build: emit debug symbols for Windows crash dumps

### DIFF
--- a/.github/workflows/vpinball.yml
+++ b/.github/workflows/vpinball.yml
@@ -289,6 +289,11 @@ jobs:
             else
               cp build/${{ matrix.config }}/VPinballX_${{ matrix.type }}.exe stage
             fi
+            if [[ "${{ matrix.platform }}" == "windows" ]]; then
+              cp build/${{ matrix.config }}/VPinballX_${{ matrix.type }}*.pdb stage
+            else
+              cp build/${{ matrix.config }}/VPinballX_${{ matrix.type }}*.debug stage
+            fi
             cp build/${{ matrix.config }}/*.dll stage
             if [[ "${{ matrix.type }}" == "GL" ]]; then
               cp -r build/${{ matrix.config }}/shaders-${{ needs.version.outputs.version_short }} stage
@@ -391,6 +396,7 @@ jobs:
           else
             cp build/${{ matrix.config }}/VPinballX.exe stage
           fi
+          cp build/${{ matrix.config }}/VPinballX*.pdb stage
           cp build/${{ matrix.config }}/*.dll stage
           cp -r build/${{ matrix.config }}/assets stage
           cp -r build/${{ matrix.config }}/scripts stage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(PLATFORM STREQUAL "windows")
       /w44005
       /Zc:__cplusplus
       /std:c++20
+      /Zi
       $<$<NOT:$<STREQUAL:${ARCH},x64>>:/arch:SSE2>
    )
 
@@ -348,6 +349,7 @@ if(PLATFORM STREQUAL "windows")
       $<$<CONFIG:Release>:/OPT:REF>
       $<$<CONFIG:Release>:/OPT:ICF>
       $<$<CONFIG:Release>:/LTCG>
+      $<$<CONFIG:Release>:/DEBUG:FULL>
       $<$<CONFIG:Release>:/DYNAMICBASE:NO>
       $<IF:$<STREQUAL:${ARCH},x64>,$<$<CONFIG:Release>:/SAFESEH:NO>,/SAFESEH:NO>
       $<$<NOT:$<STREQUAL:${ARCH},x64>>:/LARGEADDRESSAWARE>
@@ -440,6 +442,7 @@ elseif(PLATFORM STREQUAL "windows-mingw")
 
    target_compile_options(vpinball PUBLIC
       -mssse3
+      $<$<CONFIG:Release>:-g1>
       $<$<CXX_COMPILER_ID:GNU>:
          -ffast-math
          -ffp-contract=off
@@ -476,6 +479,14 @@ elseif(PLATFORM STREQUAL "windows-mingw")
    set_target_properties(vpinball PROPERTIES
       RUNTIME_OUTPUT_NAME "VPinballX_BGFX64"
    )
+
+   if(CMAKE_BUILD_TYPE STREQUAL "Release")
+      add_custom_command(TARGET vpinball POST_BUILD
+         COMMAND "${CMAKE_OBJCOPY}" --only-keep-debug "$<TARGET_FILE:vpinball>" "$<TARGET_FILE_DIR:vpinball>/VPinballX_BGFX64.debug"
+         COMMAND "${CMAKE_OBJCOPY}" --strip-debug "$<TARGET_FILE:vpinball>"
+         COMMAND "${CMAKE_OBJCOPY}" --add-gnu-debuglink="$<TARGET_FILE_DIR:vpinball>/VPinballX_BGFX64.debug" "$<TARGET_FILE:vpinball>"
+      )
+   endif()
 
    add_custom_command(TARGET vpinball POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_SOURCE_DIR}/src/assets" "$<TARGET_FILE_DIR:vpinball>/assets"


### PR DESCRIPTION
## What

Windows release builds ship without any debug symbols, so a crash dump from a user can't be resolved to function names or source lines. macOS gets away with it because its release binary is left unstripped and keeps its symbol table; the Windows builds emit nothing usable. This adds symbols for both Windows toolchains.

- MSVC (`PLATFORM=windows`, x64 and x86, all renderers including DX9): compile with `/Zi` and link with `/DEBUG`, producing a matching `.pdb`.
- MinGW (`PLATFORM=windows-mingw`, x64): compile Release with `-g1`, then split the symbols into a companion `.debug` with `objcopy` and strip the exe, leaving a `.gnu_debuglink` so a debugger finds the symbols on its own.

The CI staging steps bundle the symbol file next to the exe in the artifact zip, so whoever analyzes a dump has both halves.

Issue #3909 is the kind of report this helps with: a crash on start with only a log to go on. With symbols, the dump resolves to a real call stack.

## Why these choices

MSVC and MinGW carry symbols differently, so the two paths don't match.

MSVC never embeds debug info in the exe. `/DEBUG` writes a separate `.pdb`, and it stays separate by design, so there's no strip step to do. The one trap is that `/DEBUG` turns off `/OPT:REF` and `/OPT:ICF` unless you pass them explicitly. They were already in the link options, so the exe is the same size it was before (22.6 MB on x64). I kept the full `.pdb` rather than a stripped one: MSVC's `/PDBSTRIPPED` drops source line numbers, and at 82 MB the full pdb is small enough that giving up line info isn't worth it.

MinGW (GCC) embeds DWARF in the exe, but only with `-g`, and full `-g` produced a 486 MB `.debug`. `-g1` keeps line tables and function boundaries without per-variable and type data, which is all a backtrace needs, and drops the companion file to 63 MB. The exe is stripped and carries a `.gnu_debuglink`, so it stays the size it was.

## Sizes

| build | exe | symbols |
|-------|-----|---------|
| MSVC x64   | 22.6 MB | `VPinballX_BGFX64.pdb` 82.0 MB |
| MSVC x86   | 21.2 MB | `VPinballX_BGFX.pdb` 81.6 MB |
| MinGW x64  | 34.2 MB | `VPinballX_BGFX64.debug` 62.7 MB |

These are uncompressed. Symbol files compress well, so the zip grows by a good deal less.

## Verified

Built all three locally against VS2026 (MSVC 19.51) and UCRT64 GCC, then resolved a real address in each.

- MSVC x64, in WinDbg: `x VPinballX_BGFX64!HitBall::Contact*` resolves to `HitBall::Contact(CollisionEvent*, float)`. `dumpbin` confirms the exe's CodeView entry matches the pdb, and that `/LTCG` still coexists with `/DEBUG`.
- MSVC x86: `dumpbin /PDBPATH:VERBOSE` reports the pdb found and matched.
- MinGW x64, with `addr2line`: the same address resolves to `HitBall::Contact` at `hitball.h:48`. Without the `.debug` file present, it resolves to `??`, which is what ships today.

## Out of scope

External dependencies (bgfx, SDL3, ffmpeg, and the rest) still ship without symbols, so a frame inside those modules won't resolve. bgfx is the most likely place to want this since it links statically into the exe. That's a larger change (it touches `external.sh` and invalidates the CI dep cache), so I left it for a follow-up.
