### PR TITLE
Windows: fix crash report symbol resolution

### DIFF
--- a/src/utils/StackTrace.cpp
+++ b/src/utils/StackTrace.cpp
@@ -69,8 +69,7 @@ bool StackTrace::InitSymbols()
 						SYMOPT_LOAD_LINES |
 						SYMOPT_UNDNAME;
 		SymSetOptions(options);
-		const char* dir = nullptr;
-		if (!SymInitialize(GetCurrentProcess(), dir, options & SYMOPT_DEFERRED_LOADS))
+		if (!SymInitialize(GetCurrentProcess(), SDL_GetBasePath(), options & SYMOPT_DEFERRED_LOADS))
 		{
 			OutputDebugString("Cannot initialize symbol engine");
 			return false;
@@ -101,7 +100,7 @@ int StackTrace::GetCallStack(Address* callStack, int maxDepth, int entriesToSkip
 	return GetCallStack(pContext, callStack,  maxDepth, entriesToSkip + 1);
 }
 
-int StackTrace::GetCallStack(void* vcontext, Address* callStack, int maxDepth, 
+int StackTrace::GetCallStack(void* vcontext, Address* callStack, int maxDepth,
 							 int entriesToSkip)
 {
 #if defined(_M_ARM64)
@@ -147,10 +146,10 @@ int StackTrace::GetCallStack(void* vcontext, Address* callStack, int maxDepth,
 	stackFrame.AddrStack.Mode	= AddrModeFlat;
 
 	HANDLE process	= GetCurrentProcess();
-    HANDLE thread	= GetCurrentThread(); 
+    HANDLE thread	= GetCurrentThread();
 
 	int numEntries(0);
-	while (::StackWalk64(kStackWalkMachine, process, thread, 
+	while (::StackWalk64(kStackWalkMachine, process, thread,
 		&stackFrame, context, 0, SymFunctionTableAccess64, SymGetModuleBase64, nullptr) &&
 		stackFrame.AddrFrame.Offset != 0 && numEntries < maxDepth)
 	{
@@ -197,7 +196,7 @@ int StackTrace::GetSymbolInfo(Address address, char* symbol, int maxSymbolLen)
 		return 0;
 
 	// Start with address.
-	int charsAdded = 
+	int charsAdded =
 		_snprintf_s(symbol, maxSymbolLen, _TRUNCATE, "%p ", address);
 	symbol += charsAdded;
 	maxSymbolLen -= charsAdded;
@@ -251,7 +250,7 @@ int StackTrace::GetSymbolInfo(Address address, char* symbol, int maxSymbolLen)
 		int fileLineChars;
 		if (displacementLine > 0)
 		{
-			fileLineChars = _snprintf_s(symbol, maxSymbolLen, _TRUNCATE, 
+			fileLineChars = _snprintf_s(symbol, maxSymbolLen, _TRUNCATE,
 				" %s(%u+%04u byte(s))", fileName, lineInfo.LineNumber, displacementLine);
 		}
 		else
@@ -266,7 +265,7 @@ int StackTrace::GetSymbolInfo(Address address, char* symbol, int maxSymbolLen)
 	return charsAdded;
 }
 
-void StackTrace::GetCallStack(void* vcontext, bool includeArguments, 
+void StackTrace::GetCallStack(void* vcontext, bool includeArguments,
 							  char* symbol, int maxSymbolLen)
 {
 	const PCONTEXT context = (PCONTEXT)vcontext;
@@ -295,7 +294,7 @@ void StackTrace::GetCallStack(void* vcontext, bool includeArguments,
 		symbol += charsAdded;
 		if (maxSymbolLen > 0 && includeArguments)
 		{
-			charsAdded = _snprintf_s(symbol, maxSymbolLen, _TRUNCATE, 
+			charsAdded = _snprintf_s(symbol, maxSymbolLen, _TRUNCATE,
 				" (0x%08llX 0x%08llX 0x%08llX 0x%08llx)\n", stackFrame.Params[0],
 				stackFrame.Params[1], stackFrame.Params[2], stackFrame.Params[3]);
 			maxSymbolLen -= charsAdded;


### PR DESCRIPTION
Follow-up to #3915. The crash report from that issue walked the stack correctly but couldn't put names to any of the application's own frames. Every `VPinballX_BGFX64.exe` frame came out as a bare address, except one that resolved to `hid_winapi_descriptor_reconstruct_pp_data + 0x100CB9`, a real exported symbol a megabyte away. That huge displacement is the tell. dbghelp couldn't load the pdb and fell back to the nearest export in the exe's export table.

The confusing part was that the pdb was sitting right next to the exe on the user's machine. It should have been found.

## Root cause

The linker stamps the exe's debug directory with the pdb's absolute path from build time. For our CI builds that's the runner path, `D:\a\vpinball\vpinball\build\Release\VPinballX_BGFX64.pdb`, which doesn't exist on anyone else's machine.

`InitSymbols()` called `SymInitialize` with a null search path. When the deferred load fired at crash time, dbghelp tried the embedded build-time path, found nothing there, and stopped, without falling back to the directory the exe is actually running from. So the colocated pdb was never loaded and every app frame degraded to export-only names.

This also explains why it looked fine in local testing. A locally built exe embeds a pdb path that *does* exist on the machine that built it, so the embedded path resolves and symbols load. The failure only shows up once the exe runs somewhere other than where it was linked, which is every user and every CI artifact.

## Fix

Pass the executable's own directory to `SymInitialize` as the search path, using `SDL_GetBasePath()`:

```cpp
if (!SymInitialize(GetCurrentProcess(), SDL_GetBasePath(), options & SYMOPT_DEFERRED_LOADS))
```

`SDL_GetBasePath()` returns the exe directory with a trailing separator, resolved from the module path rather than the working directory, so it holds up even when the crash happens after VPX has changed the working directory to a table's folder. Now dbghelp finds the pdb next to the exe regardless of the dead embedded path.

## Testing

Reproduced and verified with a local MSVC BGFX x64 build against the spinner OBJ-export crash from #3915 (`Spinner::UpdatePlate` at `spinner.cpp:403`).

- Normal build, pdb colocated: resolves (the embedded build path happens to be live locally).
- Embedded pdb path made dead, pdb still colocated (the real user/CI situation): before the fix, degrades to the `+0x100CB9` export fallback; after the fix, resolves the full stack.

Ruled out along the way: missing pdb, pdb/exe mismatch, the working directory, and the scoop junction. A standalone dbghelp probe confirmed the shipped pdb is valid and matched, so the only thing wrong was where the handler looked for it.