### PR TITLE
Windows: fix empty crash report call stack

### DIFF
--- a/src/utils/CrashHandler.cpp
+++ b/src/utils/CrashHandler.cpp
@@ -13,10 +13,6 @@
 #include <cassert>
 #include "core/vpversion.h"
 
-#ifdef ENABLE_BGFX
-#include "bx/readerwriter.h"
-#endif
-
 namespace
 {
    static string s_miniDumpFileName = "crash.dmp"s;
@@ -272,19 +268,9 @@ namespace
 
    void WriteCallStack(FILE* f, PCONTEXT context)
    {
-      #ifdef ENABLE_BGFX
-      char temp[8192];
-      bx::StaticMemoryBlockWriter smb(temp, BX_COUNTOF(temp));
-      uintptr_t stack[32];
-      const uint32_t num = bx::getCallStackExact(3, BX_COUNTOF(stack), stack); // 3 to skip exception handler calls
-      const int32_t total = bx::writeCallstack(&smb, stack, num, bx::ErrorIgnore {});
-      temp[total] = '\0';
-      fprintf(f, "Call stack\n==========\n%s\n", temp);
-      #else
       char callStack[2048] = {};
       rde::StackTrace::GetCallStack(context, true, callStack, sizeof(callStack) - 1);
       fprintf(f, "Call stack\n==========\n%s\n", callStack);
-      #endif
    }
 
    volatile bool s_inFilter = 0;

--- a/src/utils/StackTrace.cpp
+++ b/src/utils/StackTrace.cpp
@@ -12,6 +12,12 @@
 
 namespace
 {
+#ifdef _WIN64
+	constexpr DWORD kStackWalkMachine = IMAGE_FILE_MACHINE_AMD64;
+#else
+	constexpr DWORD kStackWalkMachine = IMAGE_FILE_MACHINE_I386;
+#endif
+
 	void GetFileFromPath(const char* path, char* file, int fileNameSize)
 	{
 		char ext[_MAX_EXT] = {};
@@ -144,7 +150,7 @@ int StackTrace::GetCallStack(void* vcontext, Address* callStack, int maxDepth,
     HANDLE thread	= GetCurrentThread(); 
 
 	int numEntries(0);
-	while (::StackWalk64(IMAGE_FILE_MACHINE_I386, process, thread, 
+	while (::StackWalk64(kStackWalkMachine, process, thread, 
 		&stackFrame, context, 0, SymFunctionTableAccess64, SymGetModuleBase64, nullptr) &&
 		stackFrame.AddrFrame.Offset != 0 && numEntries < maxDepth)
 	{
@@ -277,7 +283,7 @@ void StackTrace::GetCallStack(void* vcontext, bool includeArguments,
 	stackFrame.AddrStack.Mode	= AddrModeFlat;
 
 	while (maxSymbolLen > 0 &&
-		::StackWalk64(IMAGE_FILE_MACHINE_I386,
+		::StackWalk64(kStackWalkMachine,
 			::GetCurrentProcess(), ::GetCurrentThread(), &stackFrame,
 			context, nullptr, /*Internal_ReadProcessMemory,*/
 			SymFunctionTableAccess64, SymGetModuleBase64, nullptr) != FALSE &&


### PR DESCRIPTION
## Issue

On Windows, `crash.txt` records the faulting call stack after an unhandled exception. For most builds that stack came out empty or as garbage addresses, so crash reports from users were not actionable. See #3909 for a recent crash-on-start with only a log to go on.

Real `crash.txt` from a 10.8.1 BGFX x64 build:

```
Call stack
==========
 (0x00000000 0x00000000 0x00000000 0x00000000)
```

Repro: build any Windows target, force an access violation, read the `crash.txt` it writes.

## Cause

Two bugs. `WriteCallStack` used `bx::getCallStackExact` for BGFX, which walks the current thread's live stack and ignores the crash `CONTEXT`, so it never sees the faulting stack. The other path (`rde::StackTrace`) does use the `CONTEXT` but passed `IMAGE_FILE_MACHINE_I386` to `StackWalk64`, correct on x86, wrong on x64. Only non-BGFX x86 produced a usable stack.

## Fix

Use the context-aware `rde::StackTrace` walk for all renderers, and select the `StackWalk64` machine type from the build target. The BGFX `bx` branch and its include are removed.

## Testing

Built BGFX x64 and x86 with VS2026 and forced an access violation. Same crash, before and after.

Before, x64 (walks the exception filter's own stack, most frames unresolved, and the PCs are truncated to 32 bits, `0xbf68caec` is the low half of `ntdll!RtlUserThreadStart`):

```
Callstack (9):
	 0: <Unknown?>   0xbf749ba0  <Unknown?>
	 1: <Unknown?>   0xbf704703  <Unknown?>
	 2: <Unknown?>   0xbf7454ff  <Unknown?>
	 3: <Unknown?>   0xbf6abd25  <Unknown?>
	 4: <Unknown?>   0xbf744e3e  <Unknown?>
	 5: main.cpp:194  0x401ae011  WinMain
	 6: exe_common.inl:288  0x406aac39  __scrt_common_main_seh
	 7: <Unknown?>   0xbd4bccb7  <Unknown?>
	 8: <Unknown?>   0xbf68caec  <Unknown?>
```

After, x64:

```
00000001401AE011 VPinballX_BGFX64.exe WinMain + 0x751 main.cpp(194)
00000001406AABC9 VPinballX_BGFX64.exe __scrt_common_main_seh + 0x109 exe_common.inl(288)
00007FFFBD4BCCB7 KERNEL32.DLL BaseThreadInitThunk + 0x17
00007FFFBF68CAEC ntdll.dll RtlUserThreadStart + 0x2C
```

After, x86 (crash placed in `VPApp::VPApp`):

```
005EE4D6 VPinballX_BGFX.exe VPApp::VPApp + 0x186 VPApp.cpp(158)
005BBDCC VPinballX_BGFX.exe WinMain + 0x3C main.cpp(195)
00A0DA00 VPinballX_BGFX.exe __scrt_common_main_seh + 0x140 exe_common.inl(288)
76975D49 KERNEL32.DLL BaseThreadInitThunk + 0x19
77CCE1FB ntdll.dll RtlInitializeExceptionChain + 0x6B
77CCE181 ntdll.dll RtlGetAppContainerNamedObjectPath + 0x231
```

Every frame now resolves to module, function, and source line. Names rely on the pdb shipped beside the exe (#3913).

I trimmed the argument columns and long CRT paths from these blocks for readability. The frames and symbols are otherwise verbatim from the test output.