### PR TITLE
macOS: in-process crash reports with named call stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,6 +550,11 @@ elseif(PLATFORM STREQUAL "macos")
    add_executable(vpinball
       ${VPX_STANDALONE_SOURCES}
 
+      src/utils/StackTrace.cpp
+      src/utils/StackTrace.h
+      src/utils/CrashHandler.cpp
+      src/utils/CrashHandler.h
+
       standalone/macos/main.mm
    )
 
@@ -571,6 +576,8 @@ elseif(PLATFORM STREQUAL "macos")
       WINE_UNICODE_NATIVE
 
       "__forceinline=__attribute__((always_inline)) inline"
+
+      VPX_STANDALONE_CRASH_HANDLER
    )
 
    if(RENDERER STREQUAL "BGFX")
@@ -597,6 +604,7 @@ elseif(PLATFORM STREQUAL "macos")
       -ffp-contract=off
       -Wno-shorten-64-to-32
       $<$<AND:$<STREQUAL:${ARCH},x64>,$<STREQUAL:${RENDERER},GL>>:-mssse3>
+      $<$<CONFIG:Release>:-g1>
    )
 
    set(RUNTIME_LIBS_DIR "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/macos-${ARCH}")
@@ -613,6 +621,8 @@ elseif(PLATFORM STREQUAL "macos")
       hidapi
       winevbs
       "-framework AppKit"
+      "-framework CoreFoundation"
+      "-F /System/Library/PrivateFrameworks" "-framework CoreSymbolication"
    )
 
    target_link_libraries(vpinball PUBLIC $<IF:$<STREQUAL:${RENDERER},BGFX>,bgfx,glad>)
@@ -651,6 +661,10 @@ elseif(PLATFORM STREQUAL "macos")
       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/standalone/macos/VPinballX.icns" "$<TARGET_FILE_DIR:vpinball>/../Resources"
       COMMAND /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${CMAKE_PROJECT_VERSION}" $<TARGET_FILE_DIR:vpinball>/../Info.plist
       COMMAND /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${CMAKE_PROJECT_VERSION}" $<TARGET_FILE_DIR:vpinball>/../Info.plist
+   )
+
+   add_custom_command(TARGET vpinball POST_BUILD
+      COMMAND dsymutil "$<TARGET_FILE:vpinball>" -o "$<TARGET_FILE_DIR:vpinball>/../Resources/$<TARGET_FILE_NAME:vpinball>.dSYM"
    )
 
 # Linux build (BGFX / GL)

--- a/src/utils/CrashHandler.cpp
+++ b/src/utils/CrashHandler.cpp
@@ -1,9 +1,227 @@
 #include "core/stdafx.h"
 
 #include "CrashHandler.h"
+#include "StackTrace.h"
+#include "core/vpversion.h"
+
+#if defined(__APPLE__)
+
+#include <csignal>
+#include <cstring>
+#include <cstdint>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ucontext.h>
+#include <dlfcn.h>
+
+// macOS in-process crash reporter. A fatal signal (SIGSEGV/SIGBUS/SIGILL/
+// SIGFPE/SIGABRT) is caught with sigaction and the report is written from the
+// signal handler using only write(2)/open/close and stack buffers. Symbol
+// resolution (CoreSymbolication + dladdr) may allocate, a pragmatic risk for a
+// best-effort in-process reporter.
+//
+// The report starts at the faulting frame, not our handler. We take a normal
+// backtrace() (reliable full walk), drop the leading frames through _sigtramp
+// (the kernel signal trampoline, above which are only our handler frames), and
+// prepend the ucontext PC as frame 0 since backtrace() omits a leaf that
+// faulted without making a call. This mirrors the Windows path starting from
+// the exception CONTEXT.
+
+#include <execinfo.h>
+
+namespace
+{
+   string s_reportFileName = "crash.txt"s;
+   string s_miniDumpFileName = "crash.dmp"s; // unused on macOS, kept for API parity
+
+   volatile sig_atomic_t s_inHandler = 0;
+   char s_altStack[SIGSTKSZ > 65536 ? SIGSTKSZ : 65536];
+
+   void WriteStr(int fd, const char* s)
+   {
+      if (s != nullptr)
+         (void)!write(fd, s, strlen(s));
+   }
+
+   const char* SignalName(int sig)
+   {
+      switch (sig)
+      {
+      case SIGSEGV: return "SIGSEGV";
+      case SIGBUS:  return "SIGBUS";
+      case SIGILL:  return "SIGILL";
+      case SIGFPE:  return "SIGFPE";
+      case SIGABRT: return "SIGABRT";
+      case SIGTRAP: return "SIGTRAP";
+      default:      return "signal";
+      }
+   }
+
+   void WriteHeader(int fd)
+   {
+      WriteStr(fd, "Crash report VPX - " VP_VERSION_STRING_FULL_LITERAL "\n============\n");
+   }
+
+   void WriteExceptionInfo(int fd, int sig, siginfo_t* si)
+   {
+      char line[MAXSTRING];
+      const void* faultAddr = (si != nullptr) ? si->si_addr : nullptr;
+      uint64_t tid = 0;
+      pthread_threadid_np(nullptr, &tid);
+      snprintf(line, sizeof(line), "Reason: %s (signo %d, code %d) at %p\nThread ID: 0x%llx\n\n",
+         SignalName(sig), sig, (si != nullptr) ? si->si_code : 0, faultAddr, (unsigned long long)tid);
+      WriteStr(fd, line);
+   }
+
+   // Build a fault-first stack: frame 0 is the ucontext PC (the exact crashing
+   // instruction, which backtrace() drops for a leaf), then the backtrace()
+   // frames from just past _sigtramp (dropping our handler and the trampoline).
+   // The first post-trampoline frame is skipped when it maps to the same
+   // function as the PC, to avoid a duplicate for a mid-function fault.
+   int CaptureFromContext(void* uctx, void** out, int max)
+   {
+      if (max <= 0)
+         return 0;
+
+      void* raw[256];
+      const int n = backtrace(raw, (int)std::size(raw));
+
+      int start = 0;
+      for (int i = 0; i < n; ++i)
+      {
+         Dl_info di;
+         if (dladdr(raw[i], &di) && di.dli_sname != nullptr && strcmp(di.dli_sname, "_sigtramp") == 0)
+         {
+            start = i + 1;
+            break;
+         }
+      }
+
+      int w = 0;
+      const void* pc = nullptr;
+      if (uctx != nullptr)
+      {
+         const ucontext_t* uc = (const ucontext_t*)uctx;
+#if defined(__aarch64__)
+         pc = (const void*)uc->uc_mcontext->__ss.__pc;
+#else
+         pc = (const void*)uc->uc_mcontext->__ss.__rip;
+#endif
+         if (pc != nullptr && w < max)
+            out[w++] = (void*)pc;
+      }
+
+      // Drop the first captured frame if it is in the same function as the PC.
+      if (pc != nullptr && start < n)
+      {
+         Dl_info a, b;
+         if (dladdr(pc, &a) && dladdr(raw[start], &b) && a.dli_saddr == b.dli_saddr)
+            ++start;
+      }
+
+      for (int i = start; i < n && w < max; ++i)
+         out[w++] = raw[i];
+      return w;
+   }
+
+   void WriteCallStack(int fd, void* const* frames, int n)
+   {
+      WriteStr(fd, "Call stack\n==========\n");
+
+      // One line per frame: our own frames resolve to symbol + file:line via
+      // CoreSymbolication, system frames to module + symbol via dladdr, and
+      // anything unresolved to the bare address (all handled by GetSymbolInfo).
+      for (int i = 0; i < n; ++i)
+      {
+         char sym[MAXSTRING];
+         const int c = rde::StackTrace::GetSymbolInfo(frames[i], sym, sizeof(sym) - 1);
+         if (c > 0)
+         {
+            sym[c] = '\0';
+            WriteStr(fd, sym);
+            WriteStr(fd, "\n");
+         }
+      }
+      WriteStr(fd, "\n");
+   }
+
+   void WriteReport(int fd, int sig, siginfo_t* si, void* const* frames, int n)
+   {
+      WriteHeader(fd);
+      WriteExceptionInfo(fd, sig, si);
+      WriteCallStack(fd, frames, n);
+   }
+
+   void CrashSignalHandler(int sig, siginfo_t* si, void* uctx)
+   {
+      if (s_inHandler)
+      {
+         signal(sig, SIG_DFL);
+         raise(sig);
+         return;
+      }
+      s_inHandler = 1;
+
+      // Capture a fault-first stack (drops this handler and the trampoline).
+      void* frames[256];
+      const int n = CaptureFromContext(uctx, frames, (int)std::size(frames));
+
+      const int fd = open(s_reportFileName.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0644);
+      if (fd >= 0)
+      {
+         WriteReport(fd, sig, si, frames, n);
+         close(fd);
+      }
+
+      // Restore default disposition and re-raise so the OS still terminates
+      // (and produces its own crash report / core if configured).
+      signal(sig, SIG_DFL);
+      raise(sig);
+   }
+
+   void InstallHandlers()
+   {
+      stack_t ss = {};
+      ss.ss_sp = s_altStack;
+      ss.ss_size = sizeof(s_altStack);
+      ss.ss_flags = 0;
+      sigaltstack(&ss, nullptr);
+
+      struct sigaction sa = {};
+      sa.sa_sigaction = CrashSignalHandler;
+      sigemptyset(&sa.sa_mask);
+      sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+
+      const int signals[] = { SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGABRT };
+      for (int s : signals)
+         sigaction(s, &sa, nullptr);
+   }
+} // namespace
+
+namespace rde
+{
+   void CrashHandler::Init()
+   {
+      // Pre-warm symbol resolution on the main thread (mirrors the MinGW arm).
+      rde::StackTrace::InitSymbols();
+      InstallHandlers();
+   }
+
+   void CrashHandler::SetMiniDumpFileName(const string& name)
+   {
+      s_miniDumpFileName = name;
+   }
+
+   void CrashHandler::SetCrashReportFileName(const string& name)
+   {
+      s_reportFileName = name;
+   }
+}
+
+#else // !__APPLE__
+
 #include "BlackBox.h"
 #include "MemoryStatus.h"
-#include "StackTrace.h"
 #include <cstdio>
 #include <cstdlib>
 #define WIN32_LEAN_AND_MEAN
@@ -11,7 +229,6 @@
 #include <windows.h>
 #include <dbghelp.h>
 #include <cassert>
-#include "core/vpversion.h"
 
 namespace
 {
@@ -365,3 +582,5 @@ namespace rde
       s_reportFileName = name;
    }
 }
+
+#endif // !__APPLE__

--- a/src/utils/StackTrace.cpp
+++ b/src/utils/StackTrace.cpp
@@ -1,6 +1,294 @@
 #include "core/stdafx.h"
 #include "StackTrace.h"
 
+#if defined(__APPLE__)
+
+#include <execinfo.h>
+#include <mach/machine.h>
+#include <mach-o/dyld.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <dlfcn.h>
+#include <cxxabi.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+
+// macOS resolves our own frames in-process with CoreSymbolication, a private
+// Apple framework (in /System/Library/PrivateFrameworks). It is the same engine
+// atos and Xcode use. There is no public header, so the small slice of the API
+// we use is declared here. If Apple changes it, the build breaks visibly and we
+// fix it; CoreSymbolication is not optional for our own frames.
+//
+// We load the .dSYM by an explicit path (derived from the running executable)
+// via CSSymbolicatorCreateWithURLAndArchitecture rather than by pid. The pid
+// path depends on Spotlight having indexed the .dSYM by UUID, which is not true
+// on an end user's machine. The explicit path is deterministic: the .dSYM ships
+// beside the app (the macOS equivalent of a Windows PDB) and we point straight
+// at it. Addresses from backtrace() are runtime addresses, so we de-slide them
+// by the main image's ASLR slide before querying the symbol owner, which is
+// addressed in the .dSYM's static (link-time) address space.
+//
+// Frames outside our .dSYM (system libraries) are named with dladdr, which reads
+// the loaded image's symbol table (module + symbol + offset, no file:line). This
+// mirrors dbghelp naming system DLL frames on Windows.
+extern "C"
+{
+	typedef struct { const void* data; const void* obj; } CSTypeRef;
+	typedef struct { cpu_type_t cpu_type; cpu_subtype_t cpu_subtype; } CSArchitecture;
+	typedef CSTypeRef CSSymbolicatorRef;
+	typedef CSTypeRef CSSymbolOwnerRef;
+	typedef CSTypeRef CSSymbolRef;
+	typedef CSTypeRef CSSourceInfoRef;
+
+	CSArchitecture CSArchitectureGetArchitectureForName(const char* name);
+	CSSymbolicatorRef CSSymbolicatorCreateWithURLAndArchitecture(CFURLRef url, CSArchitecture arch);
+	int CSSymbolicatorForeachSymbolOwnerAtTime(CSSymbolicatorRef, uint64_t time, void (^it)(CSSymbolOwnerRef));
+	CSSourceInfoRef CSSymbolOwnerGetSourceInfoWithAddress(CSSymbolOwnerRef, vm_address_t addr);
+	CSSymbolRef CSSymbolOwnerGetSymbolWithAddress(CSSymbolOwnerRef, vm_address_t addr);
+	const char* CSSymbolGetName(CSSymbolRef);
+	const char* CSSourceInfoGetPath(CSSourceInfoRef);
+	int CSSourceInfoGetLineNumber(CSSourceInfoRef);
+	CSSymbolRef CSSourceInfoGetSymbol(CSSourceInfoRef);
+	int CSIsNull(CSTypeRef);
+}
+
+namespace
+{
+	constexpr uint64_t kCSNow = 0x80000000u;
+
+	CSSymbolOwnerRef g_owner = {};
+	bool g_ready = false;
+	intptr_t g_slide = 0;
+
+	void GetBaseName(const char* path, char* out, size_t outSize)
+	{
+		const char* base = path;
+		for (const char* p = path; *p; ++p)
+			if (*p == '/')
+				base = p + 1;
+		snprintf(out, outSize, "%s", base);
+	}
+
+	// Build the path to the DWARF file inside the bundled .dSYM, from the running
+	// executable at <bundle>/Contents/MacOS/<name>:
+	//   <bundle>/Contents/Resources/<name>.dSYM/Contents/Resources/DWARF/<name>
+	bool GetDSYMDwarfPath(char* out, size_t outSize)
+	{
+		char exePath[MAXSTRING];
+		uint32_t size = sizeof(exePath);
+		if (_NSGetExecutablePath(exePath, &size) != 0)
+			return false;
+
+		char real[MAXSTRING];
+		const char* exe = realpath(exePath, real) ? real : exePath;
+
+		char name[MAXSTRING];
+		GetBaseName(exe, name, sizeof(name));
+
+		// Directory of the executable (…/Contents/MacOS).
+		char dir[MAXSTRING];
+		snprintf(dir, sizeof(dir), "%s", exe);
+		char* lastSlash = strrchr(dir, '/');
+		if (lastSlash == nullptr)
+			return false;
+		*lastSlash = '\0';
+
+		const int n = snprintf(out, outSize, "%s/../Resources/%s.dSYM/Contents/Resources/DWARF/%s", dir, name, name);
+		return n > 0 && n < (int)outSize;
+	}
+}
+
+namespace rde
+{
+// The Windows StackWalk64/context overloads have no macOS equivalent; the crash
+// handler drives GetCallStack(Address*, ...) directly via backtrace().
+bool StackTrace::InitSymbols()
+{
+	// Load the bundled .dSYM once on the main thread at startup. Mapping the
+	// symbol data must not first happen inside a crash on another thread
+	// (mirrors the MinGW libbacktrace pre-warm).
+	if (g_ready)
+		return true;
+
+	char dwarfPath[MAXSTRING];
+	if (!GetDSYMDwarfPath(dwarfPath, sizeof(dwarfPath)))
+		return false;
+
+	CFStringRef pathStr = CFStringCreateWithCString(nullptr, dwarfPath, kCFStringEncodingUTF8);
+	if (pathStr == nullptr)
+		return false;
+	CFURLRef url = CFURLCreateWithFileSystemPath(nullptr, pathStr, kCFURLPOSIXPathStyle, false);
+	CFRelease(pathStr);
+	if (url == nullptr)
+		return false;
+
+#if defined(__aarch64__)
+	const CSArchitecture arch = CSArchitectureGetArchitectureForName("arm64");
+#else
+	const CSArchitecture arch = CSArchitectureGetArchitectureForName("x86_64");
+#endif
+	const CSSymbolicatorRef symbolicator = CSSymbolicatorCreateWithURLAndArchitecture(url, arch);
+	CFRelease(url);
+	if (CSIsNull(symbolicator))
+		return false;
+
+	// The .dSYM has a single symbol owner (our executable image); capture it.
+	__block CSSymbolOwnerRef owner = {};
+	CSSymbolicatorForeachSymbolOwnerAtTime(symbolicator, kCSNow, ^(CSSymbolOwnerRef o) { owner = o; });
+	if (CSIsNull(owner))
+		return false;
+
+	g_owner = owner;
+	g_slide = _dyld_get_image_vmaddr_slide(0); // ASLR slide of the main executable
+	g_ready = true;
+	return true;
+}
+
+int StackTrace::GetCallStack(Address* callStack, int maxDepth, int entriesToSkip)
+{
+	void* frames[256];
+	if (maxDepth > (int)std::size(frames))
+		maxDepth = (int)std::size(frames);
+	const int captured = backtrace(frames, maxDepth + entriesToSkip + 1);
+	// +1 -> skip over "us" (this function's own frame)
+	int skip = entriesToSkip + 1;
+	int numEntries = 0;
+	for (int i = skip; i < captured && numEntries < maxDepth; ++i)
+		callStack[numEntries++] = frames[i];
+	return numEntries;
+}
+
+int StackTrace::GetCallStack(void* /*context*/, Address* callStack, int maxDepth, int entriesToSkip)
+{
+	// No signal context walk on macOS; fall back to the live stack.
+	return GetCallStack(callStack, maxDepth, entriesToSkip);
+}
+
+int StackTrace::GetCallStack_Fast(Address* callStack, int maxDepth, int entriesToSkip)
+{
+	return GetCallStack(callStack, maxDepth, entriesToSkip);
+}
+
+int StackTrace::GetSymbolInfo(Address address, char* symbol, int maxSymbolLen)
+{
+	if (maxSymbolLen <= 0)
+		return 0;
+
+	int charsAdded = snprintf(symbol, maxSymbolLen, "%p", address);
+	if (charsAdded < 0)
+		return 0;
+	if (charsAdded > maxSymbolLen - 1)
+		charsAdded = maxSymbolLen - 1;
+
+	if (!InitSymbols())
+		return charsAdded;
+
+	// De-slide the runtime address into the .dSYM's static address space.
+	const vm_address_t staticAddr = (vm_address_t)((uintptr_t)address - g_slide);
+	char* out = symbol + charsAdded;
+	int remaining = maxSymbolLen - charsAdded;
+
+	// Source info carries symbol + file + line; CoreSymbolication demangles the
+	// name and resolves file:line from the .dSYM DWARF.
+	CSSourceInfoRef si = CSSymbolOwnerGetSourceInfoWithAddress(g_owner, staticAddr);
+	if (!CSIsNull(si))
+	{
+		CSSymbolRef sym = CSSourceInfoGetSymbol(si);
+		const char* name = CSIsNull(sym) ? nullptr : CSSymbolGetName(sym);
+		const char* file = CSSourceInfoGetPath(si);
+		const int line = CSSourceInfoGetLineNumber(si);
+
+		int n;
+		if (file != nullptr && line > 0)
+		{
+			char fileBase[MAXSTRING];
+			GetBaseName(file, fileBase, sizeof(fileBase));
+			n = snprintf(out, remaining, " %s %s(%d)", name ? name : "<unknown>", fileBase, line);
+		}
+		else
+			n = snprintf(out, remaining, " %s", name ? name : "<unknown>");
+
+		if (n > 0)
+			charsAdded += (n > remaining - 1) ? remaining - 1 : n;
+		return charsAdded;
+	}
+
+	// No source info, but the address may still be a named symbol in our own
+	// image without line info; take the bare name from the owner.
+	CSSymbolRef sym = CSSymbolOwnerGetSymbolWithAddress(g_owner, staticAddr);
+	if (!CSIsNull(sym))
+	{
+		const char* name = CSSymbolGetName(sym);
+		const int n = snprintf(out, remaining, " %s", name ? name : "<unknown>");
+		if (n > 0)
+			charsAdded += (n > remaining - 1) ? remaining - 1 : n;
+		return charsAdded;
+	}
+
+	// Not in our .dSYM (a system library frame): name it via dladdr, which reads
+	// the loaded image's symbol table. Gives module + symbol + offset, no line.
+	Dl_info info = {};
+	if (dladdr(address, &info) != 0)
+	{
+		if (info.dli_fname != nullptr)
+		{
+			char moduleBase[MAXSTRING];
+			GetBaseName(info.dli_fname, moduleBase, sizeof(moduleBase));
+			const int n = snprintf(out, remaining, " %s", moduleBase);
+			if (n > 0)
+			{
+				const int adv = (n > remaining - 1) ? remaining - 1 : n;
+				out += adv;
+				remaining -= adv;
+				charsAdded += adv;
+			}
+		}
+
+		if (info.dli_sname != nullptr && remaining > 1)
+		{
+			char demangledBuf[MAXSTRING];
+			const char* name = info.dli_sname;
+			int status = 0;
+			size_t len = sizeof(demangledBuf);
+			char* demangled = abi::__cxa_demangle(info.dli_sname, demangledBuf, &len, &status);
+			if (status == 0 && demangled != nullptr)
+				name = demangled;
+
+			const uintptr_t offset = (info.dli_saddr != nullptr)
+				? (uintptr_t)address - (uintptr_t)info.dli_saddr
+				: 0;
+			const int n = snprintf(out, remaining, " %s + 0x%lX", name, (unsigned long)offset);
+			if (n > 0)
+				charsAdded += (n > remaining - 1) ? remaining - 1 : n;
+		}
+	}
+	return charsAdded;
+}
+
+void StackTrace::GetCallStack(void* /*vcontext*/, bool /*includeArguments*/, char* symbol, int maxSymbolLen)
+{
+	Address frames[256];
+	// entriesToSkip 1 -> skip this GetCallStack frame itself.
+	const int numFrames = GetCallStack(frames, (int)std::size(frames), 1);
+	for (int i = 0; i < numFrames && maxSymbolLen > 1; ++i)
+	{
+		const int charsAdded = GetSymbolInfo(frames[i], symbol, maxSymbolLen);
+		symbol += charsAdded;
+		maxSymbolLen -= charsAdded;
+		if (maxSymbolLen > 1)
+		{
+			*symbol++ = '\n';
+			*symbol = '\0';
+			--maxSymbolLen;
+		}
+	}
+}
+
+} // namespace rde
+
+#else // !__APPLE__
+
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
@@ -428,3 +716,5 @@ void StackTrace::GetCallStack(void* vcontext, bool includeArguments,
 }
 
 }
+
+#endif // !__APPLE__

--- a/src/utils/StackTrace.h
+++ b/src/utils/StackTrace.h
@@ -4,7 +4,7 @@ namespace rde
 {
 namespace StackTrace
 {
-#if defined (_MSC_VER) || defined (__MINGW32__)
+#if defined (_MSC_VER) || defined (__MINGW32__) || defined (__APPLE__)
 	typedef const void*	Address;
 #else
 #	error "StackTrace not implemented for this platform!"


### PR DESCRIPTION
Gives the macOS standalone build the same crash-reporting quality as the Windows builds: on a fatal signal it writes `crash.txt` with a symbolicated call stack (function names + file:line), resolved in-process, starting at the faulting frame.

## Cause / approach

The MSVC build uses dbghelp/PDB and the MinGW build uses libbacktrace/DWARF; neither works on macOS. libbacktrace specifically fails on Mach-O/dSYM (reads the dSYM but returns null, and doesn't handle the PIE slide), which is why the Rust ecosystem abandoned it there too. The fix uses CoreSymbolication (Apple's own symbolication engine, same as `atos`/Xcode) to resolve our own frames to file:line, loading the app's `.dSYM` by an explicit path and de-sliding addresses manually. System-library frames are named with `dladdr` (module + symbol + offset, no line info), mirroring dbghelp naming system DLL frames on Windows.

## Fault-first stack

A `SIGSEGV`/`SIGBUS`/`SIGILL`/`SIGFPE`/`SIGABRT` handler (installed via `sigaction` with `SA_SIGINFO` on an alternate stack) walks the crashing thread's stack so frame 0 is the faulting instruction, not our handler. It takes a `backtrace()`, drops the leading frames through `_sigtramp` (the kernel signal trampoline, above which are only our own frames), and prepends the `ucontext` PC to recover a leaf that faulted without making a call. This mirrors the Windows path starting from the exception `CONTEXT`. The report is written from the signal handler using only `write(2)` and stack buffers.

## dSYM shipping (the macOS PDB equivalent)

The `.dSYM` is generated into `Contents/Resources/` (a sealed resource, not `Contents/MacOS/` where it would count as nested code and break codesign/notarization) and ships inside the app. `InitSymbols()` computes the path relative to the running executable and loads it via `CSSymbolicatorCreateWithURLAndArchitecture`, so resolution is deterministic and does not depend on Spotlight indexing the dSYM by UUID (which isn't true on an end-user machine). Built with `-g1` for line tables at roughly half the dSYM size of `-g`. `dsymutil` runs as a POST_BUILD step (it harvests DWARF from the `.o` files, so it must run after link while they exist); the app is signed after, sealing the dSYM.

## Testing

Verified on arm64, both a startup crash (main thread) and an in-play crash (player thread), each producing a single call stack that begins at the fault, with our frames carrying file:line and system frames named.

Startup crash (main thread):

```
Call stack
==========
0x102d37254 VPApp::VPApp() VPApp.cpp(153)
0x102c4769c WinMain main.cpp(195)
0x1033fb824 -[VPXAppDelegate makeWindowExit] main.mm(70)
0x1845999ec CoreFoundation __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 0x94
...
0x1889cd13c AppKit -[NSApplication run] + 0x170
0x1033fb978 main main.mm(109)
0x18411c4e4 dyld start + 0x1B50
```

In-play crash (player thread):

```
Call stack
==========
0x100c177ec PhysicsEngine::PhysicsSimulateCycle(float) PhysicsEngine.cpp(498)
0x100c176a4 PhysicsEngine::UpdatePhysics(unsigned long long) PhysicsEngine.cpp(472)
0x100a19a90 Player::UpdateGameLogic() player.cpp(1848)
0x100a1a424 Player::MultithreadedGameLoop() player.cpp(1918)
0x1009eb8d8 PlayTableCommand::Execute() AppCommands.cpp(140)
0x100a0b6c4 WinMain main.cpp(206)
0x1011bf824 -[VPXAppDelegate makeWindowExit] main.mm(70)
0x1845999ec CoreFoundation __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 0x94
...
0x1889cd13c AppKit -[NSApplication run] + 0x170
0x1011bf978 main main.mm(109)
0x18411c4e4 dyld start + 0x1B50
```

The crash sites (`VPApp.cpp(153)`, `PhysicsEngine.cpp(498)`) are injected test faults (on a companion test branch, not this PR), pinpointed to the exact line. The player-thread case confirms cross-thread resolution: the symbolicator is created on the main thread at startup and queried from the player thread at crash time.

PTAL @jsm174
