### PR TITLE
Windows: fix spinner crash on mesh export

### DIFF
--- a/src/parts/spinner.cpp
+++ b/src/parts/spinner.cpp
@@ -388,7 +388,8 @@ void Spinner::Render(const unsigned int renderMask)
       m_renderer->m_renderDevice->DrawMesh(m_renderer->m_renderDevice->m_basicShader, false, pos, 0.f, m_bracketMeshBuffer, RenderDevice::TRIANGLELIST, 0, spinnerBracketNumFaces);
    }
 
-   if (m_phitspinner->m_spinnerMover.m_visible && !isStaticOnly)
+   const bool plateVisible = m_phitspinner ? m_phitspinner->m_spinnerMover.m_visible : m_d.m_visible;
+   if (plateVisible && !isStaticOnly)
    {
       UpdatePlate(nullptr);
       Vertex3Ds pos(m_d.m_vCenter.x, m_d.m_vCenter.y, m_posZ);
@@ -399,13 +400,16 @@ void Spinner::Render(const unsigned int renderMask)
 
 void Spinner::UpdatePlate(Vertex3D_NoTex2 * const vertBuffer)
 {
+   const float angle = m_phitspinner ? m_phitspinner->m_spinnerMover.m_angle
+      : clamp(0.f, ANGTORAD(min(m_d.m_angleMin, m_d.m_angleMax)), ANGTORAD(max(m_d.m_angleMin, m_d.m_angleMax)));
+
    // early out in case still same rotation
-   if (m_phitspinner->m_spinnerMover.m_angle == m_vertexBuffer_spinneranimangle)
+   if (angle == m_vertexBuffer_spinneranimangle)
        return;
 
-   m_vertexBuffer_spinneranimangle = m_phitspinner->m_spinnerMover.m_angle;
+   m_vertexBuffer_spinneranimangle = angle;
 
-   const Matrix3D fullMatrix = Matrix3D::MatrixRotateX(-m_phitspinner->m_spinnerMover.m_angle)
+   const Matrix3D fullMatrix = Matrix3D::MatrixRotateX(-angle)
                              * Matrix3D::MatrixRotateZ(ANGTORAD(m_d.m_rotation));
 
    Vertex3D_NoTex2 *buf;


### PR DESCRIPTION
Fixes the crash in #3915: adding a spinner and exporting the table to OBJ crashes VPX in the editor.

`Spinner::ExportMesh` calls `Spinner::UpdatePlate` to generate the plate geometry, and `UpdatePlate` read the spinner's current angle straight off `m_phitspinner->m_spinnerMover.m_angle`. `m_phitspinner` is the play-time physics object, it only exists while a table is running and is null in the editor. So the export path dereferenced a null pointer and faulted (`spinner.cpp:403`).

Every other accessor on the spinner already guards this pointer and falls back to the design value (`m_phitspinner ? ... : m_d....`). `UpdatePlate` was the one place that didn't. The fix reads the angle through the same guard, using the rest angle (0) when there's no live physics object, which is the correct neutral geometry for an export. This matches how the flipper exports its base mesh from the design start angle rather than the live mover.

```cpp
const float angle = m_phitspinner ? m_phitspinner->m_spinnerMover.m_angle : 0.0f;
```

I checked the other parts with an `ExportMesh` and a play-time hit object (gate, trigger, flipper, kicker, bumper, hittarget, ramp, rubber, surface, primitive). Spinner is the only one that dereferenced its play-time pointer on the export path, the rest build from design data or static meshes.

This is a minimal guard, not the real cleanup. As @vbousquet noted on the issue, the spinner (and trigger) mesh generation is tangled up with the play-time update and should be pulled apart so export never depends on the physics object at all. That's a larger refactor. This fix stops the crash and unblocks export in the meantime.

Tested by exporting a spinner to OBJ from the editor: before, it crashed at `Spinner::UpdatePlate`; after, the export completes and writes the mesh.